### PR TITLE
Fix/login bug in deployed

### DIFF
--- a/.github/workflows/docker-build-push.yml
+++ b/.github/workflows/docker-build-push.yml
@@ -61,6 +61,7 @@ jobs:
         env:
           NEXT_PUBLIC_BACKEND_DOMAIN: ${{ vars.NEXT_PUBLIC_BACKEND_DOMAIN }}
           NEXT_PUBLIC_WEBSITE_DOMAIN: ${{ vars.NEXT_PUBLIC_WEBSITE_DOMAIN }}
+          BACKEND_DOMAIN: ${{ vars.BACKEND_DOMAIN }}
         run: |
           if [ -z "$NEXT_PUBLIC_BACKEND_DOMAIN" ]; then
             echo "Missing repository variable: NEXT_PUBLIC_BACKEND_DOMAIN"
@@ -68,6 +69,10 @@ jobs:
           fi
           if [ -z "$NEXT_PUBLIC_WEBSITE_DOMAIN" ]; then
             echo "Missing repository variable: NEXT_PUBLIC_WEBSITE_DOMAIN"
+            exit 1
+          fi
+          if [ -z "$BACKEND_DOMAIN" ]; then
+            echo "Missing repository variable: BACKEND_DOMAIN"
             exit 1
           fi
 
@@ -84,5 +89,6 @@ jobs:
           build-args: |
             NEXT_PUBLIC_BACKEND_DOMAIN=${{ vars.NEXT_PUBLIC_BACKEND_DOMAIN }}
             NEXT_PUBLIC_WEBSITE_DOMAIN=${{ vars.NEXT_PUBLIC_WEBSITE_DOMAIN }}
+            BACKEND_DOMAIN=${{ vars.BACKEND_DOMAIN }}
           cache-from: type=local,src=/tmp/.buildx-cache
           cache-to: type=local,dest=/tmp/.buildx-cache,mode=max

--- a/.github/workflows/docker-build-push.yml
+++ b/.github/workflows/docker-build-push.yml
@@ -57,6 +57,20 @@ jobs:
           cache-from: type=local,src=/tmp/.buildx-cache
           cache-to: type=local,dest=/tmp/.buildx-cache,mode=max
 
+      - name: Validate frontend build domains
+        env:
+          NEXT_PUBLIC_BACKEND_DOMAIN: ${{ vars.NEXT_PUBLIC_BACKEND_DOMAIN }}
+          NEXT_PUBLIC_WEBSITE_DOMAIN: ${{ vars.NEXT_PUBLIC_WEBSITE_DOMAIN }}
+        run: |
+          if [ -z "$NEXT_PUBLIC_BACKEND_DOMAIN" ]; then
+            echo "Missing repository variable: NEXT_PUBLIC_BACKEND_DOMAIN"
+            exit 1
+          fi
+          if [ -z "$NEXT_PUBLIC_WEBSITE_DOMAIN" ]; then
+            echo "Missing repository variable: NEXT_PUBLIC_WEBSITE_DOMAIN"
+            exit 1
+          fi
+
       - name: Build and push frontend image
         uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6
         with:
@@ -67,5 +81,8 @@ jobs:
           tags: |
             tegelsten/course-compass-frontend:latest
             tegelsten/course-compass-frontend:${{ steps.meta.outputs.SHORT_SHA }}
+          build-args: |
+            NEXT_PUBLIC_BACKEND_DOMAIN=${{ vars.NEXT_PUBLIC_BACKEND_DOMAIN }}
+            NEXT_PUBLIC_WEBSITE_DOMAIN=${{ vars.NEXT_PUBLIC_WEBSITE_DOMAIN }}
           cache-from: type=local,src=/tmp/.buildx-cache
           cache-to: type=local,dest=/tmp/.buildx-cache,mode=max

--- a/Dockerfile.frontend
+++ b/Dockerfile.frontend
@@ -38,10 +38,12 @@ RUN npm run build:shared
 # Uncomment the following line in case you want to disable telemetry during the build.
 ENV NEXT_TELEMETRY_DISABLED=1
 
-# Build the frontend
-# Add these lines before the CMD instruction
-ENV NEXT_PUBLIC_BACKEND_DOMAIN=https://backend-eyesdze7adehhebr.norwayeast-01.azurewebsites.net
-ENV NEXT_PUBLIC_WEBSITE_DOMAIN=https://coursecompass.azurewebsites.net
+# Build-time public env vars (pass via --build-arg in CI/CD for deployed builds).
+# Defaults are local-only and avoid baking legacy hosted domains into bundles.
+ARG NEXT_PUBLIC_BACKEND_DOMAIN=http://localhost:8080
+ARG NEXT_PUBLIC_WEBSITE_DOMAIN=http://localhost:3000
+ENV NEXT_PUBLIC_BACKEND_DOMAIN=$NEXT_PUBLIC_BACKEND_DOMAIN
+ENV NEXT_PUBLIC_WEBSITE_DOMAIN=$NEXT_PUBLIC_WEBSITE_DOMAIN
 WORKDIR /app/frontend
 RUN npm run build
 

--- a/Dockerfile.frontend
+++ b/Dockerfile.frontend
@@ -42,8 +42,11 @@ ENV NEXT_TELEMETRY_DISABLED=1
 # Defaults are local-only and avoid baking legacy hosted domains into bundles.
 ARG NEXT_PUBLIC_BACKEND_DOMAIN=http://localhost:8080
 ARG NEXT_PUBLIC_WEBSITE_DOMAIN=http://localhost:3000
+# Same target as NEXT_PUBLIC_BACKEND_DOMAIN; used by next.config rewrites for /api/auth -> backend /auth
+ARG BACKEND_DOMAIN=
 ENV NEXT_PUBLIC_BACKEND_DOMAIN=$NEXT_PUBLIC_BACKEND_DOMAIN
 ENV NEXT_PUBLIC_WEBSITE_DOMAIN=$NEXT_PUBLIC_WEBSITE_DOMAIN
+ENV BACKEND_DOMAIN=$BACKEND_DOMAIN
 WORKDIR /app/frontend
 RUN npm run build
 

--- a/backend-nest/.env.example
+++ b/backend-nest/.env.example
@@ -2,6 +2,8 @@
 DATABASE_URL=postgresql://user:password@host:port/database
 
 # ElasticSearch credentials
+# Set to false to run without Elasticsearch (e.g. Vercel pgvector mode)
+ELASTICSEARCH_ENABLED=true
 ELASTICSEARCH_URL=http://localhost:9200
 ELASTICSEARCH_USERNAME=elastic
 ELASTICSEARCH_PASSWORD=
@@ -21,7 +23,9 @@ WEBSITE_DOMAIN=http://localhost:3000
 API_DOMAIN=http://localhost:8080
 
 # Extra CORS origins (comma-separated). WEBSITE_DOMAIN is always included.
+# When the frontend is on another host (e.g. public app URL), set WEBSITE_DOMAIN to that origin; add extras here.
 CORS_ORIGINS=
 
 # Vercel AI Gateway — https://vercel.com/dashboard/ai-gateway/api-keys
+# On the API service (e.g. Dokploy). Frontend only calls /ai/chat on the public API URL.
 AI_GATEWAY_API_KEY=

--- a/backend-nest/migrations/0000_baseline_current_schema.sql
+++ b/backend-nest/migrations/0000_baseline_current_schema.sql
@@ -6,6 +6,7 @@
 -- Legacy chain files are kept for historical reference only.
 
 CREATE EXTENSION IF NOT EXISTS vector;
+CREATE EXTENSION IF NOT EXISTS pg_trgm;
 
 DO $$
 BEGIN
@@ -127,3 +128,6 @@ CREATE TABLE IF NOT EXISTS "feedback_form" (
 --> statement-breakpoint
 
 CREATE INDEX IF NOT EXISTS "courses_search_vector_idx" ON "courses" USING gin ("search_vector");
+CREATE INDEX IF NOT EXISTS "courses_embedding_idx" ON "courses" USING hnsw ("embedding" vector_cosine_ops);
+CREATE INDEX IF NOT EXISTS "courses_name_trgm_idx" ON "courses" USING gin ("name" gin_trgm_ops);
+CREATE INDEX IF NOT EXISTS "courses_code_trgm_idx" ON "courses" USING gin ("code" gin_trgm_ops);

--- a/backend-nest/migrations/0000_baseline_current_schema.sql
+++ b/backend-nest/migrations/0000_baseline_current_schema.sql
@@ -1,0 +1,128 @@
+-- BASELINE MIGRATION (authoritative)
+-- Created: 2026-05-01
+-- Purpose: Canonical bootstrap for current Drizzle schema.
+-- Source of truth: src/db/schema.ts
+-- This file defines the current schema represented by src/db/schema.ts.
+-- Legacy chain files are kept for historical reference only.
+
+CREATE EXTENSION IF NOT EXISTS vector;
+
+CREATE TYPE "public"."course_state" AS ENUM('CANCELLED', 'ESTABLISHED', 'DEACTIVATED');--> statement-breakpoint
+
+CREATE TABLE "courses" (
+  "code" text PRIMARY KEY NOT NULL,
+  "name" text NOT NULL,
+  "name_swedish" text NOT NULL,
+  "name_english" text NOT NULL,
+  "state" "course_state" NOT NULL,
+  "credits" real NOT NULL,
+  "credit_unit" text,
+  "department_code" text NOT NULL,
+  "department" text NOT NULL,
+  "educational_level_code" text,
+  "grade_scale_code" text,
+  "goals" text,
+  "content" text,
+  "eligibility" text,
+  "updated_at" timestamp with time zone DEFAULT now() NOT NULL,
+  "embedding" vector(1536),
+  "embedding_hash" text,
+  "search_vector" tsvector GENERATED ALWAYS AS (to_tsvector('simple', coalesce(name_english, '') || ' ' || coalesce(name_swedish, '') || ' ' || coalesce(code, '') || ' ' || coalesce(goals, '') || ' ' || coalesce(content, ''))) STORED
+);
+--> statement-breakpoint
+
+CREATE TABLE "course_rounds" (
+  "id" serial PRIMARY KEY NOT NULL,
+  "course_code" text NOT NULL,
+  "start_term" integer NOT NULL,
+  "study_pace" integer,
+  "schema_url" text,
+  "language" text,
+  "tutoring_form" text,
+  "tutoring_time_of_day" text,
+  "formatted_periods_and_credits" text,
+  "is_pu" boolean NOT NULL,
+  "is_vu" boolean NOT NULL
+);
+--> statement-breakpoint
+
+CREATE TABLE "course_examinations" (
+  "course_code" text NOT NULL,
+  "exam_code" text NOT NULL,
+  "title" text,
+  "credits" real,
+  "grade_scale_code" text,
+  CONSTRAINT "course_examinations_course_code_exam_code_pk" PRIMARY KEY("course_code","exam_code")
+);
+--> statement-breakpoint
+
+CREATE TABLE "users" (
+  "id" text PRIMARY KEY NOT NULL,
+  "email" text NOT NULL,
+  "name" text NOT NULL,
+  "profile_picture" text,
+  "created_at" timestamp with time zone DEFAULT now() NOT NULL,
+  "updated_at" timestamp with time zone DEFAULT now() NOT NULL,
+  CONSTRAINT "users_email_unique" UNIQUE("email")
+);
+--> statement-breakpoint
+
+CREATE TABLE "user_auth_identities" (
+  "auth_user_id" text PRIMARY KEY NOT NULL,
+  "user_id" text NOT NULL,
+  "created_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+
+CREATE TABLE "reviews" (
+  "id" text PRIMARY KEY NOT NULL,
+  "user_id" text NOT NULL,
+  "course_code" text NOT NULL,
+  "examination_methods" integer DEFAULT 0 NOT NULL,
+  "theoretical_vs_applied" integer DEFAULT 0 NOT NULL,
+  "workload" integer DEFAULT 0 NOT NULL,
+  "learning_experience" integer DEFAULT 0 NOT NULL,
+  "would_recommend" boolean DEFAULT false NOT NULL,
+  "content" text NOT NULL,
+  "created_at" timestamp with time zone DEFAULT now() NOT NULL,
+  "updated_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+
+CREATE TABLE "review_likes" (
+  "user_id" text NOT NULL,
+  "review_id" text NOT NULL,
+  "vote_type" text NOT NULL,
+  "created_at" timestamp with time zone DEFAULT now() NOT NULL,
+  CONSTRAINT "review_likes_user_id_review_id_pk" PRIMARY KEY("user_id","review_id")
+);
+--> statement-breakpoint
+
+CREATE TABLE "user_favorites" (
+  "user_id" text NOT NULL,
+  "fav_course_code" text NOT NULL,
+  "created_at" timestamp with time zone DEFAULT now() NOT NULL,
+  CONSTRAINT "user_favorites_user_id_fav_course_code_pk" PRIMARY KEY("user_id","fav_course_code")
+);
+--> statement-breakpoint
+
+CREATE TABLE "feedback_form" (
+  "id" text PRIMARY KEY NOT NULL,
+  "name" text NOT NULL,
+  "email" text NOT NULL,
+  "message" text NOT NULL,
+  "created_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+
+ALTER TABLE "course_rounds" ADD CONSTRAINT "course_rounds_course_code_courses_code_fk" FOREIGN KEY ("course_code") REFERENCES "public"."courses"("code") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "course_examinations" ADD CONSTRAINT "course_examinations_course_code_courses_code_fk" FOREIGN KEY ("course_code") REFERENCES "public"."courses"("code") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "user_auth_identities" ADD CONSTRAINT "user_auth_identities_user_id_users_id_fk" FOREIGN KEY ("user_id") REFERENCES "public"."users"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "reviews" ADD CONSTRAINT "reviews_user_id_users_id_fk" FOREIGN KEY ("user_id") REFERENCES "public"."users"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "reviews" ADD CONSTRAINT "reviews_course_code_courses_code_fk" FOREIGN KEY ("course_code") REFERENCES "public"."courses"("code") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "review_likes" ADD CONSTRAINT "review_likes_user_id_users_id_fk" FOREIGN KEY ("user_id") REFERENCES "public"."users"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "review_likes" ADD CONSTRAINT "review_likes_review_id_reviews_id_fk" FOREIGN KEY ("review_id") REFERENCES "public"."reviews"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "user_favorites" ADD CONSTRAINT "user_favorites_user_id_users_id_fk" FOREIGN KEY ("user_id") REFERENCES "public"."users"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "user_favorites" ADD CONSTRAINT "user_favorites_fav_course_code_courses_code_fk" FOREIGN KEY ("fav_course_code") REFERENCES "public"."courses"("code") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+
+CREATE INDEX "courses_search_vector_idx" ON "courses" USING gin ("search_vector");

--- a/backend-nest/migrations/0000_baseline_current_schema.sql
+++ b/backend-nest/migrations/0000_baseline_current_schema.sql
@@ -7,9 +7,20 @@
 
 CREATE EXTENSION IF NOT EXISTS vector;
 
-CREATE TYPE "public"."course_state" AS ENUM('CANCELLED', 'ESTABLISHED', 'DEACTIVATED');--> statement-breakpoint
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1
+    FROM pg_type t
+    JOIN pg_namespace n ON n.oid = t.typnamespace
+    WHERE t.typname = 'course_state' AND n.nspname = 'public'
+  ) THEN
+    CREATE TYPE "public"."course_state" AS ENUM('CANCELLED', 'ESTABLISHED', 'DEACTIVATED');
+  END IF;
+END
+$$;--> statement-breakpoint
 
-CREATE TABLE "courses" (
+CREATE TABLE IF NOT EXISTS "courses" (
   "code" text PRIMARY KEY NOT NULL,
   "name" text NOT NULL,
   "name_swedish" text NOT NULL,
@@ -31,9 +42,9 @@ CREATE TABLE "courses" (
 );
 --> statement-breakpoint
 
-CREATE TABLE "course_rounds" (
+CREATE TABLE IF NOT EXISTS "course_rounds" (
   "id" serial PRIMARY KEY NOT NULL,
-  "course_code" text NOT NULL,
+  "course_code" text NOT NULL REFERENCES "public"."courses"("code") ON DELETE cascade ON UPDATE no action,
   "start_term" integer NOT NULL,
   "study_pace" integer,
   "schema_url" text,
@@ -46,8 +57,8 @@ CREATE TABLE "course_rounds" (
 );
 --> statement-breakpoint
 
-CREATE TABLE "course_examinations" (
-  "course_code" text NOT NULL,
+CREATE TABLE IF NOT EXISTS "course_examinations" (
+  "course_code" text NOT NULL REFERENCES "public"."courses"("code") ON DELETE cascade ON UPDATE no action,
   "exam_code" text NOT NULL,
   "title" text,
   "credits" real,
@@ -56,7 +67,7 @@ CREATE TABLE "course_examinations" (
 );
 --> statement-breakpoint
 
-CREATE TABLE "users" (
+CREATE TABLE IF NOT EXISTS "users" (
   "id" text PRIMARY KEY NOT NULL,
   "email" text NOT NULL,
   "name" text NOT NULL,
@@ -67,17 +78,17 @@ CREATE TABLE "users" (
 );
 --> statement-breakpoint
 
-CREATE TABLE "user_auth_identities" (
+CREATE TABLE IF NOT EXISTS "user_auth_identities" (
   "auth_user_id" text PRIMARY KEY NOT NULL,
-  "user_id" text NOT NULL,
+  "user_id" text NOT NULL REFERENCES "public"."users"("id") ON DELETE cascade ON UPDATE no action,
   "created_at" timestamp with time zone DEFAULT now() NOT NULL
 );
 --> statement-breakpoint
 
-CREATE TABLE "reviews" (
+CREATE TABLE IF NOT EXISTS "reviews" (
   "id" text PRIMARY KEY NOT NULL,
-  "user_id" text NOT NULL,
-  "course_code" text NOT NULL,
+  "user_id" text NOT NULL REFERENCES "public"."users"("id") ON DELETE cascade ON UPDATE no action,
+  "course_code" text NOT NULL REFERENCES "public"."courses"("code") ON DELETE cascade ON UPDATE no action,
   "examination_methods" integer DEFAULT 0 NOT NULL,
   "theoretical_vs_applied" integer DEFAULT 0 NOT NULL,
   "workload" integer DEFAULT 0 NOT NULL,
@@ -89,24 +100,24 @@ CREATE TABLE "reviews" (
 );
 --> statement-breakpoint
 
-CREATE TABLE "review_likes" (
-  "user_id" text NOT NULL,
-  "review_id" text NOT NULL,
+CREATE TABLE IF NOT EXISTS "review_likes" (
+  "user_id" text NOT NULL REFERENCES "public"."users"("id") ON DELETE cascade ON UPDATE no action,
+  "review_id" text NOT NULL REFERENCES "public"."reviews"("id") ON DELETE cascade ON UPDATE no action,
   "vote_type" text NOT NULL,
   "created_at" timestamp with time zone DEFAULT now() NOT NULL,
   CONSTRAINT "review_likes_user_id_review_id_pk" PRIMARY KEY("user_id","review_id")
 );
 --> statement-breakpoint
 
-CREATE TABLE "user_favorites" (
-  "user_id" text NOT NULL,
-  "fav_course_code" text NOT NULL,
+CREATE TABLE IF NOT EXISTS "user_favorites" (
+  "user_id" text NOT NULL REFERENCES "public"."users"("id") ON DELETE cascade ON UPDATE no action,
+  "fav_course_code" text NOT NULL REFERENCES "public"."courses"("code") ON DELETE cascade ON UPDATE no action,
   "created_at" timestamp with time zone DEFAULT now() NOT NULL,
   CONSTRAINT "user_favorites_user_id_fav_course_code_pk" PRIMARY KEY("user_id","fav_course_code")
 );
 --> statement-breakpoint
 
-CREATE TABLE "feedback_form" (
+CREATE TABLE IF NOT EXISTS "feedback_form" (
   "id" text PRIMARY KEY NOT NULL,
   "name" text NOT NULL,
   "email" text NOT NULL,
@@ -115,14 +126,4 @@ CREATE TABLE "feedback_form" (
 );
 --> statement-breakpoint
 
-ALTER TABLE "course_rounds" ADD CONSTRAINT "course_rounds_course_code_courses_code_fk" FOREIGN KEY ("course_code") REFERENCES "public"."courses"("code") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
-ALTER TABLE "course_examinations" ADD CONSTRAINT "course_examinations_course_code_courses_code_fk" FOREIGN KEY ("course_code") REFERENCES "public"."courses"("code") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
-ALTER TABLE "user_auth_identities" ADD CONSTRAINT "user_auth_identities_user_id_users_id_fk" FOREIGN KEY ("user_id") REFERENCES "public"."users"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
-ALTER TABLE "reviews" ADD CONSTRAINT "reviews_user_id_users_id_fk" FOREIGN KEY ("user_id") REFERENCES "public"."users"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
-ALTER TABLE "reviews" ADD CONSTRAINT "reviews_course_code_courses_code_fk" FOREIGN KEY ("course_code") REFERENCES "public"."courses"("code") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
-ALTER TABLE "review_likes" ADD CONSTRAINT "review_likes_user_id_users_id_fk" FOREIGN KEY ("user_id") REFERENCES "public"."users"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
-ALTER TABLE "review_likes" ADD CONSTRAINT "review_likes_review_id_reviews_id_fk" FOREIGN KEY ("review_id") REFERENCES "public"."reviews"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
-ALTER TABLE "user_favorites" ADD CONSTRAINT "user_favorites_user_id_users_id_fk" FOREIGN KEY ("user_id") REFERENCES "public"."users"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
-ALTER TABLE "user_favorites" ADD CONSTRAINT "user_favorites_fav_course_code_courses_code_fk" FOREIGN KEY ("fav_course_code") REFERENCES "public"."courses"("code") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
-
-CREATE INDEX "courses_search_vector_idx" ON "courses" USING gin ("search_vector");
+CREATE INDEX IF NOT EXISTS "courses_search_vector_idx" ON "courses" USING gin ("search_vector");

--- a/backend-nest/migrations/0000_bitter_unicorn.sql
+++ b/backend-nest/migrations/0000_bitter_unicorn.sql
@@ -1,3 +1,5 @@
+-- LEGACY: kept for historical reference only.
+-- Use 0000_baseline_current_schema.sql for active schema bootstrap.
 CREATE TYPE "public"."course_state" AS ENUM('CANCELLED', 'ESTABLISHED', 'DEACTIVATED');--> statement-breakpoint
 CREATE TABLE "courses" (
 	"code" text PRIMARY KEY NOT NULL,

--- a/backend-nest/migrations/0001_tense_black_tom.sql
+++ b/backend-nest/migrations/0001_tense_black_tom.sql
@@ -1,0 +1,34 @@
+-- Enable extensions
+CREATE EXTENSION IF NOT EXISTS vector;
+CREATE EXTENSION IF NOT EXISTS pg_trgm;
+
+-- Add embedding column (already exists in DB, this is for fresh environments)
+ALTER TABLE courses ADD COLUMN IF NOT EXISTS embedding vector(1536);
+
+-- Add generated search_vector column (not in Drizzle schema, managed here only)
+ALTER TABLE courses ADD COLUMN IF NOT EXISTS search_vector tsvector
+  GENERATED ALWAYS AS (
+    to_tsvector('simple',
+      coalesce(name_english, '') || ' ' ||
+      coalesce(name_swedish, '') || ' ' ||
+      coalesce(code, '') || ' ' ||
+      coalesce(goals, '') || ' ' ||
+      coalesce(content, '')
+    )
+  ) STORED;
+
+-- Add embedding hash column for incremental embedding updates
+ALTER TABLE courses ADD COLUMN IF NOT EXISTS embedding_hash text;
+
+-- Indexes
+CREATE INDEX IF NOT EXISTS courses_embedding_idx
+  ON courses USING hnsw (embedding vector_cosine_ops);
+
+CREATE INDEX IF NOT EXISTS courses_search_vector_idx
+  ON courses USING GIN (search_vector);
+
+CREATE INDEX IF NOT EXISTS courses_name_trgm_idx
+  ON courses USING GIN (name gin_trgm_ops);
+
+CREATE INDEX IF NOT EXISTS courses_code_trgm_idx
+  ON courses USING GIN (code gin_trgm_ops);

--- a/backend-nest/migrations/0001_tense_black_tom.sql
+++ b/backend-nest/migrations/0001_tense_black_tom.sql
@@ -1,3 +1,5 @@
+-- LEGACY: kept for historical reference only.
+-- Use 0000_baseline_current_schema.sql for active schema bootstrap.
 -- Enable extensions
 CREATE EXTENSION IF NOT EXISTS vector;
 CREATE EXTENSION IF NOT EXISTS pg_trgm;
@@ -5,7 +7,7 @@ CREATE EXTENSION IF NOT EXISTS pg_trgm;
 -- Add embedding column (already exists in DB, this is for fresh environments)
 ALTER TABLE courses ADD COLUMN IF NOT EXISTS embedding vector(1536);
 
--- Add generated search_vector column (not in Drizzle schema, managed here only)
+-- Add generated search_vector column 
 ALTER TABLE courses ADD COLUMN IF NOT EXISTS search_vector tsvector
   GENERATED ALWAYS AS (
     to_tsvector('simple',

--- a/backend-nest/migrations/0002_brown_jocasta.sql
+++ b/backend-nest/migrations/0002_brown_jocasta.sql
@@ -1,1 +1,3 @@
+-- LEGACY: kept for historical reference only.
+-- Use 0000_baseline_current_schema.sql for active schema bootstrap.
 ALTER TABLE "courses" ADD COLUMN IF NOT EXISTS "embedding_hash" text;

--- a/backend-nest/migrations/0002_brown_jocasta.sql
+++ b/backend-nest/migrations/0002_brown_jocasta.sql
@@ -1,1 +1,1 @@
-ALTER TABLE "courses" ADD COLUMN "embedding_hash" text;
+ALTER TABLE "courses" ADD COLUMN IF NOT EXISTS "embedding_hash" text;

--- a/backend-nest/migrations/0002_brown_jocasta.sql
+++ b/backend-nest/migrations/0002_brown_jocasta.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "courses" ADD COLUMN "embedding_hash" text;

--- a/backend-nest/migrations/LEGACY.md
+++ b/backend-nest/migrations/LEGACY.md
@@ -4,6 +4,8 @@ Legacy migration chain
 Legacy cutoff date: 2026-05-01
 Baseline replacement: `0000_baseline_current_schema.sql`
 Rationale: historical migrations drifted from current schema and are retained for reference only.
+Safety note: the baseline migration is intentionally idempotent (IF NOT EXISTS guards)
+so it can be applied safely on existing environments during migration metadata transitions.
 
 The old numbered files are kept only for historical reference:
 

--- a/backend-nest/migrations/LEGACY.md
+++ b/backend-nest/migrations/LEGACY.md
@@ -1,0 +1,18 @@
+Legacy migration chain
+======================
+
+Legacy cutoff date: 2026-05-01
+Baseline replacement: `0000_baseline_current_schema.sql`
+Rationale: historical migrations drifted from current schema and are retained for reference only.
+
+The old numbered files are kept only for historical reference:
+
+- `0000_bitter_unicorn.sql`
+- `0001_tense_black_tom.sql`
+- `0002_brown_jocasta.sql`
+
+Authoritative baseline is now:
+
+- `0000_baseline_current_schema.sql`
+
+Drizzle metadata (`migrations/meta/_journal.json`) points to the baseline chain.

--- a/backend-nest/migrations/meta/0001_snapshot.json
+++ b/backend-nest/migrations/meta/0001_snapshot.json
@@ -1,0 +1,643 @@
+{
+  "id": "100f5d0f-a77b-4c7d-9a5f-d8ec4e81c350",
+  "prevId": "51e26ba9-ee2f-48ff-83a3-ab466d50b77d",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.course_examinations": {
+      "name": "course_examinations",
+      "schema": "",
+      "columns": {
+        "course_code": {
+          "name": "course_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "exam_code": {
+          "name": "exam_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "credits": {
+          "name": "credits",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "grade_scale_code": {
+          "name": "grade_scale_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "course_examinations_course_code_courses_code_fk": {
+          "name": "course_examinations_course_code_courses_code_fk",
+          "tableFrom": "course_examinations",
+          "tableTo": "courses",
+          "columnsFrom": ["course_code"],
+          "columnsTo": ["code"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "course_examinations_course_code_exam_code_pk": {
+          "name": "course_examinations_course_code_exam_code_pk",
+          "columns": ["course_code", "exam_code"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.course_rounds": {
+      "name": "course_rounds",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "course_code": {
+          "name": "course_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "start_term": {
+          "name": "start_term",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "study_pace": {
+          "name": "study_pace",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "schema_url": {
+          "name": "schema_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "language": {
+          "name": "language",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tutoring_form": {
+          "name": "tutoring_form",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tutoring_time_of_day": {
+          "name": "tutoring_time_of_day",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "formatted_periods_and_credits": {
+          "name": "formatted_periods_and_credits",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_pu": {
+          "name": "is_pu",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_vu": {
+          "name": "is_vu",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "course_rounds_course_code_courses_code_fk": {
+          "name": "course_rounds_course_code_courses_code_fk",
+          "tableFrom": "course_rounds",
+          "tableTo": "courses",
+          "columnsFrom": ["course_code"],
+          "columnsTo": ["code"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.courses": {
+      "name": "courses",
+      "schema": "",
+      "columns": {
+        "code": {
+          "name": "code",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name_swedish": {
+          "name": "name_swedish",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name_english": {
+          "name": "name_english",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "state": {
+          "name": "state",
+          "type": "course_state",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "credits": {
+          "name": "credits",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "credit_unit": {
+          "name": "credit_unit",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "department_code": {
+          "name": "department_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "department": {
+          "name": "department",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "educational_level_code": {
+          "name": "educational_level_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "grade_scale_code": {
+          "name": "grade_scale_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "goals": {
+          "name": "goals",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "eligibility": {
+          "name": "eligibility",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "embedding": {
+          "name": "embedding",
+          "type": "vector(1536)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.feedback_form": {
+      "name": "feedback_form",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "message": {
+          "name": "message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.review_likes": {
+      "name": "review_likes",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "review_id": {
+          "name": "review_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "vote_type": {
+          "name": "vote_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "review_likes_user_id_users_id_fk": {
+          "name": "review_likes_user_id_users_id_fk",
+          "tableFrom": "review_likes",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "review_likes_review_id_reviews_id_fk": {
+          "name": "review_likes_review_id_reviews_id_fk",
+          "tableFrom": "review_likes",
+          "tableTo": "reviews",
+          "columnsFrom": ["review_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "review_likes_user_id_review_id_pk": {
+          "name": "review_likes_user_id_review_id_pk",
+          "columns": ["user_id", "review_id"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.reviews": {
+      "name": "reviews",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "course_code": {
+          "name": "course_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "examination_methods": {
+          "name": "examination_methods",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "theoretical_vs_applied": {
+          "name": "theoretical_vs_applied",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "workload": {
+          "name": "workload",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "learning_experience": {
+          "name": "learning_experience",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "would_recommend": {
+          "name": "would_recommend",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "reviews_user_id_users_id_fk": {
+          "name": "reviews_user_id_users_id_fk",
+          "tableFrom": "reviews",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "reviews_course_code_courses_code_fk": {
+          "name": "reviews_course_code_courses_code_fk",
+          "tableFrom": "reviews",
+          "tableTo": "courses",
+          "columnsFrom": ["course_code"],
+          "columnsTo": ["code"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_auth_identities": {
+      "name": "user_auth_identities",
+      "schema": "",
+      "columns": {
+        "auth_user_id": {
+          "name": "auth_user_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "user_auth_identities_user_id_users_id_fk": {
+          "name": "user_auth_identities_user_id_users_id_fk",
+          "tableFrom": "user_auth_identities",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_favorites": {
+      "name": "user_favorites",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "fav_course_code": {
+          "name": "fav_course_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "user_favorites_user_id_users_id_fk": {
+          "name": "user_favorites_user_id_users_id_fk",
+          "tableFrom": "user_favorites",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "user_favorites_fav_course_code_courses_code_fk": {
+          "name": "user_favorites_fav_course_code_courses_code_fk",
+          "tableFrom": "user_favorites",
+          "tableTo": "courses",
+          "columnsFrom": ["fav_course_code"],
+          "columnsTo": ["code"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "user_favorites_user_id_fav_course_code_pk": {
+          "name": "user_favorites_user_id_fav_course_code_pk",
+          "columns": ["user_id", "fav_course_code"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "profile_picture": {
+          "name": "profile_picture",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "nullsNotDistinct": false,
+          "columns": ["email"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/backend-nest/migrations/meta/0002_snapshot.json
+++ b/backend-nest/migrations/meta/0002_snapshot.json
@@ -1,0 +1,649 @@
+{
+  "id": "90831375-50da-4927-8e2d-d124de7ee317",
+  "prevId": "100f5d0f-a77b-4c7d-9a5f-d8ec4e81c350",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.course_examinations": {
+      "name": "course_examinations",
+      "schema": "",
+      "columns": {
+        "course_code": {
+          "name": "course_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "exam_code": {
+          "name": "exam_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "credits": {
+          "name": "credits",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "grade_scale_code": {
+          "name": "grade_scale_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "course_examinations_course_code_courses_code_fk": {
+          "name": "course_examinations_course_code_courses_code_fk",
+          "tableFrom": "course_examinations",
+          "tableTo": "courses",
+          "columnsFrom": ["course_code"],
+          "columnsTo": ["code"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "course_examinations_course_code_exam_code_pk": {
+          "name": "course_examinations_course_code_exam_code_pk",
+          "columns": ["course_code", "exam_code"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.course_rounds": {
+      "name": "course_rounds",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "course_code": {
+          "name": "course_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "start_term": {
+          "name": "start_term",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "study_pace": {
+          "name": "study_pace",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "schema_url": {
+          "name": "schema_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "language": {
+          "name": "language",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tutoring_form": {
+          "name": "tutoring_form",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tutoring_time_of_day": {
+          "name": "tutoring_time_of_day",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "formatted_periods_and_credits": {
+          "name": "formatted_periods_and_credits",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_pu": {
+          "name": "is_pu",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_vu": {
+          "name": "is_vu",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "course_rounds_course_code_courses_code_fk": {
+          "name": "course_rounds_course_code_courses_code_fk",
+          "tableFrom": "course_rounds",
+          "tableTo": "courses",
+          "columnsFrom": ["course_code"],
+          "columnsTo": ["code"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.courses": {
+      "name": "courses",
+      "schema": "",
+      "columns": {
+        "code": {
+          "name": "code",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name_swedish": {
+          "name": "name_swedish",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name_english": {
+          "name": "name_english",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "state": {
+          "name": "state",
+          "type": "course_state",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "credits": {
+          "name": "credits",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "credit_unit": {
+          "name": "credit_unit",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "department_code": {
+          "name": "department_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "department": {
+          "name": "department",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "educational_level_code": {
+          "name": "educational_level_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "grade_scale_code": {
+          "name": "grade_scale_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "goals": {
+          "name": "goals",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "eligibility": {
+          "name": "eligibility",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "embedding": {
+          "name": "embedding",
+          "type": "vector(1536)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "embedding_hash": {
+          "name": "embedding_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.feedback_form": {
+      "name": "feedback_form",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "message": {
+          "name": "message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.review_likes": {
+      "name": "review_likes",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "review_id": {
+          "name": "review_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "vote_type": {
+          "name": "vote_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "review_likes_user_id_users_id_fk": {
+          "name": "review_likes_user_id_users_id_fk",
+          "tableFrom": "review_likes",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "review_likes_review_id_reviews_id_fk": {
+          "name": "review_likes_review_id_reviews_id_fk",
+          "tableFrom": "review_likes",
+          "tableTo": "reviews",
+          "columnsFrom": ["review_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "review_likes_user_id_review_id_pk": {
+          "name": "review_likes_user_id_review_id_pk",
+          "columns": ["user_id", "review_id"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.reviews": {
+      "name": "reviews",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "course_code": {
+          "name": "course_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "examination_methods": {
+          "name": "examination_methods",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "theoretical_vs_applied": {
+          "name": "theoretical_vs_applied",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "workload": {
+          "name": "workload",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "learning_experience": {
+          "name": "learning_experience",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "would_recommend": {
+          "name": "would_recommend",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "reviews_user_id_users_id_fk": {
+          "name": "reviews_user_id_users_id_fk",
+          "tableFrom": "reviews",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "reviews_course_code_courses_code_fk": {
+          "name": "reviews_course_code_courses_code_fk",
+          "tableFrom": "reviews",
+          "tableTo": "courses",
+          "columnsFrom": ["course_code"],
+          "columnsTo": ["code"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_auth_identities": {
+      "name": "user_auth_identities",
+      "schema": "",
+      "columns": {
+        "auth_user_id": {
+          "name": "auth_user_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "user_auth_identities_user_id_users_id_fk": {
+          "name": "user_auth_identities_user_id_users_id_fk",
+          "tableFrom": "user_auth_identities",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_favorites": {
+      "name": "user_favorites",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "fav_course_code": {
+          "name": "fav_course_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "user_favorites_user_id_users_id_fk": {
+          "name": "user_favorites_user_id_users_id_fk",
+          "tableFrom": "user_favorites",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "user_favorites_fav_course_code_courses_code_fk": {
+          "name": "user_favorites_fav_course_code_courses_code_fk",
+          "tableFrom": "user_favorites",
+          "tableTo": "courses",
+          "columnsFrom": ["fav_course_code"],
+          "columnsTo": ["code"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "user_favorites_user_id_fav_course_code_pk": {
+          "name": "user_favorites_user_id_fav_course_code_pk",
+          "columns": ["user_id", "fav_course_code"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "profile_picture": {
+          "name": "profile_picture",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "nullsNotDistinct": false,
+          "columns": ["email"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/backend-nest/migrations/meta/0004_snapshot.json
+++ b/backend-nest/migrations/meta/0004_snapshot.json
@@ -1,0 +1,681 @@
+{
+  "id": "27296bf3-9ffe-465d-9d24-8f023846c964",
+  "prevId": "90831375-50da-4927-8e2d-d124de7ee317",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.course_examinations": {
+      "name": "course_examinations",
+      "schema": "",
+      "columns": {
+        "course_code": {
+          "name": "course_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "exam_code": {
+          "name": "exam_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "credits": {
+          "name": "credits",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "grade_scale_code": {
+          "name": "grade_scale_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "course_examinations_course_code_courses_code_fk": {
+          "name": "course_examinations_course_code_courses_code_fk",
+          "tableFrom": "course_examinations",
+          "tableTo": "courses",
+          "columnsFrom": ["course_code"],
+          "columnsTo": ["code"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "course_examinations_course_code_exam_code_pk": {
+          "name": "course_examinations_course_code_exam_code_pk",
+          "columns": ["course_code", "exam_code"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.course_rounds": {
+      "name": "course_rounds",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "course_code": {
+          "name": "course_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "start_term": {
+          "name": "start_term",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "study_pace": {
+          "name": "study_pace",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "schema_url": {
+          "name": "schema_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "language": {
+          "name": "language",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tutoring_form": {
+          "name": "tutoring_form",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tutoring_time_of_day": {
+          "name": "tutoring_time_of_day",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "formatted_periods_and_credits": {
+          "name": "formatted_periods_and_credits",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_pu": {
+          "name": "is_pu",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_vu": {
+          "name": "is_vu",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "course_rounds_course_code_courses_code_fk": {
+          "name": "course_rounds_course_code_courses_code_fk",
+          "tableFrom": "course_rounds",
+          "tableTo": "courses",
+          "columnsFrom": ["course_code"],
+          "columnsTo": ["code"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.courses": {
+      "name": "courses",
+      "schema": "",
+      "columns": {
+        "code": {
+          "name": "code",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name_swedish": {
+          "name": "name_swedish",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name_english": {
+          "name": "name_english",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "state": {
+          "name": "state",
+          "type": "course_state",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "credits": {
+          "name": "credits",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "credit_unit": {
+          "name": "credit_unit",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "department_code": {
+          "name": "department_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "department": {
+          "name": "department",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "educational_level_code": {
+          "name": "educational_level_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "grade_scale_code": {
+          "name": "grade_scale_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "goals": {
+          "name": "goals",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "eligibility": {
+          "name": "eligibility",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "embedding": {
+          "name": "embedding",
+          "type": "vector(1536)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "embedding_hash": {
+          "name": "embedding_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "search_vector": {
+          "name": "search_vector",
+          "type": "tsvector",
+          "primaryKey": false,
+          "notNull": false,
+          "generated": {
+            "as": "to_tsvector('simple', coalesce(name_english, '') || ' ' || coalesce(name_swedish, '') || ' ' || coalesce(code, '') || ' ' || coalesce(goals, '') || ' ' || coalesce(content, ''))",
+            "type": "stored"
+          }
+        }
+      },
+      "indexes": {
+        "courses_search_vector_idx": {
+          "name": "courses_search_vector_idx",
+          "columns": [
+            {
+              "expression": "search_vector",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.feedback_form": {
+      "name": "feedback_form",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "message": {
+          "name": "message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.review_likes": {
+      "name": "review_likes",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "review_id": {
+          "name": "review_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "vote_type": {
+          "name": "vote_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "review_likes_user_id_users_id_fk": {
+          "name": "review_likes_user_id_users_id_fk",
+          "tableFrom": "review_likes",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "review_likes_review_id_reviews_id_fk": {
+          "name": "review_likes_review_id_reviews_id_fk",
+          "tableFrom": "review_likes",
+          "tableTo": "reviews",
+          "columnsFrom": ["review_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "review_likes_user_id_review_id_pk": {
+          "name": "review_likes_user_id_review_id_pk",
+          "columns": ["user_id", "review_id"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.reviews": {
+      "name": "reviews",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "course_code": {
+          "name": "course_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "examination_methods": {
+          "name": "examination_methods",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "theoretical_vs_applied": {
+          "name": "theoretical_vs_applied",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "workload": {
+          "name": "workload",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "learning_experience": {
+          "name": "learning_experience",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "would_recommend": {
+          "name": "would_recommend",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "reviews_user_id_users_id_fk": {
+          "name": "reviews_user_id_users_id_fk",
+          "tableFrom": "reviews",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "reviews_course_code_courses_code_fk": {
+          "name": "reviews_course_code_courses_code_fk",
+          "tableFrom": "reviews",
+          "tableTo": "courses",
+          "columnsFrom": ["course_code"],
+          "columnsTo": ["code"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_auth_identities": {
+      "name": "user_auth_identities",
+      "schema": "",
+      "columns": {
+        "auth_user_id": {
+          "name": "auth_user_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "user_auth_identities_user_id_users_id_fk": {
+          "name": "user_auth_identities_user_id_users_id_fk",
+          "tableFrom": "user_auth_identities",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_favorites": {
+      "name": "user_favorites",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "fav_course_code": {
+          "name": "fav_course_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "user_favorites_user_id_users_id_fk": {
+          "name": "user_favorites_user_id_users_id_fk",
+          "tableFrom": "user_favorites",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "user_favorites_fav_course_code_courses_code_fk": {
+          "name": "user_favorites_fav_course_code_courses_code_fk",
+          "tableFrom": "user_favorites",
+          "tableTo": "courses",
+          "columnsFrom": ["fav_course_code"],
+          "columnsTo": ["code"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "user_favorites_user_id_fav_course_code_pk": {
+          "name": "user_favorites_user_id_fav_course_code_pk",
+          "columns": ["user_id", "fav_course_code"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "profile_picture": {
+          "name": "profile_picture",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "nullsNotDistinct": false,
+          "columns": ["email"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.course_state": {
+      "name": "course_state",
+      "schema": "public",
+      "values": ["CANCELLED", "ESTABLISHED", "DEACTIVATED"]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/backend-nest/migrations/meta/_journal.json
+++ b/backend-nest/migrations/meta/_journal.json
@@ -3,24 +3,10 @@
   "dialect": "postgresql",
   "entries": [
     {
-      "idx": 0,
+      "idx": 4,
       "version": "7",
-      "when": 1760436504018,
-      "tag": "0000_bitter_unicorn",
-      "breakpoints": true
-    },
-    {
-      "idx": 1,
-      "version": "7",
-      "when": 1777565694627,
-      "tag": "0001_tense_black_tom",
-      "breakpoints": true
-    },
-    {
-      "idx": 2,
-      "version": "7",
-      "when": 1777567310752,
-      "tag": "0002_brown_jocasta",
+      "when": 1777643461166,
+      "tag": "0000_baseline_current_schema",
       "breakpoints": true
     }
   ]

--- a/backend-nest/migrations/meta/_journal.json
+++ b/backend-nest/migrations/meta/_journal.json
@@ -8,6 +8,20 @@
       "when": 1760436504018,
       "tag": "0000_bitter_unicorn",
       "breakpoints": true
+    },
+    {
+      "idx": 1,
+      "version": "7",
+      "when": 1777565694627,
+      "tag": "0001_tense_black_tom",
+      "breakpoints": true
+    },
+    {
+      "idx": 2,
+      "version": "7",
+      "when": 1777567310752,
+      "tag": "0002_brown_jocasta",
+      "breakpoints": true
     }
   ]
 }

--- a/backend-nest/src/ai/ai.module.ts
+++ b/backend-nest/src/ai/ai.module.ts
@@ -4,7 +4,7 @@ import { AiService } from "./ai.service";
 
 @Module({
   controllers: [AiController],
-  // AiService is kept as a provider for future AI-related business logic.
   providers: [AiService],
+  exports: [AiService], // ← add this
 })
 export class AiModule {}

--- a/backend-nest/src/db/schema.ts
+++ b/backend-nest/src/db/schema.ts
@@ -1,6 +1,8 @@
+import { sql } from "drizzle-orm";
 import {
   boolean,
   customType,
+  index,
   integer,
   pgEnum,
   pgTable,
@@ -12,40 +14,55 @@ import {
   vector,
 } from "drizzle-orm/pg-core";
 
-const courseState = pgEnum("course_state", [
+export const courseState = pgEnum("course_state", [
   "CANCELLED",
   "ESTABLISHED",
   "DEACTIVATED",
 ]);
 
+const tsvector = customType<{ data: string }>({
+  dataType() {
+    return "tsvector";
+  },
+});
+
 // --- COURSE TABLES ----------------
 // courses table contains core course data.
 // more information is stored in courseRounds table
-export const courses = pgTable("courses", {
-  code: text("code").primaryKey(),
-  name: text("name").notNull(), // TODO: remove this, redudant info
-  titleSwe: text("name_swedish").notNull(),
-  titleEng: text("name_english").notNull(),
-  state: courseState("state").notNull(),
+export const courses = pgTable(
+  "courses",
+  {
+    code: text("code").primaryKey(),
+    name: text("name").notNull(), // TODO: remove this, redudant info
+    titleSwe: text("name_swedish").notNull(),
+    titleEng: text("name_english").notNull(),
+    state: courseState("state").notNull(),
 
-  credits: real("credits").notNull(),
-  creditUnit: text("credit_unit"),
+    credits: real("credits").notNull(),
+    creditUnit: text("credit_unit"),
 
-  departmentCode: text("department_code").notNull(),
-  department: text("department").notNull(),
-  educationalLevelCode: text("educational_level_code"),
-  gradeScaleCode: text("grade_scale_code"),
+    departmentCode: text("department_code").notNull(),
+    department: text("department").notNull(),
+    educationalLevelCode: text("educational_level_code"),
+    gradeScaleCode: text("grade_scale_code"),
 
-  // from latest publicSyllabusVersions entry
-  goals: text("goals"),
-  content: text("content"),
-  eligibility: text("eligibility"),
-  updatedAt: timestamp("updated_at", { withTimezone: true })
-    .defaultNow()
-    .notNull(),
-  embedding: vector("embedding", { dimensions: 1536 }),
-  embeddingHash: text("embedding_hash"),
-});
+    // from latest publicSyllabusVersions entry
+    goals: text("goals"),
+    content: text("content"),
+    eligibility: text("eligibility"),
+    updatedAt: timestamp("updated_at", { withTimezone: true })
+      .defaultNow()
+      .notNull(),
+    embedding: vector("embedding", { dimensions: 1536 }),
+    embeddingHash: text("embedding_hash"),
+    searchVector: tsvector("search_vector").generatedAlwaysAs(
+      sql`to_tsvector('simple', coalesce(name_english, '') || ' ' || coalesce(name_swedish, '') || ' ' || coalesce(code, '') || ' ' || coalesce(goals, '') || ' ' || coalesce(content, ''))`,
+    ),
+  },
+  (table) => [
+    index("courses_search_vector_idx").using("gin", table.searchVector),
+  ],
+);
 
 export type InsertCourse = typeof courses.$inferInsert;
 export type SelectCourse = typeof courses.$inferSelect;

--- a/backend-nest/src/db/schema.ts
+++ b/backend-nest/src/db/schema.ts
@@ -1,5 +1,6 @@
 import {
   boolean,
+  customType,
   integer,
   pgEnum,
   pgTable,
@@ -8,6 +9,7 @@ import {
   serial,
   text,
   timestamp,
+  vector,
 } from "drizzle-orm/pg-core";
 
 const courseState = pgEnum("course_state", [
@@ -41,6 +43,8 @@ export const courses = pgTable("courses", {
   updatedAt: timestamp("updated_at", { withTimezone: true })
     .defaultNow()
     .notNull(),
+  embedding: vector("embedding", { dimensions: 1536 }),
+  embeddingHash: text("embedding_hash"),
 });
 
 export type InsertCourse = typeof courses.$inferInsert;

--- a/backend-nest/src/db/schema.ts
+++ b/backend-nest/src/db/schema.ts
@@ -61,6 +61,12 @@ export const courses = pgTable(
   },
   (table) => [
     index("courses_search_vector_idx").using("gin", table.searchVector),
+    index("courses_embedding_idx").using(
+      "hnsw",
+      table.embedding.op("vector_cosine_ops"),
+    ),
+    index("courses_name_trgm_idx").using("gin", table.name.op("gin_trgm_ops")),
+    index("courses_code_trgm_idx").using("gin", table.code.op("gin_trgm_ops")),
   ],
 );
 

--- a/backend-nest/src/health/health.service.ts
+++ b/backend-nest/src/health/health.service.ts
@@ -7,6 +7,11 @@ import { firstValueFrom } from "rxjs";
 import { DRIZZLE } from "../db/drizzle.module";
 import { ES } from "../search/search.constants.js";
 
+type HealthCheckResult = {
+  ok: boolean;
+  [key: string]: unknown;
+};
+
 @Injectable()
 export class HealthService {
   constructor(
@@ -51,12 +56,47 @@ export class HealthService {
 
     const [dbRes, esRes, kthRes] = results;
 
-    /*const format = (res: PromiseSettledResult<any>) =>
-      res.status === "fulfilled"
-        ? res.value
-        : { ok: false, error: res.reason?.message ?? String(res.reason) };*/
-    const format = (res: PromiseSettledResult<unknown>) =>
-      res.status === "fulfilled" ? res.value : res.reason;
+    const serializeError = (reason: unknown) => {
+      if (reason instanceof Error) {
+        return {
+          ok: false,
+          error: reason.message,
+          name: reason.name,
+        };
+      }
+
+      if (
+        reason &&
+        typeof reason === "object" &&
+        "message" in reason &&
+        typeof (reason as { message?: unknown }).message === "string"
+      ) {
+        const maybeReason = reason as {
+          message: string;
+          name?: unknown;
+          response?: { status?: unknown };
+        };
+        return {
+          ok: false,
+          error: maybeReason.message,
+          name:
+            typeof maybeReason.name === "string"
+              ? maybeReason.name
+              : "UnknownError",
+          status:
+            typeof maybeReason.response?.status === "number"
+              ? maybeReason.response.status
+              : undefined,
+        };
+      }
+
+      return { ok: false, error: String(reason) };
+    };
+
+    const format = (
+      res: PromiseSettledResult<HealthCheckResult>,
+    ): HealthCheckResult =>
+      res.status === "fulfilled" ? res.value : serializeError(res.reason);
 
     const db = format(dbRes);
     const elasticsearch = format(esRes);

--- a/backend-nest/src/health/health.service.ts
+++ b/backend-nest/src/health/health.service.ts
@@ -12,7 +12,7 @@ export class HealthService {
   constructor(
     private readonly http: HttpService,
     @Inject(DRIZZLE) private readonly db: NeonHttpDatabase,
-    @Inject(ES) private readonly es: ESClient,
+    @Inject(ES) private readonly es: ESClient | null,
   ) {}
 
   private async checkDb() {
@@ -22,6 +22,9 @@ export class HealthService {
   }
 
   private async checkElasticsearch() {
+    if (!this.es) {
+      return { ok: true, skipped: true, reason: "disabled" };
+    }
     const start = Date.now();
     await this.es.ping();
     return { ok: true, ms: Date.now() - start };

--- a/backend-nest/src/ingest/ingest.module.ts
+++ b/backend-nest/src/ingest/ingest.module.ts
@@ -2,6 +2,7 @@
 
 import { HttpModule } from "@nestjs/axios";
 import { Module } from "@nestjs/common";
+import { AiModule } from "../ai/ai.module";
 import { DrizzleModule } from "../db/drizzle.module";
 import { ElasticSearchModule } from "../search/search.module";
 import { IngestController } from "./ingest.controller";
@@ -9,7 +10,7 @@ import { IngestService } from "./ingest.service";
 import { KoppsService } from "./kopps.service";
 
 @Module({
-  imports: [HttpModule, DrizzleModule, ElasticSearchModule],
+  imports: [HttpModule, DrizzleModule, ElasticSearchModule, AiModule],
   providers: [IngestService, KoppsService],
   controllers: [IngestController],
   exports: [IngestService, KoppsService],

--- a/backend-nest/src/ingest/ingest.service.spec.ts
+++ b/backend-nest/src/ingest/ingest.service.spec.ts
@@ -1,6 +1,7 @@
 import { Logger } from "@nestjs/common";
 import { Test, type TestingModule } from "@nestjs/testing";
 import type { z } from "zod";
+import { AiService } from "../ai/ai.service";
 import { DRIZZLE } from "../db/drizzle.module";
 import type { CourseDocumentES } from "../search/elastic.mappings";
 import { ES } from "../search/search.constants";
@@ -46,6 +47,7 @@ function callToDocument(
 describe("IngestService", () => {
   let service: IngestService;
   let mockKopps: { getCourses: jest.Mock; getCourseInformation: jest.Mock };
+  let mockAi: { embedBatch: jest.Mock };
   let mockEs: {
     indices: {
       create: jest.Mock;
@@ -60,6 +62,9 @@ describe("IngestService", () => {
     mockKopps = {
       getCourses: jest.fn(),
       getCourseInformation: jest.fn(),
+    };
+    mockAi = {
+      embedBatch: jest.fn().mockResolvedValue({ embeddings: [], usage: {} }),
     };
     mockEs = {
       indices: {
@@ -78,6 +83,7 @@ describe("IngestService", () => {
       providers: [
         IngestService,
         { provide: KoppsService, useValue: mockKopps },
+        { provide: AiService, useValue: mockAi },
         { provide: ES, useValue: mockEs },
         { provide: DRIZZLE, useValue: {} },
       ],

--- a/backend-nest/src/ingest/ingest.service.ts
+++ b/backend-nest/src/ingest/ingest.service.ts
@@ -1,3 +1,4 @@
+import { createHash } from "node:crypto";
 import type { Client as ESClient } from "@elastic/elasticsearch";
 import { Inject, Injectable, Logger } from "@nestjs/common";
 import { inArray, sql } from "drizzle-orm";
@@ -411,24 +412,63 @@ export class IngestService {
         `Embedding batch ${Math.floor(i / BATCH_SIZE) + 1}/${Math.ceil(courses.length / BATCH_SIZE)}`,
       );
 
-      // build the text to embed for each course — goals + content are the semantic core
-      const texts = batch.map((c) =>
-        [c.code, c.titleEng, c.titleSwe, c.goals, c.content]
+      // Build deterministic embedding source text + hash for incremental updates.
+      const batchWithHash = batch.map((course) => {
+        const text = [
+          course.code,
+          course.titleEng,
+          course.titleSwe,
+          course.goals,
+          course.content,
+        ]
           .filter(Boolean)
-          .join(" "),
+          .join(" ");
+        const hash = createHash("sha256").update(text).digest("hex");
+        return { course, text, hash };
+      });
+
+      const existingRows = await this.db
+        .select({
+          code: coursesTable.code,
+          embeddingHash: coursesTable.embeddingHash,
+        })
+        .from(coursesTable)
+        .where(
+          inArray(
+            coursesTable.code,
+            batch.map((c) => c.code),
+          ),
+        );
+
+      const existingHashByCode = new Map(
+        existingRows.map((row) => [row.code, row.embeddingHash]),
       );
 
-      const { embeddings } = await this.ai.embedBatch(texts);
+      const toEmbed = batchWithHash.filter(
+        ({ course, hash }) => existingHashByCode.get(course.code) !== hash,
+      );
 
-      // store each embedding back into the courses table
+      if (toEmbed.length === 0) {
+        this.logger.log(
+          `Embedding batch ${Math.floor(i / BATCH_SIZE) + 1}: skipped (all up to date)`,
+        );
+        continue;
+      }
+
+      const { embeddings } = await this.ai.embedBatch(
+        toEmbed.map((x) => x.text),
+      );
+
+      // Store vector + hash so future ingests can skip unchanged courses.
       await Promise.all(
-        batch.map((course, idx) =>
+        toEmbed.map((item, idx) =>
           this.db
             .update(coursesTable)
             .set({
               embedding: sql`${JSON.stringify(embeddings[idx])}::vector`,
+              embeddingHash: item.hash,
             })
-            .where(sql`code = ${course.code}`),
+            .where(sql`code = ${item.course.code}`),
         ),
       );
     }

--- a/backend-nest/src/ingest/ingest.service.ts
+++ b/backend-nest/src/ingest/ingest.service.ts
@@ -28,7 +28,7 @@ export class IngestService {
     private readonly kopps: KoppsService,
     private readonly ai: AiService,
     @Inject(DRIZZLE) private readonly db: NeonHttpDatabase,
-    @Inject(ES) private readonly es: ESClient,
+    @Inject(ES) private readonly es: ESClient | null,
   ) {}
 
   // used for checking ingest status
@@ -92,7 +92,11 @@ export class IngestService {
     this.logger.log("Fetching courses from KTH API (once for full ingest)...");
     const courses = await this.kopps.getCourses();
     await this.runNeonIngest(courses);
-    await this.runElasticIngest(courses);
+    if (this.es) {
+      await this.runElasticIngest(courses);
+    } else {
+      this.logger.log("Elasticsearch disabled; skipping Elastic ingest.");
+    }
   }
 
   // ingests courses into neon db
@@ -146,6 +150,11 @@ export class IngestService {
 
   // ingests into elastic db
   async runElasticIngest(coursesInput?: z.infer<typeof CoursesSchema>) {
+    if (!this.es) {
+      this.logger.warn("Elasticsearch disabled; skipping Elastic ingest");
+      return;
+    }
+
     if (this.status.elastic.running) {
       this.logger.warn(
         "Elastic ingestion already running; skipping new request",
@@ -426,6 +435,7 @@ export class IngestService {
   }
   /** If the index exists with an older strict mapping, new fields are rejected. */
   private async coursesIndexNeedsRecreate(): Promise<boolean> {
+    if (!this.es) return false;
     const exists = await this.es.indices.exists({ index: INDEX });
     if (!exists) return false;
     const mapping = await this.es.indices.getMapping({ index: INDEX });
@@ -444,6 +454,7 @@ export class IngestService {
 
   //
   private async ensureIndex() {
+    if (!this.es) return;
     if (await this.coursesIndexNeedsRecreate()) {
       await this.es.indices.delete({ index: INDEX });
     }
@@ -502,6 +513,11 @@ export class IngestService {
   }
 
   private async indexBulk(docs: CourseDocumentES[]) {
+    if (!this.es) {
+      this.logger.warn("Elasticsearch disabled; skipping bulk indexing");
+      return;
+    }
+
     if (!docs.length) {
       this.logger.warn("No course documents to index; skipping bulk request");
       return;
@@ -626,6 +642,11 @@ export class IngestService {
 
   // runs a test for the elastic ingestion with 10 courses
   async runElasticTest() {
+    if (!this.es) {
+      this.logger.warn("Elasticsearch disabled; skipping Elastic test process");
+      return;
+    }
+
     this.logger.log("Starting elastic test process");
     try {
       this.logger.log("Fetching courses from KTH API...");

--- a/backend-nest/src/ingest/ingest.service.ts
+++ b/backend-nest/src/ingest/ingest.service.ts
@@ -3,6 +3,7 @@ import { Inject, Injectable, Logger } from "@nestjs/common";
 import { inArray, sql } from "drizzle-orm";
 import type { NeonHttpDatabase } from "drizzle-orm/neon-http";
 import type { z } from "zod";
+import { AiService } from "../ai/ai.service";
 import { DRIZZLE } from "../db/drizzle.module";
 import {
   courseExaminations as courseExaminationsTable,
@@ -25,6 +26,7 @@ export class IngestService {
 
   constructor(
     private readonly kopps: KoppsService,
+    private readonly ai: AiService,
     @Inject(DRIZZLE) private readonly db: NeonHttpDatabase,
     @Inject(ES) private readonly es: ESClient,
   ) {}
@@ -126,6 +128,11 @@ export class IngestService {
       await this.upsertCourses(converted);
       await this.upsertRounds(rounds);
       await this.upsertExaminations(examinations);
+
+      this.logger.log("Generating embeddings for courses...");
+      await this.generateAndStoreEmbeddings(converted);
+      this.logger.log("Embeddings stored successfully");
+
       this.status.neon.lastCompleted = new Date();
       this.logger.log("Courses upserted successfully");
     } catch (error) {
@@ -385,6 +392,38 @@ export class IngestService {
     };
   }
 
+  private async generateAndStoreEmbeddings(courses: InsertCourse[]) {
+    const BATCH_SIZE = 100; // openai allows up to 2048 inputs per request, but keep it safe
+
+    for (let i = 0; i < courses.length; i += BATCH_SIZE) {
+      const batch = courses.slice(i, i + BATCH_SIZE);
+
+      this.logger.log(
+        `Embedding batch ${Math.floor(i / BATCH_SIZE) + 1}/${Math.ceil(courses.length / BATCH_SIZE)}`,
+      );
+
+      // build the text to embed for each course — goals + content are the semantic core
+      const texts = batch.map((c) =>
+        [c.code, c.titleEng, c.titleSwe, c.goals, c.content]
+          .filter(Boolean)
+          .join(" "),
+      );
+
+      const { embeddings } = await this.ai.embedBatch(texts);
+
+      // store each embedding back into the courses table
+      await Promise.all(
+        batch.map((course, idx) =>
+          this.db
+            .update(coursesTable)
+            .set({
+              embedding: sql`${JSON.stringify(embeddings[idx])}::vector`,
+            })
+            .where(sql`code = ${course.code}`),
+        ),
+      );
+    }
+  }
   /** If the index exists with an older strict mapping, new fields are rejected. */
   private async coursesIndexNeedsRecreate(): Promise<boolean> {
     const exists = await this.es.indices.exists({ index: INDEX });
@@ -576,6 +615,8 @@ export class IngestService {
       await this.upsertCourses(converted);
       await this.upsertRounds(rounds);
       await this.upsertExaminations(examinations);
+      await this.generateAndStoreEmbeddings(converted);
+      this.logger.log("Embeddings stored successfully");
       this.logger.log("Neon test process completed successfully");
     } catch (error) {
       this.logger.error("Neon test process failed:", error);

--- a/backend-nest/src/search/search.module.ts
+++ b/backend-nest/src/search/search.module.ts
@@ -19,7 +19,13 @@ import { SearchService } from "./search.service.js";
     {
       provide: ES,
       inject: [ConfigService],
-      useFactory: (config: ConfigService): Client => {
+      useFactory: (config: ConfigService): Client | null => {
+        const elasticsearchEnabled =
+          config.get<string>("ELASTICSEARCH_ENABLED", "true") !== "false";
+        if (!elasticsearchEnabled) {
+          return null;
+        }
+
         const url = config.get<string>("ELASTICSEARCH_URL");
         if (!url) throw new Error("ELASTICSEARCH_URL is not set");
 

--- a/backend-nest/src/search/search.service.ts
+++ b/backend-nest/src/search/search.service.ts
@@ -18,10 +18,64 @@ export interface SearchHit {
 @Injectable()
 export class SearchService {
   constructor(
-    @Inject(ES) private readonly es: ESClient,
+    @Inject(ES) private readonly es: ESClient | null,
     @Inject(DRIZZLE) private readonly db: NeonHttpDatabase<typeof schema>,
     private readonly courseService: CourseService,
   ) {}
+
+  private resolveDepartmentFilter(department?: string): string | null {
+    if (!department) return null;
+    const departments = ["EECS", "ABE", "CBH", "ITM", "SCI"];
+    const matchingDepts = departments.find((abbr) => department.includes(abbr));
+    return matchingDepts ?? department;
+  }
+
+  private async searchWithDatabase(
+    query: string,
+    size: number,
+    departmentFilter: string | null,
+    hasMinRatingFilter: boolean,
+  ): Promise<SearchHit[]> {
+    const queryUpper = query.toUpperCase();
+    const fetchSize = hasMinRatingFilter ? size * 5 : size;
+    const textPattern = `%${query}%`;
+    const codePrefix = `${queryUpper}%`;
+    const codeContains = `%${queryUpper}%`;
+
+    const conditions = [
+      sql`(
+        code ILIKE ${codePrefix}
+        OR code ILIKE ${codeContains}
+        OR name_swedish ILIKE ${textPattern}
+        OR name_english ILIKE ${textPattern}
+        OR goals ILIKE ${textPattern}
+        OR content ILIKE ${textPattern}
+      )`,
+    ];
+    if (departmentFilter) {
+      conditions.push(sql`department ILIKE ${`%${departmentFilter}%`}`);
+    }
+
+    const whereSql = sql.join(conditions, sql` AND `);
+    const result = await this.db.execute(sql`
+      SELECT code
+      FROM ${schema.courses}
+      WHERE ${whereSql}
+      ORDER BY
+        CASE
+          WHEN code ILIKE ${codePrefix} THEN 0
+          WHEN code ILIKE ${codeContains} THEN 1
+          ELSE 2
+        END,
+        code ASC
+      LIMIT ${fetchSize}
+    `);
+
+    return (result.rows as Array<{ code: string }>).map((r) => ({
+      courseCode: r.code,
+      score: null,
+    }));
+  }
 
   async searchCourses(
     query: string,
@@ -29,82 +83,84 @@ export class SearchService {
     filters?: { department?: string; minRating?: number },
   ): Promise<CourseSummary[]> {
     if (!query?.trim()) return [];
+    const departmentFilter = this.resolveDepartmentFilter(filters?.department);
+    const hasMinRatingFilter = Boolean(filters?.minRating);
 
-    // constructs the filter
-    const searchFilters: estypes.QueryDslQueryContainer[] = [];
-    if (filters?.department) {
-      const dept = filters.department;
-      const departments = ["EECS", "ABE", "CBH", "ITM", "SCI"]; // TODO: Why hardcoded?
-      const matchingDepts = departments.find((abbr) => dept.includes(abbr));
-      if (matchingDepts) {
+    let ranked: SearchHit[] = [];
+    if (this.es) {
+      // constructs the filter
+      const searchFilters: estypes.QueryDslQueryContainer[] = [];
+      if (departmentFilter) {
         searchFilters.push({
-          wildcard: { department: `*${matchingDepts}*` },
-        } as estypes.QueryDslQueryContainer);
-      } else {
-        searchFilters.push({
-          term: { department: dept },
+          wildcard: { department: `*${departmentFilter}*` },
         } as estypes.QueryDslQueryContainer);
       }
-    }
 
-    // search results for the user query
-    const res = await this.es.search<unknown>({
-      index: INDEX,
-      // over-fetch when rating filter is active so we can filter client-side
-      size: filters?.minRating ? size * 5 : size,
-      query: {
-        bool: {
-          should: [
-            { prefix: { course_code: query.toUpperCase() } },
-            { wildcard: { course_code: `*${query.toUpperCase()}*` } },
-            {
-              multi_match: {
-                query,
-                fields: ["course_name_swe^2", "course_name_eng^2"],
-                type: "phrase_prefix",
+      // search results for the user query
+      const res = await this.es.search<unknown>({
+        index: INDEX,
+        // over-fetch when rating filter is active so we can filter client-side
+        size: hasMinRatingFilter ? size * 5 : size,
+        query: {
+          bool: {
+            should: [
+              { prefix: { course_code: query.toUpperCase() } },
+              { wildcard: { course_code: `*${query.toUpperCase()}*` } },
+              {
+                multi_match: {
+                  query,
+                  fields: ["course_name_swe^2", "course_name_eng^2"],
+                  type: "phrase_prefix",
+                },
               },
-            },
-            {
-              multi_match: {
-                query,
-                fields: [
-                  "course_name_swe^2",
-                  "course_name_eng^2",
-                  "course_code^2",
-                  "department",
-                  "subject",
-                  "periods",
-                  "course_category",
-                  "state",
-                  "credits",
-                  "goals",
-                  "content",
-                  "eligibility",
-                ],
-                fuzziness: "AUTO",
-                type: "best_fields",
-                lenient: true,
+              {
+                multi_match: {
+                  query,
+                  fields: [
+                    "course_name_swe^2",
+                    "course_name_eng^2",
+                    "course_code^2",
+                    "department",
+                    "subject",
+                    "periods",
+                    "course_category",
+                    "state",
+                    "credits",
+                    "goals",
+                    "content",
+                    "eligibility",
+                  ],
+                  fuzziness: "AUTO",
+                  type: "best_fields",
+                  lenient: true,
+                },
               },
-            },
-          ],
-          minimum_should_match: 1,
-          filter: searchFilters,
+            ],
+            minimum_should_match: 1,
+            filter: searchFilters,
+          },
         },
-      },
-      _source: ["course_code"],
-    });
+        _source: ["course_code"],
+      });
 
-    //
-    const hits = (res.hits?.hits ?? []) as Array<{
-      _score: number | null;
-      _source?: { course_code?: string };
-    }>;
-    const ranked: SearchHit[] = hits
-      .map((h) => ({
-        courseCode: h._source?.course_code ?? "",
-        score: h._score,
-      }))
-      .filter((h) => h.courseCode.length > 0);
+      const hits = (res.hits?.hits ?? []) as Array<{
+        _score: number | null;
+        _source?: { course_code?: string };
+      }>;
+      ranked = hits
+        .map((h) => ({
+          courseCode: h._source?.course_code ?? "",
+          score: h._score,
+        }))
+        .filter((h) => h.courseCode.length > 0);
+    } else {
+      ranked = await this.searchWithDatabase(
+        query,
+        size,
+        departmentFilter,
+        hasMinRatingFilter,
+      );
+    }
 
     if (ranked.length === 0) return [];
 

--- a/backend-nest/src/search/search.service.ts
+++ b/backend-nest/src/search/search.service.ts
@@ -36,9 +36,10 @@ export class SearchService {
     departmentFilter: string | null,
     hasMinRatingFilter: boolean,
   ): Promise<SearchHit[]> {
-    const queryUpper = query.toUpperCase();
+    const normalizedQuery = query.trim();
+    const queryUpper = normalizedQuery.toUpperCase();
     const fetchSize = hasMinRatingFilter ? size * 5 : size;
-    const textPattern = `%${query}%`;
+    const textPattern = `%${normalizedQuery}%`;
     const codePrefix = `${queryUpper}%`;
     const codeContains = `%${queryUpper}%`;
 
@@ -48,8 +49,10 @@ export class SearchService {
         OR code ILIKE ${codeContains}
         OR name_swedish ILIKE ${textPattern}
         OR name_english ILIKE ${textPattern}
-        OR goals ILIKE ${textPattern}
-        OR content ILIKE ${textPattern}
+        OR (
+          ${normalizedQuery} <> ''
+          AND search_vector @@ plainto_tsquery('simple', ${normalizedQuery})
+        )
       )`,
     ];
     if (departmentFilter) {
@@ -65,8 +68,20 @@ export class SearchService {
         CASE
           WHEN code ILIKE ${codePrefix} THEN 0
           WHEN code ILIKE ${codeContains} THEN 1
-          ELSE 2
+          WHEN (
+            ${normalizedQuery} <> ''
+            AND search_vector @@ plainto_tsquery('simple', ${normalizedQuery})
+          ) THEN 2
+          ELSE 3
         END,
+        CASE
+          WHEN (
+            ${normalizedQuery} <> ''
+            AND search_vector @@ plainto_tsquery('simple', ${normalizedQuery})
+          )
+            THEN ts_rank(search_vector, plainto_tsquery('simple', ${normalizedQuery}))
+          ELSE 0
+        END DESC,
         code ASC
       LIMIT ${fetchSize}
     `);

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -45,11 +45,11 @@ services:
       GOOGLE_CLIENT_ID: ${GOOGLE_CLIENT_ID}
       GOOGLE_CLIENT_SECRET: ${GOOGLE_CLIENT_SECRET}
       AI_GATEWAY_API_KEY: ${AI_GATEWAY_API_KEY:-}
-      # Set false to run without Elasticsearch (matches backend-nest env names)
-      ELASTICSEARCH_ENABLED: ${ELASTICSEARCH_ENABLED:-true}
+      # Optional by default; set true (and provide ES_PASSWORD_SECRET) to enable.
+      ELASTICSEARCH_ENABLED: ${ELASTICSEARCH_ENABLED:-false}
       ELASTICSEARCH_URL: http://elasticsearch:9200
       ELASTICSEARCH_USERNAME: ${ES_USER_SECRET:-elastic}
-      ELASTICSEARCH_PASSWORD: ${ES_PASSWORD_SECRET}
+      ELASTICSEARCH_PASSWORD: ${ES_PASSWORD_SECRET:-}
     
     ports:
       - "8080:8080"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 # Local dev stack. On Dokploy (frontend + backend both on the same project/network):
 # - Set NEXT_PUBLIC_* to the public HTTPS URLs users open in the browser (API + site).
-# - Set BACKEND_DOMAIN to the internal API URL the Next.js server uses (service name + port),
-#   e.g. http://your-backend-service:8080 — see frontend/.env.example.
+# - Set BACKEND_DOMAIN when building the frontend image (not runtime only), because Next
+#   rewrites are resolved during `next build`.
 services:
   frontend:
     image: maxandreasen/course-compass-frontend:latest
@@ -14,7 +14,8 @@ services:
       PORT: 3000
       NEXT_PUBLIC_BACKEND_DOMAIN: http://localhost:8080
       NEXT_PUBLIC_WEBSITE_DOMAIN: http://localhost:3000
-      # Server-side rewrite target (Docker network). Browser still uses NEXT_PUBLIC_*.
+      # Runtime BACKEND_DOMAIN does not affect rewrites in prebuilt images.
+      # Keep for local/adhoc builds where `next build` runs in this env.
       BACKEND_DOMAIN: http://backend:8080
 
     ports:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,3 +1,7 @@
+# Local dev stack. On Dokploy (frontend + backend both on the same project/network):
+# - Set NEXT_PUBLIC_* to the public HTTPS URLs users open in the browser (API + site).
+# - Set BACKEND_DOMAIN to the internal API URL the Next.js server uses (service name + port),
+#   e.g. http://your-backend-service:8080 — see frontend/.env.example.
 services:
   frontend:
     image: maxandreasen/course-compass-frontend:latest
@@ -10,6 +14,8 @@ services:
       PORT: 3000
       NEXT_PUBLIC_BACKEND_DOMAIN: http://localhost:8080
       NEXT_PUBLIC_WEBSITE_DOMAIN: http://localhost:3000
+      # Server-side rewrite target (Docker network). Browser still uses NEXT_PUBLIC_*.
+      BACKEND_DOMAIN: http://backend:8080
 
     ports:
       - "3000:3000"
@@ -29,10 +35,20 @@ services:
     environment: # environmental variables for production
       NODE_ENV: production
       PORT: 8080
-      ELASTICSEARCH_HOST: http://elasticsearch:9200
-      ELASTIC_USER: ${ES_USER_SECRET}
-      ELASTIC_PASSWORD: ${ES_PASSWORD_SECRET}
       DATABASE_URL: ${NEON_DATABASE_URL}
+      WEBSITE_DOMAIN: ${WEBSITE_DOMAIN:-http://localhost:3000}
+      API_DOMAIN: ${API_DOMAIN:-http://localhost:8080}
+      CORS_ORIGINS: ${CORS_ORIGINS:-}
+      ST_CONNECTION_URI: ${ST_CONNECTION_URI}
+      ST_API_KEY: ${ST_API_KEY:-}
+      GOOGLE_CLIENT_ID: ${GOOGLE_CLIENT_ID}
+      GOOGLE_CLIENT_SECRET: ${GOOGLE_CLIENT_SECRET}
+      AI_GATEWAY_API_KEY: ${AI_GATEWAY_API_KEY:-}
+      # Set false to run without Elasticsearch (matches backend-nest env names)
+      ELASTICSEARCH_ENABLED: ${ELASTICSEARCH_ENABLED:-true}
+      ELASTICSEARCH_URL: http://elasticsearch:9200
+      ELASTICSEARCH_USERNAME: ${ES_USER_SECRET:-elastic}
+      ELASTICSEARCH_PASSWORD: ${ES_PASSWORD_SECRET}
     
     ports:
       - "8080:8080"

--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -1,3 +1,7 @@
+# Optional for Next.js rewrites (preferred):
+# Browser calls /auth on the website domain, and Next proxies to this backend.
+BACKEND_DOMAIN=http://localhost:8080
+
 NEXT_PUBLIC_BACKEND_DOMAIN=http://localhost:8080
 NEXT_PUBLIC_WEBSITE_DOMAIN=http://localhost:3000
 

--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -8,7 +8,8 @@ BACKEND_DOMAIN=http://localhost:8080
 # NEXT_PUBLIC_WEBSITE_DOMAIN = public site URL (https://app.yourdomain.com)
 # BACKEND_DOMAIN = URL the Next.js *server* uses to call the API (internal service name is OK), e.g.
 #   http://course-compass-backend:8080
-# Build the frontend image with these set (or inject at runtime if your setup supports it).
+# Build the frontend image with these set. `BACKEND_DOMAIN` is consumed by
+# `next.config.ts` rewrites during `next build`.
 #
 # Backend container: WEBSITE_DOMAIN = NEXT_PUBLIC_WEBSITE_DOMAIN, API_DOMAIN = NEXT_PUBLIC_BACKEND_DOMAIN,
 # CORS_ORIGINS empty or extra origins as needed.

--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -1,10 +1,22 @@
-# Optional for Next.js rewrites (preferred):
-# Browser calls /auth on the website domain, and Next proxies to this backend.
-BACKEND_DOMAIN=http://localhost:8080
-
+# --- Local dev ---
 NEXT_PUBLIC_BACKEND_DOMAIN=http://localhost:8080
 NEXT_PUBLIC_WEBSITE_DOMAIN=http://localhost:3000
+BACKEND_DOMAIN=http://localhost:8080
+
+# --- Dokploy (frontend + backend both deployed there) ---
+# NEXT_PUBLIC_BACKEND_DOMAIN = public API URL (https://api.yourdomain.com)
+# NEXT_PUBLIC_WEBSITE_DOMAIN = public site URL (https://app.yourdomain.com)
+# BACKEND_DOMAIN = URL the Next.js *server* uses to call the API (internal service name is OK), e.g.
+#   http://course-compass-backend:8080
+# Build the frontend image with these set (or inject at runtime if your setup supports it).
+#
+# Backend container: WEBSITE_DOMAIN = NEXT_PUBLIC_WEBSITE_DOMAIN, API_DOMAIN = NEXT_PUBLIC_BACKEND_DOMAIN,
+# CORS_ORIGINS empty or extra origins as needed.
+
+# --- Next.js rewrites (SuperTokens): browser hits /api/auth/* on the site origin; Next proxies to BACKEND_DOMAIN.
 
 # SuperTokens server-side (used in /api/user/me route)
 ST_CONNECTION_URI=https://try.supertokens.com
 ST_API_KEY=
+
+# LLM: browser calls NEXT_PUBLIC_BACKEND_DOMAIN/ai/chat. AI_GATEWAY_API_KEY is only on the backend service.

--- a/frontend/lib/supertokens.client.ts
+++ b/frontend/lib/supertokens.client.ts
@@ -26,10 +26,10 @@ export function initST() {
   SuperTokens.init({
     appInfo: {
       appName: "CourseCompass",
-      // Use same-origin /auth calls from the browser and rely on Next.js rewrites.
-      // This avoids exposing/calling the raw backend host directly from the client.
+      // Use same-origin API calls from the browser and rely on Next.js rewrites.
+      // Keep website auth routes on /auth while proxying API calls via /api/auth.
       apiDomain: websiteDomain,
-      apiBasePath: "/auth",
+      apiBasePath: "/api/auth",
       websiteDomain: websiteDomain,
       websiteBasePath: "/auth",
     },

--- a/frontend/lib/supertokens.client.ts
+++ b/frontend/lib/supertokens.client.ts
@@ -26,7 +26,9 @@ export function initST() {
   SuperTokens.init({
     appInfo: {
       appName: "CourseCompass",
-      apiDomain: backendDomain,
+      // Use same-origin /auth calls from the browser and rely on Next.js rewrites.
+      // This avoids exposing/calling the raw backend host directly from the client.
+      apiDomain: websiteDomain,
       apiBasePath: "/auth",
       websiteDomain: websiteDomain,
       websiteBasePath: "/auth",

--- a/frontend/next.config.ts
+++ b/frontend/next.config.ts
@@ -1,11 +1,24 @@
 import type { NextConfig } from "next";
 
+const backendDomain =
+  process.env.BACKEND_DOMAIN ?? process.env.NEXT_PUBLIC_BACKEND_DOMAIN;
+
 const nextConfig: NextConfig = {
   output: "standalone",
   images: {
     remotePatterns: [{ hostname: "lh3.googleusercontent.com" }],
   },
   serverExternalPackages: ["supertokens-node"],
+  async rewrites() {
+    if (!backendDomain) return [];
+
+    return [
+      {
+        source: "/auth/:path*",
+        destination: `${backendDomain}/auth/:path*`,
+      },
+    ];
+  },
 };
 
 export default nextConfig;

--- a/frontend/next.config.ts
+++ b/frontend/next.config.ts
@@ -14,7 +14,7 @@ const nextConfig: NextConfig = {
 
     return [
       {
-        source: "/auth/:path*",
+        source: "/api/auth/:path*",
         destination: `${backendDomain}/auth/:path*`,
       },
     ];

--- a/frontend/next.config.ts
+++ b/frontend/next.config.ts
@@ -1,7 +1,7 @@
 import type { NextConfig } from "next";
 
 const backendDomain =
-  process.env.BACKEND_DOMAIN ?? process.env.NEXT_PUBLIC_BACKEND_DOMAIN;
+  process.env.BACKEND_DOMAIN || process.env.NEXT_PUBLIC_BACKEND_DOMAIN;
 
 const nextConfig: NextConfig = {
   output: "standalone",


### PR DESCRIPTION
Stabilize deployed auth/search infra: route frontend auth through same-origin proxy (removing direct Azure dependency), make backend Elasticsearch optional with Neon fallback search, and align Drizzle schema/migrations to the current Neon pgvector + search_vector baseline.