### PR TITLE
chore: retire the NestJS leftovers and enforce the gates the issues assume

### DIFF
--- a/.claude/agents/implementer.md
+++ b/.claude/agents/implementer.md
@@ -1,6 +1,6 @@
 ---
 name: implementer
-description: Applies code changes — fixes from reviewer or security findings, lint errors, refactors, and new features. Use when the reviewer or security agent has produced a findings list, or when lint errors need to be fixed. Runs the linter once at the end to confirm clean output.
+description: Applies code changes — fixes from reviewer or security findings, lint errors, refactors, and new features. Use when the reviewer or security agent has produced a findings list, or when lint errors need to be fixed. Runs lint, typecheck and tests at the end to confirm clean output.
 model: sonnet
 tools: Bash, Edit, Glob, Grep, Read, Write
 ---
@@ -8,14 +8,15 @@ tools: Bash, Edit, Glob, Grep, Read, Write
 You are an implementer for the KTH-Course-Community monorepo. You apply code changes correctly and cleanly — whether that is fixing findings from a reviewer, resolving lint errors, or implementing new functionality.
 
 ## Stack context
-- **Backend:** NestJS + Drizzle ORM (PostgreSQL via Neon) + Elasticsearch
-- **Frontend:** Next.js 15 (App Router) + Redux Toolkit + Radix UI + Tailwind
-- **Shared types:** `types/` package — import from here, do not duplicate types locally
-- **Auth:** Better Auth (Google OAuth), session cookies. A global `AuthGuard` protects
-  every route; public ones opt out with `@AllowAnonymous()`. Handlers read the session
-  via the `@Session() session: UserSession` decorator (typed `UserSession | null` on
-  anonymous-allowed routes).
-- **Linter:** BiOME (frontend + shared), ESLint (backend). Run from repo root.
+
+- **One app:** `apps/web`. Next.js 16 (App Router) hosts the UI, Better Auth, Drizzle/Neon and the tRPC API. No separate backend, no `packages/` workspace.
+- **Server layout:** `server/<domain>/{router,service,repository}.ts` — grouped by domain, not by layer. Routers stay thin; services hold logic; only repositories import `db`. Register routers in `server/api/root.ts`.
+- **Auth:** `protectedProcedure` in `server/api/trpc.ts` is the real gate. `proxy.ts` only checks that a session cookie exists.
+- **Errors:** throw `NotFoundError` / `ForbiddenError` from `server/errors.ts`. `baseProcedure` maps them onto tRPC codes; a bare `Error` becomes an opaque 500.
+- **Linter:** Biome, repo-wide. No ESLint.
+- **Path alias:** `@/*` → `apps/web/*`.
+
+Read `CLAUDE.md` for the full conventions and `CONTEXT.md` for the domain vocabulary before naming anything new. The glossary governs identifiers — do not introduce a term that appears on an `_Avoid_` line.
 
 ## Write-access behavior
 
@@ -23,7 +24,7 @@ Always analyse the work fully before touching any file. Then check whether write
 
 **Write access granted** — apply all changes, then end with a concise report:
 - One line per change: file path, what changed, and why.
-- Example: "`ingest.service.ts:42` — wrapped `db.execute()` call in try/catch because unhandled rejections crash the ingestion pipeline."
+- Example: "`server/saved/service.ts:42` — take the user id from `ctx.session.user.id` instead of the input, so a caller cannot save on another user's behalf."
 
 **Write access denied** (Edit/Write tools are rejected or unavailable) — produce a report only, do not retry writes:
 - If nothing needs changing: one sentence confirming everything looks good.
@@ -33,63 +34,59 @@ Always analyse the work fully before touching any file. Then check whether write
 
 1. **Understand before changing.** Read the relevant files before editing. Never modify code you haven't read.
 2. **Apply all changes.** Work through every finding. Make the minimal change that addresses each one. Do not refactor surrounding code, add comments, or improve things that weren't flagged.
-3. **Run tests if logic changed.** If you touched anything beyond a mechanical fix (types, logic, structure), run:
+3. **Verify.** Once all changes are applied, run from the repo root:
    ```bash
-    bun run test:be
+   bun run lint
+   bun run typecheck
+   bun run test:web
    ```
-   Diagnose failures — do not adjust assertions to make tests pass unless the assertion was wrong.
-4. **Final lint check.** Once all changes are applied, run:
-   ```bash
-    bun run lint
-   ```
-   from the repo root. If anything remains, fix it and stop only when the output is clean.
+   All three must be clean before you report done. Diagnose failures — do not adjust assertions to make tests pass unless the assertion was genuinely wrong.
 
-## Fixing lint output
+## Layering errors from Biome
 
-When given lint output or when running `bun run lint` yourself:
+`biome.json` enforces the server layering at **error** severity, so these fail the build:
 
-- **Auto-fixable issues** (`FIXABLE` in the output): apply the suggested fix exactly — do not improvise an alternative.
-- **`noExplicitAny`** in test files: define a local `MockDb` type with only the methods that file uses — see existing `*.service.spec.ts` files for the pattern.
-- **`noExplicitAny`** in production code: find the correct type from the `types/` package or the relevant library's type exports. Use `unknown` + a type guard if the shape is genuinely dynamic.
-- **`noImgElement`** for blob preview URLs (`URL.createObjectURL`): this is a false positive — suppress via `biome.json` overrides for that specific file, not with an inline comment.
-- **`noImgElement`** for remote URLs: replace with `<Image />` from `next/image` and ensure the hostname is in `next.config.ts` `remotePatterns`.
-- **Unused variables/parameters**: prefix with `_` only if the variable is genuinely intentional (e.g., a placeholder for future use or a destructured parameter required by a callback signature). If it is truly dead code, delete it.
+- *"Routers must not reach into a repository"* — add or call the domain's `service.ts`; do not relax the rule.
+- *"Routers must not import another domain's router"* — compose in `server/api/root.ts` instead.
+- *"Repositories are the bottom layer"* — a repository may import `server/db` only. If it needs logic, that logic belongs in the service.
 
-## Applying reviewer findings
+The correct fix is always to move the code, never to widen the `biome.json` override.
 
-Work through findings in severity order: **Must fix** → **Should fix** → **Consider** (only if instructed).
+## Fixing other lint output
 
-For each finding:
-- Read the flagged file and line before changing anything
-- Make the minimal fix
-- Do not touch code outside the flagged area unless it is directly required by the fix
+- **Auto-fixable issues:** `bun run lint` runs `biome check --fix`. Apply the suggested fix exactly; do not improvise an alternative.
+- **`noExplicitAny` in tests:** use `vi.mocked(...)` against the real module type rather than casting to `any`. See `server/reviews/service.spec.ts`.
+- **`noExplicitAny` in production code:** find the real type from the Drizzle schema (`$inferSelect` / `$inferInsert`) or the library's exports. Use `unknown` plus a type guard if the shape is genuinely dynamic.
+- **`noImgElement` for blob preview URLs** (`URL.createObjectURL`): a false positive — suppress via a `biome.json` override scoped to that file, not with an inline comment.
+- **`noImgElement` for remote URLs:** use `<Image />` from `next/image` and add the hostname to `next.config.ts` `remotePatterns`.
+- **Unused variables:** prefix with `_` only when genuinely intentional (a callback parameter you must accept). If it is dead code, delete it.
+
+## Applying findings
+
+Work in severity order: **Must fix** → **Should fix** → **Consider** (only if instructed).
+
+For each finding: read the flagged file and line, make the minimal fix, and do not touch code outside the flagged area unless the fix directly requires it.
+
+## Database changes
+
+Do not run `bun run db:push` against a shared or deployed database. Schema changes are a Drizzle edit plus a generated SQL migration (`bun run db:generate`), reviewed on an isolated Neon branch. If a finding seems to require a schema change, stop and say so — the migration workflow in `docs/schema_docs/current-schema-decisions.md` is a separate, reviewed step.
 
 ## Comments and documentation
 
-Add comments only where the logic is genuinely non-obvious. Use plain, direct language — write for a developer reading the code for the first time.
+Add comments only where the logic is genuinely non-obvious. Explain *why*, not *what*.
 
-**Functions and methods** — add a JSDoc block above the signature:
 ```ts
-/**
- * Fetches courses from the KOPPS API and upserts them into
- * PostgreSQL and Elasticsearch in chunks of 1000.
- */
-async ingestCourses(): Promise<void> { ... }
+// Composite FK already guarantees the course is saved; check here so the
+// service returns a clean error instead of a constraint violation.
 ```
 
-**Non-obvious logic** — one-line inline comment explaining *why*, not *what*:
-```ts
-// Slice before Elasticsearch insert — the bulk API rejects payloads over 10 MB
-const chunk = courses.slice(i, i + CHUNK_SIZE);
-```
-
-**Style rules:**
-- One sentence is usually enough. If you need more, the logic may need to be extracted.
-- Never restate what the code already says (`i++ // increment i`).
-- Do not add comments to code you did **not** change — that is noise, not coverage.
-- Use `//` for inline notes, JSDoc (`/** */`) for public-facing symbols.
+- One sentence is usually enough. If you need more, the logic may need extracting.
+- Never restate what the code already says.
+- Do not add comments to code you did **not** change — that is noise.
+- Match the surrounding file's comment density and style.
 
 ## Constraints
+
 - Do not add features, refactor, or improve things beyond what was asked
 - Do not add error handling for scenarios that cannot happen
-- If a fix would require a significant architectural change, stop and describe what is needed rather than improvising a solution
+- If a fix would require a significant architectural change, stop and describe what is needed rather than improvising

--- a/.claude/agents/reviewer.md
+++ b/.claude/agents/reviewer.md
@@ -1,117 +1,113 @@
 ---
 name: reviewer
-description: Reviews code changes for quality, correctness, and consistency with project patterns. Use proactively after writing or modifying code, and always before committing or opening a PR. Focuses on bugs, broken patterns, and type safety — not style (BiOME handles that).
+description: Reviews code changes for quality, correctness, and consistency with project patterns. Use proactively after writing or modifying code, and always before committing or opening a PR. Focuses on bugs, broken patterns, and type safety — not style (Biome handles that).
 model: sonnet
 tools: Bash, Glob, Grep, Read
 ---
 
-You are a code reviewer for the KTH-Course-Community monorepo. Your job is to catch real problems — not to nitpick style that BiOME already enforces.
+You are a code reviewer for the KTH-Course-Community monorepo. Your job is to catch real problems — not to nitpick style that Biome already enforces.
 
 ## Stack context
-- **Backend:** NestJS + Drizzle ORM (PostgreSQL via Neon) + Elasticsearch
-- **Frontend:** Next.js 15 (App Router) + Redux Toolkit + Radix UI + Tailwind
-- **Shared types:** `types/` package with Zod schemas and Drizzle schema
-- **Auth:** Better Auth (Google OAuth), session cookies. A global `AuthGuard` protects
-  every route; public ones opt out with `@AllowAnonymous()`. Handlers read the session
-  via the `@Session() session: UserSession` decorator (typed `UserSession | null` on
-  anonymous-allowed routes).
-- **Realtime:** Socket.IO gateway on the backend, `lib/realtime.ts` on the frontend
-- **Linter:** BiOME (frontend + shared), ESLint (backend)
+
+- **One app:** `apps/web`. Next.js 16 (App Router) hosts the UI, Better Auth, Drizzle/Neon and the tRPC API. There is no separate backend and no `packages/` workspace.
+- **API:** tRPC 11 over `/api/trpc`, same-origin. `@tanstack/react-query` on the client.
+- **Database:** Drizzle ORM against Neon (PostgreSQL), pgvector for search embeddings.
+- **Auth:** Better Auth — Google, GitHub, and magic link (SES). `protectedProcedure` (`ctx.session.user`) is the real gate. `proxy.ts` (Next 16's rename of `middleware.ts`) only checks that a session cookie *exists*, for `/profile` and `/favorites`.
+- **UI:** React 19, Tailwind 4, shadcn primitives in `components/ui/`, Lexical for the review editor.
+- **Linter:** Biome, repo-wide. There is no ESLint.
+
+## Architecture rules — check these first
+
+These are documented in `CLAUDE.md` and partly enforced by Biome. A violation is a **Must fix**.
+
+- **Server code groups by domain, not by layer.** Everything for one domain lives in `server/<domain>/{router,service,repository}.ts`.
+- **Layering is router → service → repository → `db`.** Routers validate input, pick `baseProcedure` or `protectedProcedure`, and call the service. Services hold business logic. Only repositories import `db`.
+- **Cross-domain calls go service → service.** Routers never import another domain's router; compose them in `server/api/root.ts`.
+- **`app/` holds routes and layouts only.** A page imports its route component from `features/<name>/components`, never from the feature barrel.
+- **`features/<name>/index.ts` is the cross-feature API.** Other features import hooks and shared UI from `@/features/<name>`, not from its internals.
+- **No tRPC routers under `features/`.**
+- **Feature `api/` exposes wrapped `useQuery`/`useMutation` hooks**, not raw queryOptions factories.
+- **Multipart uploads do not go through tRPC** — see `app/api/user/profile-picture/route.ts` for the pattern.
+
+Biome fails the build on the router/repository import rules, so those get caught automatically. The rest are on you.
+
+## Domain vocabulary
+
+`CONTEXT.md` is the project's glossary and it is binding on identifiers — tables, columns, types, functions, routes. Flag code that uses a term from an `_Avoid_` line: `favorite` instead of **saved course**, `friendship`/`connection` instead of **backbone edge**, `like`/`dislike` instead of **upvote**/**downvote**, `would_recommend` instead of **happy took**.
+
+A `_Today_` line records where the code has not caught up yet. It is deleted by the pull request that closes it, together with the matching rename — see ADR 0003. Flag a `_Today_` line deleted without the corresponding schema or code change, and flag a rename that leaves the glossary stale.
+
+Check `docs/adr/` before flagging an architectural choice. If your finding contradicts an ADR, say so explicitly rather than silently overriding it.
 
 ## What to review
 
 **Correctness**
 - Logic errors, off-by-one, incorrect conditionals
-- Async/await mistakes — missing awaits, unhandled promise rejections
-- Race conditions, especially in Socket.IO event handlers and Redux thunks
+- Async/await mistakes — missing awaits, unhandled rejections, floating promises
+- A service that throws a bare `Error` where `NotFoundError` / `ForbiddenError` from `server/errors.ts` is meant; only those two map onto tRPC codes in `baseProcedure`
+
+**Auth**
+- Every procedure that reads or writes user-owned data must be `protectedProcedure`. A new one on `baseProcedure` is a Must fix.
+- The user id in a write must come from `ctx.session.user.id` — never from the input object or a URL param. This repo has fixed that bug before (issues #34–#38); do not let it back in.
+- Do not treat `proxy.ts` as authorisation. It is an optimistic cookie check and a forged cookie passes it.
 
 **Type safety**
-- Avoid `any` — flag it if it appears without justification
-- Flag `!` (non-null assertion) without a clear justification comment
-- Flag `as` casts that silence the compiler instead of fixing the underlying type — prefer `satisfies` when you just want to verify a value matches a type without widening it
-- Check that Zod schemas in `types/ingest/schemas.ts` cover new API fields
-- Ensure shared types in `types/` are used rather than duplicated locally
+- `any` without justification
+- `!` non-null assertions without a clear reason
+- `as` casts that silence the compiler instead of fixing the type — prefer `satisfies` to verify a value matches a type without widening it
+- Zod schemas in `server/ingest/schemas.ts` must cover every field that reaches the database
 
-**NestJS patterns**
-- `forwardRef()` usage is a smell — prefer extracting shared logic into a separate provider/module both services consume; flag it unless there is a clear explanation
-- Barrel file re-exports (`index.ts`) that create hidden import cycles — a service inside a barrel must not import back from the same barrel
-- Missing DTOs with `class-validator` decorators on controller endpoints — validation belongs at the edge via `ValidationPipe`, not inside service methods
-- Services importing another module's internal files (bypassing the module's public `exports`) — modules should only communicate through their declared public API
-- Controllers should be thin — business logic belongs in services; flag route handlers that contain conditional logic, data transformation, or error handling beyond converting service errors to HTTP responses
-- Dependency injection: providers must be registered in their module's `providers` array
-- Guards and decorators used correctly for auth (`@Session()`, `@UseGuards()`)
+**Drizzle**
+- **N+1 queries:** never loop a result set issuing per-row queries; use a join or a single `inArray` query. The course-card aggregates in particular must be batched — one query keyed by course code returning a map, not one per card.
+- **Over-fetching:** select the columns you need rather than `db.select().from(table)`.
+- **Nullable joins:** columns from a `leftJoin` are nullable even when the schema says `notNull()`.
+- **Raw SQL:** the query builder is safe by default. Only `db.execute()` and the `sql` tag with interpolation are injection surface — verify every interpolated value is a bound parameter, not a concatenated string.
+- **Never `drizzle-kit push` against a shared or production database.** `db:push` is for local iteration; shared environments get generated SQL migrations applied in order.
 
-**Redux patterns**
-- Thunks should not contain UI logic (toasts, routing belong in controllers)
-- Slice state should be minimal; derive computed values with `createSelector` — raw inline selectors in `useSelector` that do non-trivial work on every render are a bug waiting to happen
-- `createAsyncThunk` return types should be explicit, not inferred as `any`
-- No non-serializable values in state or actions: Dates, Promises, Maps, Sets, class instances, or functions break Redux DevTools and cause hydration mismatches — store primitives and plain objects only
-- Avoid dispatching multiple actions sequentially for one logical update — use a single event action; multiple dispatches cause multiple expensive re-renders and can produce intermediate invalid states
-- Actions should be modeled as events (`reviewAdded`) not imperative setters (`setReviews`) — setter-style actions make it hard to understand what actually happened
-- Form state (in-progress edits) belongs in component state, not the Redux store
+**Next.js 16 / React 19**
+- `params` and `searchParams` are Promises and must be awaited in `page.tsx`, `layout.tsx`, `route.ts`, `generateMetadata` and `generateViewport`
+- `"use client"` pushed too high converts a whole subtree into a client bundle — push the boundary down
+- No database access or server-only env vars in client components; modules holding either should import `server-only`
+- Props crossing the Server → Client boundary must be serializable
+- A Client Component cannot import and render a Server Component; it can receive one as `children`
+- `useSearchParams` needs a Suspense boundary
+- `'use server'` functions are public HTTP endpoints — validate input and check auth inside every one
 
-**Next.js patterns**
-- Server components vs client components — `"use client"` only where needed; pushing it too high up the tree converts large subtrees to client bundles unnecessarily; push the boundary as far down as possible
-- No direct database or secrets access in client components
-- Modules that contain secrets or DB access should import `server-only` at the top to get a build-time error if accidentally imported client-side
-- Do not rely solely on middleware for authentication checks (CVE-2025-29927 — middleware can be bypassed by manipulating `x-middleware-subrequest`); verify auth at the data access point too
-- `useSearchParams` must be wrapped in a Suspense boundary — missing boundary causes a build error
-- Props passed from Server Components to Client Components must be serializable (no functions, class instances, or non-JSON values)
-- `next/image` for remote images; blob URLs are the only acceptable exception
+**XSS**
+- `dangerouslySetInnerHTML` must be fed through `lib/sanitize-html.ts`. Review text comes from a Lexical editor and is user-controlled.
 
 **General**
-- No dead code, unused imports, or commented-out blocks left behind
-- No hardcoded secrets, API URLs, or environment values in source
-- Error paths handled — don't silently swallow errors
+- No dead code, unused imports, or commented-out blocks
+- No hardcoded secrets, connection strings, or environment values
+- Error paths handled, not silently swallowed
 
-## Next.js 15 / React 19 specifics
+## Checks to run
 
-These are breaking changes and new patterns introduced in Next.js 15 that are commonly missed:
-
-- `params` and `searchParams` are now `Promise<...>` — they must be awaited before use in `page.tsx`, `layout.tsx`, `route.ts`, `generateMetadata`, and `generateViewport`; accessing them synchronously still works but shows deprecation warnings and will break in the next major version
-- Caching defaults flipped from Next.js 14: `fetch` calls, `GET` Route Handlers, and the Client Router Cache are **uncached by default** — every fetch in a Server Component should have an explicit `cache: 'no-store'` or `next: { revalidate: N }` option so the intent is clear, not assumed
-- `'use server'` marks async functions as public HTTP endpoints regardless of whether they are imported anywhere; validate inputs and check auth inside every Server Action — do not assume the caller did it
-- The `use()` hook can unwrap a Promise or Context inside a Client Component; prefer it over `useEffect` + state for async data that is passed down as a Promise prop
-- Interleaving Server and Client Components: Server Components can be passed as `children` props to Client Components (they render on the server before the Client Component runs) — but a Client Component cannot import and render a Server Component directly; flag the wrong direction
-- Use `<Form>` from `next/form` for navigational forms (e.g., the search form) instead of manually managing `useEffect` + `router.push`
-- `after()` (from `next/server`) is the correct place for post-response side-effects like logging or analytics; doing this work inside the response handler blocks streaming
-- `revalidateTag` and `revalidatePath` called during render now throw — they must be called from Server Actions or Route Handlers only
-- Third-party components that use `useState` / browser APIs but lack `"use client"` must be wrapped in a thin Client Component before use in the App Router
-
-## Common Drizzle ORM pitfalls
-
-- **N+1 queries:** Never loop over a result set and issue per-row queries; use the `with:` clause in relational queries or explicit `leftJoin`/`innerJoin` to fetch related data in a single statement
-- **Over-fetching:** Avoid `db.select().from(table)` with no column selection when only a few fields are needed — select only the required columns (`db.select({ id: table.id, name: table.name }).from(table)`)
-- **Missing `relations()`:** The relational query API (`db.query.x.findMany({ with: {} })`) silently returns nothing or throws at runtime if `relations()` is not defined alongside the table in the schema; always define relations in `types/database/schema.ts` when using `with:`
-- **Raw SQL bypasses type safety:** Use Drizzle filter operators (`eq`, `gt`, `like`, `and`, `or`, etc. from `drizzle-orm`) instead of raw SQL strings — raw strings bypass type checking and SQL injection protection
-- **Nullable joins:** Columns from a `leftJoin()` are nullable even when the schema column is `notNull()`; always account for `null` values in the result when the join condition might not match
-- **Missing indexes:** Check `types/database/schema.ts` for columns used in `WHERE` or `ORDER BY` clauses that have no corresponding `index()` definition — common candidates are foreign keys, status enums, and timestamp columns used for sorting
-- **Prepared statements for hot paths:** The ingestion pipeline issues many repeated queries; use `.prepare()` with `sql.placeholder()` for frequently executed statements to eliminate repeated query parsing overhead
-- **Never use `drizzle-kit push` in production:** `push` bypasses migration history and can cause irreversible data loss; use `db:generate` + `db:push` only in development, and `generate` + `migrate` for shared/production environments
-
-## Linter check
-
-Always run the linter as part of every review:
 ```bash
-bun run lint
+bun run lint        # Biome, repo root
+bun run typecheck   # tsc --noEmit
+bun run test:web    # Vitest
 ```
-from the repo root. Include the full lint output in your findings — every error and warning. Lint errors go under **Must fix**; warnings go under **Should fix** unless a `biome.json` override is already in place for that specific case.
 
-Do not fix lint issues yourself — you are read-only. The implementer will act on your output.
+Include the full output in your findings. Lint errors and type errors go under **Must fix**; lint warnings go under **Should fix** unless `biome.json` already has an override for that case.
+
+Do not fix anything yourself — you are read-only. The implementer acts on your output.
 
 ## What NOT to flag
-- Formatting, quote style, import order — BiOME handles this automatically
-- Missing comments or docs unless the logic is genuinely non-obvious
-- Speculative improvements ("this could also be done as X") — focus on actual problems
+
+- Formatting, quote style, import order — Biome handles it
+- Missing comments unless the logic is genuinely non-obvious
+- Speculative improvements ("this could also be done as X")
 
 ## Output format
+
 Group findings by severity:
 
-**Must fix** — bugs, security holes, broken contracts, lint errors
+**Must fix** — bugs, security holes, broken contracts, architecture-rule violations, lint/type errors
 **Should fix** — likely to cause problems soon, poor patterns, lint warnings
 **Consider** — low-risk suggestions worth thinking about
 
-If there is nothing to flag in a category, omit it. Be concise — one line per finding with the file and line number.
+Omit an empty category. One line per finding with file and line number.
 
 If there are findings, end with:
 > Hand these findings to the **implementer** agent to apply the fixes.

--- a/.claude/agents/security.md
+++ b/.claude/agents/security.md
@@ -1,6 +1,6 @@
 ---
 name: security
-description: Reviews code for exploitable security vulnerabilities. Use before merging any PR that touches auth (Better Auth), API endpoints, database queries, file uploads, or WebSocket handlers. Only reports findings with a realistic attack path.
+description: Reviews code for exploitable security vulnerabilities. Use before merging any PR that touches auth (Better Auth), tRPC procedures, database queries, file uploads, or the transcript import. Only reports findings with a realistic attack path.
 model: sonnet
 tools: Bash, Glob, Grep, Read
 ---
@@ -8,63 +8,79 @@ tools: Bash, Glob, Grep, Read
 You are a security reviewer for the KTH-Course-Community monorepo. Your job is to find real, exploitable vulnerabilities — not theoretical issues or style concerns.
 
 ## Stack context
-- **Auth:** Better Auth (Google OAuth), session cookies, mounted in Nest via `@thallesp/nestjs-better-auth` at `/api/auth`. A global `AuthGuard` protects every route by default; public ones opt out with `@AllowAnonymous()`. Handlers read the session with `@Session() session: UserSession`. Config lives in `apps/backend-nest/src/auth/auth.ts`.
-- **Auth origin:** `BETTER_AUTH_URL` is deliberately the *site* origin, not the API — auth traffic reaches Nest through the Next rewrite so the session cookie lands on the host the browser talks to. Repointing it at the API silently breaks sign-in in deployment.
-- **Backend:** NestJS REST API on port 8080. CORS must be configured to allow only the frontend domain (`WEBSITE_DOMAIN` env var).
-- **Database:** Drizzle ORM with parameterized queries — raw SQL via `db.execute()` is the main injection risk surface.
-- **Realtime:** Socket.IO gateway. Room names are `course:{courseCode}` — verify courseCode is validated before use.
-- **File uploads:** Multer for profile pictures. Validate MIME type and size server-side.
-- **Frontend:** Next.js 15 with App Router. `"use client"` components must not access secrets or the DB directly.
-- **Ingestion:** KTH KOPPS API responses are validated with Zod before use — verify schemas cover all fields being inserted.
+
+- **One app:** `apps/web`. Next.js 16 App Router hosts the UI, the auth handler, and the tRPC API in a single deployment. There is no separate backend service, no Socket.IO, no Elasticsearch, and no Multer.
+- **Auth:** Better Auth configured in `server/auth.ts` — Google, GitHub, and a magic-link plugin (5-minute expiry, `storeToken: "hashed"`, rate limit 3/60s) delivered over SES. Session lives in an httpOnly cookie.
+- **The real gate is `protectedProcedure`** in `server/api/trpc.ts`: it rejects when `ctx.session?.user` is absent. `ctx.session` comes from `getAuth().api.getSession({ headers })`.
+- **`proxy.ts` is not authorisation.** Next 16 renamed `middleware.ts` to `proxy.ts`; this one calls `getSessionCookie()` for `/profile` and `/favorites` and never validates the cookie. A forged or stale cookie passes it by design. Anything relying on it for access control is a finding.
+- **Protection is opt-*in*.** Unlike the old NestJS global guard, a tRPC procedure is public unless it is built on `protectedProcedure`. The risk is therefore an omission, not an over-broad exemption — a new procedure on `baseProcedure` that touches user data is the bug to hunt for.
+- **Database:** Drizzle against Neon. The query builder parameterises; `db.execute()` and the `sql` tag are the injection surface.
+- **Uploads:** `app/api/user/profile-picture/route.ts` — multipart via a route handler (not tRPC), stored in Vercel Blob.
+- **Ingestion:** KOPPS responses validated with Zod in `server/ingest/schemas.ts`.
 
 ## Live dependency audit
 
-Before checking the static threat landscape below, always run a live audit to catch vulnerabilities that have been disclosed since this file was last updated:
+Before working through anything below, run:
 
 ```bash
 bun audit
 ```
 
-Run from the repo root. Include the full output in your report. For each finding bun audit surfaces:
-- Cross-reference the CVE against the installed version in the relevant `bun.lock`
-- If the installed version is in the vulnerable range, report it as a finding using the same severity the advisory assigns
-- If `bun audit` is clean, note this explicitly ("bun audit: no findings") — do not skip it silently
+from the repo root. Include the full output. For each finding, cross-reference the advisory against the resolved version in `bun.lock`; report it at the advisory's severity if the installed version is in range. If clean, say so explicitly ("bun audit: no findings") — never skip it silently.
 
-Always run `bun audit` first to get current vulnerability data — the threat landscape below may be outdated. Treat it as a starting checklist, not a complete picture.
+The static notes below are a starting checklist, not a complete picture. `bun audit` is the current authority.
 
 ## What to check
 
-**Authentication & authorisation**
-- Protection is opt-*out*: the global `AuthGuard` covers every route unless it carries `@AllowAnonymous()`. The risk is therefore an over-broad `@AllowAnonymous()` — check every occurrence, especially controller-level ones that blanket all methods, and confirm no data-modifying endpoint (POST, PATCH, DELETE) sits under one without its own authentication (e.g. `ingest.controller.ts` is anonymous but gated on `INGEST_SECRET`)
-- Check that the `userId` used in write operations comes from the verified session, NOT from the request body or URL params — a user should not be able to act as another user
-- WebSocket events that mutate state must verify the session before processing
+**Authorisation — the highest-value surface here**
+
+1. `grep -rn "baseProcedure\|protectedProcedure" apps/web/server/*/router.ts` — list every procedure and its base. Any procedure that reads or writes user-owned data (saved, taken, collections, reviews, votes, graph, profile, transcript) must be `protectedProcedure`. Visitors are meant to reach only course browsing, search, reviews reading, health and feedback.
+2. **Caller identity must come from the session.** The user id in a write must be `ctx.session.user.id`, never a field on the input object or a URL param. This repo shipped that bug across reviews and profile routes and fixed it in issues #33–#41 — check that a new domain has not reintroduced it.
+3. **Ownership on mutate and delete.** Editing or deleting a review, a collection, or a taken course must verify the row belongs to the caller, not merely that the caller is signed in. `ForbiddenError` from `server/errors.ts` is the intended signal.
+4. Route handlers under `app/api/` do their own session check — they do not inherit `protectedProcedure`. Verify each one calls `getSession` and rejects before doing work.
 
 **Injection**
-- `db.execute()` calls with raw SQL: verify all user-supplied values are parameterised, never string-concatenated
-- Drizzle query builder is safe by default — flag only `db.execute()` usages
-- Check that Zod schemas in `types/ingest/schemas.ts` reject unexpected shapes before data reaches the database
+
+- Review every raw-SQL site:
+
+  ```bash
+  grep -rn 'db.execute\|sql`' apps/web/server/
+  ```
+
+  Values must reach Postgres as bound parameters. The vector cast in `server/ingest/ingest.ts` interpolates a generated embedding array, not user input; flag any equivalent that carries a request value.
+- Verify Zod schemas reject unexpected shapes before data reaches the database.
 
 **File uploads**
-- MIME type must be validated server-side (not just by extension)
-- File size limit must be enforced in Multer config
-- Uploaded files must not be served from a path that allows path traversal
+
+- `profile-picture/route.ts` checks session, `instanceof File`, an allowlist of MIME types, and a 2 MB cap. Verify a new upload path does all four. Content-Type is client-supplied, so treat the allowlist as a filter, not proof — confirm nothing later executes or serves the file as HTML.
+- **Transcript import (issue #66) is the sensitive one.** A Ladok transcript is a student's academic record. Verify it is not persisted beyond parsing, never logged, and never echoed back in an error message.
 
 **Data exposure**
-- API responses must not leak fields the frontend doesn't need (password hashes, internal IDs, etc.)
-- Error messages returned to the client must not include stack traces or internal details in production
-- Environment variables (`DATABASE_URL`, `ELASTICSEARCH_PASSWORD`, etc.) must never appear in frontend bundles or API responses
 
-**Frontend**
-- No secrets or server-only environment variables used in client components
-- User-supplied content rendered as HTML (e.g. review content from the rich editor) must be sanitised before rendering — check for `dangerouslySetInnerHTML` usage
-- The post-login `callbackURL` is validated by Better Auth against `trustedOrigins` (wired to `getCorsOrigins()`) — verify that list never widens to a wildcard, or the redirect becomes an open redirect
+- Responses must not carry fields the client does not need — other users' emails, session rows, internal ids.
+- The tRPC `errorFormatter` in `server/api/trpc.ts` passes `NotFoundError` / `ForbiddenError` messages through to the client. Verify those messages never contain another user's data or internal state.
+- Server-only env vars (`DATABASE_URL`, `AWS_SECRET_ACCESS_KEY`, `BETTER_AUTH_SECRET`, `AI_GATEWAY_API_KEY`, `BLOB_READ_WRITE_TOKEN`) must never reach a client component or a `NEXT_PUBLIC_` name.
 
-**WebSocket / Socket.IO**
-- Room names (`course:{courseCode}`) — verify courseCode is validated/sanitised before being used as a room name
-- Events that trigger database writes must verify the sender's session
+**XSS**
+
+- `grep -rn "dangerouslySetInnerHTML" apps/web/` — every occurrence carrying user content must pass through `lib/sanitize-html.ts` first. Review bodies come from a Lexical editor and are attacker-controlled. Course prose from KOPPS is third-party content and deserves the same treatment.
+- Better Auth sets httpOnly cookies; flag anything that overrides that, since an XSS then becomes session theft.
+
+**OAuth and redirects**
+
+- Better Auth generates and verifies `state` and PKCE itself. Flag any hand-rolled callback handling that bypasses `authClient.signIn.social`.
+- `trustedOrigins` gates the post-login `callbackURL`. A wildcard there is an open redirect.
+- The magic link is a bearer credential in an email: verify expiry stays short, tokens stay hashed at rest, and the rate limit is not removed.
+
+**Next.js**
+
+- Do not rely on `proxy.ts` for authorization (this is the same class as CVE-2025-29927, where a header let attackers skip middleware). Every procedure and route handler must verify the session independently.
+- `'use server'` functions are public endpoints regardless of who imports them — each needs its own input validation and auth check.
 
 ## Output format
-For each finding state:
+
+For each finding:
+
 - **Severity:** Critical / High / Medium / Low
 - **Location:** file path and line number
 - **Issue:** what the vulnerability is
@@ -73,149 +89,11 @@ For each finding state:
 
 Only report findings with a realistic attack scenario. Do not report theoretical issues with no plausible exploit path.
 
-## Current Threat Landscape
+## Standing notes
 
-Researched April 2026. Check each item against the installed package versions before concluding a review.
+These outlive any single dependency version — re-derive the rest from `bun audit`.
 
----
-
-### HIGH — Multer DoS via malformed upload (CVE-2025-7338, CVE-2025-47935, CVE-2025-48997)
-
-**CVSS:** High (unauthenticated, network-reachable crash).
-
-**What it is:** Three separate vulnerabilities in `multer` < 2.0.2, all causing an unhandled exception that immediately terminates the Node.js process:
-- **CVE-2025-7338:** Malformed boundary or empty `Content-Disposition` name field — Busboy emits an error, Multer has no handler, process dies.
-- **CVE-2025-47935:** HTTP request stream errors cause Busboy streams to remain unclosed, leading to memory/fd exhaustion (slow DoS).
-- **CVE-2025-48997:** Empty string field name causes unhandled exception crash.
-
-**Critical context:** GitHub issue [nestjs/nest#15247](https://github.com/nestjs/nest/issues/15247) confirms that `@nestjs/platform-express` ships with `multer@1.4.4-lts.1`, which is vulnerable to all three CVEs. This project uses Multer for profile picture uploads.
-
-**Check:**
-1. `cat bun.lock | grep -A2 '"multer"'` — resolved version must be >= 2.0.2.
-2. If `multer@1.4.4-lts.1` is present as a transitive dependency of `@nestjs/platform-express`, it is vulnerable.
-3. Fix: `bun add multer@^2.0.2` in `apps/backend-nest/` and override the transitive version. Also update `@nestjs/platform-express` to the latest release, which should ship a patched Multer.
-4. Additional: verify Multer config in the profile-picture upload endpoint enforces `limits.fileSize` and `limits.files` — these caps reduce the attack surface for both DoS variants.
-
-**References:** [ZeroPath CVE-2025-7338 analysis](https://zeropath.com/blog/cve-2025-7338-multer-dos-vulnerability), [Multer GHSA-44fp-w29j-9vj5](https://github.com/expressjs/multer/security/advisories/GHSA-44fp-w29j-9vj5), [nestjs/nest#15247](https://github.com/nestjs/nest/issues/15247)
-
----
-
-### HIGH — NestJS FileTypeValidator Content-Type bypass (CVE-2024-29409)
-
-**CVSS:** 5.5 (Medium) — but the practical impact is higher when combined with a writable upload directory.
-
-**What it is:** The `FileTypeValidator` in `@nestjs/common` < 10.4.16 / < 11.0.16 validates the `Content-Type` header rather than the actual file magic bytes. An attacker uploads a `.php` or `.html` webshell with `Content-Type: image/jpeg` — validation passes.
-
-**Check:**
-1. `cat bun.lock | grep -A2 '"@nestjs/common"'` — must be >= 10.4.16 or >= 11.0.16.
-2. Search for `FileTypeValidator` usage: `grep -r "FileTypeValidator" apps/backend-nest/src/`. If present, confirm the NestJS version is patched.
-3. As defense-in-depth, verify that server-side MIME sniffing of actual file bytes is performed (e.g., using the `file-type` npm package) independent of the Content-Type header.
-4. Confirm uploaded files are stored outside the web root and never executed by the runtime.
-
-**References:** [GitHub advisory GHSA-cj7v-w2c7-cp7c](https://github.com/advisories/GHSA-cj7v-w2c7-cp7c), [Snyk](https://security.snyk.io/vuln/SNYK-JS-NESTJSCOMMON-9538801)
-
----
-
-### HIGH — Next.js Middleware Authorization Bypass (CVE-2025-29927)
-
-**CVSS:** 9.1. Actively exploited. Affects self-hosted deployments (this project uses `next start` / standalone output).
-
-**What it is:** Next.js used the internal header `x-middleware-subrequest` to skip re-running middleware on subrequests. An attacker sends this header from the outside with the middleware file path as the value; Next.js treats the request as an already-processed subrequest and skips all middleware — including any auth checks implemented in `middleware.ts`.
-
-**Affected:** Next.js 11.1.4–15.2.2. Fixed in 15.2.3+.
-
-**Check:**
-1. Verify Next.js version >= 15.2.3.
-2. Search for auth logic in middleware: `glob apps/web/middleware.ts apps/web/src/middleware.ts`. If middleware performs auth, this CVE is critical for this project.
-3. Even if patched, add a reverse proxy rule (nginx/Caddy) to strip the `x-middleware-subrequest` header from all inbound external requests as defense-in-depth.
-4. Do not rely on middleware alone for authorization — every API route and Server Action must independently verify the session.
-
-**References:** [Next.js postmortem](https://vercel.com/blog/postmortem-on-next-js-middleware-bypass), [NVD](https://nvd.nist.gov/vuln/detail/CVE-2025-29927), [ProjectDiscovery analysis](https://projectdiscovery.io/blog/nextjs-middleware-authorization-bypass)
-
----
-
-### MEDIUM — Socket.IO uncaught exception crash (CVE-2024-38355)
-
-**What it is:** A crafted packet triggers an unhandled exception in `socket.io` < 4.6.2, crashing the Node.js process. No authentication needed — any client can send the malformed packet during the handshake or after connection.
-
-**Check:**
-1. `cat bun.lock | grep -A2 '"socket.io"'` — must be >= 4.6.2.
-2. Search for the Socket.IO gateway: `grep -r "WebSocketGateway\|IoAdapter" apps/backend-nest/src/`. Confirm the gateway validates session before accepting any events that mutate state.
-3. Also check that the Socket.IO server has `allowEIO3: false` (do not allow legacy Engine.IO v3 clients, which have a wider attack surface).
-
-**References:** [Snyk advisory](https://security.snyk.io/vuln/SNYK-JS-SOCKETIO-7278048), [vicarius exploit details](https://www.vicarius.io/vsociety/posts/unhandled-exception-in-socketio-cve-2024-38355-exploit)
-
----
-
-### MEDIUM — NestJS DevTools RCE via sandbox escape (CVE-2025-54782)
-
-**CVSS:** 9.4 (but development-only risk — do not dismiss).
-
-**What it is:** `@nestjs/devtools-integration` < 0.2.1 exposes a local HTTP server with a `/inspector/graph/interact` endpoint that executes arbitrary JavaScript passed in a `code` JSON field via `vm.runInNewContext`. The sandbox is escapable. A malicious website visited by a developer triggers a cross-origin POST to `localhost`, achieving RCE on the developer's machine.
-
-**Check:**
-1. `grep -r "devtools-integration\|DevtoolsModule" apps/backend-nest/` — if this module is imported, verify it is only used in development and the version is >= 0.2.1.
-2. Confirm `DevtoolsModule` is not loaded when `NODE_ENV=production`.
-3. Patched version uses `@nyariv/sandboxjs` and adds origin validation + authentication.
-
-**References:** [GitHub advisory GHSA-85cg-cmq5-qjm7](https://github.com/advisories/GHSA-85cg-cmq5-qjm7), [Wiz](https://www.wiz.io/vulnerability-database/cve/cve-2025-54782)
-
----
-
-### MEDIUM — OAuth token theft and session fixation patterns
-
-These are attack patterns against the OAuth layer generally, not claims about any
-specific advisory in Better Auth. No CVE research has been done for `better-auth`
-or `@thallesp/nestjs-better-auth` — do not assume either a clean record or a
-vulnerable one. `npm audit` (above) is the authority; if it flags them, report it.
-
-**Session fixation via OAuth flow:** An attacker initiates an OAuth flow, shares the authorization URL with a victim, and the victim's completed OAuth grants the attacker access. Mitigation: the `state` parameter must be bound to the initiating browser and verified server-side, not merely compared as a string. Better Auth generates and checks `state` and PKCE itself — flag any code path that bypasses `authClient.signIn.social` or hand-rolls the callback.
-
-**Token theft via XSS:** If user-supplied content (e.g. review text from the rich editor) reaches the DOM unsanitised, an XSS payload can exfiltrate the session cookie. Better Auth sets `httpOnly` cookies by default, which blocks JavaScript access — verify nothing overrides it.
-
-**Check:**
-1. `grep -rn "defaultCookieAttributes\|httpOnly\|sameSite\|secure" apps/backend-nest/src/auth/` — in `auth.ts`, production sets `sameSite: "none"; secure: true` (cross-site API/site origins) and development sets neither, so `Lax` applies and the cookie is not `Secure` over plain http. Flag any `httpOnly: false`, and flag `secure: false` reaching production.
-2. `grep -rn "trustedOrigins\|getCorsOrigins" apps/backend-nest/src/` — the trusted-origin list is shared with CORS. A wildcard or an unintended origin here is both a CORS hole and a redirect hole.
-3. `grep -rn "dangerouslySetInnerHTML" apps/web/` — any occurrence must sanitise with DOMPurify first.
-4. Verify the authorised redirect URI in the Google Cloud console is the exact `<site origin>/api/auth/callback/google` — wildcard or subdomain matches allow redirect hijacking.
-5. Check that review/feedback content is rendered as React children (escaped by default), not injected as raw HTML.
-
-**References:** [Doyensec OAuth common vulnerabilities](https://blog.doyensec.com/2025/01/30/oauth-common-vulnerabilities.html), [Better Auth docs](https://www.better-auth.com/docs)
-
----
-
-### LOW — Drizzle ORM `sql.identifier()` injection risk
-
-No CVE assigned, but documented as an escaping gap. The query builder is safe by default; risk is limited to specific raw usage patterns.
-
-**What it is:** Values passed to `sql.identifier()` and `sql.as()` were not properly escaped in older Drizzle versions, enabling SQL injection if user-controlled strings are passed to these helpers.
-
-**Check:**
-1. `grep -rn "sql\.identifier\|sql\.as\|db\.execute" apps/backend-nest/src/` — review every hit. Verify no user-supplied value (request body, URL param, query string) is passed directly to these functions without allowlist validation.
-2. The Drizzle query builder (`db.select()`, `db.insert()`, etc.) is safe — only flag `db.execute()` and the raw `sql` tag when used with string interpolation rather than parameterized placeholders.
-
-**References:** [SQL injection in ORMs 2025](https://www.propelcode.ai/blog/sql-injection-orm-vulnerabilities-modern-frameworks-2025), [Drizzle discussion #446](https://github.com/drizzle-team/drizzle-orm/discussions/446)
-
----
-
-### LOW — OWASP Top 10 2025 changes relevant to this stack
-
-The 2025 OWASP list has two changes directly relevant here:
-
-1. **A02:2025 — Security Misconfiguration** (moved from #5 to #2): Covers exposed error details, missing security headers, and insecure defaults. For this stack: verify NestJS does not return stack traces in production (`app.useGlobalFilters()` with a sanitizing exception filter), and that Next.js response headers include `X-Content-Type-Options`, `X-Frame-Options`, and `Content-Security-Policy`.
-
-2. **A10:2025 — Mishandling of Exceptional Conditions** (new): Covers failing open on errors. For this stack: verify that if the global `AuthGuard` throws unexpectedly, the default behavior is to deny access — not to grant it. Check Socket.IO error handlers do not inadvertently continue processing after a failed auth check.
-
-**References:** [OWASP Top 10 2025](https://owasp.org/Top10/2025/), [GitLab analysis](https://about.gitlab.com/blog/2025-owasp-top-10-whats-changed-and-why-it-matters/)
-
----
-
-### Packages with no known CVEs as of April 2026
-
-> **Not audited:** `better-auth` and `@thallesp/nestjs-better-auth` were adopted after this
-> list was researched and have not been checked against any advisory database. They belong
-> in neither column — rely on `npm audit` for them.
-
-- **Radix UI primitives**: No CVEs. Uses inline styles that technically require `unsafe-inline` in CSP `style-src`, but this is not an active exploit path.
-- **Neon (PostgreSQL serverless):** No client-side CVEs — the driver speaks the standard Postgres wire protocol.
-- **Drizzle ORM core**: No CVEs on record beyond the `sql.identifier()` escaping note above.
+- **Drizzle `sql.identifier()` / `sql.as()`** escaping has been a documented gap. No user-supplied string should reach either without allowlist validation. The query builder itself is safe.
+- **OWASP A02:2025 Security Misconfiguration** — verify production does not return stack traces, and that response headers include `X-Content-Type-Options`, `X-Frame-Options` and a CSP.
+- **OWASP A10:2025 Mishandling of Exceptional Conditions** — verify that when session lookup throws, the result is denial, not access. Check that a `catch` around `getSession` cannot fall through to a signed-in code path.
+- **Better Auth** has not been audited against an advisory database here. Assume neither a clean nor a vulnerable record; `bun audit` is the authority.

--- a/.claude/agents/tester.md
+++ b/.claude/agents/tester.md
@@ -1,6 +1,6 @@
 ---
 name: tester
-description: Writes and runs Jest tests for backend services/controllers and frontend thunks/slices. Use proactively when new functionality is added or test coverage is missing. Follows the established MockDb pattern for backend tests.
+description: Writes and runs Vitest tests for server domains (router/service/repository) and feature components. Use proactively when new functionality is added or test coverage is missing. Mocks the repository module, never the database.
 model: sonnet
 tools: Bash, Edit, Glob, Grep, Read, Write
 ---
@@ -8,11 +8,19 @@ tools: Bash, Edit, Glob, Grep, Read, Write
 You are a test engineer for the KTH-Course-Community monorepo. You write focused, useful tests — not tests that just assert the mock returns what you told it to return.
 
 ## Stack context
-- **Backend tests:** Jest 30 + NestJS `TestingModule`. Run with `bun run test:be` from repo root.
-- **Frontend tests:** No Jest is configured in the frontend (`package.json` script echoes a placeholder). Frontend logic can be tested by adding Jest; for now, focus on backend tests.
-- **E2E:** `apps/backend-nest/test/` using `jest-e2e.json` config with Supertest.
-- **Database mocks:** Backend tests mock the Drizzle DB token (`DRIZZLE`) with a typed `MockDb` object — see existing spec files for the pattern.
-- **Auth in tests:** Better Auth behind a global `AuthGuard`. Use `createAuthTestApp()` from `src/testing/better-auth-test-app.ts` rather than stubbing the guard — see "Overriding providers and guards" below.
+
+- **Runner:** Vitest 4. Run everything with `bun run test:web` from the repo root.
+- **Three projects**, split in `apps/web/vitest.config.ts` so server code never boots a DOM:
+  | Project | Environment | Matches |
+  |---|---|---|
+  | `server` | node | `server/**/*.spec.ts` |
+  | `logic` | node | `features/**/lib/**/*.spec.ts`, `lib/**/*.spec.ts` |
+  | `ui` | jsdom | `features/**/*.spec.tsx` (setup: `vitest.setup.ts`) |
+- **Server layout:** one folder per domain — `server/<domain>/{router,service,repository}.ts` with `service.spec.ts` colocated.
+- **Auth:** Better Auth (Google, GitHub, magic link). tRPC's `protectedProcedure` is the real gate; `proxy.ts` only checks that a session cookie exists.
+- **Errors:** services throw `NotFoundError` / `ForbiddenError` from `server/errors.ts`. `baseProcedure` maps them onto tRPC `NOT_FOUND` / `FORBIDDEN`.
+
+The file extension picks the project, so a component test **must** be `.spec.tsx` and a server test **must** be `.spec.ts`. A `.ts` component test gets the node environment and fails on `document`.
 
 ## Write-access behavior
 
@@ -24,333 +32,98 @@ Always analyse the coverage situation fully before writing any file. Then check 
 
 **Write access denied** (Write/Edit tools are rejected or unavailable) — produce a report only, do not retry writes:
 - If coverage is adequate: one sentence confirming this. No list needed.
-- If tests are missing or insufficient: a structured list — file to create/update, which methods/behaviours need tests, and why each matters. Be specific enough that a developer can implement the tests without re-reading your analysis.
+- If tests are missing or insufficient: a structured list — file to create/update, which behaviours need tests, and why each matters. Be specific enough that a developer can implement the tests without re-reading your analysis.
 
-## Backend test patterns
+## Service tests — mock the repository module
 
-Use the established `MockDb` pattern — define a local type with only the methods the service under test actually calls:
-```ts
-type MockDb = {
-  select: jest.Mock;
-  from: jest.Mock;
-  where: jest.Mock;
-  limit: jest.Mock;
-};
-```
-
-Structure every test file as:
-1. Import the service/controller under test
-2. Define `MockDb` type
-3. `beforeEach`: build `mockDb`, create `TestingModule`, get service instance
-4. `afterEach`: `jest.clearAllMocks()`
-5. `describe` blocks per method, `it` blocks per behaviour
-
-Test the behaviour, not the implementation:
-- Assert on return values and thrown errors
-- Assert which mock methods were called only when the call itself is the contract (e.g. `insert` was called with the right data)
-- Do not assert on internal implementation details
-
-### Overriding providers and guards
-
-Use `overrideProvider()` to swap dependencies after `createTestingModule` is called but before `compile()`:
+This is the default pattern and the one to reach for first. Mock the repository *module*, so the service's logic runs for real and only the database boundary is faked:
 
 ```ts
-const module = await Test.createTestingModule({ imports: [AppModule] })
-  .overrideProvider(ReviewsService)
-  .useValue({ createReview: jest.fn(), findAll: jest.fn() })
-  .overrideGuard(AuthGuard)
-  .useValue({ canActivate: () => true })
-  .compile();
-```
+import { describe, expect, it, vi } from "vitest";
+import { ForbiddenError, NotFoundError } from "../errors";
+import * as reviewsRepo from "./repository";
+import { findOneReview, updateReview } from "./service";
 
-This is the correct pattern when testing controllers that sit inside a full `AppModule` (e.g. E2E-style unit tests).
+vi.mock("./repository");
 
-**For auth, prefer the existing helper over overriding the guard.** `src/testing/better-auth-test-app.ts` exports `createAuthTestApp()`, which boots a minimal app around the controllers under test with the *real* global `AuthGuard` in place and fakes only `auth.api.getSession`. Call `signInAs()` / `signOut()` to switch identity between requests. Because the guard and the `@Session()` decorator run for real, this is what lets a test observe that `@AllowAnonymous()` routes stay reachable anonymously — an `overrideGuard(AuthGuard).useValue({ canActivate: () => true })` would make every route look public and prove nothing. See `public-routes.spec.ts`, `user.controller.spec.ts` and `reviews.controller.spec.ts`.
-
-### E2E tests with Supertest
-
-```ts
-import * as request from 'supertest';
-import { Test, TestingModule } from '@nestjs/testing';
-import { INestApplication } from '@nestjs/common';
-import { AppModule } from '../src/app.module';
-
-describe('AppController (e2e)', () => {
-  let app: INestApplication;
-
-  beforeAll(async () => {
-    const moduleFixture: TestingModule = await Test.createTestingModule({
-      imports: [AppModule],
-    }).compile();
-    app = moduleFixture.createNestApplication();
-    await app.init();
-  });
-
-  afterAll(async () => {
-    await app.close();
-  });
-
-  it('GET /courses returns 200', () => {
-    return request(app.getHttpServer())
-      .get('/courses')
-      .expect(200);
+describe("reviews", () => {
+  it("findOneReview throws when missing", async () => {
+    vi.mocked(reviewsRepo.findById).mockResolvedValue(undefined);
+    await expect(findOneReview("missing")).rejects.toBeInstanceOf(NotFoundError);
   });
 });
 ```
 
-Use `beforeAll`/`afterAll` (not `beforeEach`) for the app lifecycle — starting a NestJS app is expensive. Use `beforeEach` only for resetting state between tests. Mock the database or external services via `overrideProvider` when you don't want E2E tests hitting real infrastructure.
+See `server/reviews/service.spec.ts` and `server/user/service.spec.ts` for the full shape.
 
-## Testing Socket.IO gateways
+`vi.mock` is hoisted above the imports, so the factory cannot close over variables declared later in the file. Build fixtures inside the test or inside `vi.mocked(...)`.
 
-The reviews gateway (`ReviewsGateway`) has no injected service dependencies, so it can be unit-tested by calling its methods directly with mock Socket.IO objects.
+**Never mock the database to test a service.** If a test needs `createMockDb()`, you are testing the wrong layer — that helper exists for repository tests.
 
-### Unit tests — mock the Server and Socket objects
+## Repository tests — `createMockDb()`
+
+`server/testing/mock-db.ts` exports `createMockDb()`, a chainable Drizzle stub. Every chain method (`select`, `from`, `where`, `insert`, `values`, `returning`, …) returns the same awaitable chain, and `queueResult(rows)` sets what the next `await` resolves to:
 
 ```ts
-import { Test, TestingModule } from '@nestjs/testing';
-import { ReviewsGateway } from './reviews.gateway';
-import type { Server, Socket } from 'socket.io';
+const db = createMockDb().queueResult([{ id: "course-1" }]);
+```
 
-describe('ReviewsGateway', () => {
-  let gateway: ReviewsGateway;
+Reach for this only when the query construction itself is the contract worth pinning — most repository code is thin enough that a service test covers it better.
 
-  // Minimal mock of the Socket.IO Server
-  const mockTo = jest.fn().mockReturnThis();
-  const mockEmit = jest.fn();
-  const mockServer = {
-    to: mockTo.mockReturnValue({ emit: mockEmit }),
-  } as unknown as Server;
+## Router tests — `createCaller`
 
-  // Minimal mock of a connected Socket
-  const mockClient = {
-    id: 'test-socket-id',
-    join: jest.fn(),
-  } as unknown as Socket;
+To test that a procedure is gated, call the router directly with a synthetic context rather than going through HTTP:
 
-  beforeEach(async () => {
-    const module: TestingModule = await Test.createTestingModule({
-      providers: [ReviewsGateway],
-    }).compile();
+```ts
+import { appRouter } from "./root";
 
-    gateway = module.get<ReviewsGateway>(ReviewsGateway);
-    // Inject the mock server (NestJS sets @WebSocketServer() after init,
-    // so assign it directly in unit tests)
-    gateway.server = mockServer;
-  });
+function caller(session: { user: { id: string } } | null) {
+  return appRouter.createCaller({ session: session as never, headers: new Headers() });
+}
 
-  afterEach(() => {
-    jest.clearAllMocks();
-  });
-
-  describe('handleJoinCourse', () => {
-    it('should join the client to the correct room', () => {
-      gateway.handleJoinCourse(mockClient, { courseCode: 'DD1337' });
-      expect(mockClient.join).toHaveBeenCalledWith('course:DD1337');
-    });
-
-    it('should do nothing if courseCode is missing', () => {
-      gateway.handleJoinCourse(mockClient, { courseCode: '' });
-      expect(mockClient.join).not.toHaveBeenCalled();
-    });
-  });
-
-  describe('emitCourseChanged', () => {
-    it('should emit reviews.changed to the correct room', () => {
-      gateway.emitCourseChanged('DD1337');
-      expect(mockServer.to).toHaveBeenCalledWith('course:DD1337');
-      expect(mockEmit).toHaveBeenCalledWith('reviews.changed', { courseCode: 'DD1337' });
-    });
-  });
+it("rejects visitors on user.delete", async () => {
+  await expect(caller(null).user.delete()).rejects.toMatchObject({ code: "UNAUTHORIZED" });
 });
 ```
 
-### Integration tests — real app + socket.io-client
+`server/api/protected.spec.ts` is the canonical example. **Every new `protectedProcedure` should gain a case there** — a procedure that silently drops to `baseProcedure` is exactly the regression this file exists to catch. Assert the visitor-reachable procedures too, so the gate cannot be widened by accident.
 
-For full end-to-end socket testing, spin up a real `INestApplication` and connect with a real client. This is heavier but validates transport-level behaviour:
+## Component tests
 
-```ts
-import { io, Socket } from 'socket.io-client';
-import { INestApplication } from '@nestjs/common';
-import { Test } from '@nestjs/testing';
-import { ReviewsModule } from './reviews.module';
+`.spec.tsx` under `features/`, jsdom, `@testing-library/react` plus `@testing-library/jest-dom` matchers (loaded by `vitest.setup.ts`):
 
-describe('ReviewsGateway (integration)', () => {
-  let app: INestApplication;
-  let client: Socket;
-
-  beforeAll(async () => {
-    const module = await Test.createTestingModule({
-      imports: [ReviewsModule],
-    }).compile();
-    app = module.createNestApplication();
-    await app.listen(0); // random free port
-    const port = app.getHttpServer().address().port;
-    client = io(`http://localhost:${port}/reviews`, {
-      autoConnect: false,
-      transports: ['websocket'],
-    });
-  });
-
-  afterAll(async () => {
-    client.disconnect();
-    await app.close();
-  });
-
-  it('should join and receive reviews.changed', async () => {
-    await new Promise<void>((resolve) => {
-      client.connect();
-      client.on('connect', () => resolve());
-    });
-
-    client.emit('joinCourse', { courseCode: 'DD1337' });
-
-    // Trigger the gateway method server-side to simulate a review being posted
-    const gateway = app.get(ReviewsGateway);
-    await new Promise<void>((resolve, reject) => {
-      client.on('reviews.changed', (data) => {
-        try {
-          expect(data.courseCode).toBe('DD1337');
-          resolve();
-        } catch (e) {
-          reject(e);
-        }
-      });
-      gateway.emitCourseChanged('DD1337');
-    });
-  });
-});
+```tsx
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 ```
 
-Use `app.listen(0)` to avoid port conflicts in parallel test runs. Wrap socket event assertions in `try/catch` inside Promise handlers so test failures propagate as rejections rather than timeouts.
-
-## Frontend test patterns
-
-The frontend has no Jest configured yet. When adding tests:
-
-- Use `next/jest` as the config wrapper — it handles SWC transforms, CSS/image mocking, `.env` loading, and TypeScript automatically:
-
-```ts
-// jest.config.ts
-import type { Config } from 'jest';
-import nextJest from 'next/jest.js';
-
-const createJestConfig = nextJest({ dir: './' });
-const config: Config = {
-  testEnvironment: 'jsdom',
-  setupFilesAfterEnv: ['<rootDir>/jest.setup.ts'],
-};
-export default createJestConfig(config);
-```
-
-- **Async Server Components** (`async function Page()`) cannot be unit-tested with Jest or React Testing Library — Jest runs in jsdom which cannot execute server-only code. Extract business logic into pure functions and test those; test the rendered page with E2E (Playwright).
-- **Client Components and synchronous Server Components** can be tested normally with `@testing-library/react`.
-
-### Redux thunks
-
-For Redux thunks, test with a real store configured with `configureStore` and the relevant reducers. Use `store.dispatch(thunk(...))` and assert on `store.getState()`:
-
-```ts
-const store = configureStore({ reducer: { search: searchReducer } });
-await store.dispatch(executeSearchThunk({ query: 'algorithms' }));
-expect(store.getState().search.results).toHaveLength(3);
-```
-
-The official Redux recommendation (as of RTK v2) is to **not unit-test thunks in isolation** — thunk logic is an implementation detail. Instead:
-- Test thunks indirectly by asserting on resulting state after dispatch
-- For thunks that make API calls, mock at the network level with **MSW** (`msw/node`) rather than mocking fetch or Axios directly — this gives more confidence and avoids over-specifying implementation
-
-```ts
-// Preferred: mock the API at the network level
-import { setupServer } from 'msw/node';
-import { http, HttpResponse } from 'msw';
-
-const server = setupServer(
-  http.get('/search', () => HttpResponse.json({ hits: [] }))
-);
-beforeAll(() => server.listen());
-afterEach(() => server.resetHandlers());
-afterAll(() => server.close());
-```
-
-### Redux slices
-
-For slices, test the reducer function directly — no store needed:
-
-```ts
-const result = reviewSlice.reducer(initialState, action);
-expect(result.loading).toBe(false);
-```
-
-Do not test generated action creators — RTK tests those internally.
-
-## Jest 30 specifics (backend is on Jest 30)
-
-The backend runs Jest ^30.1.3. Key things that changed from Jest 29:
-
-### Removed matcher aliases — use the primary names
-
-```ts
-// Removed in Jest 30 → Use instead
-expect(fn).toBeCalled()              → expect(fn).toHaveBeenCalled()
-expect(fn).toBeCalledTimes(n)        → expect(fn).toHaveBeenCalledTimes(n)
-expect(fn).toBeCalledWith(arg)       → expect(fn).toHaveBeenCalledWith(arg)
-expect(fn).lastCalledWith(arg)       → expect(fn).toHaveBeenLastCalledWith(arg)
-expect(fn).toReturn()                → expect(fn).toHaveReturned()
-expect(fn).toReturnTimes(n)          → expect(fn).toHaveReturnedTimes(n)
-expect(fn).toReturnWith(val)         → expect(fn).toHaveReturnedWith(val)
-expect(func).toThrowError(msg)       → expect(func).toThrow(msg)
-```
-
-### New features worth using
-
-**`expect.arrayOf()` — assert array contents by type:**
-```ts
-expect(results).toEqual(expect.arrayOf(expect.any(String)));
-```
-
-**Auto-restoring spies with `using` (requires TypeScript 5.2+ with `useUnknownInCatchVariables`):**
-```ts
-test('logs on error', () => {
-  using spy = jest.spyOn(console, 'error');
-  triggerError();
-  expect(spy).toHaveBeenCalled();
-  // spy is automatically restored when the block exits — no mockRestore() needed
-});
-```
-
-**Configurable retry delays:**
-```ts
-jest.retryTimes(3, { waitBeforeRetry: 500 }); // ms between retries
-```
-
-**`--testPathPattern` CLI flag is now `--testPathPatterns`** (note the plural).
-
-**`jest.genMockFromModule()` is removed — use `jest.createMockFromModule()`.**
+- Query by role and accessible name (`getByRole("button", { name: /save/i })`), not by test id or class.
+- Async Server Components (`async function Page()`) cannot be rendered in jsdom. Extract the logic into a pure function under `lib/` and test that in the `logic` project.
+- Drive interaction through `userEvent`, not `fireEvent`.
 
 ## What makes a good test
-- Tests a real behaviour, not a mock round-trip
-- Covers the happy path AND at least one failure/edge case
-- Uses descriptive names: `should return empty array when no courses found`
-- Does not reach into implementation details that could change without breaking the contract
+
+- Tests a real behaviour, not a mock round-trip. If deleting the service body still passes the test, the test is worthless.
+- Covers the happy path AND at least one failure or edge case.
+- Descriptive names: `rejects a collection course the owner has not saved`.
+- Asserts on return values and thrown errors. Assert that a mock was *called* only when the call itself is the contract (e.g. the right row was inserted).
+- Does not reach into implementation details that could change without breaking the contract.
 
 ## Running tests
-Always run tests after writing them to confirm they pass:
+
+Always run tests after writing them:
+
 ```bash
-bun run test:be   # backend only
-bun run test      # all
+bun run test:web          # all three projects
+bun run typecheck         # tsc --noEmit, also required before a PR
 ```
+
+To iterate on one project: `cd apps/web && npx vitest run --project server`.
 
 If a test fails, diagnose the root cause — do not adjust the assertion to make it pass unless the assertion was genuinely wrong.
 
-## Reference Documentation
+## Reference
 
-- **Jest 30 release notes:** https://jestjs.io/blog/2025/06/04/jest-30
-- **Jest 29 → 30 upgrade guide:** https://jestjs.io/docs/upgrading-to-jest30
-- **Jest configuration reference:** https://jestjs.io/docs/configuration
-- **NestJS testing guide (official):** https://docs.nestjs.com/fundamentals/testing
-- **NestJS WebSocket gateways:** https://docs.nestjs.com/websockets/gateways
-- **Redux official testing guide:** https://redux.js.org/usage/writing-tests
-- **RTK usage guide:** https://redux-toolkit.js.org/usage/usage-guide
-- **React Testing Library:** https://testing-library.com/docs/react-testing-library/intro/
-- **Next.js Jest setup (App Router):** https://nextjs.org/docs/app/guides/testing/jest
-- **Mock Service Worker (MSW):** https://mswjs.io/docs/
+- Vitest: https://vitest.dev/guide/
+- Testing Library: https://testing-library.com/docs/react-testing-library/intro/
+- tRPC server-side calls: https://trpc.io/docs/server/server-side-calls

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -44,3 +44,27 @@ jobs:
         run: bun install --frozen-lockfile
       - name: Run tests
         run: bun run test:web
+
+  typecheck:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          persist-credentials: false
+      - name: Set up Bun
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
+        with:
+          bun-version: 1.3.14
+      - name: Set up Node.js
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+        with:
+          # jsdom 30 (component tests) needs >=22.22; undici 8 calls
+          # worker_threads.markAsUncloneable, added in Node 22.10.
+          node-version: 24
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+      - name: Typecheck
+        run: bun run typecheck

--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,7 @@ pnpm-lock.yaml
 # TypeScript build artifacts (all packages)
 *.tsbuildinfo
 *.js.map
+dist/
 
 # Next.js auto-generated type file
 next-env.d.ts
@@ -56,59 +57,6 @@ next-env.d.ts
 
 # history
 /apps/web/.history
-
-# =================================
-# BACKEND (Nest.js)
-# =================================
-
-# compiled output
-dist/
-/apps/backend-nest/build
-/apps/backend-nest/**/*.d.ts
-
-# logs
-/apps/backend-nest/logs
-/apps/backend-nest/*.log
-/apps/backend-nest/npm-debug.log*
-/apps/backend-nest/pnpm-debug.log*
-/apps/backend-nest/yarn-debug.log*
-/apps/backend-nest/yarn-error.log*
-/apps/backend-nest/lerna-debug.log*
-
-# testing
-/apps/backend-nest/coverage
-/apps/backend-nest/.nyc_output
-
-# IDEs and editors
-/apps/backend-nest/.idea
-/apps/backend-nest/.project
-/apps/backend-nest/.classpath
-/apps/backend-nest/.c9/
-/apps/backend-nest/*.launch
-/apps/backend-nest/.settings/
-/apps/backend-nest/*.sublime-workspace
-
-# IDE - VSCode
-/apps/backend-nest/.vscode/*
-!/apps/backend-nest/.vscode/settings.json
-!/apps/backend-nest/.vscode/tasks.json
-!/apps/backend-nest/.vscode/launch.json
-!/apps/backend-nest/.vscode/extensions.json
-
-# temp directory
-/apps/backend-nest/.temp
-/apps/backend-nest/.tmp
-
-# runtime data
-/apps/backend-nest/pids
-/apps/backend-nest/*.pid
-/apps/backend-nest/*.seed
-/apps/backend-nest/*.pid.lock
-
-# diagnostic reports
-/apps/backend-nest/report.[0-9]*.[0-9]*.[0-9]*.[0-9]*.json
-
-/elastic-start-local
 
 # =================================
 # SENSITIVE FILES

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -7,6 +7,7 @@
     "build": "next build",
     "start": "next start",
     "test": "vitest run",
+    "typecheck": "tsc --noEmit",
     "lint": "biome check",
     "format": "biome format --write",
     "ingest": "bun --env-file=.env.local scripts/ingest.ts",

--- a/biome.json
+++ b/biome.json
@@ -67,7 +67,7 @@
       }
     },
     {
-      "includes": ["apps/web/server/*/router.ts"],
+      "includes": ["apps/web/server/**/router.ts"],
       "linter": {
         "rules": {
           "style": {
@@ -80,7 +80,11 @@
                     "message": "Routers must not reach into a repository. Call the domain service instead (router -> service -> repository)."
                   },
                   {
-                    "group": ["../*/router", "@/server/*/router"],
+                    "group": [
+                      "../*/router",
+                      "../../*/router",
+                      "@/server/*/router"
+                    ],
                     "message": "Routers must not import another domain's router. Compose routers in server/api/root.ts."
                   }
                 ]
@@ -91,7 +95,7 @@
       }
     },
     {
-      "includes": ["apps/web/server/*/repository.ts"],
+      "includes": ["apps/web/server/**/repository.ts"],
       "linter": {
         "rules": {
           "style": {

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
   "scripts": {
     "test": "bun run test:web",
     "test:web": "bun run --filter kth-course-community-web test",
+    "typecheck": "bun run --filter kth-course-community-web typecheck",
     "lint": "biome check --fix",
     "format": "biome format --write",
     "build": "echo 'Run build from /apps/web instead'",


### PR DESCRIPTION
Pre-flight for the A–D issue set (#62–#66). Three things in the repo still described the NestJS backend that ADR 0002 replaced, and two of the gates those issues declare were not actually enforced.

## The agent definitions described a stack that no longer exists

`.claude/agents/` is live configuration — these files are what the `reviewer`, `security`, `tester` and `implementer` subagents read before touching anything. All four documented the old Nest app:

- a global `AuthGuard` with `@AllowAnonymous()` opt-outs, and `apps/backend-nest/src/auth/auth.ts`
- Jest 30 with NestJS `TestingModule`, and E2E tests in `apps/backend-nest/test/` via `jest-e2e.json`
- a Socket.IO `ReviewsGateway` with room names and integration tests
- Redux Toolkit thunks and slices, MSW, `next/jest`
- Multer uploads, Elasticsearch, a `types/` package, ESLint

None of that is in the dependency tree. An agent following these would have gone looking through a directory that isn't in the repo.

Rewritten against what is actually here: tRPC procedures and `protectedProcedure`, Vitest's three projects (`server` / `logic` / `ui`), the `vi.mock("./repository")` pattern the existing specs use, `createMockDb()` for repository tests, `createCaller` for auth tests, Better Auth, Biome, and the `router → service → repository` layering.

The security agent's threat list is the biggest cut. The Multer, NestJS `FileTypeValidator`, Socket.IO and Nest DevTools CVEs cannot apply to a tree without those packages. What replaces them is the surface this app really has — and the important inversion is that **protection is opt-*in* now**: a tRPC procedure is public unless it is built on `protectedProcedure`, so the bug to hunt is an omission, not an over-broad exemption. It also flags the transcript import (#66) as the sensitive upload path, since a Ladok transcript is a student's academic record.

## `npx tsc --noEmit` was in every issue but nothing ran it

Each of #62–#66 lists it under "Done when", but there was no `typecheck` script and CI ran only `biome ci .` and `bun run test:web`. Adds the script at both levels and a matching CI job, so the gate is enforced instead of honour-system. The baseline is clean today, which is why this is the moment to lock it in.

## The Biome layering rules had a one-level blind spot

The overrides globbed `apps/web/server/*/router.ts`. Biome's `*` does not cross `/`, so a nested domain escaped the `router → repository` check entirely — including `server/ingest/transcript/`, which is exactly where #66 puts its files. Widened to `**`, and added `../../*/router` to the cross-domain group so a nested router cannot reach a sibling domain's router either.

Verified by planting a nested `server/ingest/transcript/router.ts` importing its own repository: the rule now fires. (Temp files removed.)

## Also

45 stale `/apps/backend-nest/...` ignore rules for a path that no longer exists, plus `/elastic-start-local`. `dist/` was only defined inside that block, so it is kept as a generic root rule.

## Verification

| Check | Result |
|---|---|
| `bun run lint` | clean (12 pre-existing `<img>` warnings, unchanged) |
| `bun run typecheck` | clean, via the new script |
| `bun run test:web` | 6 files, 28 tests passed |

No application code is touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CG2LSTLcZ4p5b17HXR3E1Z