### PR TITLE
feat(db): add target schema compatibility migrations

### DIFF
--- a/apps/web/server/db/auth-schema.ts
+++ b/apps/web/server/db/auth-schema.ts
@@ -21,8 +21,10 @@ export const users = pgTable(
     personalizationTierEarned: smallint("personalization_tier_earned")
       .default(0)
       .notNull(),
-    createdAt: timestamp("created_at").defaultNow().notNull(),
-    updatedAt: timestamp("updated_at")
+    createdAt: timestamp("created_at", { withTimezone: true })
+      .defaultNow()
+      .notNull(),
+    updatedAt: timestamp("updated_at", { withTimezone: true })
       .defaultNow()
       .$onUpdate(() => /* @__PURE__ */ new Date())
       .notNull(),

--- a/apps/web/server/db/drizzle/0006_target-schema.sql
+++ b/apps/web/server/db/drizzle/0006_target-schema.sql
@@ -6,26 +6,10 @@
 DO $$
 BEGIN
 	IF EXISTS (
-		SELECT 1 FROM "reviews"
-		WHERE "workload" NOT BETWEEN 1 AND 10
-			OR "learning_experience" NOT BETWEEN 1 AND 10
-	) THEN
-		RAISE EXCEPTION 'Cannot migrate reviews: workload and learning_experience must be between 1 and 10';
-	END IF;
-
-	IF EXISTS (
 		SELECT 1 FROM "review_likes"
 		WHERE "vote_type" NOT IN ('like', 'dislike')
 	) THEN
 		RAISE EXCEPTION 'Cannot migrate review_likes: unsupported vote_type found';
-	END IF;
-
-	IF EXISTS (
-		SELECT 1 FROM "course_rounds"
-		WHERE "study_pace" IS NOT NULL
-			AND "study_pace" NOT BETWEEN 1 AND 100
-	) THEN
-		RAISE EXCEPTION 'Cannot migrate course_rounds: study_pace must be between 1 and 100';
 	END IF;
 END
 $$;--> statement-breakpoint
@@ -133,8 +117,8 @@ ALTER TABLE "users" ALTER COLUMN "updated_at" SET DEFAULT now();--> statement-br
 ALTER TABLE "courses" ADD COLUMN "created_at" timestamp with time zone DEFAULT now() NOT NULL;--> statement-breakpoint
 ALTER TABLE "reviews" ADD COLUMN "examination_distribution" jsonb;--> statement-breakpoint
 ALTER TABLE "reviews" ADD COLUMN "approach_theory_percent" integer;--> statement-breakpoint
-ALTER TABLE "reviews" ADD COLUMN "workload_score" integer DEFAULT 1 NOT NULL;--> statement-breakpoint
-ALTER TABLE "reviews" ADD COLUMN "learning_score" integer DEFAULT 1 NOT NULL;--> statement-breakpoint
+ALTER TABLE "reviews" ADD COLUMN "workload_score" integer;--> statement-breakpoint
+ALTER TABLE "reviews" ADD COLUMN "learning_score" integer;--> statement-breakpoint
 ALTER TABLE "reviews" ADD COLUMN "happy_took" boolean DEFAULT false NOT NULL;--> statement-breakpoint
 ALTER TABLE "reviews" ADD COLUMN "message" text;--> statement-breakpoint
 ALTER TABLE "users" ADD COLUMN "personalization_tier_earned" smallint DEFAULT 0 NOT NULL;--> statement-breakpoint
@@ -201,11 +185,17 @@ FROM "courses";--> statement-breakpoint
 
 -- The old integer answers cannot safely become a distribution or percentage,
 -- so those target columns intentionally remain NULL. Directly equivalent data
--- is copied and empty comments become NULL.
+-- is copied when valid, and empty comments become NULL.
 UPDATE "reviews"
 SET
-	"workload_score" = "workload",
-	"learning_score" = "learning_experience",
+	"workload_score" = CASE
+		WHEN "workload" BETWEEN 1 AND 10 THEN "workload"
+		ELSE NULL
+	END,
+	"learning_score" = CASE
+		WHEN "learning_experience" BETWEEN 1 AND 10 THEN "learning_experience"
+		ELSE NULL
+	END,
 	"happy_took" = "would_recommend",
 	"message" = NULLIF("content", '');--> statement-breakpoint
 
@@ -215,8 +205,14 @@ RETURNS trigger
 LANGUAGE plpgsql
 AS $$
 BEGIN
-	NEW."workload_score" := NEW."workload";
-	NEW."learning_score" := NEW."learning_experience";
+	NEW."workload_score" := CASE
+		WHEN NEW."workload" BETWEEN 1 AND 10 THEN NEW."workload"
+		ELSE NULL
+	END;
+	NEW."learning_score" := CASE
+		WHEN NEW."learning_experience" BETWEEN 1 AND 10 THEN NEW."learning_experience"
+		ELSE NULL
+	END;
 	NEW."happy_took" := NEW."would_recommend";
 	NEW."message" := NULLIF(NEW."content", '');
 	RETURN NEW;
@@ -255,6 +251,10 @@ CREATE INDEX "course_explore_search_vector_idx" ON "course_explore" USING gin ("
 CREATE INDEX "course_explore_embedding_idx" ON "course_explore" USING hnsw ("embedding" vector_cosine_ops);--> statement-breakpoint
 ALTER TABLE "course_examinations" ADD CONSTRAINT "course_examinations_course_code_courses_code_fk" FOREIGN KEY ("course_code") REFERENCES "public"."courses"("code") ON DELETE restrict ON UPDATE no action;--> statement-breakpoint
 ALTER TABLE "course_rounds" ADD CONSTRAINT "course_rounds_course_code_courses_code_fk" FOREIGN KEY ("course_code") REFERENCES "public"."courses"("code") ON DELETE restrict ON UPDATE no action;--> statement-breakpoint
+UPDATE "course_rounds"
+SET "study_pace" = NULL
+WHERE "study_pace" IS NOT NULL
+	AND "study_pace" NOT BETWEEN 1 AND 100;--> statement-breakpoint
 ALTER TABLE "course_rounds" ADD CONSTRAINT "study_pace_range" CHECK ("course_rounds"."study_pace" between 1 and 100);--> statement-breakpoint
 ALTER TABLE "reviews" ADD CONSTRAINT "approach_theory_percent_range" CHECK ("reviews"."approach_theory_percent" between 0 and 100);--> statement-breakpoint
 ALTER TABLE "reviews" ADD CONSTRAINT "workload_score_range" CHECK ("reviews"."workload_score" between 1 and 10);--> statement-breakpoint

--- a/apps/web/server/db/drizzle/0006_target-schema.sql
+++ b/apps/web/server/db/drizzle/0006_target-schema.sql
@@ -1,0 +1,262 @@
+-- Data-preserving compatibility migration for issue #63.
+-- Legacy tables/columns stay readable until their repositories switch in B.
+-- course_rounds.round_code is deliberately gated: the current rows do not store
+-- KOPPS round.ladokUID, and the serial id is not stable across re-ingestion.
+-- The final PK change must follow a source-backed round rebuild, never id::text.
+DO $$
+BEGIN
+	IF EXISTS (
+		SELECT 1 FROM "reviews"
+		WHERE "workload" NOT BETWEEN 1 AND 10
+			OR "learning_experience" NOT BETWEEN 1 AND 10
+	) THEN
+		RAISE EXCEPTION 'Cannot migrate reviews: workload and learning_experience must be between 1 and 10';
+	END IF;
+
+	IF EXISTS (
+		SELECT 1 FROM "review_likes"
+		WHERE "vote_type" NOT IN ('like', 'dislike')
+	) THEN
+		RAISE EXCEPTION 'Cannot migrate review_likes: unsupported vote_type found';
+	END IF;
+
+	IF EXISTS (
+		SELECT 1 FROM "course_rounds"
+		WHERE "study_pace" IS NOT NULL
+			AND "study_pace" NOT BETWEEN 1 AND 100
+	) THEN
+		RAISE EXCEPTION 'Cannot migrate course_rounds: study_pace must be between 1 and 100';
+	END IF;
+END
+$$;--> statement-breakpoint
+CREATE TYPE "public"."node_signal_style" AS ENUM('default');--> statement-breakpoint
+CREATE TYPE "public"."node_style" AS ENUM('default');--> statement-breakpoint
+CREATE TYPE "public"."review_vote_type" AS ENUM('up', 'down');--> statement-breakpoint
+CREATE TABLE "collection_courses" (
+	"collection_id" text NOT NULL,
+	"collection_user_id" text NOT NULL,
+	"course_code" text NOT NULL,
+	"position" integer NOT NULL,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	CONSTRAINT "collection_courses_collection_id_course_code_pk" PRIMARY KEY("collection_id","course_code"),
+	CONSTRAINT "position_nonnegative" CHECK ("collection_courses"."position" >= 0)
+);
+--> statement-breakpoint
+CREATE TABLE "collections" (
+	"id" text PRIMARY KEY NOT NULL,
+	"user_id" text NOT NULL,
+	"name" text NOT NULL,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	CONSTRAINT "collections_id_user_id_unique" UNIQUE("id","user_id")
+);
+--> statement-breakpoint
+CREATE TABLE "course_explore" (
+	"course_code" text PRIMARY KEY NOT NULL,
+	"embedding" vector(1536),
+	"source_hash" text,
+	"search_vector" "tsvector",
+	"embedding_model" text,
+	"embedded_at" timestamp with time zone,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"updated_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+CREATE TABLE "course_prerequisites" (
+	"course_code" text NOT NULL,
+	"prerequisite_course_code" text NOT NULL,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	CONSTRAINT "course_prerequisites_course_code_prerequisite_course_code_pk" PRIMARY KEY("course_code","prerequisite_course_code")
+);
+--> statement-breakpoint
+CREATE TABLE "review_votes" (
+	"voter_user_id" text NOT NULL,
+	"review_id" text NOT NULL,
+	"vote_type" "review_vote_type" NOT NULL,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"updated_at" timestamp with time zone DEFAULT now() NOT NULL,
+	CONSTRAINT "review_votes_voter_user_id_review_id_pk" PRIMARY KEY("voter_user_id","review_id")
+);
+--> statement-breakpoint
+CREATE TABLE "user_saved_courses" (
+	"user_id" text NOT NULL,
+	"course_code" text NOT NULL,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	CONSTRAINT "user_saved_courses_user_id_course_code_pk" PRIMARY KEY("user_id","course_code")
+);
+--> statement-breakpoint
+CREATE TABLE "user_taken_courses" (
+	"user_id" text NOT NULL,
+	"course_code" text NOT NULL,
+	"attendance_periods" text,
+	"attendance_year" integer,
+	"grade" text,
+	"earned_credits" real,
+	"transcript_imported_at" timestamp with time zone,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"updated_at" timestamp with time zone DEFAULT now() NOT NULL,
+	CONSTRAINT "user_taken_courses_user_id_course_code_pk" PRIMARY KEY("user_id","course_code")
+);
+--> statement-breakpoint
+CREATE TABLE "users_graph_backbone_edges" (
+	"node_user_id" text NOT NULL,
+	"anchor_user_id" text NOT NULL,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	CONSTRAINT "users_graph_backbone_edges_node_user_id_anchor_user_id_pk" PRIMARY KEY("node_user_id","anchor_user_id"),
+	CONSTRAINT "no_self_backbone_edge" CHECK ("users_graph_backbone_edges"."node_user_id" <> "users_graph_backbone_edges"."anchor_user_id")
+);
+--> statement-breakpoint
+CREATE TABLE "users_graph_nodes" (
+	"user_id" text PRIMARY KEY NOT NULL,
+	"x" double precision NOT NULL,
+	"y" double precision NOT NULL,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"updated_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+CREATE TABLE "users_node_profiles" (
+	"user_id" text PRIMARY KEY NOT NULL,
+	"color" text DEFAULT 'default' NOT NULL,
+	"style" "node_style" DEFAULT 'default' NOT NULL,
+	"signal_style" "node_signal_style" DEFAULT 'default' NOT NULL,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"updated_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+ALTER TABLE "course_examinations" DROP CONSTRAINT "course_examinations_course_code_courses_code_fk";
+--> statement-breakpoint
+ALTER TABLE "course_rounds" DROP CONSTRAINT "course_rounds_course_code_courses_code_fk";
+--> statement-breakpoint
+ALTER TABLE "users" ALTER COLUMN "created_at" SET DATA TYPE timestamp with time zone USING "created_at" AT TIME ZONE 'UTC';--> statement-breakpoint
+ALTER TABLE "users" ALTER COLUMN "created_at" SET DEFAULT now();--> statement-breakpoint
+ALTER TABLE "users" ALTER COLUMN "updated_at" SET DATA TYPE timestamp with time zone USING "updated_at" AT TIME ZONE 'UTC';--> statement-breakpoint
+ALTER TABLE "users" ALTER COLUMN "updated_at" SET DEFAULT now();--> statement-breakpoint
+ALTER TABLE "courses" ADD COLUMN "created_at" timestamp with time zone DEFAULT now() NOT NULL;--> statement-breakpoint
+ALTER TABLE "reviews" ADD COLUMN "examination_distribution" jsonb;--> statement-breakpoint
+ALTER TABLE "reviews" ADD COLUMN "approach_theory_percent" integer;--> statement-breakpoint
+ALTER TABLE "reviews" ADD COLUMN "workload_score" integer DEFAULT 1 NOT NULL;--> statement-breakpoint
+ALTER TABLE "reviews" ADD COLUMN "learning_score" integer DEFAULT 1 NOT NULL;--> statement-breakpoint
+ALTER TABLE "reviews" ADD COLUMN "happy_took" boolean DEFAULT false NOT NULL;--> statement-breakpoint
+ALTER TABLE "reviews" ADD COLUMN "message" text;--> statement-breakpoint
+ALTER TABLE "users" ADD COLUMN "personalization_tier_earned" smallint DEFAULT 0 NOT NULL;--> statement-breakpoint
+ALTER TABLE "collection_courses" ADD CONSTRAINT "collection_courses_collection_owner_fk" FOREIGN KEY ("collection_id","collection_user_id") REFERENCES "public"."collections"("id","user_id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "collection_courses" ADD CONSTRAINT "collection_courses_saved_course_fk" FOREIGN KEY ("collection_user_id","course_code") REFERENCES "public"."user_saved_courses"("user_id","course_code") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "collections" ADD CONSTRAINT "collections_user_id_users_id_fk" FOREIGN KEY ("user_id") REFERENCES "public"."users"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "course_explore" ADD CONSTRAINT "course_explore_course_code_courses_code_fk" FOREIGN KEY ("course_code") REFERENCES "public"."courses"("code") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "course_prerequisites" ADD CONSTRAINT "course_prerequisites_course_code_courses_code_fk" FOREIGN KEY ("course_code") REFERENCES "public"."courses"("code") ON DELETE restrict ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "course_prerequisites" ADD CONSTRAINT "course_prerequisites_prerequisite_course_code_courses_code_fk" FOREIGN KEY ("prerequisite_course_code") REFERENCES "public"."courses"("code") ON DELETE restrict ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "review_votes" ADD CONSTRAINT "review_votes_voter_user_id_users_id_fk" FOREIGN KEY ("voter_user_id") REFERENCES "public"."users"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "review_votes" ADD CONSTRAINT "review_votes_review_id_reviews_id_fk" FOREIGN KEY ("review_id") REFERENCES "public"."reviews"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "user_saved_courses" ADD CONSTRAINT "user_saved_courses_user_id_users_id_fk" FOREIGN KEY ("user_id") REFERENCES "public"."users"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "user_saved_courses" ADD CONSTRAINT "user_saved_courses_course_code_courses_code_fk" FOREIGN KEY ("course_code") REFERENCES "public"."courses"("code") ON DELETE restrict ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "user_taken_courses" ADD CONSTRAINT "user_taken_courses_user_id_users_id_fk" FOREIGN KEY ("user_id") REFERENCES "public"."users"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "user_taken_courses" ADD CONSTRAINT "user_taken_courses_course_code_courses_code_fk" FOREIGN KEY ("course_code") REFERENCES "public"."courses"("code") ON DELETE restrict ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "users_graph_backbone_edges" ADD CONSTRAINT "users_graph_backbone_edges_node_user_id_users_graph_nodes_user_id_fk" FOREIGN KEY ("node_user_id") REFERENCES "public"."users_graph_nodes"("user_id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "users_graph_backbone_edges" ADD CONSTRAINT "users_graph_backbone_edges_anchor_user_id_users_graph_nodes_user_id_fk" FOREIGN KEY ("anchor_user_id") REFERENCES "public"."users_graph_nodes"("user_id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "users_graph_nodes" ADD CONSTRAINT "users_graph_nodes_user_id_users_id_fk" FOREIGN KEY ("user_id") REFERENCES "public"."users"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "users_node_profiles" ADD CONSTRAINT "users_node_profiles_user_id_users_id_fk" FOREIGN KEY ("user_id") REFERENCES "public"."users"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+
+-- Favorites always represented courses kept for later, so preserve every row.
+INSERT INTO "user_saved_courses" ("user_id", "course_code", "created_at")
+SELECT "user_id", "fav_course_code", "created_at"
+FROM "user_favorites";--> statement-breakpoint
+
+-- Preserve review votes while translating the legacy vocabulary.
+INSERT INTO "review_votes" (
+	"voter_user_id",
+	"review_id",
+	"vote_type",
+	"created_at",
+	"updated_at"
+)
+SELECT
+	"user_id",
+	"review_id",
+	CASE "vote_type"
+		WHEN 'like' THEN 'up'::"review_vote_type"
+		WHEN 'dislike' THEN 'down'::"review_vote_type"
+	END,
+	"created_at",
+	"created_at"
+FROM "review_likes";--> statement-breakpoint
+
+-- Move the existing derived search state without requiring a re-ingest.
+-- Legacy course columns remain until search repositories switch over.
+INSERT INTO "course_explore" (
+	"course_code",
+	"embedding",
+	"source_hash",
+	"search_vector",
+	"embedding_model"
+)
+SELECT
+	"code",
+	"embedding",
+	"embedding_hash",
+	"search_vector",
+	CASE
+		WHEN "embedding" IS NOT NULL THEN 'openai/text-embedding-3-small'
+		ELSE NULL
+	END
+FROM "courses";--> statement-breakpoint
+
+-- The old integer answers cannot safely become a distribution or percentage,
+-- so those target columns intentionally remain NULL. Directly equivalent data
+-- is copied and empty comments become NULL.
+UPDATE "reviews"
+SET
+	"workload_score" = "workload",
+	"learning_score" = "learning_experience",
+	"happy_took" = "would_recommend",
+	"message" = NULLIF("content", '');--> statement-breakpoint
+
+-- Keep old application writes valid until B switches the review repository.
+CREATE FUNCTION "sync_legacy_review_fields_to_target"()
+RETURNS trigger
+LANGUAGE plpgsql
+AS $$
+BEGIN
+	NEW."workload_score" := NEW."workload";
+	NEW."learning_score" := NEW."learning_experience";
+	NEW."happy_took" := NEW."would_recommend";
+	NEW."message" := NULLIF(NEW."content", '');
+	RETURN NEW;
+END;
+$$;--> statement-breakpoint
+CREATE TRIGGER "reviews_legacy_target_sync"
+BEFORE INSERT OR UPDATE OF
+	"workload",
+	"learning_experience",
+	"would_recommend",
+	"content"
+ON "reviews"
+FOR EACH ROW
+EXECUTE FUNCTION "sync_legacy_review_fields_to_target"();--> statement-breakpoint
+
+-- Fail rather than silently losing rows if a future source violates assumptions.
+DO $$
+BEGIN
+	IF (SELECT count(*) FROM "user_saved_courses") <>
+		(SELECT count(*) FROM "user_favorites") THEN
+		RAISE EXCEPTION 'user_favorites row preservation check failed';
+	END IF;
+
+	IF (SELECT count(*) FROM "review_votes") <>
+		(SELECT count(*) FROM "review_likes") THEN
+		RAISE EXCEPTION 'review_likes row preservation check failed';
+	END IF;
+
+	IF (SELECT count(*) FROM "course_explore") <>
+		(SELECT count(*) FROM "courses") THEN
+		RAISE EXCEPTION 'course search-state preservation check failed';
+	END IF;
+END
+$$;--> statement-breakpoint
+CREATE INDEX "course_explore_search_vector_idx" ON "course_explore" USING gin ("search_vector");--> statement-breakpoint
+CREATE INDEX "course_explore_embedding_idx" ON "course_explore" USING hnsw ("embedding" vector_cosine_ops);--> statement-breakpoint
+ALTER TABLE "course_examinations" ADD CONSTRAINT "course_examinations_course_code_courses_code_fk" FOREIGN KEY ("course_code") REFERENCES "public"."courses"("code") ON DELETE restrict ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "course_rounds" ADD CONSTRAINT "course_rounds_course_code_courses_code_fk" FOREIGN KEY ("course_code") REFERENCES "public"."courses"("code") ON DELETE restrict ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "course_rounds" ADD CONSTRAINT "study_pace_range" CHECK ("course_rounds"."study_pace" between 1 and 100);--> statement-breakpoint
+ALTER TABLE "reviews" ADD CONSTRAINT "approach_theory_percent_range" CHECK ("reviews"."approach_theory_percent" between 0 and 100);--> statement-breakpoint
+ALTER TABLE "reviews" ADD CONSTRAINT "workload_score_range" CHECK ("reviews"."workload_score" between 1 and 10);--> statement-breakpoint
+ALTER TABLE "reviews" ADD CONSTRAINT "learning_score_range" CHECK ("reviews"."learning_score" between 1 and 10);--> statement-breakpoint
+ALTER TABLE "users" ADD CONSTRAINT "personalization_tier_earned_range" CHECK ("users"."personalization_tier_earned" between 0 and 3);

--- a/apps/web/server/db/drizzle/0007_target-fk-indexes.sql
+++ b/apps/web/server/db/drizzle/0007_target-fk-indexes.sql
@@ -1,0 +1,11 @@
+CREATE INDEX "collection_courses_collection_owner_idx" ON "collection_courses" USING btree ("collection_id","collection_user_id");--> statement-breakpoint
+CREATE INDEX "collection_courses_saved_course_idx" ON "collection_courses" USING btree ("collection_user_id","course_code");--> statement-breakpoint
+CREATE INDEX "collections_user_id_idx" ON "collections" USING btree ("user_id");--> statement-breakpoint
+CREATE INDEX "course_prerequisites_prerequisite_course_code_idx" ON "course_prerequisites" USING btree ("prerequisite_course_code");--> statement-breakpoint
+CREATE INDEX "course_rounds_course_code_idx" ON "course_rounds" USING btree ("course_code");--> statement-breakpoint
+CREATE INDEX "review_votes_review_id_idx" ON "review_votes" USING btree ("review_id");--> statement-breakpoint
+CREATE INDEX "reviews_user_id_idx" ON "reviews" USING btree ("user_id");--> statement-breakpoint
+CREATE INDEX "reviews_course_code_idx" ON "reviews" USING btree ("course_code");--> statement-breakpoint
+CREATE INDEX "user_saved_courses_course_code_idx" ON "user_saved_courses" USING btree ("course_code");--> statement-breakpoint
+CREATE INDEX "user_taken_courses_course_code_idx" ON "user_taken_courses" USING btree ("course_code");--> statement-breakpoint
+CREATE INDEX "users_graph_backbone_edges_anchor_user_id_idx" ON "users_graph_backbone_edges" USING btree ("anchor_user_id");

--- a/apps/web/server/db/drizzle/0008_young_imperial_guard.sql
+++ b/apps/web/server/db/drizzle/0008_young_imperial_guard.sql
@@ -1,0 +1,5 @@
+ALTER TABLE "reviews" DROP CONSTRAINT "reviews_course_code_courses_code_fk";
+--> statement-breakpoint
+ALTER TABLE "course_rounds" ADD COLUMN "round_code" text;--> statement-breakpoint
+ALTER TABLE "reviews" ADD CONSTRAINT "reviews_course_code_courses_code_fk" FOREIGN KEY ("course_code") REFERENCES "public"."courses"("code") ON DELETE restrict ON UPDATE no action;--> statement-breakpoint
+CREATE UNIQUE INDEX "course_rounds_course_code_round_code_unique" ON "course_rounds" USING btree ("course_code","round_code") WHERE "course_rounds"."round_code" is not null;

--- a/apps/web/server/db/drizzle/0009_volatile_kinsey_walden.sql
+++ b/apps/web/server/db/drizzle/0009_volatile_kinsey_walden.sql
@@ -1,5 +1,3 @@
-ALTER TABLE "reviews" ALTER COLUMN "workload_score" SET DEFAULT NULL;--> statement-breakpoint
-ALTER TABLE "reviews" ALTER COLUMN "learning_score" SET DEFAULT NULL;--> statement-breakpoint
 ALTER TABLE "reviews" ALTER COLUMN "happy_took" SET DEFAULT NULL;--> statement-breakpoint
 
 -- Temporary expand/contract compatibility. B must drop these triggers and
@@ -17,10 +15,17 @@ BEGIN
 			AND NEW."happy_took" IS NULL;
 		-- NULL means the target field was omitted; explicit target values win.
 		IF NEW."workload_score" IS NULL THEN
-			NEW."workload_score" := NEW."workload";
+			NEW."workload_score" := CASE
+				WHEN NEW."workload" BETWEEN 1 AND 10 THEN NEW."workload"
+				ELSE NULL
+			END;
 		END IF;
 		IF NEW."learning_score" IS NULL THEN
-			NEW."learning_score" := NEW."learning_experience";
+			NEW."learning_score" := CASE
+				WHEN NEW."learning_experience" BETWEEN 1 AND 10
+					THEN NEW."learning_experience"
+				ELSE NULL
+			END;
 		END IF;
 		IF NEW."happy_took" IS NULL THEN
 			NEW."happy_took" := NEW."would_recommend";
@@ -31,10 +36,17 @@ BEGIN
 	ELSE
 		-- A target-only update must not be replaced by unchanged legacy values.
 		IF NEW."workload" IS DISTINCT FROM OLD."workload" THEN
-			NEW."workload_score" := NEW."workload";
+			NEW."workload_score" := CASE
+				WHEN NEW."workload" BETWEEN 1 AND 10 THEN NEW."workload"
+				ELSE NULL
+			END;
 		END IF;
 		IF NEW."learning_experience" IS DISTINCT FROM OLD."learning_experience" THEN
-			NEW."learning_score" := NEW."learning_experience";
+			NEW."learning_score" := CASE
+				WHEN NEW."learning_experience" BETWEEN 1 AND 10
+					THEN NEW."learning_experience"
+				ELSE NULL
+			END;
 		END IF;
 		IF NEW."would_recommend" IS DISTINCT FROM OLD."would_recommend" THEN
 			NEW."happy_took" := NEW."would_recommend";

--- a/apps/web/server/db/drizzle/0009_volatile_kinsey_walden.sql
+++ b/apps/web/server/db/drizzle/0009_volatile_kinsey_walden.sql
@@ -1,0 +1,203 @@
+ALTER TABLE "reviews" ALTER COLUMN "workload_score" SET DEFAULT NULL;--> statement-breakpoint
+ALTER TABLE "reviews" ALTER COLUMN "learning_score" SET DEFAULT NULL;--> statement-breakpoint
+ALTER TABLE "reviews" ALTER COLUMN "happy_took" SET DEFAULT NULL;--> statement-breakpoint
+
+-- Temporary expand/contract compatibility. B must drop these triggers and
+-- functions after every repository writes the target tables and columns.
+CREATE OR REPLACE FUNCTION "sync_legacy_review_fields_to_target"()
+RETURNS trigger
+LANGUAGE plpgsql
+AS $$
+DECLARE
+	legacy_insert boolean;
+BEGIN
+	IF TG_OP = 'INSERT' THEN
+		legacy_insert := NEW."workload_score" IS NULL
+			AND NEW."learning_score" IS NULL
+			AND NEW."happy_took" IS NULL;
+		-- NULL means the target field was omitted; explicit target values win.
+		IF NEW."workload_score" IS NULL THEN
+			NEW."workload_score" := NEW."workload";
+		END IF;
+		IF NEW."learning_score" IS NULL THEN
+			NEW."learning_score" := NEW."learning_experience";
+		END IF;
+		IF NEW."happy_took" IS NULL THEN
+			NEW."happy_took" := NEW."would_recommend";
+		END IF;
+		IF legacy_insert AND NEW."message" IS NULL THEN
+			NEW."message" := NULLIF(NEW."content", '');
+		END IF;
+	ELSE
+		-- A target-only update must not be replaced by unchanged legacy values.
+		IF NEW."workload" IS DISTINCT FROM OLD."workload" THEN
+			NEW."workload_score" := NEW."workload";
+		END IF;
+		IF NEW."learning_experience" IS DISTINCT FROM OLD."learning_experience" THEN
+			NEW."learning_score" := NEW."learning_experience";
+		END IF;
+		IF NEW."would_recommend" IS DISTINCT FROM OLD."would_recommend" THEN
+			NEW."happy_took" := NEW."would_recommend";
+		END IF;
+		IF NEW."content" IS DISTINCT FROM OLD."content" THEN
+			NEW."message" := NULLIF(NEW."content", '');
+		END IF;
+	END IF;
+	RETURN NEW;
+END;
+$$;--> statement-breakpoint
+
+CREATE FUNCTION "sync_user_favorites_to_saved_courses"()
+RETURNS trigger
+LANGUAGE plpgsql
+AS $$
+BEGIN
+	IF TG_OP = 'DELETE' THEN
+		DELETE FROM "user_saved_courses"
+		WHERE "user_id" = OLD."user_id"
+			AND "course_code" = OLD."fav_course_code";
+		RETURN OLD;
+	END IF;
+
+	IF TG_OP = 'UPDATE'
+		AND (NEW."user_id", NEW."fav_course_code")
+			IS DISTINCT FROM (OLD."user_id", OLD."fav_course_code") THEN
+		DELETE FROM "user_saved_courses"
+		WHERE "user_id" = OLD."user_id"
+			AND "course_code" = OLD."fav_course_code";
+	END IF;
+
+	INSERT INTO "user_saved_courses" ("user_id", "course_code", "created_at")
+	VALUES (NEW."user_id", NEW."fav_course_code", NEW."created_at")
+	ON CONFLICT ("user_id", "course_code") DO UPDATE
+	SET "created_at" = EXCLUDED."created_at";
+	RETURN NEW;
+END;
+$$;--> statement-breakpoint
+CREATE TRIGGER "user_favorites_target_sync"
+AFTER INSERT OR UPDATE OR DELETE
+ON "user_favorites"
+FOR EACH ROW
+EXECUTE FUNCTION "sync_user_favorites_to_saved_courses"();--> statement-breakpoint
+
+CREATE FUNCTION "sync_review_likes_to_votes"()
+RETURNS trigger
+LANGUAGE plpgsql
+AS $$
+DECLARE
+	target_vote_type "review_vote_type";
+BEGIN
+	IF TG_OP = 'DELETE' THEN
+		DELETE FROM "review_votes"
+		WHERE "voter_user_id" = OLD."user_id"
+			AND "review_id" = OLD."review_id";
+		RETURN OLD;
+	END IF;
+
+	target_vote_type := CASE NEW."vote_type"
+		WHEN 'like' THEN 'up'::"review_vote_type"
+		WHEN 'dislike' THEN 'down'::"review_vote_type"
+		ELSE NULL
+	END;
+	IF target_vote_type IS NULL THEN
+		RAISE EXCEPTION 'Unsupported legacy review vote type: %', NEW."vote_type";
+	END IF;
+
+	IF TG_OP = 'UPDATE'
+		AND (NEW."user_id", NEW."review_id")
+			IS DISTINCT FROM (OLD."user_id", OLD."review_id") THEN
+		DELETE FROM "review_votes"
+		WHERE "voter_user_id" = OLD."user_id"
+			AND "review_id" = OLD."review_id";
+	END IF;
+
+	INSERT INTO "review_votes" (
+		"voter_user_id",
+		"review_id",
+		"vote_type",
+		"created_at",
+		"updated_at"
+	)
+	VALUES (
+		NEW."user_id",
+		NEW."review_id",
+		target_vote_type,
+		NEW."created_at",
+		now()
+	)
+	ON CONFLICT ("voter_user_id", "review_id") DO UPDATE
+	SET
+		"vote_type" = EXCLUDED."vote_type",
+		"created_at" = EXCLUDED."created_at",
+		"updated_at" = EXCLUDED."updated_at";
+	RETURN NEW;
+END;
+$$;--> statement-breakpoint
+CREATE TRIGGER "review_likes_target_sync"
+AFTER INSERT OR UPDATE OR DELETE
+ON "review_likes"
+FOR EACH ROW
+EXECUTE FUNCTION "sync_review_likes_to_votes"();--> statement-breakpoint
+
+CREATE FUNCTION "sync_courses_to_course_explore"()
+RETURNS trigger
+LANGUAGE plpgsql
+AS $$
+BEGIN
+	IF TG_OP = 'DELETE' THEN
+		DELETE FROM "course_explore" WHERE "course_code" = OLD."code";
+		RETURN OLD;
+	END IF;
+
+	IF TG_OP = 'UPDATE' AND NEW."code" IS DISTINCT FROM OLD."code" THEN
+		DELETE FROM "course_explore" WHERE "course_code" = OLD."code";
+	END IF;
+
+	INSERT INTO "course_explore" (
+		"course_code",
+		"embedding",
+		"source_hash",
+		"search_vector",
+		"embedding_model",
+		"embedded_at"
+	)
+	VALUES (
+		NEW."code",
+		NEW."embedding",
+		NEW."embedding_hash",
+		NEW."search_vector",
+		CASE
+			WHEN NEW."embedding" IS NOT NULL THEN 'openai/text-embedding-3-small'
+			ELSE NULL
+		END,
+		CASE WHEN NEW."embedding" IS NOT NULL THEN now() ELSE NULL END
+	)
+	ON CONFLICT ("course_code") DO UPDATE
+	SET
+		"embedding" = EXCLUDED."embedding",
+		"source_hash" = EXCLUDED."source_hash",
+		"search_vector" = EXCLUDED."search_vector",
+		"embedding_model" = EXCLUDED."embedding_model",
+		"embedded_at" = CASE
+			WHEN "course_explore"."embedding" IS DISTINCT FROM EXCLUDED."embedding"
+				OR "course_explore"."source_hash" IS DISTINCT FROM EXCLUDED."source_hash"
+			THEN EXCLUDED."embedded_at"
+			ELSE "course_explore"."embedded_at"
+		END,
+		"updated_at" = now();
+	RETURN NEW;
+END;
+$$;--> statement-breakpoint
+CREATE TRIGGER "courses_explore_target_sync"
+AFTER INSERT OR UPDATE OF
+	"code",
+	"name_english",
+	"name_swedish",
+	"goals",
+	"content",
+	"embedding",
+	"embedding_hash"
+OR DELETE
+ON "courses"
+FOR EACH ROW
+EXECUTE FUNCTION "sync_courses_to_course_explore"();

--- a/apps/web/server/db/drizzle/meta/0006_snapshot.json
+++ b/apps/web/server/db/drizzle/meta/0006_snapshot.json
@@ -1,0 +1,1780 @@
+{
+  "id": "d42d91d7-cb97-4f88-a79a-0dffdc9cc91a",
+  "prevId": "d1bce3a4-f687-4e6d-83bd-530c1dddba08",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.collection_courses": {
+      "name": "collection_courses",
+      "schema": "",
+      "columns": {
+        "collection_id": {
+          "name": "collection_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "collection_user_id": {
+          "name": "collection_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "course_code": {
+          "name": "course_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "collection_courses_collection_owner_fk": {
+          "name": "collection_courses_collection_owner_fk",
+          "tableFrom": "collection_courses",
+          "tableTo": "collections",
+          "columnsFrom": ["collection_id", "collection_user_id"],
+          "columnsTo": ["id", "user_id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "collection_courses_saved_course_fk": {
+          "name": "collection_courses_saved_course_fk",
+          "tableFrom": "collection_courses",
+          "tableTo": "user_saved_courses",
+          "columnsFrom": ["collection_user_id", "course_code"],
+          "columnsTo": ["user_id", "course_code"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "collection_courses_collection_id_course_code_pk": {
+          "name": "collection_courses_collection_id_course_code_pk",
+          "columns": ["collection_id", "course_code"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "position_nonnegative": {
+          "name": "position_nonnegative",
+          "value": "\"collection_courses\".\"position\" >= 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.collections": {
+      "name": "collections",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "collections_user_id_users_id_fk": {
+          "name": "collections_user_id_users_id_fk",
+          "tableFrom": "collections",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "collections_id_user_id_unique": {
+          "name": "collections_id_user_id_unique",
+          "nullsNotDistinct": false,
+          "columns": ["id", "user_id"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.course_examinations": {
+      "name": "course_examinations",
+      "schema": "",
+      "columns": {
+        "course_code": {
+          "name": "course_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "exam_code": {
+          "name": "exam_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "credits": {
+          "name": "credits",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "grade_scale_code": {
+          "name": "grade_scale_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "course_examinations_course_code_courses_code_fk": {
+          "name": "course_examinations_course_code_courses_code_fk",
+          "tableFrom": "course_examinations",
+          "tableTo": "courses",
+          "columnsFrom": ["course_code"],
+          "columnsTo": ["code"],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "course_examinations_course_code_exam_code_pk": {
+          "name": "course_examinations_course_code_exam_code_pk",
+          "columns": ["course_code", "exam_code"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.course_explore": {
+      "name": "course_explore",
+      "schema": "",
+      "columns": {
+        "course_code": {
+          "name": "course_code",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "embedding": {
+          "name": "embedding",
+          "type": "vector(1536)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_hash": {
+          "name": "source_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "search_vector": {
+          "name": "search_vector",
+          "type": "tsvector",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "embedding_model": {
+          "name": "embedding_model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "embedded_at": {
+          "name": "embedded_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "course_explore_search_vector_idx": {
+          "name": "course_explore_search_vector_idx",
+          "columns": [
+            {
+              "expression": "search_vector",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        },
+        "course_explore_embedding_idx": {
+          "name": "course_explore_embedding_idx",
+          "columns": [
+            {
+              "expression": "embedding",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "vector_cosine_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "hnsw",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "course_explore_course_code_courses_code_fk": {
+          "name": "course_explore_course_code_courses_code_fk",
+          "tableFrom": "course_explore",
+          "tableTo": "courses",
+          "columnsFrom": ["course_code"],
+          "columnsTo": ["code"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.course_prerequisites": {
+      "name": "course_prerequisites",
+      "schema": "",
+      "columns": {
+        "course_code": {
+          "name": "course_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "prerequisite_course_code": {
+          "name": "prerequisite_course_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "course_prerequisites_course_code_courses_code_fk": {
+          "name": "course_prerequisites_course_code_courses_code_fk",
+          "tableFrom": "course_prerequisites",
+          "tableTo": "courses",
+          "columnsFrom": ["course_code"],
+          "columnsTo": ["code"],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "course_prerequisites_prerequisite_course_code_courses_code_fk": {
+          "name": "course_prerequisites_prerequisite_course_code_courses_code_fk",
+          "tableFrom": "course_prerequisites",
+          "tableTo": "courses",
+          "columnsFrom": ["prerequisite_course_code"],
+          "columnsTo": ["code"],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "course_prerequisites_course_code_prerequisite_course_code_pk": {
+          "name": "course_prerequisites_course_code_prerequisite_course_code_pk",
+          "columns": ["course_code", "prerequisite_course_code"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.course_rounds": {
+      "name": "course_rounds",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "course_code": {
+          "name": "course_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "start_term": {
+          "name": "start_term",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "study_pace": {
+          "name": "study_pace",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "schema_url": {
+          "name": "schema_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "language": {
+          "name": "language",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tutoring_form": {
+          "name": "tutoring_form",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tutoring_time_of_day": {
+          "name": "tutoring_time_of_day",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "formatted_periods_and_credits": {
+          "name": "formatted_periods_and_credits",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_pu": {
+          "name": "is_pu",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_vu": {
+          "name": "is_vu",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "course_rounds_course_code_courses_code_fk": {
+          "name": "course_rounds_course_code_courses_code_fk",
+          "tableFrom": "course_rounds",
+          "tableTo": "courses",
+          "columnsFrom": ["course_code"],
+          "columnsTo": ["code"],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "study_pace_range": {
+          "name": "study_pace_range",
+          "value": "\"course_rounds\".\"study_pace\" between 1 and 100"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.courses": {
+      "name": "courses",
+      "schema": "",
+      "columns": {
+        "code": {
+          "name": "code",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name_swedish": {
+          "name": "name_swedish",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name_english": {
+          "name": "name_english",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "state": {
+          "name": "state",
+          "type": "course_state",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "credits": {
+          "name": "credits",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "credit_unit": {
+          "name": "credit_unit",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "department_code": {
+          "name": "department_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "department": {
+          "name": "department",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "educational_level_code": {
+          "name": "educational_level_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "grade_scale_code": {
+          "name": "grade_scale_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "goals": {
+          "name": "goals",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "eligibility": {
+          "name": "eligibility",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "embedding": {
+          "name": "embedding",
+          "type": "vector(1536)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "embedding_hash": {
+          "name": "embedding_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "search_vector": {
+          "name": "search_vector",
+          "type": "tsvector",
+          "primaryKey": false,
+          "notNull": false,
+          "generated": {
+            "as": "to_tsvector('simple', coalesce(name_english, '') || ' ' || coalesce(name_swedish, '') || ' ' || coalesce(code, '') || ' ' || coalesce(goals, '') || ' ' || coalesce(content, ''))",
+            "type": "stored"
+          }
+        }
+      },
+      "indexes": {
+        "courses_search_vector_idx": {
+          "name": "courses_search_vector_idx",
+          "columns": [
+            {
+              "expression": "search_vector",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        },
+        "courses_embedding_idx": {
+          "name": "courses_embedding_idx",
+          "columns": [
+            {
+              "expression": "embedding",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "vector_cosine_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "hnsw",
+          "with": {}
+        },
+        "courses_name_trgm_idx": {
+          "name": "courses_name_trgm_idx",
+          "columns": [
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "gin_trgm_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        },
+        "courses_code_trgm_idx": {
+          "name": "courses_code_trgm_idx",
+          "columns": [
+            {
+              "expression": "code",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "gin_trgm_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.feedback_form": {
+      "name": "feedback_form",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "message": {
+          "name": "message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.review_likes": {
+      "name": "review_likes",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "review_id": {
+          "name": "review_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "vote_type": {
+          "name": "vote_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "review_likes_user_id_users_id_fk": {
+          "name": "review_likes_user_id_users_id_fk",
+          "tableFrom": "review_likes",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "review_likes_review_id_reviews_id_fk": {
+          "name": "review_likes_review_id_reviews_id_fk",
+          "tableFrom": "review_likes",
+          "tableTo": "reviews",
+          "columnsFrom": ["review_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "review_likes_user_id_review_id_pk": {
+          "name": "review_likes_user_id_review_id_pk",
+          "columns": ["user_id", "review_id"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.review_votes": {
+      "name": "review_votes",
+      "schema": "",
+      "columns": {
+        "voter_user_id": {
+          "name": "voter_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "review_id": {
+          "name": "review_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "vote_type": {
+          "name": "vote_type",
+          "type": "review_vote_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "review_votes_voter_user_id_users_id_fk": {
+          "name": "review_votes_voter_user_id_users_id_fk",
+          "tableFrom": "review_votes",
+          "tableTo": "users",
+          "columnsFrom": ["voter_user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "review_votes_review_id_reviews_id_fk": {
+          "name": "review_votes_review_id_reviews_id_fk",
+          "tableFrom": "review_votes",
+          "tableTo": "reviews",
+          "columnsFrom": ["review_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "review_votes_voter_user_id_review_id_pk": {
+          "name": "review_votes_voter_user_id_review_id_pk",
+          "columns": ["voter_user_id", "review_id"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.reviews": {
+      "name": "reviews",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "course_code": {
+          "name": "course_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "examination_methods": {
+          "name": "examination_methods",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "theoretical_vs_applied": {
+          "name": "theoretical_vs_applied",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "workload": {
+          "name": "workload",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "learning_experience": {
+          "name": "learning_experience",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "would_recommend": {
+          "name": "would_recommend",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "examination_distribution": {
+          "name": "examination_distribution",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "approach_theory_percent": {
+          "name": "approach_theory_percent",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "workload_score": {
+          "name": "workload_score",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "learning_score": {
+          "name": "learning_score",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "happy_took": {
+          "name": "happy_took",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "message": {
+          "name": "message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "reviews_user_id_users_id_fk": {
+          "name": "reviews_user_id_users_id_fk",
+          "tableFrom": "reviews",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "reviews_course_code_courses_code_fk": {
+          "name": "reviews_course_code_courses_code_fk",
+          "tableFrom": "reviews",
+          "tableTo": "courses",
+          "columnsFrom": ["course_code"],
+          "columnsTo": ["code"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "approach_theory_percent_range": {
+          "name": "approach_theory_percent_range",
+          "value": "\"reviews\".\"approach_theory_percent\" between 0 and 100"
+        },
+        "workload_score_range": {
+          "name": "workload_score_range",
+          "value": "\"reviews\".\"workload_score\" between 1 and 10"
+        },
+        "learning_score_range": {
+          "name": "learning_score_range",
+          "value": "\"reviews\".\"learning_score\" between 1 and 10"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.user_saved_courses": {
+      "name": "user_saved_courses",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "course_code": {
+          "name": "course_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "user_saved_courses_user_id_users_id_fk": {
+          "name": "user_saved_courses_user_id_users_id_fk",
+          "tableFrom": "user_saved_courses",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "user_saved_courses_course_code_courses_code_fk": {
+          "name": "user_saved_courses_course_code_courses_code_fk",
+          "tableFrom": "user_saved_courses",
+          "tableTo": "courses",
+          "columnsFrom": ["course_code"],
+          "columnsTo": ["code"],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "user_saved_courses_user_id_course_code_pk": {
+          "name": "user_saved_courses_user_id_course_code_pk",
+          "columns": ["user_id", "course_code"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_taken_courses": {
+      "name": "user_taken_courses",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "course_code": {
+          "name": "course_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "attendance_periods": {
+          "name": "attendance_periods",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "attendance_year": {
+          "name": "attendance_year",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "grade": {
+          "name": "grade",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "earned_credits": {
+          "name": "earned_credits",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "transcript_imported_at": {
+          "name": "transcript_imported_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "user_taken_courses_user_id_users_id_fk": {
+          "name": "user_taken_courses_user_id_users_id_fk",
+          "tableFrom": "user_taken_courses",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "user_taken_courses_course_code_courses_code_fk": {
+          "name": "user_taken_courses_course_code_courses_code_fk",
+          "tableFrom": "user_taken_courses",
+          "tableTo": "courses",
+          "columnsFrom": ["course_code"],
+          "columnsTo": ["code"],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "user_taken_courses_user_id_course_code_pk": {
+          "name": "user_taken_courses_user_id_course_code_pk",
+          "columns": ["user_id", "course_code"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_favorites": {
+      "name": "user_favorites",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "fav_course_code": {
+          "name": "fav_course_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "user_favorites_user_id_users_id_fk": {
+          "name": "user_favorites_user_id_users_id_fk",
+          "tableFrom": "user_favorites",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "user_favorites_fav_course_code_courses_code_fk": {
+          "name": "user_favorites_fav_course_code_courses_code_fk",
+          "tableFrom": "user_favorites",
+          "tableTo": "courses",
+          "columnsFrom": ["fav_course_code"],
+          "columnsTo": ["code"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "user_favorites_user_id_fav_course_code_pk": {
+          "name": "user_favorites_user_id_fav_course_code_pk",
+          "columns": ["user_id", "fav_course_code"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users_graph_backbone_edges": {
+      "name": "users_graph_backbone_edges",
+      "schema": "",
+      "columns": {
+        "node_user_id": {
+          "name": "node_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "anchor_user_id": {
+          "name": "anchor_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "users_graph_backbone_edges_node_user_id_users_graph_nodes_user_id_fk": {
+          "name": "users_graph_backbone_edges_node_user_id_users_graph_nodes_user_id_fk",
+          "tableFrom": "users_graph_backbone_edges",
+          "tableTo": "users_graph_nodes",
+          "columnsFrom": ["node_user_id"],
+          "columnsTo": ["user_id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "users_graph_backbone_edges_anchor_user_id_users_graph_nodes_user_id_fk": {
+          "name": "users_graph_backbone_edges_anchor_user_id_users_graph_nodes_user_id_fk",
+          "tableFrom": "users_graph_backbone_edges",
+          "tableTo": "users_graph_nodes",
+          "columnsFrom": ["anchor_user_id"],
+          "columnsTo": ["user_id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "users_graph_backbone_edges_node_user_id_anchor_user_id_pk": {
+          "name": "users_graph_backbone_edges_node_user_id_anchor_user_id_pk",
+          "columns": ["node_user_id", "anchor_user_id"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "no_self_backbone_edge": {
+          "name": "no_self_backbone_edge",
+          "value": "\"users_graph_backbone_edges\".\"node_user_id\" <> \"users_graph_backbone_edges\".\"anchor_user_id\""
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.users_graph_nodes": {
+      "name": "users_graph_nodes",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "x": {
+          "name": "x",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "y": {
+          "name": "y",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "users_graph_nodes_user_id_users_id_fk": {
+          "name": "users_graph_nodes_user_id_users_id_fk",
+          "tableFrom": "users_graph_nodes",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users_node_profiles": {
+      "name": "users_node_profiles",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "color": {
+          "name": "color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'default'"
+        },
+        "style": {
+          "name": "style",
+          "type": "node_style",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'default'"
+        },
+        "signal_style": {
+          "name": "signal_style",
+          "type": "node_signal_style",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'default'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "users_node_profiles_user_id_users_id_fk": {
+          "name": "users_node_profiles_user_id_users_id_fk",
+          "tableFrom": "users_node_profiles",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.accounts": {
+      "name": "accounts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "issuer": {
+          "name": "issuer",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "accounts_issuer_accountId_uidx": {
+          "name": "accounts_issuer_accountId_uidx",
+          "columns": [
+            {
+              "expression": "issuer",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "accounts_userId_idx": {
+          "name": "accounts_userId_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "accounts_user_id_users_id_fk": {
+          "name": "accounts_user_id_users_id_fk",
+          "tableFrom": "accounts",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sessions": {
+      "name": "sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "sessions_userId_idx": {
+          "name": "sessions_userId_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "sessions_user_id_users_id_fk": {
+          "name": "sessions_user_id_users_id_fk",
+          "tableFrom": "sessions",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "sessions_token_unique": {
+          "name": "sessions_token_unique",
+          "nullsNotDistinct": false,
+          "columns": ["token"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "personalization_tier_earned": {
+          "name": "personalization_tier_earned",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "nullsNotDistinct": false,
+          "columns": ["email"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "personalization_tier_earned_range": {
+          "name": "personalization_tier_earned_range",
+          "value": "\"users\".\"personalization_tier_earned\" between 0 and 3"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.verifications": {
+      "name": "verifications",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "verifications_identifier_idx": {
+          "name": "verifications_identifier_idx",
+          "columns": [
+            {
+              "expression": "identifier",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.course_state": {
+      "name": "course_state",
+      "schema": "public",
+      "values": ["CANCELLED", "ESTABLISHED", "DEACTIVATED"]
+    },
+    "public.node_signal_style": {
+      "name": "node_signal_style",
+      "schema": "public",
+      "values": ["default"]
+    },
+    "public.node_style": {
+      "name": "node_style",
+      "schema": "public",
+      "values": ["default"]
+    },
+    "public.review_vote_type": {
+      "name": "review_vote_type",
+      "schema": "public",
+      "values": ["up", "down"]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/apps/web/server/db/drizzle/meta/0006_snapshot.json
+++ b/apps/web/server/db/drizzle/meta/0006_snapshot.json
@@ -897,15 +897,13 @@
           "name": "workload_score",
           "type": "integer",
           "primaryKey": false,
-          "notNull": true,
-          "default": 1
+          "notNull": false
         },
         "learning_score": {
           "name": "learning_score",
           "type": "integer",
           "primaryKey": false,
-          "notNull": true,
-          "default": 1
+          "notNull": false
         },
         "happy_took": {
           "name": "happy_took",

--- a/apps/web/server/db/drizzle/meta/0007_snapshot.json
+++ b/apps/web/server/db/drizzle/meta/0007_snapshot.json
@@ -1,0 +1,1966 @@
+{
+  "id": "41704c71-e4f0-46cb-8d42-c540e46c57ea",
+  "prevId": "d42d91d7-cb97-4f88-a79a-0dffdc9cc91a",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.collection_courses": {
+      "name": "collection_courses",
+      "schema": "",
+      "columns": {
+        "collection_id": {
+          "name": "collection_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "collection_user_id": {
+          "name": "collection_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "course_code": {
+          "name": "course_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "collection_courses_collection_owner_idx": {
+          "name": "collection_courses_collection_owner_idx",
+          "columns": [
+            {
+              "expression": "collection_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "collection_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "collection_courses_saved_course_idx": {
+          "name": "collection_courses_saved_course_idx",
+          "columns": [
+            {
+              "expression": "collection_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "course_code",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "collection_courses_collection_owner_fk": {
+          "name": "collection_courses_collection_owner_fk",
+          "tableFrom": "collection_courses",
+          "tableTo": "collections",
+          "columnsFrom": ["collection_id", "collection_user_id"],
+          "columnsTo": ["id", "user_id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "collection_courses_saved_course_fk": {
+          "name": "collection_courses_saved_course_fk",
+          "tableFrom": "collection_courses",
+          "tableTo": "user_saved_courses",
+          "columnsFrom": ["collection_user_id", "course_code"],
+          "columnsTo": ["user_id", "course_code"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "collection_courses_collection_id_course_code_pk": {
+          "name": "collection_courses_collection_id_course_code_pk",
+          "columns": ["collection_id", "course_code"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "position_nonnegative": {
+          "name": "position_nonnegative",
+          "value": "\"collection_courses\".\"position\" >= 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.collections": {
+      "name": "collections",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "collections_user_id_idx": {
+          "name": "collections_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "collections_user_id_users_id_fk": {
+          "name": "collections_user_id_users_id_fk",
+          "tableFrom": "collections",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "collections_id_user_id_unique": {
+          "name": "collections_id_user_id_unique",
+          "nullsNotDistinct": false,
+          "columns": ["id", "user_id"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.course_examinations": {
+      "name": "course_examinations",
+      "schema": "",
+      "columns": {
+        "course_code": {
+          "name": "course_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "exam_code": {
+          "name": "exam_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "credits": {
+          "name": "credits",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "grade_scale_code": {
+          "name": "grade_scale_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "course_examinations_course_code_courses_code_fk": {
+          "name": "course_examinations_course_code_courses_code_fk",
+          "tableFrom": "course_examinations",
+          "tableTo": "courses",
+          "columnsFrom": ["course_code"],
+          "columnsTo": ["code"],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "course_examinations_course_code_exam_code_pk": {
+          "name": "course_examinations_course_code_exam_code_pk",
+          "columns": ["course_code", "exam_code"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.course_explore": {
+      "name": "course_explore",
+      "schema": "",
+      "columns": {
+        "course_code": {
+          "name": "course_code",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "embedding": {
+          "name": "embedding",
+          "type": "vector(1536)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_hash": {
+          "name": "source_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "search_vector": {
+          "name": "search_vector",
+          "type": "tsvector",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "embedding_model": {
+          "name": "embedding_model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "embedded_at": {
+          "name": "embedded_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "course_explore_search_vector_idx": {
+          "name": "course_explore_search_vector_idx",
+          "columns": [
+            {
+              "expression": "search_vector",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        },
+        "course_explore_embedding_idx": {
+          "name": "course_explore_embedding_idx",
+          "columns": [
+            {
+              "expression": "embedding",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "vector_cosine_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "hnsw",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "course_explore_course_code_courses_code_fk": {
+          "name": "course_explore_course_code_courses_code_fk",
+          "tableFrom": "course_explore",
+          "tableTo": "courses",
+          "columnsFrom": ["course_code"],
+          "columnsTo": ["code"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.course_prerequisites": {
+      "name": "course_prerequisites",
+      "schema": "",
+      "columns": {
+        "course_code": {
+          "name": "course_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "prerequisite_course_code": {
+          "name": "prerequisite_course_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "course_prerequisites_prerequisite_course_code_idx": {
+          "name": "course_prerequisites_prerequisite_course_code_idx",
+          "columns": [
+            {
+              "expression": "prerequisite_course_code",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "course_prerequisites_course_code_courses_code_fk": {
+          "name": "course_prerequisites_course_code_courses_code_fk",
+          "tableFrom": "course_prerequisites",
+          "tableTo": "courses",
+          "columnsFrom": ["course_code"],
+          "columnsTo": ["code"],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "course_prerequisites_prerequisite_course_code_courses_code_fk": {
+          "name": "course_prerequisites_prerequisite_course_code_courses_code_fk",
+          "tableFrom": "course_prerequisites",
+          "tableTo": "courses",
+          "columnsFrom": ["prerequisite_course_code"],
+          "columnsTo": ["code"],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "course_prerequisites_course_code_prerequisite_course_code_pk": {
+          "name": "course_prerequisites_course_code_prerequisite_course_code_pk",
+          "columns": ["course_code", "prerequisite_course_code"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.course_rounds": {
+      "name": "course_rounds",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "course_code": {
+          "name": "course_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "start_term": {
+          "name": "start_term",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "study_pace": {
+          "name": "study_pace",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "schema_url": {
+          "name": "schema_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "language": {
+          "name": "language",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tutoring_form": {
+          "name": "tutoring_form",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tutoring_time_of_day": {
+          "name": "tutoring_time_of_day",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "formatted_periods_and_credits": {
+          "name": "formatted_periods_and_credits",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_pu": {
+          "name": "is_pu",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_vu": {
+          "name": "is_vu",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "course_rounds_course_code_idx": {
+          "name": "course_rounds_course_code_idx",
+          "columns": [
+            {
+              "expression": "course_code",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "course_rounds_course_code_courses_code_fk": {
+          "name": "course_rounds_course_code_courses_code_fk",
+          "tableFrom": "course_rounds",
+          "tableTo": "courses",
+          "columnsFrom": ["course_code"],
+          "columnsTo": ["code"],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "study_pace_range": {
+          "name": "study_pace_range",
+          "value": "\"course_rounds\".\"study_pace\" between 1 and 100"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.courses": {
+      "name": "courses",
+      "schema": "",
+      "columns": {
+        "code": {
+          "name": "code",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name_swedish": {
+          "name": "name_swedish",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name_english": {
+          "name": "name_english",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "state": {
+          "name": "state",
+          "type": "course_state",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "credits": {
+          "name": "credits",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "credit_unit": {
+          "name": "credit_unit",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "department_code": {
+          "name": "department_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "department": {
+          "name": "department",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "educational_level_code": {
+          "name": "educational_level_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "grade_scale_code": {
+          "name": "grade_scale_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "goals": {
+          "name": "goals",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "eligibility": {
+          "name": "eligibility",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "embedding": {
+          "name": "embedding",
+          "type": "vector(1536)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "embedding_hash": {
+          "name": "embedding_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "search_vector": {
+          "name": "search_vector",
+          "type": "tsvector",
+          "primaryKey": false,
+          "notNull": false,
+          "generated": {
+            "as": "to_tsvector('simple', coalesce(name_english, '') || ' ' || coalesce(name_swedish, '') || ' ' || coalesce(code, '') || ' ' || coalesce(goals, '') || ' ' || coalesce(content, ''))",
+            "type": "stored"
+          }
+        }
+      },
+      "indexes": {
+        "courses_search_vector_idx": {
+          "name": "courses_search_vector_idx",
+          "columns": [
+            {
+              "expression": "search_vector",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        },
+        "courses_embedding_idx": {
+          "name": "courses_embedding_idx",
+          "columns": [
+            {
+              "expression": "embedding",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "vector_cosine_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "hnsw",
+          "with": {}
+        },
+        "courses_name_trgm_idx": {
+          "name": "courses_name_trgm_idx",
+          "columns": [
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "gin_trgm_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        },
+        "courses_code_trgm_idx": {
+          "name": "courses_code_trgm_idx",
+          "columns": [
+            {
+              "expression": "code",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "gin_trgm_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.feedback_form": {
+      "name": "feedback_form",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "message": {
+          "name": "message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.review_likes": {
+      "name": "review_likes",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "review_id": {
+          "name": "review_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "vote_type": {
+          "name": "vote_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "review_likes_user_id_users_id_fk": {
+          "name": "review_likes_user_id_users_id_fk",
+          "tableFrom": "review_likes",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "review_likes_review_id_reviews_id_fk": {
+          "name": "review_likes_review_id_reviews_id_fk",
+          "tableFrom": "review_likes",
+          "tableTo": "reviews",
+          "columnsFrom": ["review_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "review_likes_user_id_review_id_pk": {
+          "name": "review_likes_user_id_review_id_pk",
+          "columns": ["user_id", "review_id"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.review_votes": {
+      "name": "review_votes",
+      "schema": "",
+      "columns": {
+        "voter_user_id": {
+          "name": "voter_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "review_id": {
+          "name": "review_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "vote_type": {
+          "name": "vote_type",
+          "type": "review_vote_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "review_votes_review_id_idx": {
+          "name": "review_votes_review_id_idx",
+          "columns": [
+            {
+              "expression": "review_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "review_votes_voter_user_id_users_id_fk": {
+          "name": "review_votes_voter_user_id_users_id_fk",
+          "tableFrom": "review_votes",
+          "tableTo": "users",
+          "columnsFrom": ["voter_user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "review_votes_review_id_reviews_id_fk": {
+          "name": "review_votes_review_id_reviews_id_fk",
+          "tableFrom": "review_votes",
+          "tableTo": "reviews",
+          "columnsFrom": ["review_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "review_votes_voter_user_id_review_id_pk": {
+          "name": "review_votes_voter_user_id_review_id_pk",
+          "columns": ["voter_user_id", "review_id"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.reviews": {
+      "name": "reviews",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "course_code": {
+          "name": "course_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "examination_methods": {
+          "name": "examination_methods",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "theoretical_vs_applied": {
+          "name": "theoretical_vs_applied",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "workload": {
+          "name": "workload",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "learning_experience": {
+          "name": "learning_experience",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "would_recommend": {
+          "name": "would_recommend",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "examination_distribution": {
+          "name": "examination_distribution",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "approach_theory_percent": {
+          "name": "approach_theory_percent",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "workload_score": {
+          "name": "workload_score",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "learning_score": {
+          "name": "learning_score",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "happy_took": {
+          "name": "happy_took",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "message": {
+          "name": "message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "reviews_user_id_idx": {
+          "name": "reviews_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "reviews_course_code_idx": {
+          "name": "reviews_course_code_idx",
+          "columns": [
+            {
+              "expression": "course_code",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "reviews_user_id_users_id_fk": {
+          "name": "reviews_user_id_users_id_fk",
+          "tableFrom": "reviews",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "reviews_course_code_courses_code_fk": {
+          "name": "reviews_course_code_courses_code_fk",
+          "tableFrom": "reviews",
+          "tableTo": "courses",
+          "columnsFrom": ["course_code"],
+          "columnsTo": ["code"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "approach_theory_percent_range": {
+          "name": "approach_theory_percent_range",
+          "value": "\"reviews\".\"approach_theory_percent\" between 0 and 100"
+        },
+        "workload_score_range": {
+          "name": "workload_score_range",
+          "value": "\"reviews\".\"workload_score\" between 1 and 10"
+        },
+        "learning_score_range": {
+          "name": "learning_score_range",
+          "value": "\"reviews\".\"learning_score\" between 1 and 10"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.user_saved_courses": {
+      "name": "user_saved_courses",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "course_code": {
+          "name": "course_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "user_saved_courses_course_code_idx": {
+          "name": "user_saved_courses_course_code_idx",
+          "columns": [
+            {
+              "expression": "course_code",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_saved_courses_user_id_users_id_fk": {
+          "name": "user_saved_courses_user_id_users_id_fk",
+          "tableFrom": "user_saved_courses",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "user_saved_courses_course_code_courses_code_fk": {
+          "name": "user_saved_courses_course_code_courses_code_fk",
+          "tableFrom": "user_saved_courses",
+          "tableTo": "courses",
+          "columnsFrom": ["course_code"],
+          "columnsTo": ["code"],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "user_saved_courses_user_id_course_code_pk": {
+          "name": "user_saved_courses_user_id_course_code_pk",
+          "columns": ["user_id", "course_code"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_taken_courses": {
+      "name": "user_taken_courses",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "course_code": {
+          "name": "course_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "attendance_periods": {
+          "name": "attendance_periods",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "attendance_year": {
+          "name": "attendance_year",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "grade": {
+          "name": "grade",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "earned_credits": {
+          "name": "earned_credits",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "transcript_imported_at": {
+          "name": "transcript_imported_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "user_taken_courses_course_code_idx": {
+          "name": "user_taken_courses_course_code_idx",
+          "columns": [
+            {
+              "expression": "course_code",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_taken_courses_user_id_users_id_fk": {
+          "name": "user_taken_courses_user_id_users_id_fk",
+          "tableFrom": "user_taken_courses",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "user_taken_courses_course_code_courses_code_fk": {
+          "name": "user_taken_courses_course_code_courses_code_fk",
+          "tableFrom": "user_taken_courses",
+          "tableTo": "courses",
+          "columnsFrom": ["course_code"],
+          "columnsTo": ["code"],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "user_taken_courses_user_id_course_code_pk": {
+          "name": "user_taken_courses_user_id_course_code_pk",
+          "columns": ["user_id", "course_code"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_favorites": {
+      "name": "user_favorites",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "fav_course_code": {
+          "name": "fav_course_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "user_favorites_user_id_users_id_fk": {
+          "name": "user_favorites_user_id_users_id_fk",
+          "tableFrom": "user_favorites",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "user_favorites_fav_course_code_courses_code_fk": {
+          "name": "user_favorites_fav_course_code_courses_code_fk",
+          "tableFrom": "user_favorites",
+          "tableTo": "courses",
+          "columnsFrom": ["fav_course_code"],
+          "columnsTo": ["code"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "user_favorites_user_id_fav_course_code_pk": {
+          "name": "user_favorites_user_id_fav_course_code_pk",
+          "columns": ["user_id", "fav_course_code"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users_graph_backbone_edges": {
+      "name": "users_graph_backbone_edges",
+      "schema": "",
+      "columns": {
+        "node_user_id": {
+          "name": "node_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "anchor_user_id": {
+          "name": "anchor_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "users_graph_backbone_edges_anchor_user_id_idx": {
+          "name": "users_graph_backbone_edges_anchor_user_id_idx",
+          "columns": [
+            {
+              "expression": "anchor_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "users_graph_backbone_edges_node_user_id_users_graph_nodes_user_id_fk": {
+          "name": "users_graph_backbone_edges_node_user_id_users_graph_nodes_user_id_fk",
+          "tableFrom": "users_graph_backbone_edges",
+          "tableTo": "users_graph_nodes",
+          "columnsFrom": ["node_user_id"],
+          "columnsTo": ["user_id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "users_graph_backbone_edges_anchor_user_id_users_graph_nodes_user_id_fk": {
+          "name": "users_graph_backbone_edges_anchor_user_id_users_graph_nodes_user_id_fk",
+          "tableFrom": "users_graph_backbone_edges",
+          "tableTo": "users_graph_nodes",
+          "columnsFrom": ["anchor_user_id"],
+          "columnsTo": ["user_id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "users_graph_backbone_edges_node_user_id_anchor_user_id_pk": {
+          "name": "users_graph_backbone_edges_node_user_id_anchor_user_id_pk",
+          "columns": ["node_user_id", "anchor_user_id"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "no_self_backbone_edge": {
+          "name": "no_self_backbone_edge",
+          "value": "\"users_graph_backbone_edges\".\"node_user_id\" <> \"users_graph_backbone_edges\".\"anchor_user_id\""
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.users_graph_nodes": {
+      "name": "users_graph_nodes",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "x": {
+          "name": "x",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "y": {
+          "name": "y",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "users_graph_nodes_user_id_users_id_fk": {
+          "name": "users_graph_nodes_user_id_users_id_fk",
+          "tableFrom": "users_graph_nodes",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users_node_profiles": {
+      "name": "users_node_profiles",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "color": {
+          "name": "color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'default'"
+        },
+        "style": {
+          "name": "style",
+          "type": "node_style",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'default'"
+        },
+        "signal_style": {
+          "name": "signal_style",
+          "type": "node_signal_style",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'default'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "users_node_profiles_user_id_users_id_fk": {
+          "name": "users_node_profiles_user_id_users_id_fk",
+          "tableFrom": "users_node_profiles",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.accounts": {
+      "name": "accounts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "issuer": {
+          "name": "issuer",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "accounts_issuer_accountId_uidx": {
+          "name": "accounts_issuer_accountId_uidx",
+          "columns": [
+            {
+              "expression": "issuer",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "accounts_userId_idx": {
+          "name": "accounts_userId_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "accounts_user_id_users_id_fk": {
+          "name": "accounts_user_id_users_id_fk",
+          "tableFrom": "accounts",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sessions": {
+      "name": "sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "sessions_userId_idx": {
+          "name": "sessions_userId_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "sessions_user_id_users_id_fk": {
+          "name": "sessions_user_id_users_id_fk",
+          "tableFrom": "sessions",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "sessions_token_unique": {
+          "name": "sessions_token_unique",
+          "nullsNotDistinct": false,
+          "columns": ["token"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "personalization_tier_earned": {
+          "name": "personalization_tier_earned",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "nullsNotDistinct": false,
+          "columns": ["email"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "personalization_tier_earned_range": {
+          "name": "personalization_tier_earned_range",
+          "value": "\"users\".\"personalization_tier_earned\" between 0 and 3"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.verifications": {
+      "name": "verifications",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "verifications_identifier_idx": {
+          "name": "verifications_identifier_idx",
+          "columns": [
+            {
+              "expression": "identifier",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.course_state": {
+      "name": "course_state",
+      "schema": "public",
+      "values": ["CANCELLED", "ESTABLISHED", "DEACTIVATED"]
+    },
+    "public.node_signal_style": {
+      "name": "node_signal_style",
+      "schema": "public",
+      "values": ["default"]
+    },
+    "public.node_style": {
+      "name": "node_style",
+      "schema": "public",
+      "values": ["default"]
+    },
+    "public.review_vote_type": {
+      "name": "review_vote_type",
+      "schema": "public",
+      "values": ["up", "down"]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/apps/web/server/db/drizzle/meta/0007_snapshot.json
+++ b/apps/web/server/db/drizzle/meta/0007_snapshot.json
@@ -1004,15 +1004,13 @@
           "name": "workload_score",
           "type": "integer",
           "primaryKey": false,
-          "notNull": true,
-          "default": 1
+          "notNull": false
         },
         "learning_score": {
           "name": "learning_score",
           "type": "integer",
           "primaryKey": false,
-          "notNull": true,
-          "default": 1
+          "notNull": false
         },
         "happy_took": {
           "name": "happy_took",

--- a/apps/web/server/db/drizzle/meta/0008_snapshot.json
+++ b/apps/web/server/db/drizzle/meta/0008_snapshot.json
@@ -1,0 +1,1994 @@
+{
+  "id": "a2bde574-f3f6-4dbf-b8a7-f2b42c061947",
+  "prevId": "41704c71-e4f0-46cb-8d42-c540e46c57ea",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.accounts": {
+      "name": "accounts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "issuer": {
+          "name": "issuer",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "accounts_issuer_accountId_uidx": {
+          "name": "accounts_issuer_accountId_uidx",
+          "columns": [
+            {
+              "expression": "issuer",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "accounts_userId_idx": {
+          "name": "accounts_userId_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "accounts_user_id_users_id_fk": {
+          "name": "accounts_user_id_users_id_fk",
+          "tableFrom": "accounts",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.collection_courses": {
+      "name": "collection_courses",
+      "schema": "",
+      "columns": {
+        "collection_id": {
+          "name": "collection_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "collection_user_id": {
+          "name": "collection_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "course_code": {
+          "name": "course_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "collection_courses_collection_owner_idx": {
+          "name": "collection_courses_collection_owner_idx",
+          "columns": [
+            {
+              "expression": "collection_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "collection_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "collection_courses_saved_course_idx": {
+          "name": "collection_courses_saved_course_idx",
+          "columns": [
+            {
+              "expression": "collection_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "course_code",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "collection_courses_collection_owner_fk": {
+          "name": "collection_courses_collection_owner_fk",
+          "tableFrom": "collection_courses",
+          "tableTo": "collections",
+          "columnsFrom": ["collection_id", "collection_user_id"],
+          "columnsTo": ["id", "user_id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "collection_courses_saved_course_fk": {
+          "name": "collection_courses_saved_course_fk",
+          "tableFrom": "collection_courses",
+          "tableTo": "user_saved_courses",
+          "columnsFrom": ["collection_user_id", "course_code"],
+          "columnsTo": ["user_id", "course_code"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "collection_courses_collection_id_course_code_pk": {
+          "name": "collection_courses_collection_id_course_code_pk",
+          "columns": ["collection_id", "course_code"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "position_nonnegative": {
+          "name": "position_nonnegative",
+          "value": "\"collection_courses\".\"position\" >= 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.collections": {
+      "name": "collections",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "collections_user_id_idx": {
+          "name": "collections_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "collections_user_id_users_id_fk": {
+          "name": "collections_user_id_users_id_fk",
+          "tableFrom": "collections",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "collections_id_user_id_unique": {
+          "name": "collections_id_user_id_unique",
+          "nullsNotDistinct": false,
+          "columns": ["id", "user_id"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.course_examinations": {
+      "name": "course_examinations",
+      "schema": "",
+      "columns": {
+        "course_code": {
+          "name": "course_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "exam_code": {
+          "name": "exam_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "credits": {
+          "name": "credits",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "grade_scale_code": {
+          "name": "grade_scale_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "course_examinations_course_code_courses_code_fk": {
+          "name": "course_examinations_course_code_courses_code_fk",
+          "tableFrom": "course_examinations",
+          "tableTo": "courses",
+          "columnsFrom": ["course_code"],
+          "columnsTo": ["code"],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "course_examinations_course_code_exam_code_pk": {
+          "name": "course_examinations_course_code_exam_code_pk",
+          "columns": ["course_code", "exam_code"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.course_explore": {
+      "name": "course_explore",
+      "schema": "",
+      "columns": {
+        "course_code": {
+          "name": "course_code",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "embedding": {
+          "name": "embedding",
+          "type": "vector(1536)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_hash": {
+          "name": "source_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "search_vector": {
+          "name": "search_vector",
+          "type": "tsvector",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "embedding_model": {
+          "name": "embedding_model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "embedded_at": {
+          "name": "embedded_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "course_explore_search_vector_idx": {
+          "name": "course_explore_search_vector_idx",
+          "columns": [
+            {
+              "expression": "search_vector",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        },
+        "course_explore_embedding_idx": {
+          "name": "course_explore_embedding_idx",
+          "columns": [
+            {
+              "expression": "embedding",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "vector_cosine_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "hnsw",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "course_explore_course_code_courses_code_fk": {
+          "name": "course_explore_course_code_courses_code_fk",
+          "tableFrom": "course_explore",
+          "tableTo": "courses",
+          "columnsFrom": ["course_code"],
+          "columnsTo": ["code"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.course_prerequisites": {
+      "name": "course_prerequisites",
+      "schema": "",
+      "columns": {
+        "course_code": {
+          "name": "course_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "prerequisite_course_code": {
+          "name": "prerequisite_course_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "course_prerequisites_prerequisite_course_code_idx": {
+          "name": "course_prerequisites_prerequisite_course_code_idx",
+          "columns": [
+            {
+              "expression": "prerequisite_course_code",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "course_prerequisites_course_code_courses_code_fk": {
+          "name": "course_prerequisites_course_code_courses_code_fk",
+          "tableFrom": "course_prerequisites",
+          "tableTo": "courses",
+          "columnsFrom": ["course_code"],
+          "columnsTo": ["code"],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "course_prerequisites_prerequisite_course_code_courses_code_fk": {
+          "name": "course_prerequisites_prerequisite_course_code_courses_code_fk",
+          "tableFrom": "course_prerequisites",
+          "tableTo": "courses",
+          "columnsFrom": ["prerequisite_course_code"],
+          "columnsTo": ["code"],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "course_prerequisites_course_code_prerequisite_course_code_pk": {
+          "name": "course_prerequisites_course_code_prerequisite_course_code_pk",
+          "columns": ["course_code", "prerequisite_course_code"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.course_rounds": {
+      "name": "course_rounds",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "round_code": {
+          "name": "round_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "course_code": {
+          "name": "course_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "start_term": {
+          "name": "start_term",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "study_pace": {
+          "name": "study_pace",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "schema_url": {
+          "name": "schema_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "language": {
+          "name": "language",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tutoring_form": {
+          "name": "tutoring_form",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tutoring_time_of_day": {
+          "name": "tutoring_time_of_day",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "formatted_periods_and_credits": {
+          "name": "formatted_periods_and_credits",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_pu": {
+          "name": "is_pu",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_vu": {
+          "name": "is_vu",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "course_rounds_course_code_round_code_unique": {
+          "name": "course_rounds_course_code_round_code_unique",
+          "columns": [
+            {
+              "expression": "course_code",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "round_code",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"course_rounds\".\"round_code\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "course_rounds_course_code_idx": {
+          "name": "course_rounds_course_code_idx",
+          "columns": [
+            {
+              "expression": "course_code",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "course_rounds_course_code_courses_code_fk": {
+          "name": "course_rounds_course_code_courses_code_fk",
+          "tableFrom": "course_rounds",
+          "tableTo": "courses",
+          "columnsFrom": ["course_code"],
+          "columnsTo": ["code"],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "study_pace_range": {
+          "name": "study_pace_range",
+          "value": "\"course_rounds\".\"study_pace\" between 1 and 100"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.courses": {
+      "name": "courses",
+      "schema": "",
+      "columns": {
+        "code": {
+          "name": "code",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name_swedish": {
+          "name": "name_swedish",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name_english": {
+          "name": "name_english",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "state": {
+          "name": "state",
+          "type": "course_state",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "credits": {
+          "name": "credits",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "credit_unit": {
+          "name": "credit_unit",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "department_code": {
+          "name": "department_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "department": {
+          "name": "department",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "educational_level_code": {
+          "name": "educational_level_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "grade_scale_code": {
+          "name": "grade_scale_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "goals": {
+          "name": "goals",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "eligibility": {
+          "name": "eligibility",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "embedding": {
+          "name": "embedding",
+          "type": "vector(1536)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "embedding_hash": {
+          "name": "embedding_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "search_vector": {
+          "name": "search_vector",
+          "type": "tsvector",
+          "primaryKey": false,
+          "notNull": false,
+          "generated": {
+            "as": "to_tsvector('simple', coalesce(name_english, '') || ' ' || coalesce(name_swedish, '') || ' ' || coalesce(code, '') || ' ' || coalesce(goals, '') || ' ' || coalesce(content, ''))",
+            "type": "stored"
+          }
+        }
+      },
+      "indexes": {
+        "courses_search_vector_idx": {
+          "name": "courses_search_vector_idx",
+          "columns": [
+            {
+              "expression": "search_vector",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        },
+        "courses_embedding_idx": {
+          "name": "courses_embedding_idx",
+          "columns": [
+            {
+              "expression": "embedding",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "vector_cosine_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "hnsw",
+          "with": {}
+        },
+        "courses_name_trgm_idx": {
+          "name": "courses_name_trgm_idx",
+          "columns": [
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "gin_trgm_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        },
+        "courses_code_trgm_idx": {
+          "name": "courses_code_trgm_idx",
+          "columns": [
+            {
+              "expression": "code",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "gin_trgm_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.feedback_form": {
+      "name": "feedback_form",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "message": {
+          "name": "message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.review_likes": {
+      "name": "review_likes",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "review_id": {
+          "name": "review_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "vote_type": {
+          "name": "vote_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "review_likes_user_id_users_id_fk": {
+          "name": "review_likes_user_id_users_id_fk",
+          "tableFrom": "review_likes",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "review_likes_review_id_reviews_id_fk": {
+          "name": "review_likes_review_id_reviews_id_fk",
+          "tableFrom": "review_likes",
+          "tableTo": "reviews",
+          "columnsFrom": ["review_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "review_likes_user_id_review_id_pk": {
+          "name": "review_likes_user_id_review_id_pk",
+          "columns": ["user_id", "review_id"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.review_votes": {
+      "name": "review_votes",
+      "schema": "",
+      "columns": {
+        "voter_user_id": {
+          "name": "voter_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "review_id": {
+          "name": "review_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "vote_type": {
+          "name": "vote_type",
+          "type": "review_vote_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "review_votes_review_id_idx": {
+          "name": "review_votes_review_id_idx",
+          "columns": [
+            {
+              "expression": "review_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "review_votes_voter_user_id_users_id_fk": {
+          "name": "review_votes_voter_user_id_users_id_fk",
+          "tableFrom": "review_votes",
+          "tableTo": "users",
+          "columnsFrom": ["voter_user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "review_votes_review_id_reviews_id_fk": {
+          "name": "review_votes_review_id_reviews_id_fk",
+          "tableFrom": "review_votes",
+          "tableTo": "reviews",
+          "columnsFrom": ["review_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "review_votes_voter_user_id_review_id_pk": {
+          "name": "review_votes_voter_user_id_review_id_pk",
+          "columns": ["voter_user_id", "review_id"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.reviews": {
+      "name": "reviews",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "course_code": {
+          "name": "course_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "examination_methods": {
+          "name": "examination_methods",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "theoretical_vs_applied": {
+          "name": "theoretical_vs_applied",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "workload": {
+          "name": "workload",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "learning_experience": {
+          "name": "learning_experience",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "would_recommend": {
+          "name": "would_recommend",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "examination_distribution": {
+          "name": "examination_distribution",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "approach_theory_percent": {
+          "name": "approach_theory_percent",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "workload_score": {
+          "name": "workload_score",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "learning_score": {
+          "name": "learning_score",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "happy_took": {
+          "name": "happy_took",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "message": {
+          "name": "message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "reviews_user_id_idx": {
+          "name": "reviews_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "reviews_course_code_idx": {
+          "name": "reviews_course_code_idx",
+          "columns": [
+            {
+              "expression": "course_code",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "reviews_user_id_users_id_fk": {
+          "name": "reviews_user_id_users_id_fk",
+          "tableFrom": "reviews",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "reviews_course_code_courses_code_fk": {
+          "name": "reviews_course_code_courses_code_fk",
+          "tableFrom": "reviews",
+          "tableTo": "courses",
+          "columnsFrom": ["course_code"],
+          "columnsTo": ["code"],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "approach_theory_percent_range": {
+          "name": "approach_theory_percent_range",
+          "value": "\"reviews\".\"approach_theory_percent\" between 0 and 100"
+        },
+        "workload_score_range": {
+          "name": "workload_score_range",
+          "value": "\"reviews\".\"workload_score\" between 1 and 10"
+        },
+        "learning_score_range": {
+          "name": "learning_score_range",
+          "value": "\"reviews\".\"learning_score\" between 1 and 10"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.sessions": {
+      "name": "sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "sessions_userId_idx": {
+          "name": "sessions_userId_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "sessions_user_id_users_id_fk": {
+          "name": "sessions_user_id_users_id_fk",
+          "tableFrom": "sessions",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "sessions_token_unique": {
+          "name": "sessions_token_unique",
+          "nullsNotDistinct": false,
+          "columns": ["token"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_saved_courses": {
+      "name": "user_saved_courses",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "course_code": {
+          "name": "course_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "user_saved_courses_course_code_idx": {
+          "name": "user_saved_courses_course_code_idx",
+          "columns": [
+            {
+              "expression": "course_code",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_saved_courses_user_id_users_id_fk": {
+          "name": "user_saved_courses_user_id_users_id_fk",
+          "tableFrom": "user_saved_courses",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "user_saved_courses_course_code_courses_code_fk": {
+          "name": "user_saved_courses_course_code_courses_code_fk",
+          "tableFrom": "user_saved_courses",
+          "tableTo": "courses",
+          "columnsFrom": ["course_code"],
+          "columnsTo": ["code"],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "user_saved_courses_user_id_course_code_pk": {
+          "name": "user_saved_courses_user_id_course_code_pk",
+          "columns": ["user_id", "course_code"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_taken_courses": {
+      "name": "user_taken_courses",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "course_code": {
+          "name": "course_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "attendance_periods": {
+          "name": "attendance_periods",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "attendance_year": {
+          "name": "attendance_year",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "grade": {
+          "name": "grade",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "earned_credits": {
+          "name": "earned_credits",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "transcript_imported_at": {
+          "name": "transcript_imported_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "user_taken_courses_course_code_idx": {
+          "name": "user_taken_courses_course_code_idx",
+          "columns": [
+            {
+              "expression": "course_code",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_taken_courses_user_id_users_id_fk": {
+          "name": "user_taken_courses_user_id_users_id_fk",
+          "tableFrom": "user_taken_courses",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "user_taken_courses_course_code_courses_code_fk": {
+          "name": "user_taken_courses_course_code_courses_code_fk",
+          "tableFrom": "user_taken_courses",
+          "tableTo": "courses",
+          "columnsFrom": ["course_code"],
+          "columnsTo": ["code"],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "user_taken_courses_user_id_course_code_pk": {
+          "name": "user_taken_courses_user_id_course_code_pk",
+          "columns": ["user_id", "course_code"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_favorites": {
+      "name": "user_favorites",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "fav_course_code": {
+          "name": "fav_course_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "user_favorites_user_id_users_id_fk": {
+          "name": "user_favorites_user_id_users_id_fk",
+          "tableFrom": "user_favorites",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "user_favorites_fav_course_code_courses_code_fk": {
+          "name": "user_favorites_fav_course_code_courses_code_fk",
+          "tableFrom": "user_favorites",
+          "tableTo": "courses",
+          "columnsFrom": ["fav_course_code"],
+          "columnsTo": ["code"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "user_favorites_user_id_fav_course_code_pk": {
+          "name": "user_favorites_user_id_fav_course_code_pk",
+          "columns": ["user_id", "fav_course_code"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "personalization_tier_earned": {
+          "name": "personalization_tier_earned",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "nullsNotDistinct": false,
+          "columns": ["email"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "personalization_tier_earned_range": {
+          "name": "personalization_tier_earned_range",
+          "value": "\"users\".\"personalization_tier_earned\" between 0 and 3"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.users_graph_backbone_edges": {
+      "name": "users_graph_backbone_edges",
+      "schema": "",
+      "columns": {
+        "node_user_id": {
+          "name": "node_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "anchor_user_id": {
+          "name": "anchor_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "users_graph_backbone_edges_anchor_user_id_idx": {
+          "name": "users_graph_backbone_edges_anchor_user_id_idx",
+          "columns": [
+            {
+              "expression": "anchor_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "users_graph_backbone_edges_node_user_id_users_graph_nodes_user_id_fk": {
+          "name": "users_graph_backbone_edges_node_user_id_users_graph_nodes_user_id_fk",
+          "tableFrom": "users_graph_backbone_edges",
+          "tableTo": "users_graph_nodes",
+          "columnsFrom": ["node_user_id"],
+          "columnsTo": ["user_id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "users_graph_backbone_edges_anchor_user_id_users_graph_nodes_user_id_fk": {
+          "name": "users_graph_backbone_edges_anchor_user_id_users_graph_nodes_user_id_fk",
+          "tableFrom": "users_graph_backbone_edges",
+          "tableTo": "users_graph_nodes",
+          "columnsFrom": ["anchor_user_id"],
+          "columnsTo": ["user_id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "users_graph_backbone_edges_node_user_id_anchor_user_id_pk": {
+          "name": "users_graph_backbone_edges_node_user_id_anchor_user_id_pk",
+          "columns": ["node_user_id", "anchor_user_id"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "no_self_backbone_edge": {
+          "name": "no_self_backbone_edge",
+          "value": "\"users_graph_backbone_edges\".\"node_user_id\" <> \"users_graph_backbone_edges\".\"anchor_user_id\""
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.users_graph_nodes": {
+      "name": "users_graph_nodes",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "x": {
+          "name": "x",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "y": {
+          "name": "y",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "users_graph_nodes_user_id_users_id_fk": {
+          "name": "users_graph_nodes_user_id_users_id_fk",
+          "tableFrom": "users_graph_nodes",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users_node_profiles": {
+      "name": "users_node_profiles",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "color": {
+          "name": "color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'default'"
+        },
+        "style": {
+          "name": "style",
+          "type": "node_style",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'default'"
+        },
+        "signal_style": {
+          "name": "signal_style",
+          "type": "node_signal_style",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'default'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "users_node_profiles_user_id_users_id_fk": {
+          "name": "users_node_profiles_user_id_users_id_fk",
+          "tableFrom": "users_node_profiles",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.verifications": {
+      "name": "verifications",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "verifications_identifier_idx": {
+          "name": "verifications_identifier_idx",
+          "columns": [
+            {
+              "expression": "identifier",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.course_state": {
+      "name": "course_state",
+      "schema": "public",
+      "values": ["CANCELLED", "ESTABLISHED", "DEACTIVATED"]
+    },
+    "public.node_signal_style": {
+      "name": "node_signal_style",
+      "schema": "public",
+      "values": ["default"]
+    },
+    "public.node_style": {
+      "name": "node_style",
+      "schema": "public",
+      "values": ["default"]
+    },
+    "public.review_vote_type": {
+      "name": "review_vote_type",
+      "schema": "public",
+      "values": ["up", "down"]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/apps/web/server/db/drizzle/meta/0008_snapshot.json
+++ b/apps/web/server/db/drizzle/meta/0008_snapshot.json
@@ -1177,15 +1177,13 @@
           "name": "workload_score",
           "type": "integer",
           "primaryKey": false,
-          "notNull": true,
-          "default": 1
+          "notNull": false
         },
         "learning_score": {
           "name": "learning_score",
           "type": "integer",
           "primaryKey": false,
-          "notNull": true,
-          "default": 1
+          "notNull": false
         },
         "happy_took": {
           "name": "happy_took",

--- a/apps/web/server/db/drizzle/meta/0009_snapshot.json
+++ b/apps/web/server/db/drizzle/meta/0009_snapshot.json
@@ -1177,15 +1177,13 @@
           "name": "workload_score",
           "type": "integer",
           "primaryKey": false,
-          "notNull": true,
-          "default": "NULL"
+          "notNull": false
         },
         "learning_score": {
           "name": "learning_score",
           "type": "integer",
           "primaryKey": false,
-          "notNull": true,
-          "default": "NULL"
+          "notNull": false
         },
         "happy_took": {
           "name": "happy_took",

--- a/apps/web/server/db/drizzle/meta/0009_snapshot.json
+++ b/apps/web/server/db/drizzle/meta/0009_snapshot.json
@@ -1,0 +1,1994 @@
+{
+  "id": "a6dc89d3-c077-4d97-9f1c-aa63eedb8983",
+  "prevId": "a2bde574-f3f6-4dbf-b8a7-f2b42c061947",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.accounts": {
+      "name": "accounts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "issuer": {
+          "name": "issuer",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "accounts_issuer_accountId_uidx": {
+          "name": "accounts_issuer_accountId_uidx",
+          "columns": [
+            {
+              "expression": "issuer",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "accounts_userId_idx": {
+          "name": "accounts_userId_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "accounts_user_id_users_id_fk": {
+          "name": "accounts_user_id_users_id_fk",
+          "tableFrom": "accounts",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.collection_courses": {
+      "name": "collection_courses",
+      "schema": "",
+      "columns": {
+        "collection_id": {
+          "name": "collection_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "collection_user_id": {
+          "name": "collection_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "course_code": {
+          "name": "course_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "collection_courses_collection_owner_idx": {
+          "name": "collection_courses_collection_owner_idx",
+          "columns": [
+            {
+              "expression": "collection_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "collection_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "collection_courses_saved_course_idx": {
+          "name": "collection_courses_saved_course_idx",
+          "columns": [
+            {
+              "expression": "collection_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "course_code",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "collection_courses_collection_owner_fk": {
+          "name": "collection_courses_collection_owner_fk",
+          "tableFrom": "collection_courses",
+          "tableTo": "collections",
+          "columnsFrom": ["collection_id", "collection_user_id"],
+          "columnsTo": ["id", "user_id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "collection_courses_saved_course_fk": {
+          "name": "collection_courses_saved_course_fk",
+          "tableFrom": "collection_courses",
+          "tableTo": "user_saved_courses",
+          "columnsFrom": ["collection_user_id", "course_code"],
+          "columnsTo": ["user_id", "course_code"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "collection_courses_collection_id_course_code_pk": {
+          "name": "collection_courses_collection_id_course_code_pk",
+          "columns": ["collection_id", "course_code"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "position_nonnegative": {
+          "name": "position_nonnegative",
+          "value": "\"collection_courses\".\"position\" >= 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.collections": {
+      "name": "collections",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "collections_user_id_idx": {
+          "name": "collections_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "collections_user_id_users_id_fk": {
+          "name": "collections_user_id_users_id_fk",
+          "tableFrom": "collections",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "collections_id_user_id_unique": {
+          "name": "collections_id_user_id_unique",
+          "nullsNotDistinct": false,
+          "columns": ["id", "user_id"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.course_examinations": {
+      "name": "course_examinations",
+      "schema": "",
+      "columns": {
+        "course_code": {
+          "name": "course_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "exam_code": {
+          "name": "exam_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "credits": {
+          "name": "credits",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "grade_scale_code": {
+          "name": "grade_scale_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "course_examinations_course_code_courses_code_fk": {
+          "name": "course_examinations_course_code_courses_code_fk",
+          "tableFrom": "course_examinations",
+          "tableTo": "courses",
+          "columnsFrom": ["course_code"],
+          "columnsTo": ["code"],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "course_examinations_course_code_exam_code_pk": {
+          "name": "course_examinations_course_code_exam_code_pk",
+          "columns": ["course_code", "exam_code"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.course_explore": {
+      "name": "course_explore",
+      "schema": "",
+      "columns": {
+        "course_code": {
+          "name": "course_code",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "embedding": {
+          "name": "embedding",
+          "type": "vector(1536)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_hash": {
+          "name": "source_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "search_vector": {
+          "name": "search_vector",
+          "type": "tsvector",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "embedding_model": {
+          "name": "embedding_model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "embedded_at": {
+          "name": "embedded_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "course_explore_search_vector_idx": {
+          "name": "course_explore_search_vector_idx",
+          "columns": [
+            {
+              "expression": "search_vector",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        },
+        "course_explore_embedding_idx": {
+          "name": "course_explore_embedding_idx",
+          "columns": [
+            {
+              "expression": "embedding",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "vector_cosine_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "hnsw",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "course_explore_course_code_courses_code_fk": {
+          "name": "course_explore_course_code_courses_code_fk",
+          "tableFrom": "course_explore",
+          "tableTo": "courses",
+          "columnsFrom": ["course_code"],
+          "columnsTo": ["code"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.course_prerequisites": {
+      "name": "course_prerequisites",
+      "schema": "",
+      "columns": {
+        "course_code": {
+          "name": "course_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "prerequisite_course_code": {
+          "name": "prerequisite_course_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "course_prerequisites_prerequisite_course_code_idx": {
+          "name": "course_prerequisites_prerequisite_course_code_idx",
+          "columns": [
+            {
+              "expression": "prerequisite_course_code",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "course_prerequisites_course_code_courses_code_fk": {
+          "name": "course_prerequisites_course_code_courses_code_fk",
+          "tableFrom": "course_prerequisites",
+          "tableTo": "courses",
+          "columnsFrom": ["course_code"],
+          "columnsTo": ["code"],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "course_prerequisites_prerequisite_course_code_courses_code_fk": {
+          "name": "course_prerequisites_prerequisite_course_code_courses_code_fk",
+          "tableFrom": "course_prerequisites",
+          "tableTo": "courses",
+          "columnsFrom": ["prerequisite_course_code"],
+          "columnsTo": ["code"],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "course_prerequisites_course_code_prerequisite_course_code_pk": {
+          "name": "course_prerequisites_course_code_prerequisite_course_code_pk",
+          "columns": ["course_code", "prerequisite_course_code"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.course_rounds": {
+      "name": "course_rounds",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "round_code": {
+          "name": "round_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "course_code": {
+          "name": "course_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "start_term": {
+          "name": "start_term",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "study_pace": {
+          "name": "study_pace",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "schema_url": {
+          "name": "schema_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "language": {
+          "name": "language",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tutoring_form": {
+          "name": "tutoring_form",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tutoring_time_of_day": {
+          "name": "tutoring_time_of_day",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "formatted_periods_and_credits": {
+          "name": "formatted_periods_and_credits",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_pu": {
+          "name": "is_pu",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_vu": {
+          "name": "is_vu",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "course_rounds_course_code_round_code_unique": {
+          "name": "course_rounds_course_code_round_code_unique",
+          "columns": [
+            {
+              "expression": "course_code",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "round_code",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"course_rounds\".\"round_code\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "course_rounds_course_code_idx": {
+          "name": "course_rounds_course_code_idx",
+          "columns": [
+            {
+              "expression": "course_code",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "course_rounds_course_code_courses_code_fk": {
+          "name": "course_rounds_course_code_courses_code_fk",
+          "tableFrom": "course_rounds",
+          "tableTo": "courses",
+          "columnsFrom": ["course_code"],
+          "columnsTo": ["code"],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "study_pace_range": {
+          "name": "study_pace_range",
+          "value": "\"course_rounds\".\"study_pace\" between 1 and 100"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.courses": {
+      "name": "courses",
+      "schema": "",
+      "columns": {
+        "code": {
+          "name": "code",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name_swedish": {
+          "name": "name_swedish",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name_english": {
+          "name": "name_english",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "state": {
+          "name": "state",
+          "type": "course_state",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "credits": {
+          "name": "credits",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "credit_unit": {
+          "name": "credit_unit",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "department_code": {
+          "name": "department_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "department": {
+          "name": "department",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "educational_level_code": {
+          "name": "educational_level_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "grade_scale_code": {
+          "name": "grade_scale_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "goals": {
+          "name": "goals",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "eligibility": {
+          "name": "eligibility",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "embedding": {
+          "name": "embedding",
+          "type": "vector(1536)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "embedding_hash": {
+          "name": "embedding_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "search_vector": {
+          "name": "search_vector",
+          "type": "tsvector",
+          "primaryKey": false,
+          "notNull": false,
+          "generated": {
+            "as": "to_tsvector('simple', coalesce(name_english, '') || ' ' || coalesce(name_swedish, '') || ' ' || coalesce(code, '') || ' ' || coalesce(goals, '') || ' ' || coalesce(content, ''))",
+            "type": "stored"
+          }
+        }
+      },
+      "indexes": {
+        "courses_search_vector_idx": {
+          "name": "courses_search_vector_idx",
+          "columns": [
+            {
+              "expression": "search_vector",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        },
+        "courses_embedding_idx": {
+          "name": "courses_embedding_idx",
+          "columns": [
+            {
+              "expression": "embedding",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "vector_cosine_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "hnsw",
+          "with": {}
+        },
+        "courses_name_trgm_idx": {
+          "name": "courses_name_trgm_idx",
+          "columns": [
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "gin_trgm_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        },
+        "courses_code_trgm_idx": {
+          "name": "courses_code_trgm_idx",
+          "columns": [
+            {
+              "expression": "code",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "gin_trgm_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.feedback_form": {
+      "name": "feedback_form",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "message": {
+          "name": "message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.review_likes": {
+      "name": "review_likes",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "review_id": {
+          "name": "review_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "vote_type": {
+          "name": "vote_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "review_likes_user_id_users_id_fk": {
+          "name": "review_likes_user_id_users_id_fk",
+          "tableFrom": "review_likes",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "review_likes_review_id_reviews_id_fk": {
+          "name": "review_likes_review_id_reviews_id_fk",
+          "tableFrom": "review_likes",
+          "tableTo": "reviews",
+          "columnsFrom": ["review_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "review_likes_user_id_review_id_pk": {
+          "name": "review_likes_user_id_review_id_pk",
+          "columns": ["user_id", "review_id"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.review_votes": {
+      "name": "review_votes",
+      "schema": "",
+      "columns": {
+        "voter_user_id": {
+          "name": "voter_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "review_id": {
+          "name": "review_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "vote_type": {
+          "name": "vote_type",
+          "type": "review_vote_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "review_votes_review_id_idx": {
+          "name": "review_votes_review_id_idx",
+          "columns": [
+            {
+              "expression": "review_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "review_votes_voter_user_id_users_id_fk": {
+          "name": "review_votes_voter_user_id_users_id_fk",
+          "tableFrom": "review_votes",
+          "tableTo": "users",
+          "columnsFrom": ["voter_user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "review_votes_review_id_reviews_id_fk": {
+          "name": "review_votes_review_id_reviews_id_fk",
+          "tableFrom": "review_votes",
+          "tableTo": "reviews",
+          "columnsFrom": ["review_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "review_votes_voter_user_id_review_id_pk": {
+          "name": "review_votes_voter_user_id_review_id_pk",
+          "columns": ["voter_user_id", "review_id"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.reviews": {
+      "name": "reviews",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "course_code": {
+          "name": "course_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "examination_methods": {
+          "name": "examination_methods",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "theoretical_vs_applied": {
+          "name": "theoretical_vs_applied",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "workload": {
+          "name": "workload",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "learning_experience": {
+          "name": "learning_experience",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "would_recommend": {
+          "name": "would_recommend",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "examination_distribution": {
+          "name": "examination_distribution",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "approach_theory_percent": {
+          "name": "approach_theory_percent",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "workload_score": {
+          "name": "workload_score",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "NULL"
+        },
+        "learning_score": {
+          "name": "learning_score",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "NULL"
+        },
+        "happy_took": {
+          "name": "happy_took",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "NULL"
+        },
+        "message": {
+          "name": "message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "reviews_user_id_idx": {
+          "name": "reviews_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "reviews_course_code_idx": {
+          "name": "reviews_course_code_idx",
+          "columns": [
+            {
+              "expression": "course_code",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "reviews_user_id_users_id_fk": {
+          "name": "reviews_user_id_users_id_fk",
+          "tableFrom": "reviews",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "reviews_course_code_courses_code_fk": {
+          "name": "reviews_course_code_courses_code_fk",
+          "tableFrom": "reviews",
+          "tableTo": "courses",
+          "columnsFrom": ["course_code"],
+          "columnsTo": ["code"],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "approach_theory_percent_range": {
+          "name": "approach_theory_percent_range",
+          "value": "\"reviews\".\"approach_theory_percent\" between 0 and 100"
+        },
+        "workload_score_range": {
+          "name": "workload_score_range",
+          "value": "\"reviews\".\"workload_score\" between 1 and 10"
+        },
+        "learning_score_range": {
+          "name": "learning_score_range",
+          "value": "\"reviews\".\"learning_score\" between 1 and 10"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.sessions": {
+      "name": "sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "sessions_userId_idx": {
+          "name": "sessions_userId_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "sessions_user_id_users_id_fk": {
+          "name": "sessions_user_id_users_id_fk",
+          "tableFrom": "sessions",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "sessions_token_unique": {
+          "name": "sessions_token_unique",
+          "nullsNotDistinct": false,
+          "columns": ["token"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_saved_courses": {
+      "name": "user_saved_courses",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "course_code": {
+          "name": "course_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "user_saved_courses_course_code_idx": {
+          "name": "user_saved_courses_course_code_idx",
+          "columns": [
+            {
+              "expression": "course_code",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_saved_courses_user_id_users_id_fk": {
+          "name": "user_saved_courses_user_id_users_id_fk",
+          "tableFrom": "user_saved_courses",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "user_saved_courses_course_code_courses_code_fk": {
+          "name": "user_saved_courses_course_code_courses_code_fk",
+          "tableFrom": "user_saved_courses",
+          "tableTo": "courses",
+          "columnsFrom": ["course_code"],
+          "columnsTo": ["code"],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "user_saved_courses_user_id_course_code_pk": {
+          "name": "user_saved_courses_user_id_course_code_pk",
+          "columns": ["user_id", "course_code"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_taken_courses": {
+      "name": "user_taken_courses",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "course_code": {
+          "name": "course_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "attendance_periods": {
+          "name": "attendance_periods",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "attendance_year": {
+          "name": "attendance_year",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "grade": {
+          "name": "grade",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "earned_credits": {
+          "name": "earned_credits",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "transcript_imported_at": {
+          "name": "transcript_imported_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "user_taken_courses_course_code_idx": {
+          "name": "user_taken_courses_course_code_idx",
+          "columns": [
+            {
+              "expression": "course_code",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_taken_courses_user_id_users_id_fk": {
+          "name": "user_taken_courses_user_id_users_id_fk",
+          "tableFrom": "user_taken_courses",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "user_taken_courses_course_code_courses_code_fk": {
+          "name": "user_taken_courses_course_code_courses_code_fk",
+          "tableFrom": "user_taken_courses",
+          "tableTo": "courses",
+          "columnsFrom": ["course_code"],
+          "columnsTo": ["code"],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "user_taken_courses_user_id_course_code_pk": {
+          "name": "user_taken_courses_user_id_course_code_pk",
+          "columns": ["user_id", "course_code"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_favorites": {
+      "name": "user_favorites",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "fav_course_code": {
+          "name": "fav_course_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "user_favorites_user_id_users_id_fk": {
+          "name": "user_favorites_user_id_users_id_fk",
+          "tableFrom": "user_favorites",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "user_favorites_fav_course_code_courses_code_fk": {
+          "name": "user_favorites_fav_course_code_courses_code_fk",
+          "tableFrom": "user_favorites",
+          "tableTo": "courses",
+          "columnsFrom": ["fav_course_code"],
+          "columnsTo": ["code"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "user_favorites_user_id_fav_course_code_pk": {
+          "name": "user_favorites_user_id_fav_course_code_pk",
+          "columns": ["user_id", "fav_course_code"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "personalization_tier_earned": {
+          "name": "personalization_tier_earned",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "nullsNotDistinct": false,
+          "columns": ["email"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "personalization_tier_earned_range": {
+          "name": "personalization_tier_earned_range",
+          "value": "\"users\".\"personalization_tier_earned\" between 0 and 3"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.users_graph_backbone_edges": {
+      "name": "users_graph_backbone_edges",
+      "schema": "",
+      "columns": {
+        "node_user_id": {
+          "name": "node_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "anchor_user_id": {
+          "name": "anchor_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "users_graph_backbone_edges_anchor_user_id_idx": {
+          "name": "users_graph_backbone_edges_anchor_user_id_idx",
+          "columns": [
+            {
+              "expression": "anchor_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "users_graph_backbone_edges_node_user_id_users_graph_nodes_user_id_fk": {
+          "name": "users_graph_backbone_edges_node_user_id_users_graph_nodes_user_id_fk",
+          "tableFrom": "users_graph_backbone_edges",
+          "tableTo": "users_graph_nodes",
+          "columnsFrom": ["node_user_id"],
+          "columnsTo": ["user_id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "users_graph_backbone_edges_anchor_user_id_users_graph_nodes_user_id_fk": {
+          "name": "users_graph_backbone_edges_anchor_user_id_users_graph_nodes_user_id_fk",
+          "tableFrom": "users_graph_backbone_edges",
+          "tableTo": "users_graph_nodes",
+          "columnsFrom": ["anchor_user_id"],
+          "columnsTo": ["user_id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "users_graph_backbone_edges_node_user_id_anchor_user_id_pk": {
+          "name": "users_graph_backbone_edges_node_user_id_anchor_user_id_pk",
+          "columns": ["node_user_id", "anchor_user_id"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "no_self_backbone_edge": {
+          "name": "no_self_backbone_edge",
+          "value": "\"users_graph_backbone_edges\".\"node_user_id\" <> \"users_graph_backbone_edges\".\"anchor_user_id\""
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.users_graph_nodes": {
+      "name": "users_graph_nodes",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "x": {
+          "name": "x",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "y": {
+          "name": "y",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "users_graph_nodes_user_id_users_id_fk": {
+          "name": "users_graph_nodes_user_id_users_id_fk",
+          "tableFrom": "users_graph_nodes",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users_node_profiles": {
+      "name": "users_node_profiles",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "color": {
+          "name": "color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'default'"
+        },
+        "style": {
+          "name": "style",
+          "type": "node_style",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'default'"
+        },
+        "signal_style": {
+          "name": "signal_style",
+          "type": "node_signal_style",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'default'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "users_node_profiles_user_id_users_id_fk": {
+          "name": "users_node_profiles_user_id_users_id_fk",
+          "tableFrom": "users_node_profiles",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.verifications": {
+      "name": "verifications",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "verifications_identifier_idx": {
+          "name": "verifications_identifier_idx",
+          "columns": [
+            {
+              "expression": "identifier",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.course_state": {
+      "name": "course_state",
+      "schema": "public",
+      "values": ["CANCELLED", "ESTABLISHED", "DEACTIVATED"]
+    },
+    "public.node_signal_style": {
+      "name": "node_signal_style",
+      "schema": "public",
+      "values": ["default"]
+    },
+    "public.node_style": {
+      "name": "node_style",
+      "schema": "public",
+      "values": ["default"]
+    },
+    "public.review_vote_type": {
+      "name": "review_vote_type",
+      "schema": "public",
+      "values": ["up", "down"]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/apps/web/server/db/drizzle/meta/_journal.json
+++ b/apps/web/server/db/drizzle/meta/_journal.json
@@ -15,6 +15,20 @@
       "when": 1788254785864,
       "tag": "0005_equal_pestilence",
       "breakpoints": true
+    },
+    {
+      "idx": 6,
+      "version": "7",
+      "when": 1788460368360,
+      "tag": "0006_target-schema",
+      "breakpoints": true
+    },
+    {
+      "idx": 7,
+      "version": "7",
+      "when": 1788460696189,
+      "tag": "0007_target-fk-indexes",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/web/server/db/drizzle/meta/_journal.json
+++ b/apps/web/server/db/drizzle/meta/_journal.json
@@ -29,6 +29,20 @@
       "when": 1788460696189,
       "tag": "0007_target-fk-indexes",
       "breakpoints": true
+    },
+    {
+      "idx": 8,
+      "version": "7",
+      "when": 1788461624931,
+      "tag": "0008_young_imperial_guard",
+      "breakpoints": true
+    },
+    {
+      "idx": 9,
+      "version": "7",
+      "when": 1788461690477,
+      "tag": "0009_volatile_kinsey_walden",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/web/server/db/schema.ts
+++ b/apps/web/server/db/schema.ts
@@ -7,6 +7,7 @@ import {
   foreignKey,
   index,
   integer,
+  jsonb,
   pgEnum,
   pgTable,
   primaryKey,
@@ -30,17 +31,9 @@ export const courseState = pgEnum("course_state", [
 
 export const reviewVoteType = pgEnum("review_vote_type", ["up", "down"]);
 
-export const nodeStyle = customType<{ data: string }>({
-  dataType() {
-    return "node_style";
-  },
-});
+export const nodeStyle = pgEnum("node_style", ["default"]);
 
-export const nodeSignalStyle = customType<{ data: string }>({
-  dataType() {
-    return "node_signal_style";
-  },
-});
+export const nodeSignalStyle = pgEnum("node_signal_style", ["default"]);
 
 // used for pgvector full-text search
 const tsvector = customType<{ data: string }>({
@@ -73,6 +66,9 @@ export const courses = pgTable(
     goals: text("goals"),
     content: text("content"),
     eligibility: text("eligibility"),
+    createdAt: timestamp("created_at", { withTimezone: true })
+      .defaultNow()
+      .notNull(),
     updatedAt: timestamp("updated_at", { withTimezone: true })
       .defaultNow()
       .notNull(),
@@ -98,21 +94,31 @@ export type SelectCourse = typeof courses.$inferSelect;
 
 // courseRounds is used for multiple course offerings across semesters
 // e.g. DD2421, which can be taken P2 or in P3. This table round-specific information.
-export const courseRounds = pgTable("course_rounds", {
-  id: serial("id").primaryKey(),
-  courseCode: text("course_code")
-    .notNull()
-    .references(() => courses.code, { onDelete: "cascade" }),
-  startTerm: integer("start_term").notNull(), // e.g. 20252
-  studyPace: integer("study_pace"), // percentage, e.g. 50
-  schemaUrl: text("schema_url"),
-  language: text("language"),
-  tutoringForm: text("tutoring_form"), // "NML (Normal) or DST (Distance)"
-  tutoringTimeOfDay: text("tutoring_time_of_day"), // "DAG (Day-time) or KVÄ (evenings)"
-  formattedPeriodsAndCredits: text("formatted_periods_and_credits"), // e.g. "P1 (7,5 hp)"
-  isPU: boolean("is_pu").notNull(), // Part of KTH programme
-  isVU: boolean("is_vu").notNull(), // open course
-});
+export const courseRounds = pgTable(
+  "course_rounds",
+  {
+    id: serial("id").primaryKey(),
+    courseCode: text("course_code")
+      .notNull()
+      .references(() => courses.code, {
+        onDelete: "restrict",
+        onUpdate: "no action",
+      }),
+    startTerm: integer("start_term").notNull(), // e.g. 20252
+    studyPace: integer("study_pace"), // percentage, e.g. 50
+    schemaUrl: text("schema_url"),
+    language: text("language"),
+    tutoringForm: text("tutoring_form"), // "NML (Normal) or DST (Distance)"
+    tutoringTimeOfDay: text("tutoring_time_of_day"), // "DAG (Day-time) or KVÄ (evenings)"
+    formattedPeriodsAndCredits: text("formatted_periods_and_credits"), // e.g. "P1 (7,5 hp)"
+    isPU: boolean("is_pu").notNull(), // Part of KTH programme
+    isVU: boolean("is_vu").notNull(), // open course
+  },
+  (table) => [
+    check("study_pace_range", sql`${table.studyPace} between 1 and 100`),
+    index("course_rounds_course_code_idx").on(table.courseCode),
+  ],
+);
 
 export type InsertCourseRound = typeof courseRounds.$inferInsert;
 export type SelectCourseRound = typeof courseRounds.$inferSelect;
@@ -124,7 +130,10 @@ export const courseExaminations = pgTable(
   {
     courseCode: text("course_code")
       .notNull()
-      .references(() => courses.code, { onDelete: "cascade" }),
+      .references(() => courses.code, {
+        onDelete: "restrict",
+        onUpdate: "no action",
+      }),
     examCode: text("exam_code").notNull(), // e.g. "TEN1"
     title: text("title"), // e.g. "Tentamen"
     credits: real("credits"),
@@ -141,34 +150,62 @@ export const coursePrerequisites = pgTable(
   {
     courseCode: text("course_code")
       .notNull()
-      .references(() => courses.code),
+      .references(() => courses.code, {
+        onDelete: "restrict",
+        onUpdate: "no action",
+      }),
     prerequisiteCourseCode: text("prerequisite_course_code")
       .notNull()
-      .references(() => courses.code),
-    createdAt: timestamp("created_at", { withTimezone: true }).notNull(),
+      .references(() => courses.code, {
+        onDelete: "restrict",
+        onUpdate: "no action",
+      }),
+    createdAt: timestamp("created_at", { withTimezone: true })
+      .defaultNow()
+      .notNull(),
   },
   (table) => [
     primaryKey({
       columns: [table.courseCode, table.prerequisiteCourseCode],
     }),
+    index("course_prerequisites_prerequisite_course_code_idx").on(
+      table.prerequisiteCourseCode,
+    ),
   ],
 );
 
 export type InsertCoursePrerequisite = typeof coursePrerequisites.$inferInsert;
 export type SelectCoursePrerequisite = typeof coursePrerequisites.$inferSelect;
 
-export const courseExplore = pgTable("course_explore", {
-  courseCode: text("course_code")
-    .primaryKey()
-    .references(() => courses.code),
-  embedding: vector("embedding", { dimensions: 1536 }),
-  sourceHash: text("source_hash"),
-  searchVector: tsvector("search_vector"),
-  embeddingModel: text("embedding_model"),
-  embeddedAt: timestamp("embedded_at", { withTimezone: true }),
-  createdAt: timestamp("created_at", { withTimezone: true }).notNull(),
-  updatedAt: timestamp("updated_at", { withTimezone: true }).notNull(),
-});
+export const courseExplore = pgTable(
+  "course_explore",
+  {
+    courseCode: text("course_code")
+      .primaryKey()
+      .references(() => courses.code, {
+        onDelete: "cascade",
+        onUpdate: "no action",
+      }),
+    embedding: vector("embedding", { dimensions: 1536 }),
+    sourceHash: text("source_hash"),
+    searchVector: tsvector("search_vector"),
+    embeddingModel: text("embedding_model"),
+    embeddedAt: timestamp("embedded_at", { withTimezone: true }),
+    createdAt: timestamp("created_at", { withTimezone: true })
+      .defaultNow()
+      .notNull(),
+    updatedAt: timestamp("updated_at", { withTimezone: true })
+      .defaultNow()
+      .notNull(),
+  },
+  (table) => [
+    index("course_explore_search_vector_idx").using("gin", table.searchVector),
+    index("course_explore_embedding_idx").using(
+      "hnsw",
+      table.embedding.op("vector_cosine_ops"),
+    ),
+  ],
+);
 
 export type InsertCourseExplore = typeof courseExplore.$inferInsert;
 export type SelectCourseExplore = typeof courseExplore.$inferSelect;
@@ -178,13 +215,24 @@ export const userSavedCourses = pgTable(
   {
     userId: text("user_id")
       .notNull()
-      .references(() => users.id),
+      .references(() => users.id, {
+        onDelete: "cascade",
+        onUpdate: "no action",
+      }),
     courseCode: text("course_code")
       .notNull()
-      .references(() => courses.code),
-    createdAt: timestamp("created_at", { withTimezone: true }).notNull(),
+      .references(() => courses.code, {
+        onDelete: "restrict",
+        onUpdate: "no action",
+      }),
+    createdAt: timestamp("created_at", { withTimezone: true })
+      .defaultNow()
+      .notNull(),
   },
-  (table) => [primaryKey({ columns: [table.userId, table.courseCode] })],
+  (table) => [
+    primaryKey({ columns: [table.userId, table.courseCode] }),
+    index("user_saved_courses_course_code_idx").on(table.courseCode),
+  ],
 );
 
 export type InsertUserSavedCourse = typeof userSavedCourses.$inferInsert;
@@ -195,10 +243,16 @@ export const userTakenCourses = pgTable(
   {
     userId: text("user_id")
       .notNull()
-      .references(() => users.id),
+      .references(() => users.id, {
+        onDelete: "cascade",
+        onUpdate: "no action",
+      }),
     courseCode: text("course_code")
       .notNull()
-      .references(() => courses.code),
+      .references(() => courses.code, {
+        onDelete: "restrict",
+        onUpdate: "no action",
+      }),
     attendancePeriods: text("attendance_periods"),
     attendanceYear: integer("attendance_year"),
     grade: text("grade"),
@@ -206,10 +260,17 @@ export const userTakenCourses = pgTable(
     transcriptImportedAt: timestamp("transcript_imported_at", {
       withTimezone: true,
     }),
-    createdAt: timestamp("created_at", { withTimezone: true }).notNull(),
-    updatedAt: timestamp("updated_at", { withTimezone: true }).notNull(),
+    createdAt: timestamp("created_at", { withTimezone: true })
+      .defaultNow()
+      .notNull(),
+    updatedAt: timestamp("updated_at", { withTimezone: true })
+      .defaultNow()
+      .notNull(),
   },
-  (table) => [primaryKey({ columns: [table.userId, table.courseCode] })],
+  (table) => [
+    primaryKey({ columns: [table.userId, table.courseCode] }),
+    index("user_taken_courses_course_code_idx").on(table.courseCode),
+  ],
 );
 
 export type InsertUserTakenCourse = typeof userTakenCourses.$inferInsert;
@@ -221,12 +282,18 @@ export const collections = pgTable(
     id: text("id").primaryKey(),
     userId: text("user_id")
       .notNull()
-      .references(() => users.id),
+      .references(() => users.id, {
+        onDelete: "cascade",
+        onUpdate: "no action",
+      }),
     name: text("name").notNull(),
-    createdAt: timestamp("created_at", { withTimezone: true }).notNull(),
+    createdAt: timestamp("created_at", { withTimezone: true })
+      .defaultNow()
+      .notNull(),
   },
   (table) => [
     unique("collections_id_user_id_unique").on(table.id, table.userId),
+    index("collections_user_id_idx").on(table.userId),
   ],
 );
 
@@ -240,7 +307,9 @@ export const collectionCourses = pgTable(
     collectionUserId: text("collection_user_id").notNull(),
     courseCode: text("course_code").notNull(),
     position: integer("position").notNull(),
-    createdAt: timestamp("created_at", { withTimezone: true }).notNull(),
+    createdAt: timestamp("created_at", { withTimezone: true })
+      .defaultNow()
+      .notNull(),
   },
   (table) => [
     primaryKey({ columns: [table.collectionId, table.courseCode] }),
@@ -248,13 +317,21 @@ export const collectionCourses = pgTable(
       name: "collection_courses_collection_owner_fk",
       columns: [table.collectionId, table.collectionUserId],
       foreignColumns: [collections.id, collections.userId],
-    }),
+    }).onDelete("cascade"),
     foreignKey({
       name: "collection_courses_saved_course_fk",
       columns: [table.collectionUserId, table.courseCode],
       foreignColumns: [userSavedCourses.userId, userSavedCourses.courseCode],
-    }),
+    }).onDelete("cascade"),
     check("position_nonnegative", sql`${table.position} >= 0`),
+    index("collection_courses_collection_owner_idx").on(
+      table.collectionId,
+      table.collectionUserId,
+    ),
+    index("collection_courses_saved_course_idx").on(
+      table.collectionUserId,
+      table.courseCode,
+    ),
   ],
 );
 
@@ -264,11 +341,18 @@ export type SelectCollectionCourse = typeof collectionCourses.$inferSelect;
 export const usersGraphNodes = pgTable("users_graph_nodes", {
   userId: text("user_id")
     .primaryKey()
-    .references(() => users.id),
+    .references(() => users.id, {
+      onDelete: "cascade",
+      onUpdate: "no action",
+    }),
   x: doublePrecision("x").notNull(),
   y: doublePrecision("y").notNull(),
-  createdAt: timestamp("created_at", { withTimezone: true }).notNull(),
-  updatedAt: timestamp("updated_at", { withTimezone: true }).notNull(),
+  createdAt: timestamp("created_at", { withTimezone: true })
+    .defaultNow()
+    .notNull(),
+  updatedAt: timestamp("updated_at", { withTimezone: true })
+    .defaultNow()
+    .notNull(),
 });
 
 export type InsertUsersGraphNode = typeof usersGraphNodes.$inferInsert;
@@ -279,17 +363,28 @@ export const usersGraphBackboneEdges = pgTable(
   {
     nodeUserId: text("node_user_id")
       .notNull()
-      .references(() => usersGraphNodes.userId),
+      .references(() => usersGraphNodes.userId, {
+        onDelete: "cascade",
+        onUpdate: "no action",
+      }),
     anchorUserId: text("anchor_user_id")
       .notNull()
-      .references(() => usersGraphNodes.userId),
-    createdAt: timestamp("created_at", { withTimezone: true }).notNull(),
+      .references(() => usersGraphNodes.userId, {
+        onDelete: "cascade",
+        onUpdate: "no action",
+      }),
+    createdAt: timestamp("created_at", { withTimezone: true })
+      .defaultNow()
+      .notNull(),
   },
   (table) => [
     primaryKey({ columns: [table.nodeUserId, table.anchorUserId] }),
     check(
       "no_self_backbone_edge",
       sql`${table.nodeUserId} <> ${table.anchorUserId}`,
+    ),
+    index("users_graph_backbone_edges_anchor_user_id_idx").on(
+      table.anchorUserId,
     ),
   ],
 );
@@ -302,12 +397,19 @@ export type SelectUsersGraphBackboneEdge =
 export const usersNodeProfiles = pgTable("users_node_profiles", {
   userId: text("user_id")
     .primaryKey()
-    .references(() => users.id),
-  color: text("color").notNull(),
-  style: nodeStyle("style").notNull(),
-  signalStyle: nodeSignalStyle("signal_style").notNull(),
-  createdAt: timestamp("created_at", { withTimezone: true }).notNull(),
-  updatedAt: timestamp("updated_at", { withTimezone: true }).notNull(),
+    .references(() => users.id, {
+      onDelete: "cascade",
+      onUpdate: "no action",
+    }),
+  color: text("color").default("default").notNull(),
+  style: nodeStyle("style").default("default").notNull(),
+  signalStyle: nodeSignalStyle("signal_style").default("default").notNull(),
+  createdAt: timestamp("created_at", { withTimezone: true })
+    .defaultNow()
+    .notNull(),
+  updatedAt: timestamp("updated_at", { withTimezone: true })
+    .defaultNow()
+    .notNull(),
 });
 
 export type InsertUsersNodeProfile = typeof usersNodeProfiles.$inferInsert;
@@ -335,49 +437,111 @@ export const user_favorites = pgTable(
 
 // --- REVIEW / FORUM TABLES ----------------
 // table for reviews that references users (posters) and courses (reviewed)
-export const reviews = pgTable("reviews", {
-  id: text("id").primaryKey(), // review id
-  userId: text("user_id")
-    .notNull()
-    .references(() => users.id, { onDelete: "cascade" }), // foreign key to users table
-  courseCode: text("course_code")
-    .notNull()
-    .references(() => courses.code, { onDelete: "cascade" }), // foreign key to courses table
+const reviewsTable = pgTable(
+  "reviews",
+  {
+    id: text("id").primaryKey(), // review id
+    userId: text("user_id")
+      .notNull()
+      .references(() => users.id, { onDelete: "cascade" }), // foreign key to users table
+    courseCode: text("course_code")
+      .notNull()
+      .references(() => courses.code, { onDelete: "cascade" }), // foreign key to courses table
 
-  // scores
-  examinationMethods: integer("examination_methods").notNull().default(0), // 1-5
-  theoreticalVsApplied: integer("theoretical_vs_applied").notNull().default(0), // 1-5
-  workload: integer("workload").notNull().default(0), // 1-5
-  learningExperience: integer("learning_experience").notNull().default(0), // 1-5
+    // scores
+    examinationMethods: integer("examination_methods").notNull().default(0), // 1-5
+    theoreticalVsApplied: integer("theoretical_vs_applied")
+      .notNull()
+      .default(0), // 1-5
+    workload: integer("workload").notNull().default(0), // 1-5
+    learningExperience: integer("learning_experience").notNull().default(0), // 1-5
 
-  wouldRecommend: boolean("would_recommend").notNull().default(false),
-  content: text("content").notNull(),
+    wouldRecommend: boolean("would_recommend").notNull().default(false),
+    content: text("content").notNull(),
 
-  // timestamps
-  createdAt: timestamp("created_at", { withTimezone: true })
-    .defaultNow()
-    .notNull(),
-  updatedAt: timestamp("updated_at", { withTimezone: true })
-    .defaultNow()
-    .notNull(),
-});
-export type InsertReview = typeof reviews.$inferInsert;
-export type SelectReview = typeof reviews.$inferSelect;
+    // Target fields coexist with the legacy fields until the review domain
+    // switches. Defaults keep legacy inserts type-compatible; the A2 migration
+    // installs a trigger that mirrors actual legacy values into these columns.
+    examinationDistribution: jsonb("examination_distribution"),
+    approachTheoryPercent: integer("approach_theory_percent"),
+    workloadScore: integer("workload_score").default(1).notNull(),
+    learningScore: integer("learning_score").default(1).notNull(),
+    happyTook: boolean("happy_took").default(false).notNull(),
+    message: text("message"),
+
+    // timestamps
+    createdAt: timestamp("created_at", { withTimezone: true })
+      .defaultNow()
+      .notNull(),
+    updatedAt: timestamp("updated_at", { withTimezone: true })
+      .defaultNow()
+      .notNull(),
+  },
+  (table) => [
+    check(
+      "approach_theory_percent_range",
+      sql`${table.approachTheoryPercent} between 0 and 100`,
+    ),
+    check("workload_score_range", sql`${table.workloadScore} between 1 and 10`),
+    check("learning_score_range", sql`${table.learningScore} between 1 and 10`),
+    index("reviews_user_id_idx").on(table.userId),
+    index("reviews_course_code_idx").on(table.courseCode),
+  ],
+);
+
+type FullSelectReview = typeof reviewsTable.$inferSelect;
+type LegacyReviewKey =
+  | "id"
+  | "userId"
+  | "courseCode"
+  | "examinationMethods"
+  | "theoreticalVsApplied"
+  | "workload"
+  | "learningExperience"
+  | "wouldRecommend"
+  | "content"
+  | "createdAt"
+  | "updatedAt";
+
+// Temporary compatibility: current review services infer their read model from
+// this property. B removes the override when it switches to the target fields.
+export const reviews = reviewsTable as Omit<
+  typeof reviewsTable,
+  "$inferSelect"
+> & {
+  $inferSelect: Pick<FullSelectReview, LegacyReviewKey>;
+};
+
+export type InsertReview = typeof reviewsTable.$inferInsert;
+export type SelectReview = Pick<FullSelectReview, LegacyReviewKey>;
 
 export const reviewVotes = pgTable(
   "review_votes",
   {
     voterUserId: text("voter_user_id")
       .notNull()
-      .references(() => users.id),
+      .references(() => users.id, {
+        onDelete: "cascade",
+        onUpdate: "no action",
+      }),
     reviewId: text("review_id")
       .notNull()
-      .references(() => reviews.id),
+      .references(() => reviews.id, {
+        onDelete: "cascade",
+        onUpdate: "no action",
+      }),
     voteType: reviewVoteType("vote_type").notNull(),
-    createdAt: timestamp("created_at", { withTimezone: true }).notNull(),
-    updatedAt: timestamp("updated_at", { withTimezone: true }).notNull(),
+    createdAt: timestamp("created_at", { withTimezone: true })
+      .defaultNow()
+      .notNull(),
+    updatedAt: timestamp("updated_at", { withTimezone: true })
+      .defaultNow()
+      .notNull(),
   },
-  (table) => [primaryKey({ columns: [table.voterUserId, table.reviewId] })],
+  (table) => [
+    primaryKey({ columns: [table.voterUserId, table.reviewId] }),
+    index("review_votes_review_id_idx").on(table.reviewId),
+  ],
 );
 
 export type InsertReviewVote = typeof reviewVotes.$inferInsert;

--- a/apps/web/server/db/schema.ts
+++ b/apps/web/server/db/schema.ts
@@ -16,6 +16,7 @@ import {
   text,
   timestamp,
   unique,
+  uniqueIndex,
   vector,
 } from "drizzle-orm/pg-core";
 
@@ -98,6 +99,9 @@ export const courseRounds = pgTable(
   "course_rounds",
   {
     id: serial("id").primaryKey(),
+    // Expand phase: populated from KOPPS round.ladokUID. The contract migration
+    // may make this required only after a verified source-backed round rebuild.
+    roundCode: text("round_code"),
     courseCode: text("course_code")
       .notNull()
       .references(() => courses.code, {
@@ -116,6 +120,9 @@ export const courseRounds = pgTable(
   },
   (table) => [
     check("study_pace_range", sql`${table.studyPace} between 1 and 100`),
+    uniqueIndex("course_rounds_course_code_round_code_unique")
+      .on(table.courseCode, table.roundCode)
+      .where(sql`${table.roundCode} is not null`),
     index("course_rounds_course_code_idx").on(table.courseCode),
   ],
 );
@@ -446,7 +453,10 @@ const reviewsTable = pgTable(
       .references(() => users.id, { onDelete: "cascade" }), // foreign key to users table
     courseCode: text("course_code")
       .notNull()
-      .references(() => courses.code, { onDelete: "cascade" }), // foreign key to courses table
+      .references(() => courses.code, {
+        onDelete: "restrict",
+        onUpdate: "no action",
+      }), // foreign key to courses table
 
     // scores
     examinationMethods: integer("examination_methods").notNull().default(0), // 1-5
@@ -460,13 +470,13 @@ const reviewsTable = pgTable(
     content: text("content").notNull(),
 
     // Target fields coexist with the legacy fields until the review domain
-    // switches. Defaults keep legacy inserts type-compatible; the A2 migration
-    // installs a trigger that mirrors actual legacy values into these columns.
+    // switches. Temporary NULL defaults let the compatibility trigger identify
+    // omitted target values while keeping legacy inserts type-compatible.
     examinationDistribution: jsonb("examination_distribution"),
     approachTheoryPercent: integer("approach_theory_percent"),
-    workloadScore: integer("workload_score").default(1).notNull(),
-    learningScore: integer("learning_score").default(1).notNull(),
-    happyTook: boolean("happy_took").default(false).notNull(),
+    workloadScore: integer("workload_score").default(sql`NULL`).notNull(),
+    learningScore: integer("learning_score").default(sql`NULL`).notNull(),
+    happyTook: boolean("happy_took").default(sql`NULL`).notNull(),
     message: text("message"),
 
     // timestamps

--- a/apps/web/server/db/schema.ts
+++ b/apps/web/server/db/schema.ts
@@ -470,12 +470,12 @@ const reviewsTable = pgTable(
     content: text("content").notNull(),
 
     // Target fields coexist with the legacy fields until the review domain
-    // switches. Temporary NULL defaults let the compatibility trigger identify
-    // omitted target values while keeping legacy inserts type-compatible.
+    // switches. Scores stay nullable during the expand phase because legacy
+    // zeroes do not represent valid target ratings.
     examinationDistribution: jsonb("examination_distribution"),
     approachTheoryPercent: integer("approach_theory_percent"),
-    workloadScore: integer("workload_score").default(sql`NULL`).notNull(),
-    learningScore: integer("learning_score").default(sql`NULL`).notNull(),
+    workloadScore: integer("workload_score"),
+    learningScore: integer("learning_score"),
     happyTook: boolean("happy_took").default(sql`NULL`).notNull(),
     message: text("message"),
 

--- a/apps/web/server/ingest/ingest.ts
+++ b/apps/web/server/ingest/ingest.ts
@@ -163,6 +163,7 @@ async function convertCourses(courses: z.infer<typeof CoursesSchema>): Promise<{
 
       const insertRounds: InsertCourseRound[] = detail.roundInfos.map((r) => ({
         courseCode: detail.course.courseCode,
+        roundCode: r.round.ladokUID,
         startTerm: r.round.startTerm.term,
         studyPace: r.round.studyPace ?? null,
         schemaUrl: r.schemaUrl ?? null,

--- a/apps/web/server/ingest/schemas.ts
+++ b/apps/web/server/ingest/schemas.ts
@@ -36,7 +36,7 @@ export const CourseDetailSchema = z.object({
         startTerm: z.object({ term: z.number() }),
         isPU: z.boolean(),
         isVU: z.boolean(),
-        studyPace: z.number().optional(),
+        studyPace: z.number().int().min(1).max(100).optional(),
         tutoringTimeOfDay: z.object({ name: z.string() }).optional(),
         tutoringForm: z.object({ name: z.string() }).optional(),
         language: z.string().optional(),

--- a/apps/web/server/ingest/schemas.ts
+++ b/apps/web/server/ingest/schemas.ts
@@ -32,6 +32,7 @@ export const CourseDetailSchema = z.object({
     z.object({
       schemaUrl: z.string().optional(),
       round: z.object({
+        ladokUID: z.string().min(1),
         startTerm: z.object({ term: z.number() }),
         isPU: z.boolean(),
         isVU: z.boolean(),


### PR DESCRIPTION
Addresses #63
Depends on #71

## Summary
- add ordered target-schema and FK-index migrations without rewriting migration history
- preserve and backfill saved courses, review votes, review fields, and course search data
- keep legacy writers synchronized through temporary compatibility triggers
- settle referential actions, node defaults, timestamptz behavior, real credits, vector(1536), GIN, and HNSW
- capture KOPPS round.ladokUID and add the safe nullable round_code expansion

## Validation
- TypeScript check passes
- 28/28 tests pass
- Drizzle migration integrity check passes
- lint exits successfully; remaining warnings are pre-existing and outside this PR
- diff and historical-migration immutability checks pass

## Remaining before ready for merge
- merge #71 so this stacked PR shows only A2 changes
- apply and verify on a fresh and data-containing isolated Neon child branch
- rebuild course rounds from KOPPS ladokUID values, then add the contract migration for NOT NULL, composite primary key, and serial id removal
- attach the Neon schema diff

No database migration was applied from this worktree.