### PR TITLE
chore(db): key course_rounds on its serial id and drop round_code

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -85,7 +85,7 @@ _Avoid_: transcript sync, Ladok scrape, upload (that is the file step, not this)
 A named, ordered group of one app user's saved courses. A course may only join a
 collection its owner has also saved.
 _Today_: no table. Closed by `collections` and `collection_courses`.
-_Avoid_: list, folder, group, playlist
+_Avoid_: comparison, list, folder, group, playlist
 
 ### Reviews
 

--- a/apps/web/server/db/drizzle/0010_abnormal_shocker.sql
+++ b/apps/web/server/db/drizzle/0010_abnormal_shocker.sql
@@ -1,0 +1,2 @@
+DROP INDEX "course_rounds_course_code_round_code_unique";--> statement-breakpoint
+ALTER TABLE "course_rounds" DROP COLUMN "round_code";

--- a/apps/web/server/db/drizzle/meta/0010_snapshot.json
+++ b/apps/web/server/db/drizzle/meta/0010_snapshot.json
@@ -1,0 +1,1964 @@
+{
+  "id": "3642ca47-7c55-4c74-acb8-20c1d1dadc8d",
+  "prevId": "a6dc89d3-c077-4d97-9f1c-aa63eedb8983",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.collection_courses": {
+      "name": "collection_courses",
+      "schema": "",
+      "columns": {
+        "collection_id": {
+          "name": "collection_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "collection_user_id": {
+          "name": "collection_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "course_code": {
+          "name": "course_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "collection_courses_collection_owner_idx": {
+          "name": "collection_courses_collection_owner_idx",
+          "columns": [
+            {
+              "expression": "collection_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "collection_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "collection_courses_saved_course_idx": {
+          "name": "collection_courses_saved_course_idx",
+          "columns": [
+            {
+              "expression": "collection_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "course_code",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "collection_courses_collection_owner_fk": {
+          "name": "collection_courses_collection_owner_fk",
+          "tableFrom": "collection_courses",
+          "tableTo": "collections",
+          "columnsFrom": ["collection_id", "collection_user_id"],
+          "columnsTo": ["id", "user_id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "collection_courses_saved_course_fk": {
+          "name": "collection_courses_saved_course_fk",
+          "tableFrom": "collection_courses",
+          "tableTo": "user_saved_courses",
+          "columnsFrom": ["collection_user_id", "course_code"],
+          "columnsTo": ["user_id", "course_code"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "collection_courses_collection_id_course_code_pk": {
+          "name": "collection_courses_collection_id_course_code_pk",
+          "columns": ["collection_id", "course_code"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "position_nonnegative": {
+          "name": "position_nonnegative",
+          "value": "\"collection_courses\".\"position\" >= 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.collections": {
+      "name": "collections",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "collections_user_id_idx": {
+          "name": "collections_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "collections_user_id_users_id_fk": {
+          "name": "collections_user_id_users_id_fk",
+          "tableFrom": "collections",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "collections_id_user_id_unique": {
+          "name": "collections_id_user_id_unique",
+          "nullsNotDistinct": false,
+          "columns": ["id", "user_id"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.course_examinations": {
+      "name": "course_examinations",
+      "schema": "",
+      "columns": {
+        "course_code": {
+          "name": "course_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "exam_code": {
+          "name": "exam_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "credits": {
+          "name": "credits",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "grade_scale_code": {
+          "name": "grade_scale_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "course_examinations_course_code_courses_code_fk": {
+          "name": "course_examinations_course_code_courses_code_fk",
+          "tableFrom": "course_examinations",
+          "tableTo": "courses",
+          "columnsFrom": ["course_code"],
+          "columnsTo": ["code"],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "course_examinations_course_code_exam_code_pk": {
+          "name": "course_examinations_course_code_exam_code_pk",
+          "columns": ["course_code", "exam_code"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.course_explore": {
+      "name": "course_explore",
+      "schema": "",
+      "columns": {
+        "course_code": {
+          "name": "course_code",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "embedding": {
+          "name": "embedding",
+          "type": "vector(1536)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_hash": {
+          "name": "source_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "search_vector": {
+          "name": "search_vector",
+          "type": "tsvector",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "embedding_model": {
+          "name": "embedding_model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "embedded_at": {
+          "name": "embedded_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "course_explore_search_vector_idx": {
+          "name": "course_explore_search_vector_idx",
+          "columns": [
+            {
+              "expression": "search_vector",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        },
+        "course_explore_embedding_idx": {
+          "name": "course_explore_embedding_idx",
+          "columns": [
+            {
+              "expression": "embedding",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "vector_cosine_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "hnsw",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "course_explore_course_code_courses_code_fk": {
+          "name": "course_explore_course_code_courses_code_fk",
+          "tableFrom": "course_explore",
+          "tableTo": "courses",
+          "columnsFrom": ["course_code"],
+          "columnsTo": ["code"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.course_prerequisites": {
+      "name": "course_prerequisites",
+      "schema": "",
+      "columns": {
+        "course_code": {
+          "name": "course_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "prerequisite_course_code": {
+          "name": "prerequisite_course_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "course_prerequisites_prerequisite_course_code_idx": {
+          "name": "course_prerequisites_prerequisite_course_code_idx",
+          "columns": [
+            {
+              "expression": "prerequisite_course_code",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "course_prerequisites_course_code_courses_code_fk": {
+          "name": "course_prerequisites_course_code_courses_code_fk",
+          "tableFrom": "course_prerequisites",
+          "tableTo": "courses",
+          "columnsFrom": ["course_code"],
+          "columnsTo": ["code"],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "course_prerequisites_prerequisite_course_code_courses_code_fk": {
+          "name": "course_prerequisites_prerequisite_course_code_courses_code_fk",
+          "tableFrom": "course_prerequisites",
+          "tableTo": "courses",
+          "columnsFrom": ["prerequisite_course_code"],
+          "columnsTo": ["code"],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "course_prerequisites_course_code_prerequisite_course_code_pk": {
+          "name": "course_prerequisites_course_code_prerequisite_course_code_pk",
+          "columns": ["course_code", "prerequisite_course_code"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.course_rounds": {
+      "name": "course_rounds",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "course_code": {
+          "name": "course_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "start_term": {
+          "name": "start_term",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "study_pace": {
+          "name": "study_pace",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "schema_url": {
+          "name": "schema_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "language": {
+          "name": "language",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tutoring_form": {
+          "name": "tutoring_form",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tutoring_time_of_day": {
+          "name": "tutoring_time_of_day",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "formatted_periods_and_credits": {
+          "name": "formatted_periods_and_credits",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_pu": {
+          "name": "is_pu",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_vu": {
+          "name": "is_vu",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "course_rounds_course_code_idx": {
+          "name": "course_rounds_course_code_idx",
+          "columns": [
+            {
+              "expression": "course_code",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "course_rounds_course_code_courses_code_fk": {
+          "name": "course_rounds_course_code_courses_code_fk",
+          "tableFrom": "course_rounds",
+          "tableTo": "courses",
+          "columnsFrom": ["course_code"],
+          "columnsTo": ["code"],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "study_pace_range": {
+          "name": "study_pace_range",
+          "value": "\"course_rounds\".\"study_pace\" between 1 and 100"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.courses": {
+      "name": "courses",
+      "schema": "",
+      "columns": {
+        "code": {
+          "name": "code",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name_swedish": {
+          "name": "name_swedish",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name_english": {
+          "name": "name_english",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "state": {
+          "name": "state",
+          "type": "course_state",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "credits": {
+          "name": "credits",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "credit_unit": {
+          "name": "credit_unit",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "department_code": {
+          "name": "department_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "department": {
+          "name": "department",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "educational_level_code": {
+          "name": "educational_level_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "grade_scale_code": {
+          "name": "grade_scale_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "goals": {
+          "name": "goals",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "eligibility": {
+          "name": "eligibility",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "embedding": {
+          "name": "embedding",
+          "type": "vector(1536)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "embedding_hash": {
+          "name": "embedding_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "search_vector": {
+          "name": "search_vector",
+          "type": "tsvector",
+          "primaryKey": false,
+          "notNull": false,
+          "generated": {
+            "as": "to_tsvector('simple', coalesce(name_english, '') || ' ' || coalesce(name_swedish, '') || ' ' || coalesce(code, '') || ' ' || coalesce(goals, '') || ' ' || coalesce(content, ''))",
+            "type": "stored"
+          }
+        }
+      },
+      "indexes": {
+        "courses_search_vector_idx": {
+          "name": "courses_search_vector_idx",
+          "columns": [
+            {
+              "expression": "search_vector",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        },
+        "courses_embedding_idx": {
+          "name": "courses_embedding_idx",
+          "columns": [
+            {
+              "expression": "embedding",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "vector_cosine_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "hnsw",
+          "with": {}
+        },
+        "courses_name_trgm_idx": {
+          "name": "courses_name_trgm_idx",
+          "columns": [
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "gin_trgm_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        },
+        "courses_code_trgm_idx": {
+          "name": "courses_code_trgm_idx",
+          "columns": [
+            {
+              "expression": "code",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "gin_trgm_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.feedback_form": {
+      "name": "feedback_form",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "message": {
+          "name": "message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.review_likes": {
+      "name": "review_likes",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "review_id": {
+          "name": "review_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "vote_type": {
+          "name": "vote_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "review_likes_user_id_users_id_fk": {
+          "name": "review_likes_user_id_users_id_fk",
+          "tableFrom": "review_likes",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "review_likes_review_id_reviews_id_fk": {
+          "name": "review_likes_review_id_reviews_id_fk",
+          "tableFrom": "review_likes",
+          "tableTo": "reviews",
+          "columnsFrom": ["review_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "review_likes_user_id_review_id_pk": {
+          "name": "review_likes_user_id_review_id_pk",
+          "columns": ["user_id", "review_id"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.review_votes": {
+      "name": "review_votes",
+      "schema": "",
+      "columns": {
+        "voter_user_id": {
+          "name": "voter_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "review_id": {
+          "name": "review_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "vote_type": {
+          "name": "vote_type",
+          "type": "review_vote_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "review_votes_review_id_idx": {
+          "name": "review_votes_review_id_idx",
+          "columns": [
+            {
+              "expression": "review_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "review_votes_voter_user_id_users_id_fk": {
+          "name": "review_votes_voter_user_id_users_id_fk",
+          "tableFrom": "review_votes",
+          "tableTo": "users",
+          "columnsFrom": ["voter_user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "review_votes_review_id_reviews_id_fk": {
+          "name": "review_votes_review_id_reviews_id_fk",
+          "tableFrom": "review_votes",
+          "tableTo": "reviews",
+          "columnsFrom": ["review_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "review_votes_voter_user_id_review_id_pk": {
+          "name": "review_votes_voter_user_id_review_id_pk",
+          "columns": ["voter_user_id", "review_id"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.reviews": {
+      "name": "reviews",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "course_code": {
+          "name": "course_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "examination_methods": {
+          "name": "examination_methods",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "theoretical_vs_applied": {
+          "name": "theoretical_vs_applied",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "workload": {
+          "name": "workload",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "learning_experience": {
+          "name": "learning_experience",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "would_recommend": {
+          "name": "would_recommend",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "examination_distribution": {
+          "name": "examination_distribution",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "approach_theory_percent": {
+          "name": "approach_theory_percent",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "workload_score": {
+          "name": "workload_score",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "learning_score": {
+          "name": "learning_score",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "happy_took": {
+          "name": "happy_took",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "NULL"
+        },
+        "message": {
+          "name": "message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "reviews_user_id_idx": {
+          "name": "reviews_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "reviews_course_code_idx": {
+          "name": "reviews_course_code_idx",
+          "columns": [
+            {
+              "expression": "course_code",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "reviews_user_id_users_id_fk": {
+          "name": "reviews_user_id_users_id_fk",
+          "tableFrom": "reviews",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "reviews_course_code_courses_code_fk": {
+          "name": "reviews_course_code_courses_code_fk",
+          "tableFrom": "reviews",
+          "tableTo": "courses",
+          "columnsFrom": ["course_code"],
+          "columnsTo": ["code"],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "approach_theory_percent_range": {
+          "name": "approach_theory_percent_range",
+          "value": "\"reviews\".\"approach_theory_percent\" between 0 and 100"
+        },
+        "workload_score_range": {
+          "name": "workload_score_range",
+          "value": "\"reviews\".\"workload_score\" between 1 and 10"
+        },
+        "learning_score_range": {
+          "name": "learning_score_range",
+          "value": "\"reviews\".\"learning_score\" between 1 and 10"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.user_saved_courses": {
+      "name": "user_saved_courses",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "course_code": {
+          "name": "course_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "user_saved_courses_course_code_idx": {
+          "name": "user_saved_courses_course_code_idx",
+          "columns": [
+            {
+              "expression": "course_code",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_saved_courses_user_id_users_id_fk": {
+          "name": "user_saved_courses_user_id_users_id_fk",
+          "tableFrom": "user_saved_courses",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "user_saved_courses_course_code_courses_code_fk": {
+          "name": "user_saved_courses_course_code_courses_code_fk",
+          "tableFrom": "user_saved_courses",
+          "tableTo": "courses",
+          "columnsFrom": ["course_code"],
+          "columnsTo": ["code"],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "user_saved_courses_user_id_course_code_pk": {
+          "name": "user_saved_courses_user_id_course_code_pk",
+          "columns": ["user_id", "course_code"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_taken_courses": {
+      "name": "user_taken_courses",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "course_code": {
+          "name": "course_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "attendance_periods": {
+          "name": "attendance_periods",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "attendance_year": {
+          "name": "attendance_year",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "grade": {
+          "name": "grade",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "earned_credits": {
+          "name": "earned_credits",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "transcript_imported_at": {
+          "name": "transcript_imported_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "user_taken_courses_course_code_idx": {
+          "name": "user_taken_courses_course_code_idx",
+          "columns": [
+            {
+              "expression": "course_code",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_taken_courses_user_id_users_id_fk": {
+          "name": "user_taken_courses_user_id_users_id_fk",
+          "tableFrom": "user_taken_courses",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "user_taken_courses_course_code_courses_code_fk": {
+          "name": "user_taken_courses_course_code_courses_code_fk",
+          "tableFrom": "user_taken_courses",
+          "tableTo": "courses",
+          "columnsFrom": ["course_code"],
+          "columnsTo": ["code"],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "user_taken_courses_user_id_course_code_pk": {
+          "name": "user_taken_courses_user_id_course_code_pk",
+          "columns": ["user_id", "course_code"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_favorites": {
+      "name": "user_favorites",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "fav_course_code": {
+          "name": "fav_course_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "user_favorites_user_id_users_id_fk": {
+          "name": "user_favorites_user_id_users_id_fk",
+          "tableFrom": "user_favorites",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "user_favorites_fav_course_code_courses_code_fk": {
+          "name": "user_favorites_fav_course_code_courses_code_fk",
+          "tableFrom": "user_favorites",
+          "tableTo": "courses",
+          "columnsFrom": ["fav_course_code"],
+          "columnsTo": ["code"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "user_favorites_user_id_fav_course_code_pk": {
+          "name": "user_favorites_user_id_fav_course_code_pk",
+          "columns": ["user_id", "fav_course_code"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users_graph_backbone_edges": {
+      "name": "users_graph_backbone_edges",
+      "schema": "",
+      "columns": {
+        "node_user_id": {
+          "name": "node_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "anchor_user_id": {
+          "name": "anchor_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "users_graph_backbone_edges_anchor_user_id_idx": {
+          "name": "users_graph_backbone_edges_anchor_user_id_idx",
+          "columns": [
+            {
+              "expression": "anchor_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "users_graph_backbone_edges_node_user_id_users_graph_nodes_user_id_fk": {
+          "name": "users_graph_backbone_edges_node_user_id_users_graph_nodes_user_id_fk",
+          "tableFrom": "users_graph_backbone_edges",
+          "tableTo": "users_graph_nodes",
+          "columnsFrom": ["node_user_id"],
+          "columnsTo": ["user_id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "users_graph_backbone_edges_anchor_user_id_users_graph_nodes_user_id_fk": {
+          "name": "users_graph_backbone_edges_anchor_user_id_users_graph_nodes_user_id_fk",
+          "tableFrom": "users_graph_backbone_edges",
+          "tableTo": "users_graph_nodes",
+          "columnsFrom": ["anchor_user_id"],
+          "columnsTo": ["user_id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "users_graph_backbone_edges_node_user_id_anchor_user_id_pk": {
+          "name": "users_graph_backbone_edges_node_user_id_anchor_user_id_pk",
+          "columns": ["node_user_id", "anchor_user_id"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "no_self_backbone_edge": {
+          "name": "no_self_backbone_edge",
+          "value": "\"users_graph_backbone_edges\".\"node_user_id\" <> \"users_graph_backbone_edges\".\"anchor_user_id\""
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.users_graph_nodes": {
+      "name": "users_graph_nodes",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "x": {
+          "name": "x",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "y": {
+          "name": "y",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "users_graph_nodes_user_id_users_id_fk": {
+          "name": "users_graph_nodes_user_id_users_id_fk",
+          "tableFrom": "users_graph_nodes",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users_node_profiles": {
+      "name": "users_node_profiles",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "color": {
+          "name": "color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'default'"
+        },
+        "style": {
+          "name": "style",
+          "type": "node_style",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'default'"
+        },
+        "signal_style": {
+          "name": "signal_style",
+          "type": "node_signal_style",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'default'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "users_node_profiles_user_id_users_id_fk": {
+          "name": "users_node_profiles_user_id_users_id_fk",
+          "tableFrom": "users_node_profiles",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.accounts": {
+      "name": "accounts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "issuer": {
+          "name": "issuer",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "accounts_issuer_accountId_uidx": {
+          "name": "accounts_issuer_accountId_uidx",
+          "columns": [
+            {
+              "expression": "issuer",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "accounts_userId_idx": {
+          "name": "accounts_userId_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "accounts_user_id_users_id_fk": {
+          "name": "accounts_user_id_users_id_fk",
+          "tableFrom": "accounts",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sessions": {
+      "name": "sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "sessions_userId_idx": {
+          "name": "sessions_userId_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "sessions_user_id_users_id_fk": {
+          "name": "sessions_user_id_users_id_fk",
+          "tableFrom": "sessions",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "sessions_token_unique": {
+          "name": "sessions_token_unique",
+          "nullsNotDistinct": false,
+          "columns": ["token"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "personalization_tier_earned": {
+          "name": "personalization_tier_earned",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "nullsNotDistinct": false,
+          "columns": ["email"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "personalization_tier_earned_range": {
+          "name": "personalization_tier_earned_range",
+          "value": "\"users\".\"personalization_tier_earned\" between 0 and 3"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.verifications": {
+      "name": "verifications",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "verifications_identifier_idx": {
+          "name": "verifications_identifier_idx",
+          "columns": [
+            {
+              "expression": "identifier",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.course_state": {
+      "name": "course_state",
+      "schema": "public",
+      "values": ["CANCELLED", "ESTABLISHED", "DEACTIVATED"]
+    },
+    "public.node_signal_style": {
+      "name": "node_signal_style",
+      "schema": "public",
+      "values": ["default"]
+    },
+    "public.node_style": {
+      "name": "node_style",
+      "schema": "public",
+      "values": ["default"]
+    },
+    "public.review_vote_type": {
+      "name": "review_vote_type",
+      "schema": "public",
+      "values": ["up", "down"]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/apps/web/server/db/drizzle/meta/_journal.json
+++ b/apps/web/server/db/drizzle/meta/_journal.json
@@ -43,6 +43,13 @@
       "when": 1788461690477,
       "tag": "0009_volatile_kinsey_walden",
       "breakpoints": true
+    },
+    {
+      "idx": 10,
+      "version": "7",
+      "when": 1788474088550,
+      "tag": "0010_abnormal_shocker",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/web/server/db/schema.ts
+++ b/apps/web/server/db/schema.ts
@@ -16,7 +16,6 @@ import {
   text,
   timestamp,
   unique,
-  uniqueIndex,
   vector,
 } from "drizzle-orm/pg-core";
 
@@ -98,10 +97,10 @@ export type SelectCourse = typeof courses.$inferSelect;
 export const courseRounds = pgTable(
   "course_rounds",
   {
+    // The serial id is the permanent key. A natural (course_code, round_code)
+    // key needed KOPPS round.ladokUID, and that API is closed — see
+    // docs/adr/0004-course-round-identity.md.
     id: serial("id").primaryKey(),
-    // Expand phase: populated from KOPPS round.ladokUID. The contract migration
-    // may make this required only after a verified source-backed round rebuild.
-    roundCode: text("round_code"),
     courseCode: text("course_code")
       .notNull()
       .references(() => courses.code, {
@@ -120,9 +119,6 @@ export const courseRounds = pgTable(
   },
   (table) => [
     check("study_pace_range", sql`${table.studyPace} between 1 and 100`),
-    uniqueIndex("course_rounds_course_code_round_code_unique")
-      .on(table.courseCode, table.roundCode)
-      .where(sql`${table.roundCode} is not null`),
     index("course_rounds_course_code_idx").on(table.courseCode),
   ],
 );

--- a/apps/web/server/ingest/ingest.ts
+++ b/apps/web/server/ingest/ingest.ts
@@ -163,7 +163,6 @@ async function convertCourses(courses: z.infer<typeof CoursesSchema>): Promise<{
 
       const insertRounds: InsertCourseRound[] = detail.roundInfos.map((r) => ({
         courseCode: detail.course.courseCode,
-        roundCode: r.round.ladokUID,
         startTerm: r.round.startTerm.term,
         studyPace: r.round.studyPace ?? null,
         schemaUrl: r.schemaUrl ?? null,

--- a/apps/web/server/ingest/schemas.ts
+++ b/apps/web/server/ingest/schemas.ts
@@ -32,7 +32,6 @@ export const CourseDetailSchema = z.object({
     z.object({
       schemaUrl: z.string().optional(),
       round: z.object({
-        ladokUID: z.string().min(1),
         startTerm: z.object({ term: z.number() }),
         isPU: z.boolean(),
         isVU: z.boolean(),

--- a/docs/adr/0004-course-round-identity.md
+++ b/docs/adr/0004-course-round-identity.md
@@ -49,8 +49,13 @@ fields.
 ## Decision
 
 `course_rounds` keys on its serial `id`. `round_code` is removed from the
-schema, the canonical planned schema, and the schema documents. The column is
-dropped from the database as part of the legacy cleanup.
+schema, the canonical planned schema, and the schema documents, and the column
+is dropped from the database by migration `0010`.
+
+The drop ships here rather than with the wider legacy cleanup because it has no
+prerequisite: the column is NULL on every row, no foreign key or query
+references it, and nothing has to be rewired first. Deferring it would leave
+the Drizzle model and the database disagreeing for no benefit.
 
 `schema_url` is retained. It embeds KTH's own subgroup slug
 (`.../subgroup/ht-2025-555/...`), present and distinct on 1831 of 2320 rows,
@@ -66,8 +71,10 @@ decision forecloses nothing.
   identical to another row on every column but `id`. Whether those are
   ingestion artefacts or genuinely parallel rounds cannot be determined from
   the retained data.
-- The `course_rounds` half of the contract migration reduces to one
-  `DROP COLUMN`, with no key swap, no NOT NULL, and no re-ingest prerequisite.
+- `course_rounds` needs nothing from the later contract migration: no key swap,
+  no NOT NULL, and no re-ingest prerequisite. Migration `0010` also drops the
+  partial unique index `course_rounds_course_code_round_code_unique`, which
+  only ever guarded an always-NULL column.
 - The Lucid diagram is the visual authority for the planned schema and still
   shows the composite key. **It needs the matching edit**; this ADR and
   `planned-schema-lucid.json` record the intent until it does.

--- a/docs/adr/0004-course-round-identity.md
+++ b/docs/adr/0004-course-round-identity.md
@@ -1,0 +1,77 @@
+# 4. Course round identity: keep the serial id, drop round_code
+
+Date: 2026-09-04
+
+## Status
+
+Accepted. Supersedes the `course_rounds` primary key decision in
+`docs/schema_docs/current-schema-decisions.md`.
+
+## Context
+
+The approved target keyed `course_rounds` on `(course_code, round_code)`, where
+`round_code` was to hold KOPPS `round.ladokUID`. Migration `0006` added the
+column as nullable on purpose and deferred the key change, noting that the
+serial `id` is not stable across re-ingestion and that the final change "must
+follow a source-backed round rebuild, never `id::text`".
+
+That rebuild is no longer possible. **The KOPPS API is closed.** The 2320 rows
+now in `course_rounds` are all the round data there will be, `round_code` was
+never populated, and `ladokUID` is unobtainable.
+
+Two facts settle what to do instead.
+
+**No key derivable from the retained data identifies a round.** Uniqueness fails
+at every level short of the whole row:
+
+| Candidate key | Colliding groups | Excess rows |
+| --- | ---: | ---: |
+| `(course_code, start_term)` | 184 | 215 |
+| `+ language, tutoring_form, tutoring_time_of_day, is_pu, is_vu` | 77 | 104 |
+| every column except `id` | 4 | 4 |
+
+Only `ladokUID` ever separated those 77 groups. So a composite key cannot
+deliver the guarantee it was chosen for — one round per course per offering.
+
+**A synthetic `round_code` would be the id under another name.** Setting
+`round_code = id::text` makes `(course_code, round_code)` unique by
+construction, not by meaning: a second column, a NOT NULL and a key swap bought
+for a constraint that constrains nothing. A generated UUID is worse still — it
+discards the identity the rows already have and is not reproducible. The `0006`
+objection to `id::text` was specifically instability across re-ingestion, and
+with the source closed there is no re-ingestion.
+
+Nothing depends on the current key. No foreign key references `course_rounds`,
+and no application code selects `id` or `round_code` — every query in
+`server/course/repository.ts` filters by `course_code` and reads descriptive
+fields.
+
+## Decision
+
+`course_rounds` keys on its serial `id`. `round_code` is removed from the
+schema, the canonical planned schema, and the schema documents. The column is
+dropped from the database as part of the legacy cleanup.
+
+`schema_url` is retained. It embeds KTH's own subgroup slug
+(`.../subgroup/ht-2025-555/...`), present and distinct on 1831 of 2320 rows,
+which is the only real round identifier still in the data. Keeping it means a
+meaningful round code remains derivable if a source ever reappears, so this
+decision forecloses nothing.
+
+## Consequences
+
+- Rounds cannot be addressed by a stable external identifier. Acceptable: they
+  are only ever listed under a course.
+- Duplicate rounds are not prevented by the schema. Four rows are already
+  identical to another row on every column but `id`. Whether those are
+  ingestion artefacts or genuinely parallel rounds cannot be determined from
+  the retained data.
+- The `course_rounds` half of the contract migration reduces to one
+  `DROP COLUMN`, with no key swap, no NOT NULL, and no re-ingest prerequisite.
+- The Lucid diagram is the visual authority for the planned schema and still
+  shows the composite key. **It needs the matching edit**; this ADR and
+  `planned-schema-lucid.json` record the intent until it does.
+- The ingest pipeline reads KOPPS and can no longer refresh anything. The
+  `ladokUID` field and its `round_code` mapping are removed from
+  `server/ingest/`. The wider question of what ingest means with the source
+  closed is not settled here.

--- a/docs/schema_docs/current-schema-decisions.md
+++ b/docs/schema_docs/current-schema-decisions.md
@@ -14,7 +14,10 @@ The old TSV export was removed. It duplicated the JSON, could not represent comp
 ## Approved structural decisions
 
 - Keep the source course domain normalized into `courses`, `course_rounds`, and `course_examinations`.
-- Use `(course_code, round_code)` as the composite primary key of `course_rounds`.
+- Key `course_rounds` on its serial `id`. The natural `(course_code, round_code)` key
+  required KOPPS `round.ladokUID`; that API is closed, the column was never populated,
+  and no key derivable from the retained data separates parallel rounds. Superseded by
+  [ADR 0004](../adr/0004-course-round-identity.md).
 - Keep search data in the one-to-one `course_explore` table rather than `courses`; it is derived and rebuildable.
 - Keep `user_saved_courses` and `user_taken_courses` separate. Saved and taken are independent relationships.
 - A collection course must be saved by the collection owner. `collection_courses` therefore has two separate composite foreign keys:

--- a/docs/schema_docs/planned-database-formats.md
+++ b/docs/schema_docs/planned-database-formats.md
@@ -15,7 +15,7 @@ Updated: 2026-09-01. This document explains the approved Lucidchart target. The 
 
 `courses` contains canonical imported course information. The redundant legacy `name` and search columns are absent from the target.
 
-`course_rounds` uses `(course_code, round_code)` as its PK and retains source offering data. Confirm that the ingested `round_code` is stable before migration. `study_pace` is optional and checked from 1 through 100.
+`course_rounds` keys on its serial `id` and retains source offering data. `study_pace` is optional and checked from 1 through 100. `schema_url` is retained: it embeds KTH's own subgroup slug (`.../subgroup/ht-2025-555/...`), which is the only real round identifier still present in the data. See [ADR 0004](../adr/0004-course-round-identity.md).
 
 `course_examinations` retains original source codes, titles, credits, and grade scales. `(course_code, exam_code)` is the PK. Do not treat an exam code as a globally unique examination method.
 
@@ -57,4 +57,4 @@ If mappings are persisted later, design a separate versioned mapping table or ar
 
 ## Implementation gates
 
-Before production migration: inspect the current Neon schema and data, verify `round_code`, check new constraints against existing rows, decide referential actions, confirm the pgvector extension is enabled on the target branch, and generate the Drizzle schema plus explicit SQL migrations. Test those migrations first on an isolated data-containing Neon branch.
+Before production migration: inspect the current Neon schema and data, check new constraints against existing rows, decide referential actions, confirm the pgvector extension is enabled on the target branch, and generate the Drizzle schema plus explicit SQL migrations. Test those migrations first on an isolated data-containing Neon branch.

--- a/docs/schema_docs/planned-schema-lucid.json
+++ b/docs/schema_docs/planned-schema-lucid.json
@@ -9,7 +9,8 @@
     "Lucidchart is the visual authority; this JSON is its canonical machine-readable transcription.",
     "Defaults, referential actions and indexes not shown here are migration-time decisions documented in planned-database-formats.md.",
     "The classification taxonomy and Better Auth-managed tables are outside this 16-table target.",
-    "The allowed values for node_style and node_signal_style are product decisions not enumerated in the diagram."
+    "The allowed values for node_style and node_signal_style are product decisions not enumerated in the diagram.",
+    "course_rounds keys on a serial id. The planned (course_code, round_code) key required KOPPS round.ladokUID; that API is closed and no key derivable from the retained data distinguishes parallel rounds. See docs/adr/0004-course-round-identity.md."
   ],
   "extensions": ["vector"],
   "enums": {
@@ -225,8 +226,8 @@
     },
     "course_rounds": {
       "columns": {
+        "id": { "type": "serial", "nullable": false },
         "course_code": { "type": "text", "nullable": false },
-        "round_code": { "type": "text", "nullable": false },
         "start_term": { "type": "integer", "nullable": false },
         "study_pace": { "type": "integer", "nullable": true },
         "schema_url": { "type": "text", "nullable": true },
@@ -237,7 +238,7 @@
         "is_pu": { "type": "boolean", "nullable": false },
         "is_vu": { "type": "boolean", "nullable": false }
       },
-      "primaryKey": ["course_code", "round_code"],
+      "primaryKey": ["id"],
       "foreignKeys": [
         {
           "columns": ["course_code"],


### PR DESCRIPTION
Amends an approved structural decision, so it carries an ADR rather than a silent edit.

## Why

The target keyed `course_rounds` on `(course_code, round_code)`, where `round_code` was to hold KOPPS `round.ladokUID`. `0006` added the column nullable on purpose and deferred the key change until a source-backed rebuild.

**That rebuild is impossible — the KOPPS API is closed.** The 2320 rows in `course_rounds` are all the round data there will be, `round_code` is NULL on every one of them, and `ladokUID` is unobtainable.

Two facts decide the replacement:

**No key derivable from the retained data identifies a round.** Measured against the live database:

| Candidate key | Colliding groups | Excess rows |
| --- | ---: | ---: |
| `(course_code, start_term)` | 184 | 215 |
| `+ language, tutoring_form, tutoring_time_of_day, is_pu, is_vu` | 77 | 104 |
| every column except `id` | 4 | 4 |

Only `ladokUID` ever separated those 77 groups, so a composite key cannot deliver the guarantee it was chosen for — one round per course per offering.

**A synthetic `round_code` would be the id under another name.** `(course_code, id::text)` is unique by construction, not by meaning: a second column, a NOT NULL and a key swap bought for a constraint that constrains nothing. A generated UUID is worse — it discards the identity the rows already have and isn't reproducible. `0006`'s objection to `id::text` was specifically instability across re-ingestion, which cannot occur with the source closed.

Nothing depends on the current key: no foreign key references `course_rounds`, and no query selects `id` or `round_code` — every query in `server/course/repository.ts` filters by `course_code` and reads descriptive fields.

## Changes

- `schema.ts` — `roundCode` removed, along with the partial unique index that only guarded an always-NULL column. `id: serial().primaryKey()` stays
- `server/ingest/` — drops the `roundCode: r.round.ladokUID` mapping and the `ladokUID` field. That field was made *required* in #72 for data that can now never arrive, so leaving it would fail every parse
- `planned-schema-lucid.json` — column removed, `"primaryKey": ["id"]`, note added
- `current-schema-decisions.md` — the approved decision rewritten as superseded rather than deleted
- `planned-database-formats.md` — both references removed; records that `schema_url` is retained because it embeds KTH's own subgroup slug (`.../subgroup/ht-2025-555/...`), present and distinct on 1831 of 2320 rows and the only real round identifier left
- `docs/adr/0004-course-round-identity.md` — new

## Needs a human follow-up

**The Lucid diagram is the visual authority and still shows `(course_code, round_code)`.** It needs the matching edit; I can't make it. Flagged in the ADR's consequences.

## The drop ships here

`0010_abnormal_shocker.sql` drops the column and the partial unique index `0008` added to guard it:

```sql
DROP INDEX "course_rounds_course_code_round_code_unique";
ALTER TABLE "course_rounds" DROP COLUMN "round_code";
```

It was originally deferred to #75 for batching, but unlike the review columns this has **no prerequisite** — NULL on every row, no foreign key, no query, nothing to rewire — so deferring only left the model and the database disagreeing for no benefit. Raised by Greptile; the finding was right. #75 no longer carries it.

## Validation

- `typecheck` exit 0
- 28/28 tests pass
- lint clean; pre-commit hook passes
- Schema diff against `planned-schema-lucid.json`: `course_rounds` now differs only by the pending `round_code` drop. The 2 remaining discrepancies repo-wide are the known `workload_score` / `learning_score` nullability from #72

No database migration was applied from this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015KWRLRZZ3epsR3iHo8YCve
