### PR TITLE
feat(graph): community graph placement, backbone anchors and bounded viewport query (#65)

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -135,21 +135,16 @@ _Avoid_: theory rating, theoretical vs applied
 One persistent global graph of app users in a shared world coordinate space. It
 is not rebuilt per visit: a returning user keeps their place and their
 neighbourhood.
-_Today_: no tables. The landing hero renders a synthetic field from a generated
-sequence. Closed by the graph tables below.
 _Avoid_: network, social graph, map, constellation
 
 **Node**:
 One app user's presence in the community graph. Every node is a user; there are
 no non-user nodes.
-_Today_: no table. Closed by `users_graph_nodes`.
 _Avoid_: point, vertex, avatar, dot (except in **Find your dot**)
 
 **World position**:
 A node's persistent place in the graph. World units are not browser pixels — the
 frontend projects them, and responsive adjustments never write back.
-_Today_: not persisted; the hero generates a position per render. Closed by
-`users_graph_nodes.x` / `.y`.
 _Avoid_: screen position, canvas coordinates, pixel position
 
 **Anchor**:
@@ -161,12 +156,10 @@ _Avoid_: parent, host, neighbour
 The stored attachment between a node and its anchor. Its direction records
 placement history — newer to older — and the UI may draw it undirected. It is
 not a friendship and carries no social meaning.
-_Today_: no table. Closed by `users_graph_backbone_edges`.
 _Avoid_: friendship, connection, follow, link, relationship
 
 **Node profile**:
 A node's appearance, stored separately from graph topology.
-_Today_: no table. Closed by `users_node_profiles`.
 _Avoid_: avatar, skin, theme
 
 **Signal**:
@@ -177,7 +170,6 @@ _Avoid_: pulse, ping, animation, activity
 How far an app user has unlocked node personalisation, held as the highest value
 ever reached. An effective tier may decay with inactivity, but that is derived at
 read time and never overwrites what was earned.
-_Today_: no column. Closed by `users.personalization_tier_earned`.
 _Avoid_: level, rank, XP, points, streak
 
 **Find your dot**:

--- a/apps/web/server/api/root.ts
+++ b/apps/web/server/api/root.ts
@@ -1,5 +1,6 @@
 import { courseRouter } from "../course/router";
 import { feedbackRouter } from "../feedback/router";
+import { graphRouter } from "../graph/router";
 import { healthRouter } from "../health/router";
 import { reviewsRouter } from "../reviews/router";
 import { searchRouter } from "../search/router";
@@ -11,6 +12,7 @@ export const appRouter = createTRPCRouter({
   search: searchRouter,
   reviews: reviewsRouter,
   user: userRouter,
+  graph: graphRouter,
   feedback: feedbackRouter,
   health: healthRouter,
 });

--- a/apps/web/server/graph/placement.spec.ts
+++ b/apps/web/server/graph/placement.spec.ts
@@ -1,0 +1,99 @@
+import { describe, expect, it } from "vitest";
+import {
+  chooseAnchorCount,
+  computeWorldPosition,
+  MAX_ANCHORS,
+  MIN_ANCHORS,
+  NODE_COLORS,
+  pickNodeColor,
+} from "./placement";
+
+const ids = Array.from({ length: 300 }, (_, i) => `user-${i}`);
+const radiusOf = (p: { x: number; y: number }) => Math.hypot(p.x, p.y);
+
+describe("pickNodeColor", () => {
+  it("gives the same app user the same colour every time", () => {
+    expect(pickNodeColor("user-42")).toBe(pickNodeColor("user-42"));
+  });
+
+  it("only ever picks a name from the palette", () => {
+    for (const id of ids) {
+      expect(NODE_COLORS).toContain(pickNodeColor(id));
+    }
+  });
+
+  it("uses the whole palette across a community", () => {
+    const used = new Set(ids.map(pickNodeColor));
+
+    expect(used.size).toBe(NODE_COLORS.length);
+  });
+});
+
+describe("computeWorldPosition", () => {
+  it("places the same app user in the same spot for a given community size", () => {
+    expect(computeWorldPosition("user-7", 12)).toEqual(
+      computeWorldPosition("user-7", 12),
+    );
+  });
+
+  it("places each new node further out than the one before it", () => {
+    for (let placed = 0; placed < 50; placed++) {
+      expect(
+        radiusOf(computeWorldPosition("user-7", placed + 1)),
+      ).toBeGreaterThan(radiusOf(computeWorldPosition("user-7", placed)));
+    }
+  });
+
+  it("puts the very first node at the centre of the world", () => {
+    expect(radiusOf(computeWorldPosition("user-7", 0))).toBe(0);
+  });
+
+  it("separates two app users who join at the same community size", () => {
+    const a = computeWorldPosition("user-a", 30);
+    const b = computeWorldPosition("user-b", 30);
+
+    expect(a).not.toEqual(b);
+  });
+
+  it("spreads a community around the origin rather than along one ray", () => {
+    const angles = ids
+      .slice(1, 60)
+      .map((id, i) => computeWorldPosition(id, i + 1))
+      .map((p) => Math.atan2(p.y, p.x));
+    const quadrants = new Set(
+      angles.map((a) =>
+        Math.floor(((a + 2 * Math.PI) % (2 * Math.PI)) / (Math.PI / 2)),
+      ),
+    );
+
+    expect(quadrants.size).toBe(4);
+  });
+
+  it("returns finite world units", () => {
+    for (const [i, id] of ids.entries()) {
+      const { x, y } = computeWorldPosition(id, i);
+      expect(Number.isFinite(x)).toBe(true);
+      expect(Number.isFinite(y)).toBe(true);
+    }
+  });
+});
+
+describe("chooseAnchorCount", () => {
+  it("always asks for three to five anchors", () => {
+    for (const id of ids) {
+      const count = chooseAnchorCount(id);
+      expect(count).toBeGreaterThanOrEqual(MIN_ANCHORS);
+      expect(count).toBeLessThanOrEqual(MAX_ANCHORS);
+    }
+  });
+
+  it("uses every count in the range across a community", () => {
+    expect(new Set(ids.map(chooseAnchorCount)).size).toBe(
+      MAX_ANCHORS - MIN_ANCHORS + 1,
+    );
+  });
+
+  it("is stable for an app user", () => {
+    expect(chooseAnchorCount("user-42")).toBe(chooseAnchorCount("user-42"));
+  });
+});

--- a/apps/web/server/graph/placement.ts
+++ b/apps/web/server/graph/placement.ts
@@ -1,0 +1,111 @@
+/**
+ * Placement: where a joining node lands in the community graph, and what it
+ * looks like when it gets there.
+ *
+ * Everything here is pure and deterministic. World units are not browser
+ * pixels — the frontend projects them and its responsive adjustments never
+ * come back to the database.
+ */
+
+/**
+ * The node colour palette. The server stores a **name**; the client maps names
+ * onto its `--cc-*` tokens, so the palette can be re-skinned without a data
+ * migration. This is the one place the list lives.
+ */
+export const NODE_COLORS = [
+  "aurora",
+  "ember",
+  "frost",
+  "moss",
+  "slate",
+  "violet",
+] as const;
+
+export type NodeColor = (typeof NODE_COLORS)[number];
+
+/**
+ * `node_style` and `node_signal_style` are Postgres enums that today declare
+ * exactly one value. Adding values needs an `ALTER TYPE` migration, and node
+ * appearance is being redesigned wholesale, so placement writes the only value
+ * there is.
+ */
+export const DEFAULT_NODE_STYLE = "default" as const;
+export const DEFAULT_NODE_SIGNAL_STYLE = "default" as const;
+
+/** A joining node takes roughly three to five anchors. */
+export const MIN_ANCHORS = 3;
+export const MAX_ANCHORS = 5;
+
+export type WorldPosition = { x: number; y: number };
+
+/**
+ * Radial spacing between successive placements, in world units. Radius grows
+ * with the square root of the community size so nodes stay at roughly constant
+ * density instead of thinning out as the graph grows.
+ */
+const RADIUS_STEP = 120;
+
+/** The golden angle, which spreads successive placements evenly around the origin. */
+const GOLDEN_ANGLE = Math.PI * (3 - Math.sqrt(5));
+
+/**
+ * Angular wobble, in radians, applied per app user. It keeps two people who
+ * join against the same community size off the same point without disturbing
+ * the radius, which stays a pure function of the placement index.
+ */
+const ANGLE_JITTER = 0.08;
+
+/** Deterministic node colour for an app user. */
+export function pickNodeColor(userId: string): NodeColor {
+  return NODE_COLORS[hashUserId(userId) % NODE_COLORS.length];
+}
+
+/** Deterministic anchor count for an app user, within `[MIN_ANCHORS, MAX_ANCHORS]`. */
+export function chooseAnchorCount(userId: string): number {
+  const span = MAX_ANCHORS - MIN_ANCHORS + 1;
+  // A different slice of the hash than pickNodeColor uses, so colour and anchor
+  // count are not correlated.
+  return MIN_ANCHORS + (hashUserId(`anchors:${userId}`) % span);
+}
+
+/**
+ * Where a joining node goes, given how many nodes are already placed.
+ *
+ * New nodes land at the outer edge of the current community: the radius is a
+ * strictly increasing function of `placedNodeCount`, so joining pushes outward
+ * and never asks an established node to move. Placement is local and additive
+ * by construction — there is no global layout pass.
+ */
+export function computeWorldPosition(
+  userId: string,
+  placedNodeCount: number,
+): WorldPosition {
+  const index = Math.max(0, Math.trunc(placedNodeCount));
+  const radius = RADIUS_STEP * Math.sqrt(index);
+  const jitter = (unitFromHash(`angle:${userId}`) * 2 - 1) * ANGLE_JITTER;
+  const angle = index * GOLDEN_ANGLE + jitter;
+  return {
+    x: roundWorldUnit(radius * Math.cos(angle)),
+    y: roundWorldUnit(radius * Math.sin(angle)),
+  };
+}
+
+/** World units are stored as double precision; a micro-unit is far below what renders. */
+function roundWorldUnit(value: number): number {
+  return Math.round(value * 1e6) / 1e6;
+}
+
+/** FNV-1a, 32-bit unsigned. Stable across processes, unlike `Math.random`. */
+function hashUserId(userId: string): number {
+  let hash = 0x811c9dc5;
+  for (let i = 0; i < userId.length; i++) {
+    hash ^= userId.charCodeAt(i);
+    hash = Math.imul(hash, 0x01000193) >>> 0;
+  }
+  return hash;
+}
+
+/** The same hash mapped into `[0, 1)`. */
+function unitFromHash(seed: string): number {
+  return hashUserId(seed) / 0x100000000;
+}

--- a/apps/web/server/graph/repository.ts
+++ b/apps/web/server/graph/repository.ts
@@ -1,0 +1,190 @@
+import { and, count, eq, inArray, max, ne, sql } from "drizzle-orm";
+import { db } from "../db";
+import * as schema from "../db/schema";
+import type {
+  DEFAULT_NODE_SIGNAL_STYLE,
+  DEFAULT_NODE_STYLE,
+  NodeColor,
+  WorldPosition,
+} from "./placement";
+
+/** A node's identity and its persistent world position. */
+export type GraphNode = {
+  userId: string;
+  x: number;
+  y: number;
+};
+
+/** A node plus the appearance the client needs to draw it. */
+export type NeighbourNode = GraphNode & {
+  color: string;
+  style: string;
+  signalStyle: string;
+};
+
+/**
+ * A stored backbone edge. Its direction records placement history — the newer
+ * node to the older anchor. It is not a friendship and carries no social
+ * meaning; the UI may draw it undirected.
+ */
+export type BackboneEdge = {
+  nodeUserId: string;
+  anchorUserId: string;
+};
+
+/** Everything one placement writes, so it lands in a single transaction. */
+export type PlacementWrite = {
+  node: GraphNode;
+  profile: {
+    userId: string;
+    color: NodeColor;
+    style: typeof DEFAULT_NODE_STYLE;
+    signalStyle: typeof DEFAULT_NODE_SIGNAL_STYLE;
+  };
+  edges: BackboneEdge[];
+};
+
+/** What the effective personalization tier is derived from. */
+export type TierBasis = {
+  earnedTier: number;
+  accountCreatedAt: Date;
+};
+
+export async function findNode(userId: string): Promise<GraphNode | undefined> {
+  const [row] = await db
+    .select({
+      userId: schema.usersGraphNodes.userId,
+      x: schema.usersGraphNodes.x,
+      y: schema.usersGraphNodes.y,
+    })
+    .from(schema.usersGraphNodes)
+    .where(eq(schema.usersGraphNodes.userId, userId))
+    .limit(1);
+  return row;
+}
+
+export async function countNodes(): Promise<number> {
+  const [row] = await db
+    .select({ value: count() })
+    .from(schema.usersGraphNodes);
+  return row?.value ?? 0;
+}
+
+/**
+ * The `limit` nodes closest to `origin` in world space, nearest first.
+ *
+ * `limit` is a query policy the caller owns — the bound is never a column.
+ */
+export async function findNearestNodes(
+  origin: WorldPosition,
+  limit: number,
+  excludeUserId?: string,
+): Promise<NeighbourNode[]> {
+  const dx = sql`${schema.usersGraphNodes.x} - ${origin.x}`;
+  const dy = sql`${schema.usersGraphNodes.y} - ${origin.y}`;
+  // Squared distance: monotonic in distance, and it avoids a sqrt per row.
+  const distance = sql`(${dx}) * (${dx}) + (${dy}) * (${dy})`;
+
+  return (
+    db
+      .select({
+        userId: schema.usersGraphNodes.userId,
+        x: schema.usersGraphNodes.x,
+        y: schema.usersGraphNodes.y,
+        color: sql<string>`coalesce(${schema.usersNodeProfiles.color}, 'default')`,
+        style: sql<string>`coalesce(${schema.usersNodeProfiles.style}::text, 'default')`,
+        signalStyle: sql<string>`coalesce(${schema.usersNodeProfiles.signalStyle}::text, 'default')`,
+      })
+      .from(schema.usersGraphNodes)
+      .leftJoin(
+        schema.usersNodeProfiles,
+        eq(schema.usersNodeProfiles.userId, schema.usersGraphNodes.userId),
+      )
+      .where(
+        excludeUserId
+          ? ne(schema.usersGraphNodes.userId, excludeUserId)
+          : undefined,
+      )
+      // The node id breaks distance ties so paging and repeat reads are stable.
+      .orderBy(distance, schema.usersGraphNodes.userId)
+      .limit(limit)
+  );
+}
+
+/**
+ * Write one placement: the node, its profile and its backbone edges, together.
+ *
+ * Every insert is `on conflict do nothing`, so re-running a placement can never
+ * move a node that is already there or duplicate a backbone edge. The
+ * `no_self_backbone_edge` check constraint rejects self-edges in the database
+ * even if a caller ever asks for one.
+ */
+export async function persistPlacement(write: PlacementWrite): Promise<void> {
+  await db.transaction(async (tx) => {
+    await tx
+      .insert(schema.usersGraphNodes)
+      .values(write.node)
+      .onConflictDoNothing();
+    await tx
+      .insert(schema.usersNodeProfiles)
+      .values(write.profile)
+      .onConflictDoNothing();
+    if (write.edges.length > 0) {
+      await tx
+        .insert(schema.usersGraphBackboneEdges)
+        .values(write.edges)
+        .onConflictDoNothing();
+    }
+  });
+}
+
+/** Backbone edges with both endpoints inside `userIds`. */
+export async function findBackboneEdgesWithin(
+  userIds: string[],
+): Promise<BackboneEdge[]> {
+  if (userIds.length === 0) return [];
+  return db
+    .select({
+      nodeUserId: schema.usersGraphBackboneEdges.nodeUserId,
+      anchorUserId: schema.usersGraphBackboneEdges.anchorUserId,
+    })
+    .from(schema.usersGraphBackboneEdges)
+    .where(
+      and(
+        inArray(schema.usersGraphBackboneEdges.nodeUserId, userIds),
+        inArray(schema.usersGraphBackboneEdges.anchorUserId, userIds),
+      ),
+    );
+}
+
+export async function findTierBasis(
+  userId: string,
+): Promise<TierBasis | undefined> {
+  const [row] = await db
+    .select({
+      earnedTier: schema.users.personalizationTierEarned,
+      accountCreatedAt: schema.users.createdAt,
+    })
+    .from(schema.users)
+    .where(eq(schema.users.id, userId))
+    .limit(1);
+  return row;
+}
+
+/**
+ * The app user's most recent review, or `null` if they have never reviewed.
+ *
+ * This reads the reviews table directly, which crosses a domain boundary the
+ * repo normally routes service -> service. The exception is deliberate and
+ * approved: it is a single read-only aggregate, `reviews_user_id_idx` covers
+ * it, and routing it through `server/reviews/service.ts` would couple the graph
+ * domain to a review domain that is being rewritten in parallel. Nothing else
+ * here may reach into `server/reviews/`.
+ */
+export async function findLastReviewAt(userId: string): Promise<Date | null> {
+  const [row] = await db
+    .select({ lastReviewAt: max(schema.reviews.createdAt) })
+    .from(schema.reviews)
+    .where(eq(schema.reviews.userId, userId));
+  return row?.lastReviewAt ?? null;
+}

--- a/apps/web/server/graph/repository.ts
+++ b/apps/web/server/graph/repository.ts
@@ -114,17 +114,33 @@ export async function findNearestNodes(
 /**
  * Write one placement: the node, its profile and its backbone edges, together.
  *
- * Every insert is `on conflict do nothing`, so re-running a placement can never
- * move a node that is already there or duplicate a backbone edge. The
- * `no_self_backbone_edge` check constraint rejects self-edges in the database
- * even if a caller ever asks for one.
+ * The node insert is the gate. `on conflict do nothing ... returning` inserts a
+ * row and hands it back, or hands back nothing because a placement for this app
+ * user committed first. When it hands back nothing the whole placement is
+ * abandoned — profile and backbone edges included — so a node that is already
+ * there can never be moved, and can never collect a second set of anchors from
+ * a placement that lost the race. `undefined` tells the caller that happened.
+ *
+ * The profile and edge inserts stay `on conflict do nothing` so that repairing
+ * a half-written placement is safe. Duplicate backbone edges are impossible by
+ * composite primary key, and `no_self_backbone_edge` rejects a self-edge in the
+ * database even if a caller ever asks for one.
  */
-export async function persistPlacement(write: PlacementWrite): Promise<void> {
-  await db.transaction(async (tx) => {
-    await tx
+export async function persistPlacement(
+  write: PlacementWrite,
+): Promise<GraphNode | undefined> {
+  return db.transaction(async (tx) => {
+    const [placed] = await tx
       .insert(schema.usersGraphNodes)
       .values(write.node)
-      .onConflictDoNothing();
+      .onConflictDoNothing()
+      .returning({
+        userId: schema.usersGraphNodes.userId,
+        x: schema.usersGraphNodes.x,
+        y: schema.usersGraphNodes.y,
+      });
+    if (!placed) return undefined;
+
     await tx
       .insert(schema.usersNodeProfiles)
       .values(write.profile)
@@ -135,6 +151,7 @@ export async function persistPlacement(write: PlacementWrite): Promise<void> {
         .values(write.edges)
         .onConflictDoNothing();
     }
+    return placed;
   });
 }
 

--- a/apps/web/server/graph/router.spec.ts
+++ b/apps/web/server/graph/router.spec.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it, vi } from "vitest";
+import { createCallerFactory } from "../api/trpc";
+import { graphRouter } from "./router";
+import * as graphService from "./service";
+
+vi.mock("./service");
+
+function caller(session: { user: { id: string } } | null) {
+  return createCallerFactory(graphRouter)({
+    session: session as never,
+    headers: new Headers(),
+  });
+}
+
+describe("graph router", () => {
+  it("rejects visitors on every procedure", async () => {
+    const visitor = caller(null);
+
+    await expect(visitor.join()).rejects.toMatchObject({
+      code: "UNAUTHORIZED",
+    });
+    await expect(visitor.neighbourhood()).rejects.toMatchObject({
+      code: "UNAUTHORIZED",
+    });
+    await expect(visitor.effectiveTier()).rejects.toMatchObject({
+      code: "UNAUTHORIZED",
+    });
+  });
+
+  it("answers for the signed-in app user, never an id from the input", async () => {
+    await caller({ user: { id: "user-1" } }).neighbourhood();
+
+    expect(graphService.getNeighbourhood).toHaveBeenCalledWith("user-1");
+  });
+});

--- a/apps/web/server/graph/router.ts
+++ b/apps/web/server/graph/router.ts
@@ -1,0 +1,22 @@
+import { createTRPCRouter, protectedProcedure } from "../api/trpc";
+import {
+  getEffectiveTier,
+  getNeighbourhood,
+  joinCommunityGraph,
+} from "./service";
+
+/**
+ * The community graph is personal: every read is relative to the caller's own
+ * node, so there is nothing here a visitor could ask for.
+ */
+export const graphRouter = createTRPCRouter({
+  join: protectedProcedure.mutation(({ ctx }) =>
+    joinCommunityGraph(ctx.session.user.id),
+  ),
+  neighbourhood: protectedProcedure.query(({ ctx }) =>
+    getNeighbourhood(ctx.session.user.id),
+  ),
+  effectiveTier: protectedProcedure.query(({ ctx }) =>
+    getEffectiveTier(ctx.session.user.id),
+  ),
+});

--- a/apps/web/server/graph/service.spec.ts
+++ b/apps/web/server/graph/service.spec.ts
@@ -1,0 +1,326 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { NotFoundError } from "../errors";
+import { MAX_ANCHORS, MIN_ANCHORS, NODE_COLORS } from "./placement";
+import type { BackboneEdge, NeighbourNode, PlacementWrite } from "./repository";
+import * as graphRepo from "./repository";
+import {
+  getEffectiveTier,
+  getNeighbourhood,
+  joinCommunityGraph,
+  MAX_NEIGHBOURHOOD_NODES,
+} from "./service";
+
+vi.mock("./repository");
+
+const JOINED = new Date("2024-01-15T12:00:00.000Z");
+
+function neighbour(userId: string, x: number, y: number): NeighbourNode {
+  return {
+    userId,
+    x,
+    y,
+    color: "aurora",
+    style: "default",
+    signalStyle: "default",
+  };
+}
+
+/** An established community of `size` nodes on a coarse grid. */
+function community(size: number): NeighbourNode[] {
+  return Array.from({ length: size }, (_, i) =>
+    neighbour(`established-${i}`, i * 37, i * -19),
+  );
+}
+
+function lastPlacement(): PlacementWrite {
+  const call = vi.mocked(graphRepo.persistPlacement).mock.calls.at(-1);
+  if (!call) throw new Error("persistPlacement was never called");
+  return call[0];
+}
+
+/**
+ * A stateful stand-in for the graph repository: an in-memory community that
+ * remembers what placement wrote, so a test can join several app users in a
+ * row and inspect what happened to the ones already there.
+ */
+function inMemoryCommunity() {
+  const nodes: NeighbourNode[] = [];
+  const edges: BackboneEdge[] = [];
+
+  vi.mocked(graphRepo.countNodes).mockImplementation(async () => nodes.length);
+  vi.mocked(graphRepo.findNode).mockImplementation(async (userId) => {
+    const found = nodes.find((node) => node.userId === userId);
+    return found && { userId: found.userId, x: found.x, y: found.y };
+  });
+  vi.mocked(graphRepo.findNearestNodes).mockImplementation(
+    async (origin, limit, excludeUserId) =>
+      nodes
+        .filter((node) => node.userId !== excludeUserId)
+        .sort(
+          (a, b) =>
+            Math.hypot(a.x - origin.x, a.y - origin.y) -
+            Math.hypot(b.x - origin.x, b.y - origin.y),
+        )
+        .slice(0, limit),
+  );
+  vi.mocked(graphRepo.persistPlacement).mockImplementation(async (write) => {
+    nodes.push({ ...write.node, ...write.profile });
+    edges.push(...write.edges);
+  });
+
+  return { nodes, edges };
+}
+
+beforeEach(() => {
+  vi.resetAllMocks();
+  vi.mocked(graphRepo.countNodes).mockResolvedValue(0);
+  vi.mocked(graphRepo.findNode).mockResolvedValue(undefined);
+  vi.mocked(graphRepo.findNearestNodes).mockResolvedValue([]);
+  vi.mocked(graphRepo.findBackboneEdgesWithin).mockResolvedValue([]);
+  vi.mocked(graphRepo.persistPlacement).mockResolvedValue(undefined);
+  vi.mocked(graphRepo.findTierBasis).mockResolvedValue({
+    earnedTier: 3,
+    accountCreatedAt: JOINED,
+  });
+  vi.mocked(graphRepo.findLastReviewAt).mockResolvedValue(null);
+});
+
+describe("joinCommunityGraph", () => {
+  it("persists a world position for the joining app user", async () => {
+    vi.mocked(graphRepo.countNodes).mockResolvedValue(20);
+    vi.mocked(graphRepo.findNearestNodes).mockResolvedValue(community(20));
+
+    const node = await joinCommunityGraph("newcomer");
+
+    expect(node.userId).toBe("newcomer");
+    expect(Number.isFinite(node.x)).toBe(true);
+    expect(Number.isFinite(node.y)).toBe(true);
+    expect(lastPlacement().node).toEqual(node);
+  });
+
+  it("attaches the new node to three to five anchors", async () => {
+    vi.mocked(graphRepo.countNodes).mockResolvedValue(20);
+    vi.mocked(graphRepo.findNearestNodes).mockResolvedValue(community(20));
+
+    await joinCommunityGraph("newcomer");
+    const { edges } = lastPlacement();
+
+    expect(edges.length).toBeGreaterThanOrEqual(MIN_ANCHORS);
+    expect(edges.length).toBeLessThanOrEqual(MAX_ANCHORS);
+  });
+
+  it("points every backbone edge from the new node at an older anchor", async () => {
+    vi.mocked(graphRepo.countNodes).mockResolvedValue(20);
+    vi.mocked(graphRepo.findNearestNodes).mockResolvedValue(community(20));
+
+    await joinCommunityGraph("newcomer");
+    const { edges } = lastPlacement();
+
+    expect(edges.every((edge) => edge.nodeUserId === "newcomer")).toBe(true);
+    expect(new Set(edges.map((edge) => edge.anchorUserId)).size).toBe(
+      edges.length,
+    );
+  });
+
+  it("never writes a self-edge, even if the joining node is offered as a candidate", async () => {
+    vi.mocked(graphRepo.countNodes).mockResolvedValue(4);
+    vi.mocked(graphRepo.findNearestNodes).mockResolvedValue([
+      neighbour("newcomer", 0, 0),
+      ...community(3),
+    ]);
+
+    await joinCommunityGraph("newcomer");
+    const { edges } = lastPlacement();
+
+    expect(edges.some((edge) => edge.anchorUserId === "newcomer")).toBe(false);
+  });
+
+  it("takes every established node when the community is smaller than the anchor count", async () => {
+    vi.mocked(graphRepo.countNodes).mockResolvedValue(2);
+    vi.mocked(graphRepo.findNearestNodes).mockResolvedValue(community(2));
+
+    await joinCommunityGraph("newcomer");
+
+    expect(lastPlacement().edges).toHaveLength(2);
+  });
+
+  it("places the very first app user with no anchors at all", async () => {
+    await joinCommunityGraph("first");
+
+    expect(lastPlacement().edges).toEqual([]);
+  });
+
+  it("supplies a valid node profile", async () => {
+    await joinCommunityGraph("newcomer");
+    const { profile } = lastPlacement();
+
+    expect(profile.userId).toBe("newcomer");
+    expect(NODE_COLORS).toContain(profile.color);
+    expect(profile.style).toBe("default");
+    expect(profile.signalStyle).toBe("default");
+  });
+
+  it("leaves an already-placed app user exactly where they are", async () => {
+    vi.mocked(graphRepo.findNode).mockResolvedValue({
+      userId: "returning",
+      x: 12.5,
+      y: -8.25,
+    });
+
+    const node = await joinCommunityGraph("returning");
+
+    expect(node).toEqual({ userId: "returning", x: 12.5, y: -8.25 });
+    expect(graphRepo.persistPlacement).not.toHaveBeenCalled();
+  });
+
+  it("does not move anyone already placed when the community grows", async () => {
+    const { nodes } = inMemoryCommunity();
+    const seen: Record<string, { x: number; y: number }> = {};
+
+    for (let i = 0; i < 12; i++) {
+      await joinCommunityGraph(`member-${i}`);
+
+      for (const node of nodes) {
+        const before = seen[node.userId];
+        if (before) {
+          expect({ x: node.x, y: node.y }).toEqual(before);
+        }
+        seen[node.userId] = { x: node.x, y: node.y };
+      }
+    }
+
+    expect(nodes).toHaveLength(12);
+  });
+});
+
+describe("getNeighbourhood", () => {
+  const viewer = neighbour("viewer", 100, 100);
+
+  it("bounds the node set to the neighbourhood maximum", async () => {
+    vi.mocked(graphRepo.findNode).mockResolvedValue({
+      userId: "viewer",
+      x: 100,
+      y: 100,
+    });
+    vi.mocked(graphRepo.findNearestNodes).mockResolvedValue([viewer]);
+
+    await getNeighbourhood("viewer");
+
+    expect(graphRepo.findNearestNodes).toHaveBeenCalledWith(
+      { x: 100, y: 100 },
+      MAX_NEIGHBOURHOOD_NODES,
+    );
+  });
+
+  it("returns only the backbone edges spanning the returned set", async () => {
+    const inside = [viewer, neighbour("a", 1, 1), neighbour("b", 2, 2)];
+    vi.mocked(graphRepo.findNode).mockResolvedValue({
+      userId: "viewer",
+      x: 100,
+      y: 100,
+    });
+    vi.mocked(graphRepo.findNearestNodes).mockResolvedValue(inside);
+    vi.mocked(graphRepo.findBackboneEdgesWithin).mockResolvedValue([
+      { nodeUserId: "a", anchorUserId: "b" },
+      { nodeUserId: "a", anchorUserId: "far-away" },
+      { nodeUserId: "far-away", anchorUserId: "viewer" },
+    ]);
+
+    const neighbourhood = await getNeighbourhood("viewer");
+
+    expect(graphRepo.findBackboneEdgesWithin).toHaveBeenCalledWith([
+      "viewer",
+      "a",
+      "b",
+    ]);
+    expect(neighbourhood.edges).toEqual([
+      { nodeUserId: "a", anchorUserId: "b" },
+    ]);
+  });
+
+  it("reports the viewer's effective tier alongside their own node", async () => {
+    vi.mocked(graphRepo.findNode).mockResolvedValue({
+      userId: "viewer",
+      x: 100,
+      y: 100,
+    });
+    vi.mocked(graphRepo.findNearestNodes).mockResolvedValue([viewer]);
+    vi.mocked(graphRepo.findLastReviewAt).mockResolvedValue(
+      new Date("2024-01-15T12:00:00.000Z"),
+    );
+
+    const neighbourhood = await getNeighbourhood(
+      "viewer",
+      new Date("2025-01-15T12:00:00.000Z"),
+    );
+
+    expect(neighbourhood.viewer).toEqual({
+      userId: "viewer",
+      x: 100,
+      y: 100,
+      effectiveTier: 1,
+    });
+    expect(neighbourhood.nodes).toEqual([viewer]);
+  });
+
+  it("rejects an app user who has no node yet", async () => {
+    vi.mocked(graphRepo.findNode).mockResolvedValue(undefined);
+
+    await expect(getNeighbourhood("stranger")).rejects.toBeInstanceOf(
+      NotFoundError,
+    );
+  });
+});
+
+describe("getEffectiveTier", () => {
+  it("decays from the app user's most recent review", async () => {
+    vi.mocked(graphRepo.findTierBasis).mockResolvedValue({
+      earnedTier: 3,
+      accountCreatedAt: new Date("2020-01-01T00:00:00.000Z"),
+    });
+    vi.mocked(graphRepo.findLastReviewAt).mockResolvedValue(JOINED);
+
+    const tier = await getEffectiveTier(
+      "reviewer",
+      new Date("2025-01-15T12:00:00.000Z"),
+    );
+
+    expect(tier).toBe(1);
+  });
+
+  it("decays from the account creation date when the app user has never reviewed", async () => {
+    vi.mocked(graphRepo.findTierBasis).mockResolvedValue({
+      earnedTier: 2,
+      accountCreatedAt: JOINED,
+    });
+    vi.mocked(graphRepo.findLastReviewAt).mockResolvedValue(null);
+
+    expect(
+      await getEffectiveTier("quiet", new Date("2024-07-14T12:00:00.000Z")),
+    ).toBe(2);
+    expect(
+      await getEffectiveTier("quiet", new Date("2024-07-15T12:00:00.000Z")),
+    ).toBe(1);
+  });
+
+  it("rejects an unknown app user", async () => {
+    vi.mocked(graphRepo.findTierBasis).mockResolvedValue(undefined);
+
+    await expect(getEffectiveTier("ghost")).rejects.toBeInstanceOf(
+      NotFoundError,
+    );
+  });
+
+  it("never writes the earned tier back", async () => {
+    await getEffectiveTier("reader", new Date("2044-01-01T00:00:00.000Z"));
+
+    // The only write the graph domain owns is placement; there is deliberately
+    // no repository function that could update personalization_tier_earned.
+    expect(graphRepo.persistPlacement).not.toHaveBeenCalled();
+    expect(
+      Object.keys(graphRepo).filter((name) =>
+        /^(insert|update|upsert|delete|save|persist|set)/.test(name),
+      ),
+    ).toEqual(["persistPlacement"]);
+  });
+});

--- a/apps/web/server/graph/service.spec.ts
+++ b/apps/web/server/graph/service.spec.ts
@@ -212,6 +212,22 @@ describe("getNeighbourhood", () => {
     );
   });
 
+  it("includes the viewer's own node in the set, so they can find their dot", async () => {
+    vi.mocked(graphRepo.findNode).mockResolvedValue({
+      userId: "viewer",
+      x: 100,
+      y: 100,
+    });
+    vi.mocked(graphRepo.findNearestNodes).mockResolvedValue([
+      viewer,
+      neighbour("a", 1, 1),
+    ]);
+
+    const neighbourhood = await getNeighbourhood("viewer");
+
+    expect(neighbourhood.nodes.map((node) => node.userId)).toContain("viewer");
+  });
+
   it("returns only the backbone edges spanning the returned set", async () => {
     const inside = [viewer, neighbour("a", 1, 1), neighbour("b", 2, 2)];
     vi.mocked(graphRepo.findNode).mockResolvedValue({

--- a/apps/web/server/graph/service.spec.ts
+++ b/apps/web/server/graph/service.spec.ts
@@ -64,8 +64,11 @@ function inMemoryCommunity() {
         .slice(0, limit),
   );
   vi.mocked(graphRepo.persistPlacement).mockImplementation(async (write) => {
+    if (nodes.some((node) => node.userId === write.node.userId))
+      return undefined;
     nodes.push({ ...write.node, ...write.profile });
     edges.push(...write.edges);
+    return write.node;
   });
 
   return { nodes, edges };
@@ -77,7 +80,9 @@ beforeEach(() => {
   vi.mocked(graphRepo.findNode).mockResolvedValue(undefined);
   vi.mocked(graphRepo.findNearestNodes).mockResolvedValue([]);
   vi.mocked(graphRepo.findBackboneEdgesWithin).mockResolvedValue([]);
-  vi.mocked(graphRepo.persistPlacement).mockResolvedValue(undefined);
+  vi.mocked(graphRepo.persistPlacement).mockImplementation(
+    async (write) => write.node,
+  );
   vi.mocked(graphRepo.findTierBasis).mockResolvedValue({
     earnedTier: 3,
     accountCreatedAt: JOINED,
@@ -171,6 +176,28 @@ describe("joinCommunityGraph", () => {
 
     expect(node).toEqual({ userId: "returning", x: 12.5, y: -8.25 });
     expect(graphRepo.persistPlacement).not.toHaveBeenCalled();
+  });
+
+  it("yields to a concurrent join that was persisted first", async () => {
+    const winner = { userId: "newcomer", x: 42, y: -17 };
+    vi.mocked(graphRepo.findNode)
+      .mockResolvedValueOnce(undefined)
+      .mockResolvedValueOnce(winner);
+    vi.mocked(graphRepo.persistPlacement).mockResolvedValue(undefined);
+
+    const node = await joinCommunityGraph("newcomer");
+
+    // The losing request reports where the app user really is, never the
+    // position it computed and failed to store.
+    expect(node).toEqual(winner);
+  });
+
+  it("refuses to invent a position when a conflicted placement leaves no node", async () => {
+    vi.mocked(graphRepo.persistPlacement).mockResolvedValue(undefined);
+
+    await expect(joinCommunityGraph("newcomer")).rejects.toThrow(
+      /conflicted but no node was found/,
+    );
   });
 
   it("does not move anyone already placed when the community grows", async () => {

--- a/apps/web/server/graph/service.ts
+++ b/apps/web/server/graph/service.ts
@@ -5,6 +5,7 @@ import {
   DEFAULT_NODE_SIGNAL_STYLE,
   DEFAULT_NODE_STYLE,
   pickNodeColor,
+  type WorldPosition,
 } from "./placement";
 import type { BackboneEdge, GraphNode, NeighbourNode } from "./repository";
 import * as graphRepo from "./repository";
@@ -65,6 +66,11 @@ export async function joinCommunityGraph(userId: string): Promise<GraphNode> {
  * The bounded neighbourhood around an app user's own node: the nearby nodes,
  * the backbone edges spanning exactly that set, and the app user's effective
  * personalization tier.
+ *
+ * `nodes` deliberately contains the viewer's own node — it is the one they came
+ * to find, and it needs the same appearance every other node has. `viewer`
+ * repeats its position because the client's projection is expressed relative to
+ * it, so it should not have to search the set for itself.
  *
  * World units come back untouched. Projecting them into screen pixels, and any
  * responsive keep-out adjustment, happens on the client and never returns here.
@@ -129,7 +135,7 @@ export async function getEffectiveTier(
  */
 async function findAnchors(
   userId: string,
-  position: { x: number; y: number },
+  position: WorldPosition,
 ): Promise<NeighbourNode[]> {
   const anchorCount = chooseAnchorCount(userId);
   const candidates = await graphRepo.findNearestNodes(

--- a/apps/web/server/graph/service.ts
+++ b/apps/web/server/graph/service.ts
@@ -43,7 +43,7 @@ export async function joinCommunityGraph(userId: string): Promise<GraphNode> {
   const node: GraphNode = { userId, ...position };
   const anchors = await findAnchors(userId, position);
 
-  await graphRepo.persistPlacement({
+  const placed = await graphRepo.persistPlacement({
     node,
     profile: {
       userId,
@@ -58,8 +58,18 @@ export async function joinCommunityGraph(userId: string): Promise<GraphNode> {
       anchorUserId: anchor.userId,
     })),
   });
+  if (placed) return placed;
 
-  return node;
+  // A concurrent join for the same app user committed first. Their placement
+  // stands and ours was abandoned whole, so report where this app user really
+  // is rather than coordinates that were never stored.
+  const winner = await graphRepo.findNode(userId);
+  if (!winner) {
+    throw new Error(
+      `Placement for app user ${userId} conflicted but no node was found`,
+    );
+  }
+  return winner;
 }
 
 /**

--- a/apps/web/server/graph/service.ts
+++ b/apps/web/server/graph/service.ts
@@ -1,0 +1,143 @@
+import { NotFoundError } from "../errors";
+import {
+  chooseAnchorCount,
+  computeWorldPosition,
+  DEFAULT_NODE_SIGNAL_STYLE,
+  DEFAULT_NODE_STYLE,
+  pickNodeColor,
+} from "./placement";
+import type { BackboneEdge, GraphNode, NeighbourNode } from "./repository";
+import * as graphRepo from "./repository";
+import { deriveEffectiveTier } from "./tier";
+
+/**
+ * How many nodes one bounded neighbourhood read may return.
+ *
+ * This is a query policy, not a database column: the landing page never loads
+ * the whole community, and the bound belongs to the domain that answers the
+ * question.
+ */
+export const MAX_NEIGHBOURHOOD_NODES = 150;
+
+/** A bounded slice of the community graph around one app user. */
+export type Neighbourhood = {
+  viewer: GraphNode & { effectiveTier: number };
+  nodes: NeighbourNode[];
+  edges: BackboneEdge[];
+};
+
+/**
+ * Give an app user their place in the community graph.
+ *
+ * Idempotent: an app user who already has a node keeps it, untouched. A new
+ * node is placed at the outer edge of the community and attached to three to
+ * five established anchors — nobody already placed is asked to move, and no
+ * global layout pass ever runs.
+ */
+export async function joinCommunityGraph(userId: string): Promise<GraphNode> {
+  const existing = await graphRepo.findNode(userId);
+  if (existing) return existing;
+
+  const position = computeWorldPosition(userId, await graphRepo.countNodes());
+  const node: GraphNode = { userId, ...position };
+  const anchors = await findAnchors(userId, position);
+
+  await graphRepo.persistPlacement({
+    node,
+    profile: {
+      userId,
+      color: pickNodeColor(userId),
+      style: DEFAULT_NODE_STYLE,
+      signalStyle: DEFAULT_NODE_SIGNAL_STYLE,
+    },
+    // Direction records placement history: the newer node points at the older
+    // anchor. A backbone edge is not a friendship and carries no social meaning.
+    edges: anchors.map((anchor) => ({
+      nodeUserId: userId,
+      anchorUserId: anchor.userId,
+    })),
+  });
+
+  return node;
+}
+
+/**
+ * The bounded neighbourhood around an app user's own node: the nearby nodes,
+ * the backbone edges spanning exactly that set, and the app user's effective
+ * personalization tier.
+ *
+ * World units come back untouched. Projecting them into screen pixels, and any
+ * responsive keep-out adjustment, happens on the client and never returns here.
+ */
+export async function getNeighbourhood(
+  userId: string,
+  now: Date = new Date(),
+): Promise<Neighbourhood> {
+  const node = await graphRepo.findNode(userId);
+  if (!node) {
+    throw new NotFoundError(`No community graph node for app user ${userId}`);
+  }
+
+  const nodes = await graphRepo.findNearestNodes(
+    { x: node.x, y: node.y },
+    MAX_NEIGHBOURHOOD_NODES,
+  );
+  const withinSet = new Set(nodes.map((neighbour) => neighbour.userId));
+  const edges = await graphRepo.findBackboneEdgesWithin([...withinSet]);
+
+  return {
+    viewer: { ...node, effectiveTier: await getEffectiveTier(userId, now) },
+    nodes,
+    // The query already scopes to this set. Narrowing here too keeps the
+    // guarantee true of the service whatever that query later becomes.
+    edges: edges.filter(
+      (edge) =>
+        withinSet.has(edge.nodeUserId) && withinSet.has(edge.anchorUserId),
+    ),
+  };
+}
+
+/**
+ * The personalization tier an app user effectively has right now.
+ *
+ * Read-only by construction: the earned tier is the highest ever reached and
+ * decay is derived from it, never written back.
+ */
+export async function getEffectiveTier(
+  userId: string,
+  now: Date = new Date(),
+): Promise<number> {
+  const basis = await graphRepo.findTierBasis(userId);
+  if (!basis) throw new NotFoundError(`No such app user: ${userId}`);
+
+  const lastReviewAt = await graphRepo.findLastReviewAt(userId);
+  // An app user who has never reviewed decays from when they joined, so a
+  // brand-new account is not instantly decayed.
+  return deriveEffectiveTier(
+    basis.earnedTier,
+    lastReviewAt ?? basis.accountCreatedAt,
+    now,
+  );
+}
+
+/**
+ * The established nodes a joining node attaches to: the ones nearest its new
+ * world position. One extra candidate is requested so that a row for the
+ * joining app user, if the community ever contains one, can be dropped without
+ * costing an anchor. Self-edges are impossible here and rejected by the
+ * `no_self_backbone_edge` check constraint besides.
+ */
+async function findAnchors(
+  userId: string,
+  position: { x: number; y: number },
+): Promise<NeighbourNode[]> {
+  const anchorCount = chooseAnchorCount(userId);
+  const candidates = await graphRepo.findNearestNodes(
+    position,
+    anchorCount + 1,
+    userId,
+  );
+  return candidates
+    .filter((candidate) => candidate.userId !== userId)
+    .slice(0, anchorCount);
+}

--- a/apps/web/server/graph/tier.spec.ts
+++ b/apps/web/server/graph/tier.spec.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it } from "vitest";
+import { deriveEffectiveTier } from "./tier";
+
+// Fixed dates only: deriveEffectiveTier is pure, so there is no clock to inject
+// beyond its own `now` parameter.
+const JOINED = new Date("2024-01-15T12:00:00.000Z");
+
+describe("deriveEffectiveTier", () => {
+  it("keeps the earned tier while the six months are still running", () => {
+    const almostSixMonths = new Date("2024-07-14T12:00:00.000Z");
+
+    expect(deriveEffectiveTier(3, JOINED, almostSixMonths)).toBe(3);
+  });
+
+  it("drops one step once six complete months have passed", () => {
+    const sixMonths = new Date("2024-07-15T12:00:00.000Z");
+
+    expect(deriveEffectiveTier(3, JOINED, sixMonths)).toBe(2);
+  });
+
+  it("drops one step per further complete six months", () => {
+    expect(
+      deriveEffectiveTier(3, JOINED, new Date("2025-01-15T12:00:00.000Z")),
+    ).toBe(1);
+    expect(
+      deriveEffectiveTier(3, JOINED, new Date("2025-07-15T12:00:00.000Z")),
+    ).toBe(0);
+  });
+
+  it("floors at zero however long the inactivity runs", () => {
+    expect(
+      deriveEffectiveTier(3, JOINED, new Date("2044-01-15T12:00:00.000Z")),
+    ).toBe(0);
+    expect(
+      deriveEffectiveTier(0, JOINED, new Date("2044-01-15T12:00:00.000Z")),
+    ).toBe(0);
+  });
+
+  it("never exceeds the earned tier, even with a future reference date", () => {
+    const before = new Date("2023-01-15T12:00:00.000Z");
+
+    expect(deriveEffectiveTier(1, JOINED, before)).toBe(1);
+  });
+
+  it("counts a month only when the calendar day is reached", () => {
+    // 31 Jan + 6 months lands on 31 Jul; 30 Jul is not yet six complete months.
+    const endOfMonth = new Date("2024-01-31T00:00:00.000Z");
+
+    expect(
+      deriveEffectiveTier(2, endOfMonth, new Date("2024-07-30T23:59:59.000Z")),
+    ).toBe(2);
+    expect(
+      deriveEffectiveTier(2, endOfMonth, new Date("2024-07-31T00:00:00.000Z")),
+    ).toBe(1);
+  });
+
+  it("does not decay when there is no reference date at all", () => {
+    expect(
+      deriveEffectiveTier(2, null, new Date("2044-01-15T12:00:00.000Z")),
+    ).toBe(2);
+  });
+});

--- a/apps/web/server/graph/tier.ts
+++ b/apps/web/server/graph/tier.ts
@@ -1,0 +1,72 @@
+/**
+ * Effective personalization tier.
+ *
+ * `users.personalization_tier_earned` stores the highest tier an app user has
+ * ever reached. Inactivity decay is derived at read time and is never written
+ * back — nothing in this file, or any caller of it, may update that column.
+ *
+ * The formula lives here, alone and pure, so product can swap it without
+ * touching a service or a query.
+ */
+
+/** Complete months of inactivity that cost one tier step. */
+const MONTHS_PER_DECAY_STEP = 6;
+
+/**
+ * Derive the tier an app user effectively has right now.
+ *
+ * @param earnedTier The highest tier ever reached (`users.personalization_tier_earned`).
+ * @param lastReviewAt The date decay is measured from: the app user's most
+ *   recent qualifying review, or — when they have never reviewed — their
+ *   `users.created_at`, so a brand-new account is not instantly decayed and an
+ *   account that never reviewed decays from when it joined. `null` means no
+ *   reference date is known at all and yields no decay.
+ * @param now The instant to evaluate against.
+ * @returns The effective tier, clamped to `[0, earnedTier]`.
+ */
+export function deriveEffectiveTier(
+  earnedTier: number,
+  lastReviewAt: Date | null,
+  now: Date,
+): number {
+  if (lastReviewAt === null) return earnedTier;
+
+  const steps = Math.floor(
+    completeMonthsBetween(lastReviewAt, now) / MONTHS_PER_DECAY_STEP,
+  );
+  return clamp(earnedTier - steps, 0, earnedTier);
+}
+
+function clamp(value: number, min: number, max: number): number {
+  return Math.min(Math.max(value, min), max);
+}
+
+/**
+ * Whole calendar months from `from` to `to`, in UTC. A month is complete only
+ * once its day-of-month anniversary is reached, so 31 Jan → 30 Jul is five
+ * months and 31 Jan → 31 Jul is six.
+ */
+function completeMonthsBetween(from: Date, to: Date): number {
+  if (to.getTime() <= from.getTime()) return 0;
+
+  const calendarMonths =
+    (to.getUTCFullYear() - from.getUTCFullYear()) * 12 +
+    (to.getUTCMonth() - from.getUTCMonth());
+  const anniversary = addUTCMonths(from, calendarMonths);
+  return anniversary.getTime() > to.getTime()
+    ? calendarMonths - 1
+    : calendarMonths;
+}
+
+/** `from` shifted by whole months, clamping to the last day of a short month. */
+function addUTCMonths(from: Date, months: number): Date {
+  const dayOfMonth = from.getUTCDate();
+  const shifted = new Date(from.getTime());
+  shifted.setUTCDate(1);
+  shifted.setUTCMonth(shifted.getUTCMonth() + months);
+  const daysInTargetMonth = new Date(
+    Date.UTC(shifted.getUTCFullYear(), shifted.getUTCMonth() + 1, 0),
+  ).getUTCDate();
+  shifted.setUTCDate(Math.min(dayOfMonth, daysInTargetMonth));
+  return shifted;
+}


### PR DESCRIPTION
Closes #65 once merged (the product owner merges and closes; this PR is not to be self-merged).

## Before merging

Merge order is fixed: **#64 → #75 → #65 (this) → #66**. Neither #64 nor #75 had an open PR when this branch was cut, so:

- **Merge #64 and #75 first.** This branch is rebased on `dev` at `a65f9dc`.
- **Expect one trivial conflict in `apps/web/server/api/root.ts`.** #64 registers three routers there and this PR registers one (`graph: graphRouter`). Resolve by **keeping both** — the registrations are independent.
- Nothing else here depends on #64 or #75. There is **no migration** in this PR, so no snapshot to regenerate and no numbering to renumber.
- `graph.join` is **not yet wired into signup** — see "What the product owner should know" below.

## What this does

Builds the server side of the community graph in one new domain folder, `apps/web/server/graph/`.

**Placement on join** (`placement.ts`, `service.ts`). A joining app user gets a persisted world `x`/`y` and is attached to three to five established **anchors**. Radius is `RADIUS_STEP * sqrt(placedNodeCount)` and the angle is the golden angle plus a small per-user wobble, so:

- new nodes land in the outer region, which is what the spec asks for;
- the radius depends only on how many nodes were already there, so **adding a user cannot move anyone already placed**. There is no global layout pass. `service.spec.ts` asserts this directly: it joins twelve app users in a row against an in-memory community and checks every earlier node's `x`/`y` byte-for-byte after each join.

**Backbone edges.** Stored as `(node_user_id, anchor_user_id)`, directed newer node → older anchor, recording placement history only. A backbone edge is not a friendship and carries no social meaning. Self-edges are filtered in the service *and* rejected by the `no_self_backbone_edge` check constraint; duplicates are impossible by primary key plus `on conflict do nothing`. Node, profile and edges are written in one transaction.

**Bounded neighbourhood query.** `MAX_NEIGHBOURHOOD_NODES = 150`, an exported named constant in the service — a query policy, never a database column. `getNeighbourhood` returns the nearest nodes up to that bound plus **only the backbone edges spanning that exact set**. World units come back untouched; the projection into screen pixels runs on the client and never writes back.

**Effective personalization tier** (`tier.ts`). `deriveEffectiveTier(earnedTier, lastReviewAt, now)` is pure and tested with fixed dates and no mocks: one step of decay per complete six months, clamped to `[0, earnedTier]`. When the app user has never reviewed, the service measures from `users.created_at`, so a brand-new account is not instantly decayed. **`personalization_tier_earned` is never written** — the graph domain has no write function that could, and a test asserts that the only writer it exposes is `persistPlacement`.

**Node appearance.** `color` is one of the six palette **names** (`aurora`, `ember`, `frost`, `moss`, `slate`, `violet`), picked deterministically from the user id so a given app user always looks the same; the client maps names to `--cc-*` tokens, so the palette re-skins without a data migration. `style` and `signal_style` are written as `"default"`. **No enum values added and no migration**, as decided.

**Router.** `graph.join` (mutation), `graph.neighbourhood`, `graph.effectiveTier` — all `protectedProcedure`, all keyed on `ctx.session.user.id`, never an id from the input. The community graph is personal, so there is nothing here a visitor could ask for.

**`CONTEXT.md`.** Exactly six `_Today_` entries deleted — Community graph, Node, World position, Backbone edge, Node profile, Personalization tier — all of which named tables that now exist. No others were touched.

## The one deliberate convention exception

`server/graph/repository.ts` reads `max(reviews.created_at) where user_id = ?` directly instead of going service → service. It is commented in place as an approved exception: a single read-only aggregate covered by `reviews_user_id_idx`, and routing it through `server/reviews/service.ts` would couple this to #75, which is rewriting that file in parallel. **Nothing is imported from `server/reviews/`.**

## What the product owner should know

1. **`graph.join` is not called from anywhere yet.** Placement needs a trigger, and the natural one is a Better Auth `databaseHooks` after-create hook in `server/auth.ts` — a file this issue does not own. Until that is wired (or the landing page calls `graph.join` on first visit), no node is ever created and `graph.neighbourhood` returns `NOT_FOUND` with "No community graph node for app user …". The client can treat that as "call join, then retry".
2. **Two *different* people joining in the same instant land at the same radius.** The placement index comes from `count(*)` read outside the placement transaction, so simultaneous joins by different app users share a radius and are separated only by the per-user angular wobble. Positions are cosmetic and no constraint is at risk, so this is accepted rather than serialised — say the word if near-collisions on a busy signup day matter. (Two simultaneous joins for the *same* app user are handled: the losing placement is abandoned whole and the caller is told where they really are. See the Greptile thread.)
3. **The viewer's own node is inside `nodes`, and its position is repeated in `viewer`.** Intentional: it is the dot they came to find, so it needs the same appearance every other node has, and the client's projection is expressed relative to `viewer` and should not have to search the set for itself.
4. **The palette and the decay formula are built to be swapped.** `NODE_COLORS` lives in exactly one place and `deriveEffectiveTier` is a single pure function; changing either is a one-file edit with no migration.

## One judgement call the spec did not settle

The decided signature `deriveEffectiveTier(earnedTier, lastReviewAt: Date | null, now)` has three parameters, but the rule "measure from `users.created_at` when the app user has never reviewed" needs a fourth date. Rather than change a signature the issue pinned, the **service** resolves the reference date (`lastReviewAt ?? accountCreatedAt`) and the pure function treats an explicit `null` as "no reference date at all, therefore no decay". Both paths are tested. Happy to move the fallback inside the function if you would rather it own the whole rule.

## Gates

- `bun run test:web` — 67 passed (10 files), 37 of them new
- `npx tsc --noEmit` — clean
- `bun run lint` — clean

Layering is Biome-enforced and holds: the router only touches the service, the repository only touches `db`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01D3d7V2JceJZvtJED18HXFJ
