### PR TITLE
feat(transcript): Ladok transcript import as proposed taken courses (#66)

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -74,8 +74,6 @@ _Avoid_: completed course, course history, my courses, enrolled course
 **Transcript import**:
 Reading a Ladok transcript and turning its rows into taken courses after the
 user confirms them. Imported grades and credits remain self-reported.
-_Today_: not implemented. Closed by
-`user_taken_courses.transcript_imported_at`.
 _Avoid_: transcript sync, Ladok scrape, upload (that is the file step, not this)
 
 **Collection**:

--- a/apps/web/app/api/user/transcript/route.ts
+++ b/apps/web/app/api/user/transcript/route.ts
@@ -4,7 +4,7 @@ import { extractTranscriptText } from "@/server/ingest/transcript/pdf-text";
 import { buildTranscriptProposal } from "@/server/ingest/transcript/service";
 import {
   capRequestBody,
-  TranscriptTooLargeError,
+  isTranscriptTooLarge,
 } from "@/server/ingest/transcript/upload";
 
 export const runtime = "nodejs";
@@ -35,7 +35,7 @@ export async function POST(request: Request) {
   try {
     formData = await capRequestBody(request, MAX_BYTES).formData();
   } catch (error) {
-    if (error instanceof TranscriptTooLargeError) {
+    if (isTranscriptTooLarge(error)) {
       return Response.json({ message: TOO_LARGE }, { status: 413 });
     }
     return Response.json(

--- a/apps/web/app/api/user/transcript/route.ts
+++ b/apps/web/app/api/user/transcript/route.ts
@@ -1,0 +1,64 @@
+import { getAuth } from "@/server/auth";
+import { TranscriptParseError } from "@/server/ingest/transcript/parse";
+import { extractTranscriptText } from "@/server/ingest/transcript/pdf-text";
+import { buildTranscriptProposal } from "@/server/ingest/transcript/service";
+
+export const runtime = "nodejs";
+
+const MAX_BYTES = 4 * 1024 * 1024;
+const TOO_LARGE = "Transcript must be less than 4MB";
+
+/**
+ * Turns an uploaded Ladok transcript into a proposal of taken courses.
+ *
+ * Multipart does not go through tRPC in this repo, so the file arrives here —
+ * and because a transcript may not be stored, the same request that receives
+ * the file also parses it and returns the proposal. Confirming the proposal is
+ * `transcript.confirm` over tRPC; this route writes nothing.
+ *
+ * Neither the file nor its text is persisted or logged.
+ */
+export async function POST(request: Request) {
+  const session = await getAuth().api.getSession({ headers: request.headers });
+  if (!session?.user) {
+    return Response.json({ message: "Unauthorized" }, { status: 401 });
+  }
+
+  // Checked before `formData()` so an oversized upload is refused rather than
+  // buffered into memory first. `file.size` below is the check that counts; a
+  // client can send any Content-Length it likes.
+  const declaredLength = Number(request.headers.get("content-length"));
+  if (declaredLength > MAX_BYTES) {
+    return Response.json({ message: TOO_LARGE }, { status: 413 });
+  }
+
+  const formData = await request.formData();
+  const file = formData.get("file");
+  if (!(file instanceof File) || file.size === 0) {
+    return Response.json(
+      { message: "No transcript provided" },
+      { status: 400 },
+    );
+  }
+  if (file.type !== "application/pdf") {
+    return Response.json(
+      { message: "Upload the transcript PDF that Ladok generates" },
+      { status: 400 },
+    );
+  }
+  if (file.size > MAX_BYTES) {
+    return Response.json({ message: TOO_LARGE }, { status: 413 });
+  }
+
+  try {
+    const text = await extractTranscriptText(
+      new Uint8Array(await file.arrayBuffer()),
+    );
+    return Response.json(await buildTranscriptProposal(text));
+  } catch (error) {
+    if (error instanceof TranscriptParseError) {
+      return Response.json({ message: error.message }, { status: 422 });
+    }
+    throw error;
+  }
+}

--- a/apps/web/app/api/user/transcript/route.ts
+++ b/apps/web/app/api/user/transcript/route.ts
@@ -2,6 +2,10 @@ import { getAuth } from "@/server/auth";
 import { TranscriptParseError } from "@/server/ingest/transcript/parse";
 import { extractTranscriptText } from "@/server/ingest/transcript/pdf-text";
 import { buildTranscriptProposal } from "@/server/ingest/transcript/service";
+import {
+  capRequestBody,
+  TranscriptTooLargeError,
+} from "@/server/ingest/transcript/upload";
 
 export const runtime = "nodejs";
 
@@ -24,15 +28,22 @@ export async function POST(request: Request) {
     return Response.json({ message: "Unauthorized" }, { status: 401 });
   }
 
-  // Checked before `formData()` so an oversized upload is refused rather than
-  // buffered into memory first. `file.size` below is the check that counts; a
-  // client can send any Content-Length it likes.
-  const declaredLength = Number(request.headers.get("content-length"));
-  if (declaredLength > MAX_BYTES) {
-    return Response.json({ message: TOO_LARGE }, { status: 413 });
+  // Counted as the body arrives: `formData()` would otherwise buffer the whole
+  // upload before anything could look at the file's size, and Content-Length is
+  // absent on a chunked upload and a lie whenever the client wants it to be.
+  let formData: FormData;
+  try {
+    formData = await capRequestBody(request, MAX_BYTES).formData();
+  } catch (error) {
+    if (error instanceof TranscriptTooLargeError) {
+      return Response.json({ message: TOO_LARGE }, { status: 413 });
+    }
+    return Response.json(
+      { message: "Upload the transcript PDF that Ladok generates" },
+      { status: 400 },
+    );
   }
 
-  const formData = await request.formData();
   const file = formData.get("file");
   if (!(file instanceof File) || file.size === 0) {
     return Response.json(
@@ -40,14 +51,13 @@ export async function POST(request: Request) {
       { status: 400 },
     );
   }
+  // Advisory only — the browser sets this and a client may lie. The real check
+  // is `extractTranscriptText` below, which fails on anything that is not a PDF.
   if (file.type !== "application/pdf") {
     return Response.json(
       { message: "Upload the transcript PDF that Ladok generates" },
       { status: 400 },
     );
-  }
-  if (file.size > MAX_BYTES) {
-    return Response.json({ message: TOO_LARGE }, { status: 413 });
   }
 
   try {

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -83,6 +83,7 @@
     "tailwindcss-animate": "^1.0.7",
     "tsx": "^4.20.5",
     "tw-animate-css": "^1.3.8",
+    "unpdf": "^1.8.1",
     "uuid": "^8.3.2",
     "vaul": "^1.1.2",
     "xss": "^1.0.15",

--- a/apps/web/server/api/protected.spec.ts
+++ b/apps/web/server/api/protected.spec.ts
@@ -74,6 +74,13 @@ describe("protected procedures", () => {
           courseCode: "DD2421",
         }),
     ],
+    [
+      "transcript.confirm",
+      () =>
+        caller(null).transcript.confirm({
+          courses: [{ courseCode: "DD2421", grade: "A" }],
+        }),
+    ],
   ])("rejects visitors on %s", async (_name, call) => {
     await expect(call()).rejects.toMatchObject({ code: "UNAUTHORIZED" });
   });

--- a/apps/web/server/api/root.ts
+++ b/apps/web/server/api/root.ts
@@ -3,6 +3,7 @@ import { courseRouter } from "../course/router";
 import { feedbackRouter } from "../feedback/router";
 import { graphRouter } from "../graph/router";
 import { healthRouter } from "../health/router";
+import { transcriptRouter } from "../ingest/transcript/router";
 import { reviewsRouter } from "../reviews/router";
 import { savedRouter } from "../saved/router";
 import { searchRouter } from "../search/router";
@@ -21,6 +22,7 @@ export const appRouter = createTRPCRouter({
   graph: graphRouter,
   feedback: feedbackRouter,
   health: healthRouter,
+  transcript: transcriptRouter,
 });
 
 export type AppRouter = typeof appRouter;

--- a/apps/web/server/ingest/transcript/fixtures/ladok-english.txt
+++ b/apps/web/server/ingest/transcript/fixtures/ladok-english.txt
@@ -1,0 +1,29 @@
+Official Transcript of Records Print date
+2026-08-29
+Name Personal identity number
+Anna Exempelsson 19900101-0000
+Completed courses
+Code Name Scope Grade Date Note
+SF1625 Calculus in One Variable 7.5 hp A 2023-01-13 1
+DD1337 Programming 6.0 hp P 2023-06-02 2
+SF1672 Linear Algebra 7.5 hp C 2024-01-12 1
+DD1389 Interactive Programming and Computer Games in
+Distributed Environments
+9.0 hp B 2024-06-03 1
+ME1003 Industrial Management, Basic Course 6.0 hp P 2025-10-10 2
+Summation
+Total included credited parts Credited education
+36.0 hp
+Notes and information
+60 credits (hp) represent a full academic year. The system is compatible with ECTS credits (the European
+Credit Transfer System) as one credit is equal to one ECTS credit.
+1 Grading scale: Excellent (A), Very Good (B), Good (C), Satisfactory (D), Sufficient (E), Not
+satisfactory (FX), Failed (F)
+2 Grading scale: Pass (P), Failed (F)
+The above is an excerpt from the student registry.
+Check the certificate on: https://student.ladok.se/verifiera/ Personal identity number: 19900101-0000
+Verifiable until: 2026-11-27 Control code: AAAA0AAAAA
+Postal address Contact information Page 1 / 1
+KTH Royal Institute of Technology
+100 44 Stockholm
+https://www.kth.se/en

--- a/apps/web/server/ingest/transcript/fixtures/ladok-swedish.txt
+++ b/apps/web/server/ingest/transcript/fixtures/ladok-swedish.txt
@@ -1,0 +1,29 @@
+Resultatintyg Utskriftsdatum
+2026-08-29
+Namn Personnummer
+Anna Exempelsson 19900101-0000
+Avslutade kurser
+Kod Benämning Omfattning Betyg Datum Not
+SF1625 Envariabelanalys 7,5 hp A 2023-01-13 1
+DD1337 Programmering 6,0 hp P 2023-06-02 2
+SF1672 Linjär algebra 7,5 hp C 2024-01-12 1
+DD1389 Interaktiv programmering och datorspel i distribuerade
+miljöer
+9,0 hp B 2024-06-03 1
+ME1003 Industriell ekonomi, grundkurs 6,0 hp P 2025-10-10 2
+Summering
+Totalt varav tillgodoräknat Övrig tillgodoräknad utbildning
+36,0 hp
+Noter och information
+60 högskolepoäng (hp) motsvarar ett års heltidsstudier. Poängsystemet är likvärdigt med European Credit
+Transfer System (ECTS), då en högskolepoäng svarar mot en ECTS-poäng.
+1 Betygsskala: Utmärkt (A), Mycket bra (B), Bra (C), Tillfredsställande (D), Tillräcklig (E), Underkänd
+(FX), Underkänd (F)
+2 Betygsskala: Godkänd (P), Underkänd (F)
+Ovanstående är ett utdrag ur registret för studiedokumentation.
+Kontrollera intyget på: https://student.ladok.se/verifiera/ Personnummer: 19900101-0000
+Verifierbart tom: 2026-11-27 Kontrollkod: AAAA0AAAAA
+Postadress Kontaktinformation Sida 1 / 1
+Kungliga Tekniska högskolan
+100 44 Stockholm
+https://www.kth.se/

--- a/apps/web/server/ingest/transcript/fixtures/ladok-two-pages.txt
+++ b/apps/web/server/ingest/transcript/fixtures/ladok-two-pages.txt
@@ -1,0 +1,30 @@
+Official Transcript of Records Print date
+2026-08-29
+Name Personal identity number
+Anna Exempelsson 19900101-0000
+Completed courses
+Code Name Scope Grade Date Note
+SF1625 Calculus in One Variable 7.5 hp A 2023-01-13 1
+DD1337 Programming 6.0 hp P 2023-06-02 2
+Check the certificate on: https://student.ladok.se/verifiera/ Personal identity number: 19900101-0000
+Verifiable until: 2026-11-27 Control code: AAAA0AAAAA
+Postal address Contact information Page 1 / 2
+KTH Royal Institute of Technology
+100 44 Stockholm
+https://www.kth.se/en
+Code Name Scope Grade Date Note
+SF1672 Linear Algebra 7.5 hp C 2024-01-12 1
+ME1003 Industrial Management, Basic Course 6.0 hp P 2025-10-10 2
+Summation
+Total included credited parts Credited education
+27.0 hp
+Notes and information
+1 Grading scale: Excellent (A), Very Good (B), Good (C), Satisfactory (D), Sufficient (E), Not
+satisfactory (FX), Failed (F)
+2 Grading scale: Pass (P), Failed (F)
+Check the certificate on: https://student.ladok.se/verifiera/ Personal identity number: 19900101-0000
+Verifiable until: 2026-11-27 Control code: AAAA0AAAAA
+Postal address Contact information Page 2 / 2
+KTH Royal Institute of Technology
+100 44 Stockholm
+https://www.kth.se/en

--- a/apps/web/server/ingest/transcript/fixtures/not-a-transcript.txt
+++ b/apps/web/server/ingest/transcript/fixtures/not-a-transcript.txt
@@ -1,0 +1,6 @@
+KTH Royal Institute of Technology
+Certificate of Registration
+Anna Exempelsson 19900101-0000
+This certifies that the student named above is registered for the autumn
+semester of 2026 in the Degree Programme in Computer Science and Engineering.
+Issued 2026-08-29.

--- a/apps/web/server/ingest/transcript/match.spec.ts
+++ b/apps/web/server/ingest/transcript/match.spec.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it } from "vitest";
+import { matchCandidates } from "./match";
+import type { TranscriptCandidate } from "./parse";
+
+const candidate = (
+  courseCode: string,
+  overrides: Partial<TranscriptCandidate> = {},
+): TranscriptCandidate => ({
+  courseCode,
+  courseName: `Course ${courseCode}`,
+  credits: 7.5,
+  grade: "A",
+  completedOn: "2024-01-12",
+  ...overrides,
+});
+
+describe("matchCandidates", () => {
+  it("keeps the courses the catalogue knows", () => {
+    const result = matchCandidates(
+      [candidate("SF1625"), candidate("DD1337")],
+      ["SF1625", "DD1337", "ME1003"],
+    );
+
+    expect(result.matched.map((row) => row.courseCode)).toEqual([
+      "SF1625",
+      "DD1337",
+    ]);
+    expect(result.unmatched).toEqual([]);
+  });
+
+  it("reports a code the catalogue does not have rather than inventing it", () => {
+    const result = matchCandidates(
+      [candidate("SF1625"), candidate("ZZ9999", { courseName: "Retired" })],
+      ["SF1625"],
+    );
+
+    expect(result.matched.map((row) => row.courseCode)).toEqual(["SF1625"]);
+    expect(result.unmatched).toEqual([
+      { courseCode: "ZZ9999", courseName: "Retired" },
+    ]);
+  });
+
+  it("matches regardless of how the transcript cased or spaced the code", () => {
+    const result = matchCandidates([candidate(" sf1625 ")], ["SF1625"]);
+
+    expect(result.matched).toEqual([
+      expect.objectContaining({ courseCode: "SF1625" }),
+    ]);
+    expect(result.unmatched).toEqual([]);
+  });
+
+  it("keeps one row per course code", () => {
+    const result = matchCandidates(
+      [
+        candidate("SF1625", { grade: "C" }),
+        candidate("SF1625", { grade: "A" }),
+      ],
+      ["SF1625"],
+    );
+
+    expect(result.matched).toHaveLength(1);
+    expect(result.matched[0].grade).toBe("C");
+  });
+});

--- a/apps/web/server/ingest/transcript/match.ts
+++ b/apps/web/server/ingest/transcript/match.ts
@@ -1,0 +1,50 @@
+import type { TranscriptCandidate } from "./parse";
+
+/** A candidate whose code the catalogue does not have. Reported, never written. */
+export type UnmatchedCandidate = {
+  courseCode: string;
+  courseName: string;
+};
+
+export type TranscriptMatch = {
+  /** Candidates that correspond to a course in the catalogue. */
+  matched: TranscriptCandidate[];
+  /** Candidates that do not. Only catalogue courses can become taken courses. */
+  unmatched: UnmatchedCandidate[];
+};
+
+function normalise(courseCode: string): string {
+  return courseCode.trim().toUpperCase();
+}
+
+/**
+ * Splits parsed candidates by whether the catalogue knows their course code.
+ *
+ * Pure: `knownCodes` is whatever the caller looked up, so this stays testable
+ * without a database. A course code the catalogue does not have is reported
+ * back to the user, never invented as a taken course.
+ *
+ * A transcript that lists the same code twice yields one row — the first — so
+ * that the confirmed proposal never asks the write path to touch one
+ * `(user, course)` pair twice.
+ */
+export function matchCandidates(
+  candidates: TranscriptCandidate[],
+  knownCodes: Iterable<string>,
+): TranscriptMatch {
+  const known = new Set([...knownCodes].map(normalise));
+  const matched: TranscriptCandidate[] = [];
+  const unmatched: UnmatchedCandidate[] = [];
+  const seen = new Set<string>();
+
+  for (const candidate of candidates) {
+    const courseCode = normalise(candidate.courseCode);
+    if (seen.has(courseCode)) continue;
+    seen.add(courseCode);
+
+    if (known.has(courseCode)) matched.push({ ...candidate, courseCode });
+    else unmatched.push({ courseCode, courseName: candidate.courseName });
+  }
+
+  return { matched, unmatched };
+}

--- a/apps/web/server/ingest/transcript/parse.spec.ts
+++ b/apps/web/server/ingest/transcript/parse.spec.ts
@@ -1,0 +1,203 @@
+import { readFileSync } from "node:fs";
+import { describe, expect, it } from "vitest";
+import { parseLadokTranscript, TranscriptParseError } from "./parse";
+
+function fixture(name: string): string {
+  return readFileSync(new URL(`./fixtures/${name}`, import.meta.url), "utf8");
+}
+
+describe("parseLadokTranscript", () => {
+  it("reads every completed course off an English transcript", () => {
+    const candidates = parseLadokTranscript(fixture("ladok-english.txt"));
+
+    expect(candidates).toEqual([
+      {
+        courseCode: "SF1625",
+        courseName: "Calculus in One Variable",
+        credits: 7.5,
+        grade: "A",
+        completedOn: "2023-01-13",
+      },
+      {
+        courseCode: "DD1337",
+        courseName: "Programming",
+        credits: 6,
+        grade: "P",
+        completedOn: "2023-06-02",
+      },
+      {
+        courseCode: "SF1672",
+        courseName: "Linear Algebra",
+        credits: 7.5,
+        grade: "C",
+        completedOn: "2024-01-12",
+      },
+      {
+        courseCode: "DD1389",
+        courseName:
+          "Interactive Programming and Computer Games in Distributed Environments",
+        credits: 9,
+        grade: "B",
+        completedOn: "2024-06-03",
+      },
+      {
+        courseCode: "ME1003",
+        courseName: "Industrial Management, Basic Course",
+        credits: 6,
+        grade: "P",
+        completedOn: "2025-10-10",
+      },
+    ]);
+  });
+
+  it("reads a Swedish transcript, whose credits use a decimal comma", () => {
+    const candidates = parseLadokTranscript(fixture("ladok-swedish.txt"));
+
+    expect(candidates).toEqual([
+      {
+        courseCode: "SF1625",
+        courseName: "Envariabelanalys",
+        credits: 7.5,
+        grade: "A",
+        completedOn: "2023-01-13",
+      },
+      {
+        courseCode: "DD1337",
+        courseName: "Programmering",
+        credits: 6,
+        grade: "P",
+        completedOn: "2023-06-02",
+      },
+      {
+        courseCode: "SF1672",
+        courseName: "Linjär algebra",
+        credits: 7.5,
+        grade: "C",
+        completedOn: "2024-01-12",
+      },
+      {
+        courseCode: "DD1389",
+        courseName:
+          "Interaktiv programmering och datorspel i distribuerade miljöer",
+        credits: 9,
+        grade: "B",
+        completedOn: "2024-06-03",
+      },
+      {
+        courseCode: "ME1003",
+        courseName: "Industriell ekonomi, grundkurs",
+        credits: 6,
+        grade: "P",
+        completedOn: "2025-10-10",
+      },
+    ]);
+  });
+
+  it("stops at the summation block instead of reading the grading-scale notes", () => {
+    const codes = parseLadokTranscript(fixture("ladok-english.txt")).map(
+      (candidate) => candidate.courseCode,
+    );
+
+    expect(codes).toHaveLength(5);
+    expect(codes).not.toContain("ECTS");
+  });
+
+  it("rejects a document that is not a transcript", () => {
+    expect(() => parseLadokTranscript(fixture("not-a-transcript.txt"))).toThrow(
+      TranscriptParseError,
+    );
+  });
+
+  it("rejects an empty document", () => {
+    expect(() => parseLadokTranscript("")).toThrow(TranscriptParseError);
+  });
+
+  it("reads across a page break, past the footer and the repeated header", () => {
+    const candidates = parseLadokTranscript(fixture("ladok-two-pages.txt"));
+
+    expect(candidates).toEqual([
+      {
+        courseCode: "SF1625",
+        courseName: "Calculus in One Variable",
+        credits: 7.5,
+        grade: "A",
+        completedOn: "2023-01-13",
+      },
+      {
+        courseCode: "DD1337",
+        courseName: "Programming",
+        credits: 6,
+        grade: "P",
+        completedOn: "2023-06-02",
+      },
+      {
+        courseCode: "SF1672",
+        courseName: "Linear Algebra",
+        credits: 7.5,
+        grade: "C",
+        completedOn: "2024-01-12",
+      },
+      {
+        courseCode: "ME1003",
+        courseName: "Industrial Management, Basic Course",
+        credits: 6,
+        grade: "P",
+        completedOn: "2025-10-10",
+      },
+    ]);
+  });
+
+  it("reports a row whose scope, grade and date it cannot read", () => {
+    const oddRow = [
+      "Code Name Scope Grade Date Note",
+      "SF1625 Calculus in One Variable 7.5 hp A 2023-01-13 1",
+      "AK2030 Theory and Method of Science, with applications",
+      "Summation",
+    ].join("\n");
+
+    expect(parseLadokTranscript(oddRow)).toEqual([
+      {
+        courseCode: "SF1625",
+        courseName: "Calculus in One Variable",
+        credits: 7.5,
+        grade: "A",
+        completedOn: "2023-01-13",
+      },
+      {
+        courseCode: "AK2030",
+        courseName: "Theory and Method of Science, with applications",
+        credits: null,
+        grade: null,
+        completedOn: null,
+      },
+    ]);
+  });
+
+  it("rejects a transcript whose completed-courses table is empty", () => {
+    const noResultsYet = [
+      "Official Transcript of Records Print date",
+      "2026-08-29",
+      "Completed courses",
+      "Code Name Scope Grade Date Note",
+      "Summation",
+      "Total included credited parts Credited education",
+      "0.0 hp",
+    ].join("\n");
+
+    expect(() => parseLadokTranscript(noResultsYet)).toThrow(
+      TranscriptParseError,
+    );
+  });
+
+  it("keeps the transcript out of the error it reports", () => {
+    const transcript = fixture("not-a-transcript.txt");
+
+    try {
+      parseLadokTranscript(transcript);
+      expect.unreachable("should have thrown");
+    } catch (error) {
+      expect((error as Error).message).not.toContain("Anna Exempelsson");
+      expect((error as Error).message).not.toContain("19900101-0000");
+    }
+  });
+});

--- a/apps/web/server/ingest/transcript/parse.spec.ts
+++ b/apps/web/server/ingest/transcript/parse.spec.ts
@@ -173,6 +173,36 @@ describe("parseLadokTranscript", () => {
     ]);
   });
 
+  it("rejects a document too large to be a transcript, without scanning it", () => {
+    const huge = `Code Name Scope Grade Date Note\nSF1625 ${"x".repeat(3_000_000)}`;
+
+    const startedAt = performance.now();
+    expect(() => parseLadokTranscript(huge)).toThrow(TranscriptParseError);
+    expect(performance.now() - startedAt).toBeLessThan(1000);
+  });
+
+  it("does not let one unterminated row absorb the rest of the document", () => {
+    const runaway = [
+      "Code Name Scope Grade Date Note",
+      "SF1625 Calculus in One Variable",
+      ...Array.from({ length: 500 }, (_, index) => `filler line ${index}`),
+      "DD1337 Programming 6.0 hp P 2023-06-02 2",
+      "Summation",
+    ].join("\n");
+
+    const candidates = parseLadokTranscript(runaway);
+
+    expect(candidates).toHaveLength(2);
+    expect(candidates[0].courseName).not.toContain("filler line 499");
+    expect(candidates[1]).toEqual({
+      courseCode: "DD1337",
+      courseName: "Programming",
+      credits: 6,
+      grade: "P",
+      completedOn: "2023-06-02",
+    });
+  });
+
   it("rejects a transcript whose completed-courses table is empty", () => {
     const noResultsYet = [
       "Official Transcript of Records Print date",

--- a/apps/web/server/ingest/transcript/parse.spec.ts
+++ b/apps/web/server/ingest/transcript/parse.spec.ts
@@ -194,6 +194,32 @@ describe("parseLadokTranscript", () => {
     ]);
   });
 
+  it("rejoins a course row that wraps across a page break", () => {
+    const wrappedAcrossBreak = [
+      "Code Name Scope Grade Date Note",
+      "DD1337 Programming and",
+      "Check the certificate on: https://student.ladok.se/verifiera/ Personal identity number: 19900101-0000",
+      "Verifiable until: 2026-11-27 Control code: AAAA0AAAAA",
+      "Postal address Contact information Page 1 / 2",
+      "KTH Royal Institute of Technology",
+      "100 44 Stockholm",
+      "https://www.kth.se/en",
+      "Code Name Scope Grade Date Note",
+      "Computer Science 6.0 hp P 2023-06-02 2",
+      "Summation",
+    ].join("\n");
+
+    expect(parseLadokTranscript(wrappedAcrossBreak)).toEqual([
+      {
+        courseCode: "DD1337",
+        courseName: "Programming and Computer Science",
+        credits: 6,
+        grade: "P",
+        completedOn: "2023-06-02",
+      },
+    ]);
+  });
+
   it("reports a row whose scope, grade and date it cannot read", () => {
     const oddRow = [
       "Code Name Scope Grade Date Note",

--- a/apps/web/server/ingest/transcript/parse.spec.ts
+++ b/apps/web/server/ingest/transcript/parse.spec.ts
@@ -147,6 +147,53 @@ describe("parseLadokTranscript", () => {
     ]);
   });
 
+  it("never joins page furniture onto an incomplete row at a page break", () => {
+    const incompleteBeforeBreak = [
+      "Code Name Scope Grade Date Note",
+      "SF1625 Calculus in One Variable 7.5 hp A 2023-01-13 1",
+      "DD1337 Programming",
+      "Check the certificate on: https://student.ladok.se/verifiera/ Personal identity number: 19900101-0000",
+      "Verifiable until: 2026-11-27 Control code: AAAA0AAAAA",
+      "Postal address Contact information Page 1 / 2",
+      "KTH Royal Institute of Technology",
+      "100 44 Stockholm",
+      "Code Name Scope Grade Date Note",
+      "SF1672 Linear Algebra 7.5 hp C 2024-01-12 1",
+      "Summation",
+    ].join("\n");
+
+    const candidates = parseLadokTranscript(incompleteBeforeBreak);
+    const names = candidates.map((candidate) => candidate.courseName).join(" ");
+
+    expect(names).not.toContain("19900101-0000");
+    expect(names).not.toContain("ladok.se");
+    expect(names).not.toContain("Page 1 / 2");
+    expect(names).not.toContain("Scope Grade Date");
+    expect(candidates).toEqual([
+      {
+        courseCode: "SF1625",
+        courseName: "Calculus in One Variable",
+        credits: 7.5,
+        grade: "A",
+        completedOn: "2023-01-13",
+      },
+      {
+        courseCode: "DD1337",
+        courseName: "Programming",
+        credits: null,
+        grade: null,
+        completedOn: null,
+      },
+      {
+        courseCode: "SF1672",
+        courseName: "Linear Algebra",
+        credits: 7.5,
+        grade: "C",
+        completedOn: "2024-01-12",
+      },
+    ]);
+  });
+
   it("reports a row whose scope, grade and date it cannot read", () => {
     const oddRow = [
       "Code Name Scope Grade Date Note",

--- a/apps/web/server/ingest/transcript/parse.ts
+++ b/apps/web/server/ingest/transcript/parse.ts
@@ -1,0 +1,129 @@
+/**
+ * Pure parser for the text layer of a Ladok transcript ("Resultatintyg" /
+ * "Official Transcript of Records"). Extracting that text from a PDF is
+ * `pdf-text.ts`; this module never sees the file.
+ */
+
+/**
+ * Raised when the text does not look like a Ladok transcript.
+ *
+ * Its message is a fixed string: an academic record must never reach a log line
+ * or an API response by way of an error.
+ */
+export class TranscriptParseError extends Error {
+  readonly code = "TRANSCRIPT_UNREADABLE" as const;
+  constructor(message: string) {
+    super(message);
+    this.name = "TranscriptParseError";
+  }
+}
+
+/** One completed-course row as the transcript printed it. Self-reported data. */
+export type TranscriptCandidate = {
+  courseCode: string;
+  courseName: string;
+  credits: number | null;
+  grade: string | null;
+  /** The result date Ladok printed, as `YYYY-MM-DD`. */
+  completedOn: string | null;
+};
+
+/** Start of the completed-courses table, in either transcript language. */
+const TABLE_HEADER = /^(?:Code|Kod)\s+(?:Name|Benämning)\b/;
+
+/** First line after the table; Ladok always prints a summation block. */
+const TABLE_END = /^(?:Summation|Summering)\b/;
+
+/** A KTH course code: two or three letters then four digits. */
+const COURSE_CODE = /^[A-ZÅÄÖ]{2,3}\d{4}[A-Z]?$/;
+
+/**
+ * `<code> <name> <credits> hp <grade> <YYYY-MM-DD> [note]`, matched against a
+ * whole row after its wrapped lines have been rejoined.
+ */
+const ROW =
+  /^([A-ZÅÄÖ]{2,3}\d{4}[A-Z]?)\s+(.+?)\s+(\d+(?:[.,]\d+)?)\s*hp\s+(\S{1,3})\s+(\d{4}-\d{2}-\d{2})(?:\s+\d+)?$/;
+
+/** The fallback when a row's trailing columns are unreadable: code and name. */
+const ROW_HEAD = /^([A-ZÅÄÖ]{2,3}\d{4}[A-Z]?)\s+(.*)$/;
+
+function toLines(text: string): string[] {
+  return text.split(/\r\n|\r|\n/).map((line) => line.trim());
+}
+
+function startsRow(line: string): boolean {
+  return COURSE_CODE.test(line.split(/\s+/)[0] ?? "");
+}
+
+/**
+ * Splits the table body into one string per course, rejoining the lines a long
+ * course name wrapped onto.
+ *
+ * A row keeps absorbing following lines only until it has all of its columns.
+ * That is what carries the table over a page break: once a row is complete, the
+ * page footer and the repeated column header that follow it belong to no row
+ * and are dropped instead of being glued onto the last course name.
+ */
+function rowBlocks(lines: string[]): string[] {
+  const blocks: string[] = [];
+  for (const line of lines) {
+    if (line === "") continue;
+    if (startsRow(line)) {
+      blocks.push(line);
+      continue;
+    }
+    const open = blocks.at(-1);
+    if (open === undefined || ROW.test(open)) continue;
+    blocks[blocks.length - 1] = `${open} ${line}`;
+  }
+  return blocks;
+}
+
+export function parseLadokTranscript(text: string): TranscriptCandidate[] {
+  const lines = toLines(text);
+  const headerAt = lines.findIndex((line) => TABLE_HEADER.test(line));
+  if (headerAt === -1) {
+    throw new TranscriptParseError(
+      "This file does not look like a Ladok transcript. Export your " +
+        "transcript from Ladok as a PDF and upload that file.",
+    );
+  }
+  const rest = lines.slice(headerAt + 1);
+  const endAt = rest.findIndex((line) => TABLE_END.test(line));
+  const body = endAt === -1 ? rest : rest.slice(0, endAt);
+
+  const candidates: TranscriptCandidate[] = [];
+  for (const block of rowBlocks(body)) {
+    const match = ROW.exec(block);
+    if (match) {
+      const [, courseCode, courseName, credits, grade, completedOn] = match;
+      candidates.push({
+        courseCode,
+        courseName,
+        credits: Number(credits.replace(",", ".")),
+        grade,
+        completedOn,
+      });
+      continue;
+    }
+
+    // A row whose trailing columns did not survive the PDF's text layer still
+    // has to reach the user: dropping it would silently lose a taken course.
+    const head = ROW_HEAD.exec(block);
+    if (!head) continue;
+    candidates.push({
+      courseCode: head[1],
+      courseName: head[2].trim(),
+      credits: null,
+      grade: null,
+      completedOn: null,
+    });
+  }
+
+  if (candidates.length === 0) {
+    throw new TranscriptParseError(
+      "No completed courses were found in this transcript.",
+    );
+  }
+  return candidates;
+}

--- a/apps/web/server/ingest/transcript/parse.ts
+++ b/apps/web/server/ingest/transcript/parse.ts
@@ -70,10 +70,11 @@ const ROW_HEAD = /^([A-ZÅÄÖ]{2,3}\d{4}[A-Z]?)\s+(.*)$/;
  * verification footer, the address block, the page counter, and the column
  * header repeated at the top of each page.
  *
- * Only the first line of that run has to be recognised — reaching one closes
- * the row being built, and nothing is absorbed again until the next course
- * code. Without this, a row whose columns are missing swallows the footer, and
- * the footer carries the student's personal identity number.
+ * These lines are stepped over rather than joined, so a course name really does
+ * survive a page break — while the footer, which carries the student's personal
+ * identity number, never lands inside a course name. Every line of the run has
+ * to be recognised for that to hold, which is why the address block is listed
+ * as well as the verification lines.
  */
 const PAGE_FURNITURE = [
   TABLE_HEADER,
@@ -85,6 +86,9 @@ const PAGE_FURNITURE = [
   /(?:Personal identity number|Personnummer)\s*:/,
   /(?:Control code|Kontrollkod)\s*:/,
   /^https?:\/\//i,
+  /^(?:KTH Royal Institute of Technology|Kungliga Tekniska högskolan)\b/,
+  // The postal-address line, e.g. "100 44 Stockholm".
+  /^\d{3}\s?\d{2}\s+\S/,
 ];
 
 function isPageFurniture(line: string): boolean {
@@ -103,31 +107,25 @@ function startsRow(line: string): boolean {
  * Splits the table body into one string per course, rejoining the lines a long
  * course name wrapped onto.
  *
- * A row absorbs following lines only until it has all of its columns, and never
- * across page furniture. Both bounds matter at a page break: a complete row
- * stops on its own, and an incomplete one is closed by the footer rather than
- * swallowing it. A row left incomplete by the break is still reported, with
- * null columns — losing a course's grade is recoverable, putting the footer's
- * personal identity number in its name is not.
+ * A row absorbs following lines until it has all of its columns, stepping over
+ * page furniture without joining it. That is what carries a row over a page
+ * break intact: a name wrapped across the boundary is rejoined, while the
+ * footer between the halves — which carries the student's personal identity
+ * number — is never part of a course name. Furniture does not count against
+ * the continuation budget, since a page break is not a wrapped line.
  */
 function rowBlocks(lines: string[]): string[] {
   const blocks: string[] = [];
   let continuations = 0;
-  let openForContinuation = false;
 
   for (const line of lines) {
     if (line === "") continue;
     if (startsRow(line)) {
       blocks.push(line);
       continuations = 0;
-      openForContinuation = true;
       continue;
     }
-    if (isPageFurniture(line)) {
-      openForContinuation = false;
-      continue;
-    }
-    if (!openForContinuation) continue;
+    if (isPageFurniture(line)) continue;
 
     const open = blocks.at(-1);
     if (open === undefined) continue;

--- a/apps/web/server/ingest/transcript/parse.ts
+++ b/apps/web/server/ingest/transcript/parse.ts
@@ -65,6 +65,32 @@ const ROW = new RegExp(
 /** The fallback when a row's trailing columns are unreadable: code and name. */
 const ROW_HEAD = /^([A-ZÅÄÖ]{2,3}\d{4}[A-Z]?)\s+(.*)$/;
 
+/**
+ * Marks a line as belonging to the page rather than to the table: the Ladok
+ * verification footer, the address block, the page counter, and the column
+ * header repeated at the top of each page.
+ *
+ * Only the first line of that run has to be recognised — reaching one closes
+ * the row being built, and nothing is absorbed again until the next course
+ * code. Without this, a row whose columns are missing swallows the footer, and
+ * the footer carries the student's personal identity number.
+ */
+const PAGE_FURNITURE = [
+  TABLE_HEADER,
+  /student\.ladok\.se/i,
+  /\b(?:Page|Sida)\s+\d+\s*\/\s*\d+/,
+  /^(?:Verifiable until|Verifierbart tom)\b/,
+  /^(?:Postal address|Postadress)\b/,
+  /^(?:Contact information|Kontaktinformation)\b/,
+  /(?:Personal identity number|Personnummer)\s*:/,
+  /(?:Control code|Kontrollkod)\s*:/,
+  /^https?:\/\//i,
+];
+
+function isPageFurniture(line: string): boolean {
+  return PAGE_FURNITURE.some((pattern) => pattern.test(line));
+}
+
 function toLines(text: string): string[] {
   return text.split(/\r\n|\r|\n/).map((line) => line.trim());
 }
@@ -77,21 +103,32 @@ function startsRow(line: string): boolean {
  * Splits the table body into one string per course, rejoining the lines a long
  * course name wrapped onto.
  *
- * A row keeps absorbing following lines only until it has all of its columns.
- * That is what carries the table over a page break: once a row is complete, the
- * page footer and the repeated column header that follow it belong to no row
- * and are dropped instead of being glued onto the last course name.
+ * A row absorbs following lines only until it has all of its columns, and never
+ * across page furniture. Both bounds matter at a page break: a complete row
+ * stops on its own, and an incomplete one is closed by the footer rather than
+ * swallowing it. A row left incomplete by the break is still reported, with
+ * null columns — losing a course's grade is recoverable, putting the footer's
+ * personal identity number in its name is not.
  */
 function rowBlocks(lines: string[]): string[] {
   const blocks: string[] = [];
   let continuations = 0;
+  let openForContinuation = false;
+
   for (const line of lines) {
     if (line === "") continue;
     if (startsRow(line)) {
       blocks.push(line);
       continuations = 0;
+      openForContinuation = true;
       continue;
     }
+    if (isPageFurniture(line)) {
+      openForContinuation = false;
+      continue;
+    }
+    if (!openForContinuation) continue;
+
     const open = blocks.at(-1);
     if (open === undefined) continue;
     if (continuations >= MAX_CONTINUATION_LINES || ROW.test(open)) continue;

--- a/apps/web/server/ingest/transcript/parse.ts
+++ b/apps/web/server/ingest/transcript/parse.ts
@@ -37,12 +37,30 @@ const TABLE_END = /^(?:Summation|Summering)\b/;
 /** A KTH course code: two or three letters then four digits. */
 const COURSE_CODE = /^[A-ZÅÄÖ]{2,3}\d{4}[A-Z]?$/;
 
+/** The longest course name KTH prints is well under this. */
+const MAX_NAME_LENGTH = 300;
+
+/**
+ * A real transcript's text layer is tens of kilobytes. The bound is not a
+ * judgement about the document: it stops a crafted PDF from handing the regexes
+ * below a megabyte-long line to backtrack over.
+ */
+const MAX_TEXT_LENGTH = 500_000;
+
+/**
+ * A wrapped course name runs to a second or third line, and its remaining
+ * columns may land on one more. Past that, the lines belong to something else.
+ */
+const MAX_CONTINUATION_LINES = 4;
+
 /**
  * `<code> <name> <credits> hp <grade> <YYYY-MM-DD> [note]`, matched against a
- * whole row after its wrapped lines have been rejoined.
+ * whole row after its wrapped lines have been rejoined. The name is length-
+ * bounded so a failed match cannot backtrack across a long line.
  */
-const ROW =
-  /^([A-ZÅÄÖ]{2,3}\d{4}[A-Z]?)\s+(.+?)\s+(\d+(?:[.,]\d+)?)\s*hp\s+(\S{1,3})\s+(\d{4}-\d{2}-\d{2})(?:\s+\d+)?$/;
+const ROW = new RegExp(
+  `^([A-ZÅÄÖ]{2,3}\\d{4}[A-Z]?)\\s+(.{1,${MAX_NAME_LENGTH}}?)\\s+(\\d+(?:[.,]\\d+)?)\\s*hp\\s+(\\S{1,3})\\s+(\\d{4}-\\d{2}-\\d{2})(?:\\s+\\d+)?$`,
+);
 
 /** The fallback when a row's trailing columns are unreadable: code and name. */
 const ROW_HEAD = /^([A-ZÅÄÖ]{2,3}\d{4}[A-Z]?)\s+(.*)$/;
@@ -66,20 +84,30 @@ function startsRow(line: string): boolean {
  */
 function rowBlocks(lines: string[]): string[] {
   const blocks: string[] = [];
+  let continuations = 0;
   for (const line of lines) {
     if (line === "") continue;
     if (startsRow(line)) {
       blocks.push(line);
+      continuations = 0;
       continue;
     }
     const open = blocks.at(-1);
-    if (open === undefined || ROW.test(open)) continue;
+    if (open === undefined) continue;
+    if (continuations >= MAX_CONTINUATION_LINES || ROW.test(open)) continue;
     blocks[blocks.length - 1] = `${open} ${line}`;
+    continuations += 1;
   }
   return blocks;
 }
 
 export function parseLadokTranscript(text: string): TranscriptCandidate[] {
+  if (text.length > MAX_TEXT_LENGTH) {
+    throw new TranscriptParseError(
+      "This document is too large to be a Ladok transcript.",
+    );
+  }
+
   const lines = toLines(text);
   const headerAt = lines.findIndex((line) => TABLE_HEADER.test(line));
   if (headerAt === -1) {
@@ -113,7 +141,7 @@ export function parseLadokTranscript(text: string): TranscriptCandidate[] {
     if (!head) continue;
     candidates.push({
       courseCode: head[1],
-      courseName: head[2].trim(),
+      courseName: head[2].trim().slice(0, MAX_NAME_LENGTH),
       credits: null,
       grade: null,
       completedOn: null,

--- a/apps/web/server/ingest/transcript/pdf-text.spec.ts
+++ b/apps/web/server/ingest/transcript/pdf-text.spec.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from "vitest";
+import { TranscriptParseError } from "./parse";
+import { extractTranscriptText } from "./pdf-text";
+
+describe("extractTranscriptText", () => {
+  it("rejects bytes that are not a PDF", async () => {
+    const notAPdf = new TextEncoder().encode("just some text, not a PDF");
+
+    await expect(extractTranscriptText(notAPdf)).rejects.toBeInstanceOf(
+      TranscriptParseError,
+    );
+  });
+
+  it("rejects a truncated PDF without quoting it back", async () => {
+    const truncated = new TextEncoder().encode("%PDF-1.7\n1 0 obj\n<< /Sec");
+
+    await expect(extractTranscriptText(truncated)).rejects.toSatisfy(
+      (error: Error) => !error.message.includes("Sec"),
+    );
+  });
+});

--- a/apps/web/server/ingest/transcript/pdf-text.ts
+++ b/apps/web/server/ingest/transcript/pdf-text.ts
@@ -1,0 +1,28 @@
+import { extractText } from "unpdf";
+import { TranscriptParseError } from "./parse";
+
+/**
+ * Pulls the text layer out of a transcript PDF.
+ *
+ * This is the only impure part of transcript import: everything downstream is a
+ * pure function over the string it returns. The bytes stay in memory for the
+ * length of one request — a transcript is a student's academic record and is
+ * never written to disk, to blob storage, or to a log.
+ *
+ * The underlying error is deliberately dropped rather than chained: a PDF
+ * library's failure message can quote bytes from the document, and nothing from
+ * inside the file may reach a log line or an API response.
+ */
+export async function extractTranscriptText(
+  bytes: Uint8Array,
+): Promise<string> {
+  try {
+    const { text } = await extractText(bytes, { mergePages: true });
+    return text;
+  } catch {
+    throw new TranscriptParseError(
+      "This file could not be read. Upload the PDF that Ladok generates, " +
+        "not a scan or a screenshot of it.",
+    );
+  }
+}

--- a/apps/web/server/ingest/transcript/router.ts
+++ b/apps/web/server/ingest/transcript/router.ts
@@ -1,0 +1,39 @@
+import { z } from "zod";
+import { createTRPCRouter, protectedProcedure } from "../../api/trpc";
+import { confirmTranscriptImport } from "./service";
+
+/**
+ * A transcript is a single student's record; nobody has more results on one
+ * than this. The bound is here to keep a hostile client from asking the write
+ * path to touch an unbounded number of rows, not to judge the transcript.
+ */
+const MAX_CONFIRMED_COURSES = 300;
+
+/**
+ * Grade and credits are self-reported even when they came off a transcript, so
+ * these bounds are length limits only. There is deliberately no list of valid
+ * grades and no check that the credits match the catalogue.
+ */
+const confirmedCourse = z.object({
+  courseCode: z.string().trim().min(2).max(16),
+  grade: z.string().trim().max(16).nullish(),
+  earnedCredits: z.number().nonnegative().max(1000).nullish(),
+  attendanceYear: z.number().int().min(1900).max(2200).nullish(),
+});
+
+export const transcriptRouter = createTRPCRouter({
+  /**
+   * Writes the courses the user picked out of a proposal. The proposal itself
+   * comes back from `POST /api/user/transcript`, which parses the uploaded file
+   * without storing it.
+   */
+  confirm: protectedProcedure
+    .input(
+      z.object({
+        courses: z.array(confirmedCourse).max(MAX_CONFIRMED_COURSES),
+      }),
+    )
+    .mutation(({ ctx, input }) =>
+      confirmTranscriptImport(ctx.session.user.id, input.courses, new Date()),
+    ),
+});

--- a/apps/web/server/ingest/transcript/service.spec.ts
+++ b/apps/web/server/ingest/transcript/service.spec.ts
@@ -185,7 +185,7 @@ describe("confirmTranscriptImport", () => {
     }
   });
 
-  it("sends one row when the same course is confirmed twice in one import", async () => {
+  it("normalises a course code before checking it against the catalogue", async () => {
     vi.mocked(courseService.getSummariesByCodes).mockResolvedValue(
       catalogue("SF1625"),
     );
@@ -196,10 +196,7 @@ describe("confirmTranscriptImport", () => {
 
     await confirmTranscriptImport(
       "user-1",
-      [
-        { courseCode: "SF1625", grade: "A" },
-        { courseCode: "SF1625", grade: "C" },
-      ],
+      [{ courseCode: " sf1625 ", grade: "A" }],
       importedAt,
     );
 

--- a/apps/web/server/ingest/transcript/service.spec.ts
+++ b/apps/web/server/ingest/transcript/service.spec.ts
@@ -1,0 +1,224 @@
+import { readFileSync } from "node:fs";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { CourseSummary } from "@/types";
+import * as courseService from "../../course/service";
+import { NotFoundError } from "../../errors";
+import * as takenService from "../../taken/service";
+import { buildTranscriptProposal, confirmTranscriptImport } from "./service";
+
+vi.mock("../../course/service");
+vi.mock("../../taken/service");
+
+function fixture(name: string): string {
+  return readFileSync(new URL(`./fixtures/${name}`, import.meta.url), "utf8");
+}
+
+function catalogue(...codes: string[]): CourseSummary[] {
+  return codes.map((courseCode) => ({
+    courseCode,
+    titleEng: `Title of ${courseCode}`,
+    currentStatus: "ESTABLISHED",
+    credits: 7.5,
+    creditUnit: "hp",
+    department: "Mathematics",
+    startTerms: [],
+    examTypes: [],
+    languages: [],
+    updatedAt: "2026-01-01T00:00:00.000Z",
+  }));
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("buildTranscriptProposal", () => {
+  it("proposes the catalogue courses and reports the codes it could not place", async () => {
+    vi.mocked(courseService.getSummariesByCodes).mockResolvedValue(
+      catalogue("SF1625", "DD1337", "SF1672", "DD1389"),
+    );
+
+    const proposal = await buildTranscriptProposal(
+      fixture("ladok-english.txt"),
+    );
+
+    expect(proposal.candidates).toEqual([
+      {
+        courseCode: "SF1625",
+        transcriptName: "Calculus in One Variable",
+        catalogueName: "Title of SF1625",
+        grade: "A",
+        earnedCredits: 7.5,
+        attendanceYear: 2023,
+      },
+      {
+        courseCode: "DD1337",
+        transcriptName: "Programming",
+        catalogueName: "Title of DD1337",
+        grade: "P",
+        earnedCredits: 6,
+        attendanceYear: 2023,
+      },
+      {
+        courseCode: "SF1672",
+        transcriptName: "Linear Algebra",
+        catalogueName: "Title of SF1672",
+        grade: "C",
+        earnedCredits: 7.5,
+        attendanceYear: 2024,
+      },
+      {
+        courseCode: "DD1389",
+        transcriptName:
+          "Interactive Programming and Computer Games in Distributed Environments",
+        catalogueName: "Title of DD1389",
+        grade: "B",
+        earnedCredits: 9,
+        attendanceYear: 2024,
+      },
+    ]);
+    expect(proposal.unmatched).toEqual([
+      {
+        courseCode: "ME1003",
+        courseName: "Industrial Management, Basic Course",
+      },
+    ]);
+  });
+
+  it("writes nothing", async () => {
+    vi.mocked(courseService.getSummariesByCodes).mockResolvedValue(
+      catalogue("SF1625", "DD1337", "SF1672", "DD1389", "ME1003"),
+    );
+
+    await buildTranscriptProposal(fixture("ladok-english.txt"));
+
+    expect(takenService.recordTakenCourses).not.toHaveBeenCalled();
+  });
+});
+
+describe("confirmTranscriptImport", () => {
+  const importedAt = new Date("2026-09-04T10:00:00.000Z");
+
+  const confirmed = [
+    {
+      courseCode: "SF1625",
+      grade: "A",
+      earnedCredits: 7.5,
+      attendanceYear: 2023,
+    },
+    {
+      courseCode: "DD1337",
+      grade: "P",
+      earnedCredits: 6,
+      attendanceYear: 2023,
+    },
+  ];
+
+  it("hands the confirmed rows to the taken service as a transcript import", async () => {
+    vi.mocked(courseService.getSummariesByCodes).mockResolvedValue(
+      catalogue("SF1625", "DD1337"),
+    );
+    vi.mocked(takenService.recordTakenCourses).mockResolvedValue({
+      inserted: 2,
+      updated: 0,
+    });
+
+    const result = await confirmTranscriptImport(
+      "user-1",
+      confirmed,
+      importedAt,
+    );
+
+    expect(takenService.recordTakenCourses).toHaveBeenCalledTimes(1);
+    expect(takenService.recordTakenCourses).toHaveBeenCalledWith(
+      "user-1",
+      [
+        {
+          courseCode: "SF1625",
+          grade: "A",
+          earnedCredits: 7.5,
+          attendanceYear: 2023,
+        },
+        {
+          courseCode: "DD1337",
+          grade: "P",
+          earnedCredits: 6,
+          attendanceYear: 2023,
+        },
+      ],
+      { source: "transcript", importedAt },
+    );
+    expect(result).toEqual({ inserted: 2, updated: 0 });
+  });
+
+  it("refuses a course code the catalogue does not have, and writes nothing", async () => {
+    vi.mocked(courseService.getSummariesByCodes).mockResolvedValue(
+      catalogue("SF1625"),
+    );
+
+    await expect(
+      confirmTranscriptImport(
+        "user-1",
+        [...confirmed, { courseCode: "ZZ9999", grade: null }],
+        importedAt,
+      ),
+    ).rejects.toBeInstanceOf(NotFoundError);
+    expect(takenService.recordTakenCourses).not.toHaveBeenCalled();
+  });
+
+  it("sends one row per course code when a transcript is imported twice", async () => {
+    vi.mocked(courseService.getSummariesByCodes).mockResolvedValue(
+      catalogue("SF1625", "DD1337"),
+    );
+    vi.mocked(takenService.recordTakenCourses).mockResolvedValue({
+      inserted: 0,
+      updated: 2,
+    });
+
+    await confirmTranscriptImport("user-1", confirmed, importedAt);
+    await confirmTranscriptImport("user-1", confirmed, importedAt);
+
+    expect(takenService.recordTakenCourses).toHaveBeenCalledTimes(2);
+    for (const [, rows] of vi.mocked(takenService.recordTakenCourses).mock
+      .calls) {
+      expect(rows.map((row) => row.courseCode)).toEqual(["SF1625", "DD1337"]);
+    }
+  });
+
+  it("sends one row when the same course is confirmed twice in one import", async () => {
+    vi.mocked(courseService.getSummariesByCodes).mockResolvedValue(
+      catalogue("SF1625"),
+    );
+    vi.mocked(takenService.recordTakenCourses).mockResolvedValue({
+      inserted: 1,
+      updated: 0,
+    });
+
+    await confirmTranscriptImport(
+      "user-1",
+      [
+        { courseCode: "SF1625", grade: "A" },
+        { courseCode: "SF1625", grade: "C" },
+      ],
+      importedAt,
+    );
+
+    const [, rows] = vi.mocked(takenService.recordTakenCourses).mock.calls[0];
+    expect(rows).toEqual([
+      {
+        courseCode: "SF1625",
+        grade: "A",
+        earnedCredits: null,
+        attendanceYear: null,
+      },
+    ]);
+  });
+
+  it("writes nothing when the user confirms no courses", async () => {
+    const result = await confirmTranscriptImport("user-1", [], importedAt);
+
+    expect(result).toEqual({ inserted: 0, updated: 0 });
+    expect(takenService.recordTakenCourses).not.toHaveBeenCalled();
+    expect(courseService.getSummariesByCodes).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/server/ingest/transcript/service.ts
+++ b/apps/web/server/ingest/transcript/service.ts
@@ -1,0 +1,127 @@
+import { getSummariesByCodes } from "../../course/service";
+import { NotFoundError } from "../../errors";
+import { recordTakenCourses, type TakenCourseInput } from "../../taken/service";
+import { matchCandidates, type UnmatchedCandidate } from "./match";
+import { parseLadokTranscript, type TranscriptCandidate } from "./parse";
+
+/**
+ * One course the user is being offered for import. Grade and credits come off
+ * the transcript but stay self-reported: the file is not authoritative and the
+ * user may change them before confirming.
+ */
+export type TranscriptProposalRow = {
+  courseCode: string;
+  /** The course name as the transcript printed it, in its own language. */
+  transcriptName: string;
+  /** The catalogue's name for the same course, so the user can tell them apart. */
+  catalogueName: string;
+  grade: string | null;
+  earnedCredits: number | null;
+  attendanceYear: number | null;
+};
+
+/** What a parsed transcript offers. Nothing here has been written. */
+export type TranscriptProposal = {
+  candidates: TranscriptProposalRow[];
+  /** Course codes with no catalogue entry. Reported, never invented. */
+  unmatched: UnmatchedCandidate[];
+};
+
+/**
+ * Ladok prints the date a result was reported, not the term the course ran.
+ * Its year is the closest thing the transcript has to when the course was
+ * taken, and the user can correct it — `attendance_year` is self-reported.
+ */
+function attendanceYearOf(candidate: TranscriptCandidate): number | null {
+  if (!candidate.completedOn) return null;
+  const year = Number(candidate.completedOn.slice(0, 4));
+  return Number.isFinite(year) ? year : null;
+}
+
+/**
+ * Turns the text of a Ladok transcript into a proposal for the user to confirm.
+ *
+ * Reads only; the transcript is never stored and never logged. Throws
+ * `TranscriptParseError` when the text is not a readable transcript.
+ */
+export async function buildTranscriptProposal(
+  text: string,
+): Promise<TranscriptProposal> {
+  const candidates = parseLadokTranscript(text);
+  const summaries = await getSummariesByCodes(
+    candidates.map((candidate) => candidate.courseCode),
+  );
+  const titles = new Map(
+    summaries.map((summary) => [summary.courseCode, summary.titleEng]),
+  );
+
+  const { matched, unmatched } = matchCandidates(candidates, titles.keys());
+
+  return {
+    candidates: matched.map((candidate) => ({
+      courseCode: candidate.courseCode,
+      transcriptName: candidate.courseName,
+      catalogueName: titles.get(candidate.courseCode) ?? candidate.courseName,
+      grade: candidate.grade,
+      earnedCredits: candidate.credits,
+      attendanceYear: attendanceYearOf(candidate),
+    })),
+    unmatched,
+  };
+}
+
+/** A row the user accepted, possibly after editing what the transcript said. */
+export type ConfirmedTranscriptRow = {
+  courseCode: string;
+  grade?: string | null;
+  earnedCredits?: number | null;
+  attendanceYear?: number | null;
+};
+
+/**
+ * Writes the courses the user confirmed, and only those.
+ *
+ * The rows arrive from the browser, so the catalogue check runs again here:
+ * `buildTranscriptProposal` filtered the parsed candidates, but nothing stops a
+ * client from confirming a code that was never proposed. Only catalogue courses
+ * become taken courses.
+ *
+ * The write itself belongs to `server/taken` (#64). Its upsert is what makes a
+ * second import of the same transcript update rather than duplicate; this
+ * function's part is to send each course code exactly once.
+ */
+export async function confirmTranscriptImport(
+  userId: string,
+  rows: ConfirmedTranscriptRow[],
+  importedAt: Date,
+): Promise<{ inserted: number; updated: number }> {
+  const byCode = new Map<string, ConfirmedTranscriptRow>();
+  for (const row of rows) {
+    const courseCode = row.courseCode.trim().toUpperCase();
+    if (!byCode.has(courseCode)) byCode.set(courseCode, { ...row, courseCode });
+  }
+  if (byCode.size === 0) return { inserted: 0, updated: 0 };
+
+  const codes = [...byCode.keys()];
+  const known = new Set(
+    (await getSummariesByCodes(codes)).map((summary) => summary.courseCode),
+  );
+  const missing = codes.filter((code) => !known.has(code));
+  if (missing.length > 0) {
+    throw new NotFoundError(
+      `No course in the catalogue matches ${missing.join(", ")}.`,
+    );
+  }
+
+  const inputs: TakenCourseInput[] = [...byCode.values()].map((row) => ({
+    courseCode: row.courseCode,
+    grade: row.grade ?? null,
+    earnedCredits: row.earnedCredits ?? null,
+    attendanceYear: row.attendanceYear ?? null,
+  }));
+
+  return recordTakenCourses(userId, inputs, {
+    source: "transcript",
+    importedAt,
+  });
+}

--- a/apps/web/server/ingest/transcript/service.ts
+++ b/apps/web/server/ingest/transcript/service.ts
@@ -70,13 +70,18 @@ export async function buildTranscriptProposal(
   };
 }
 
-/** A row the user accepted, possibly after editing what the transcript said. */
-export type ConfirmedTranscriptRow = {
-  courseCode: string;
-  grade?: string | null;
-  earnedCredits?: number | null;
-  attendanceYear?: number | null;
-};
+/**
+ * A row the user accepted, possibly after editing what the transcript said.
+ *
+ * Derived from #64's pinned `TakenCourseInput` rather than restated, so that a
+ * change to the write contract fails the typecheck here instead of drifting.
+ * `attendancePeriods` is dropped: a Ladok transcript has no period column, and
+ * an import must not pretend to know one.
+ */
+export type ConfirmedTranscriptRow = Omit<
+  TakenCourseInput,
+  "attendancePeriods"
+>;
 
 /**
  * Writes the courses the user confirmed, and only those.

--- a/apps/web/server/ingest/transcript/service.ts
+++ b/apps/web/server/ingest/transcript/service.ts
@@ -91,39 +91,33 @@ export type ConfirmedTranscriptRow = Omit<
  * client from confirming a code that was never proposed. Only catalogue courses
  * become taken courses.
  *
- * The write itself belongs to `server/taken` (#64). Its upsert is what makes a
- * second import of the same transcript update rather than duplicate; this
- * function's part is to send each course code exactly once.
+ * The write itself belongs to `server/taken`. Its upsert is what makes a second
+ * import of the same transcript update rather than duplicate, and it collapses
+ * a course code repeated inside one batch; neither is re-implemented here.
  */
 export async function confirmTranscriptImport(
   userId: string,
   rows: ConfirmedTranscriptRow[],
   importedAt: Date,
 ): Promise<{ inserted: number; updated: number }> {
-  const byCode = new Map<string, ConfirmedTranscriptRow>();
-  for (const row of rows) {
-    const courseCode = row.courseCode.trim().toUpperCase();
-    if (!byCode.has(courseCode)) byCode.set(courseCode, { ...row, courseCode });
-  }
-  if (byCode.size === 0) return { inserted: 0, updated: 0 };
+  const inputs: TakenCourseInput[] = rows.map((row) => ({
+    courseCode: row.courseCode.trim().toUpperCase(),
+    grade: row.grade ?? null,
+    earnedCredits: row.earnedCredits ?? null,
+    attendanceYear: row.attendanceYear ?? null,
+  }));
+  if (inputs.length === 0) return { inserted: 0, updated: 0 };
 
-  const codes = [...byCode.keys()];
+  const codes = inputs.map((input) => input.courseCode);
   const known = new Set(
     (await getSummariesByCodes(codes)).map((summary) => summary.courseCode),
   );
-  const missing = codes.filter((code) => !known.has(code));
+  const missing = [...new Set(codes.filter((code) => !known.has(code)))];
   if (missing.length > 0) {
     throw new NotFoundError(
       `No course in the catalogue matches ${missing.join(", ")}.`,
     );
   }
-
-  const inputs: TakenCourseInput[] = [...byCode.values()].map((row) => ({
-    courseCode: row.courseCode,
-    grade: row.grade ?? null,
-    earnedCredits: row.earnedCredits ?? null,
-    attendanceYear: row.attendanceYear ?? null,
-  }));
 
   return recordTakenCourses(userId, inputs, {
     source: "transcript",

--- a/apps/web/server/ingest/transcript/upload.spec.ts
+++ b/apps/web/server/ingest/transcript/upload.spec.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from "vitest";
+import { capRequestBody, TranscriptTooLargeError } from "./upload";
+
+function streamingRequest(chunks: number[]): Request {
+  const body = new ReadableStream<Uint8Array>({
+    start(controller) {
+      for (const size of chunks) controller.enqueue(new Uint8Array(size));
+      controller.close();
+    },
+  });
+  return new Request("https://example.test/api/user/transcript", {
+    method: "POST",
+    body,
+    // @ts-expect-error `duplex` is required for a stream body and is missing
+    // from the DOM RequestInit types Next ships.
+    duplex: "half",
+  });
+}
+
+describe("capRequestBody", () => {
+  it("passes a body that stays under the cap through unchanged", async () => {
+    const capped = capRequestBody(streamingRequest([100, 100]), 1000);
+
+    expect((await capped.arrayBuffer()).byteLength).toBe(200);
+  });
+
+  it("rejects once the body passes the cap, rather than buffering it", async () => {
+    const capped = capRequestBody(streamingRequest([600, 600, 600]), 1000);
+
+    await expect(capped.arrayBuffer()).rejects.toBeInstanceOf(
+      TranscriptTooLargeError,
+    );
+  });
+
+  it("does not trust a Content-Length that undercounts the body", async () => {
+    const request = new Request("https://example.test/api/user/transcript", {
+      method: "POST",
+      body: new Uint8Array(5000),
+      headers: { "content-length": "10" },
+    });
+
+    await expect(capRequestBody(request, 1000).arrayBuffer()).rejects.toThrow();
+  });
+});

--- a/apps/web/server/ingest/transcript/upload.spec.ts
+++ b/apps/web/server/ingest/transcript/upload.spec.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it } from "vitest";
-import { capRequestBody, TranscriptTooLargeError } from "./upload";
+import {
+  capRequestBody,
+  isTranscriptTooLarge,
+  TranscriptTooLargeError,
+} from "./upload";
 
 function streamingRequest(chunks: number[]): Request {
   const body = new ReadableStream<Uint8Array>({
@@ -30,6 +34,16 @@ describe("capRequestBody", () => {
     await expect(capped.arrayBuffer()).rejects.toBeInstanceOf(
       TranscriptTooLargeError,
     );
+  });
+
+  it("recognises the cap failure through a wrapping error", () => {
+    const wrapped = new TypeError("terminated", {
+      cause: new TranscriptTooLargeError(),
+    });
+
+    expect(isTranscriptTooLarge(new TranscriptTooLargeError())).toBe(true);
+    expect(isTranscriptTooLarge(wrapped)).toBe(true);
+    expect(isTranscriptTooLarge(new Error("something else"))).toBe(false);
   });
 
   it("does not trust a Content-Length that undercounts the body", async () => {

--- a/apps/web/server/ingest/transcript/upload.ts
+++ b/apps/web/server/ingest/transcript/upload.ts
@@ -8,6 +8,19 @@ export class TranscriptTooLargeError extends Error {
 }
 
 /**
+ * Whether reading a capped body failed because it ran past the cap.
+ *
+ * The body readers wrap a mid-stream error in one of their own on some
+ * runtimes, so the cause is worth checking as well as the error itself.
+ */
+export function isTranscriptTooLarge(error: unknown): boolean {
+  return (
+    error instanceof TranscriptTooLargeError ||
+    (error instanceof Error && error.cause instanceof TranscriptTooLargeError)
+  );
+}
+
+/**
  * Re-wraps a request so that reading its body fails past `maxBytes`.
  *
  * `request.formData()` buffers the whole body before anything can look at the

--- a/apps/web/server/ingest/transcript/upload.ts
+++ b/apps/web/server/ingest/transcript/upload.ts
@@ -1,0 +1,43 @@
+/** Raised while reading a request body that runs past the size cap. */
+export class TranscriptTooLargeError extends Error {
+  readonly code = "TRANSCRIPT_TOO_LARGE" as const;
+  constructor() {
+    super("Transcript upload exceeded the size limit");
+    this.name = "TranscriptTooLargeError";
+  }
+}
+
+/**
+ * Re-wraps a request so that reading its body fails past `maxBytes`.
+ *
+ * `request.formData()` buffers the whole body before anything can look at the
+ * file's size, and `Content-Length` is absent on a chunked upload and a lie
+ * whenever the client wants it to be. Counting the bytes as they arrive is the
+ * only cap that holds: the transform errors mid-stream, so an oversized upload
+ * is abandoned rather than held in memory.
+ */
+export function capRequestBody(request: Request, maxBytes: number): Request {
+  if (!request.body) return request;
+
+  let seen = 0;
+  const capped = request.body.pipeThrough(
+    new TransformStream<Uint8Array, Uint8Array>({
+      transform(chunk, controller) {
+        seen += chunk.byteLength;
+        if (seen > maxBytes) {
+          controller.error(new TranscriptTooLargeError());
+          return;
+        }
+        controller.enqueue(chunk);
+      },
+    }),
+  );
+
+  return new Request(request.url, {
+    method: request.method,
+    headers: request.headers,
+    body: capped,
+    // Required whenever the body is a stream; missing from the DOM types.
+    duplex: "half",
+  } as RequestInit & { duplex: "half" });
+}

--- a/bun.lock
+++ b/bun.lock
@@ -86,6 +86,7 @@
         "tailwindcss-animate": "^1.0.7",
         "tsx": "^4.20.5",
         "tw-animate-css": "^1.3.8",
+        "unpdf": "^1.8.1",
         "uuid": "^8.3.2",
         "vaul": "^1.1.2",
         "xss": "^1.0.15",
@@ -1160,6 +1161,8 @@
     "undici": ["undici@8.10.1", "", {}, "sha512-YQ3WlbqjYMmNpdvDH64jAgLjxuAR9+649calDWhbshYaeQGO2bR4nI94ORJmwI3J9YhoKQnpyGOK+0zlWS5N5Q=="],
 
     "undici-types": ["undici-types@6.21.0", "", {}, "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ=="],
+
+    "unpdf": ["unpdf@1.8.1", "", { "peerDependencies": { "@napi-rs/canvas": "^0.1.69 || ^1.0.0" }, "optionalPeers": ["@napi-rs/canvas"] }, "sha512-xkURhy2SoGpOIH0a1gLHNkASPIQYonadDJs2AQwPEfUakafeD9EA1WTWWsaR++gfTCXJpV27W7tU1nXuk82UKQ=="],
 
     "use-callback-ref": ["use-callback-ref@1.3.3", "", { "dependencies": { "tslib": "^2.0.0" }, "peerDependencies": { "@types/react": "*", "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-jQL3lRnocaFtu3V00JToYz/4QkNWswxijDaCVNZRiRTO3HQDLsdu1ZtmIUvV4yPp+rvWm5j0y0TG/S61cuijTg=="],
 


### PR DESCRIPTION
## Status

Rebased onto `dev` with **#64 and #65 merged** (`5c388ed`, `bfb7536`). The temporary `server/taken/service.ts` placeholder is **deleted** — this branch no longer touches `server/taken/` at all, and every gate has been re-run against #64's real implementation. Clean rebase, no conflicts left.

#64's merged `TakenCourseInput`, `TakenCourseWriteSource` and `recordTakenCourses` match the pinned contract exactly, so there was **no divergence to report**.

Merge order was **#64 → #75 → #65 → #66**; #65 landed ahead of #75 in practice, so **#75 (PR #81) is the only one still ahead of this**. Nothing in this branch depends on it.

---

Implements #66. (The product owner closes the issue, not this PR.)

## What this does

Turns an uploaded Ladok transcript into **candidate** taken courses that the user confirms before anything is written.

```
POST /api/user/transcript   (multipart, session required)
        │  parse + match — stores nothing, writes nothing
        ▼
   TranscriptProposal { candidates[], unmatched[] }
        │  user picks and may edit
        ▼
tRPC transcript.confirm  ──►  recordTakenCourses(userId, rows,
                                { source: "transcript", importedAt })
```

| File | What it is |
| --- | --- |
| `server/ingest/transcript/parse.ts` | **Pure.** Transcript text → candidate rows. |
| `server/ingest/transcript/match.ts` | **Pure.** Candidates → matched against `courses.code`, plus unmatched. |
| `server/ingest/transcript/service.ts` | Builds the proposal; on confirm, calls `recordTakenCourses`. |
| `server/ingest/transcript/pdf-text.ts` | The only impure step: PDF bytes → text, via `unpdf`. |
| `server/ingest/transcript/upload.ts` | Caps the request body as it streams in. |
| `server/ingest/transcript/router.ts` | `transcript.confirm`, `protectedProcedure`. |
| `app/api/user/transcript/route.ts` | The multipart upload; answers with the proposal. |

## The pinned constraints, and where each is honoured

- **`recordTakenCourses` is the only write path.** Nothing here touches `user_taken_courses`, and nothing imports `server/taken/repository.ts`. `service.ts` calls the pinned contract, once, per confirmation.
- **Nothing is written before confirmation.** `buildTranscriptProposal` is read-only, with a test asserting `recordTakenCourses` is never called by it.
- **Unmatched codes are reported, never invented.** `matchCandidates` returns them under `unmatched`. `confirmTranscriptImport` re-checks the catalogue — the confirmed rows arrive from a browser, and nothing stops a client confirming a code that was never proposed — and throws `NotFoundError`, writing nothing, if a code is not in `courses.code`.
- **The file is not stored and not logged.** The bytes live in memory for one request. `TranscriptParseError` messages are fixed strings, and the PDF library's own error is deliberately **dropped rather than chained**, because a PDF parser's message can quote bytes from the document. There is a test asserting the transcript never appears in an error message.
- **Grades and credits stay self-reported.** No grade list, no check of credits against the catalogue — only length and range bounds on the tRPC input.
- **No `happy_took`**, no migration, no `schema.ts` edit, and exactly one `_Today_` line deleted from `CONTEXT.md`: **Transcript import**.

## Parsing, and why it is shaped this way

`unpdf` (new dependency, `apps/web`) reconstructs lines from the PDF's text layer. I compared it against `pdftotext -layout` on the two real KTH transcripts in `transcript_pdfs/`: `pdftotext` scrambled the row/column alignment on the Swedish one, `unpdf` did not. That is why the seam is *text → rows*, and why the fixtures are `.txt`.

Each of these has a test:

- English (`Completed courses`) and Swedish (`Avslutade kurser`)
- Decimal point (`7.5 hp`) and decimal comma (`7,5 hp`)
- A course name wrapped over several lines, with the scope/grade/date landing on a line of its own
- A table continued **across a page break** — including a course name whose two halves sit on either side of the footer. Greptile found both failure modes here in review: the footer being glued into a course name (it carries the student's **personal identity number**), and then, after the first fix, a wrapped row being truncated at the boundary. Page furniture is now stepped over rather than joined or treated as a stop, and **both** properties are pinned by tests so neither fix can undo the other.
- Stopping at `Summation` / `Summering`, so the grading-scale notes (`Excellent (A), Very Good (B)…`) are never read as course rows
- A row whose trailing columns are unreadable: still reported, with nulls, rather than silently dropped
- An unparseable file, an empty table, and a document too large to be a transcript

Verified end to end against both real transcripts (the Swedish and English editions of the same record): **6/6 rows each, every field correct**, including the wrapped course name.

**Those PDFs are not in this PR.** `transcript_pdfs/` and `*.pdf` are both gitignored. The committed fixtures are anonymised — invented name, invented personal identity number, a different course set.

## Security

A security pass over the whole feature found **no exploitable path** for privacy (nothing stores, logs, or leaks a transcript or a personnummer), authorisation (the user id is only ever `ctx.session.user.id`; both endpoints require a session), or integrity (a client cannot confirm a course the catalogue does not have). Two things it did turn up are fixed here:

1. **The parser could be hung by a crafted PDF.** One course code followed by a long run of text made the row pattern backtrack over a growing string on every line — an authenticated request that never returns. Fixed by a cap on the text handed to the parser, a *bounded* lazy quantifier for the name group in the row regex, a cap on continuation lines per row, and truncation of the fallback name.
2. **An oversized upload was buffered before it could be rejected.** A `Content-Length` pre-check is worth less than it looks: the header is absent on a chunked upload and a lie whenever the client wants it to be, and `formData()` buffers the whole body before `file.size` can be read. Replaced with `capRequestBody`, which counts bytes through a `TransformStream` and errors mid-stream, so an oversized body is abandoned rather than held. It has its own spec — under the cap, over the cap, and a `Content-Length` that undercounts.

`bun audit` reports **no advisory against `unpdf@1.8.1`**. (It reports 30 pre-existing findings elsewhere in the tree — `sharp` via `next`, `uuid` — none introduced here.)

**Residual risk, for the record:** `unpdf` is pdf.js, running in-process on attacker-supplied PDFs. The caps here bound *size*, not parser CPU time on a pathologically structured document. Running extraction in a worker with a timeout would be the defence-in-depth fix; it is out of scope for this PR and worth its own issue if you want it.

## Decisions the issue did not settle

1. **Parsing happens in the upload route, not in a tRPC procedure.** The issue says "parsing and confirming can be tRPC procedures; only the file itself needs a route handler". Splitting them would mean holding the transcript's text between two requests — storing a student's academic record, which the issue forbids. So one request uploads *and* parses and returns the proposal; only confirm is tRPC.
2. **`attendance_year` is the year of the result date.** Ladok prints when a result was reported, not which term the course ran. That year is the closest signal the transcript carries, and it is self-reported and user-editable like the rest.
3. **`attendance_periods` is not set by import.** A transcript has no period column; an import must not pretend to know one. The field is left for manual entry, and `ConfirmedTranscriptRow` is `Omit<TakenCourseInput, "attendancePeriods">` to say so at the type level.
4. **Duplicate handling is the write contract's.** `recordTakenCourses` collapses a course code repeated inside one batch (last row winning), so confirming does not dedupe ahead of it — a second filter with the opposite tie-break would be two rules for one behaviour. `matchCandidates` still keeps one row per code in the *proposal*, so the confirm screen never shows a course the user cannot act on twice. Re-import idempotency is the upsert's guarantee; the test here asserts the arguments, mocking the taken service, as the issue instructs.
5. **New dependency: `unpdf`** (~1 MB, no native deps, built for serverless Node). If you would rather not take it, the seam is `pdf-text.ts` alone — everything else is pure and would not change.

## Two open questions for the product owner

1. **Location.** `server/ingest/transcript/` is what issue #66 assigns ("Files you own"), so the router sits one level deeper than the `server/<domain>/router.ts` layout in `CLAUDE.md`, and inside a folder `CLAUDE.md` documents as the KOPPS→Neon pipeline. Code review flagged this: `CONTEXT.md` treats **Transcript import** as a first-class domain, parallel to **Taken course**. I kept the issue's path rather than improvise across the parallel issues' scope, but **`server/transcript/` is arguably the right home** — say the word and it moves.
2. **`catalogueName` is always `titleEng`**, even for a Swedish transcript, because that is the only title `CourseSummary` carries. The response also returns `transcriptName` (the name as printed, in the transcript's own language), so the confirm screen has both. Whoever builds that screen should decide which to show.

## No UI

Per the issue, the upload control and the confirm screen are the frontend track. This PR exposes the endpoints only.

## Gates

`bun run test:web` (144 passed across the suite; 30 of them this feature's), `npx tsc --noEmit`, `bun run lint` — all green. The 12 lint warnings are pre-existing `<img>` warnings in `components/layout/app-sidebar.tsx`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01D3d7V2JceJZvtJED18HXFJ
