### PR TITLE
feat(reviews): switch the review domain to the target columns and contract the review migration (#75)

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -93,36 +93,27 @@ _Avoid_: rating, comment, post, feedback (see **Feedback form**)
 **Upvote** / **Downvote**:
 An app user's judgement that a review was or was not worth reading. A vote is
 about the review, never about the reviewer.
-_Today_: `review_likes.vote_type`, a text column holding `"like"` or
-`"dislike"`. Closed by `review_votes` with an `up`/`down` enum.
 _Avoid_: like, dislike, helpful, helpful score, karma, points, reaction
 
 **Happy took**:
 Whether the reviewer is glad they took the course. A different question from
 whether they would advise a stranger to take it, and it belongs to the review.
-_Today_: `reviews.would_recommend`. Closed by `reviews.happy_took`.
 _Avoid_: would recommend, satisfaction, overall rating
 
 **Workload score** / **Learning score**:
 Two separate axes on a review: how much work the course was, and how much the
 reviewer got out of it. Neither is an overall verdict.
-_Today_: `reviews.workload` and `reviews.learning_experience`, unconstrained
-integers defaulting to 0. Closed by 1-10 scores with check constraints.
 _Avoid_: difficulty, quality, star rating, overall score
 
 **Examination distribution**:
 A reviewer's recollection of how assessment was split across a course. "I don't
 remember" is an answer and stores null, never zeroes. Distinct from **Course
 examination**, which is source data rather than memory.
-_Today_: the single integer `reviews.examination_methods`. Closed by a nullable
-`examination_distribution`.
 _Avoid_: exam breakdown, assessment mix, examination methods
 
 **Approach theory percent**:
 How theoretical rather than applied the reviewer found the course, on the same
 "I don't remember" rule.
-_Today_: the single integer `reviews.theoretical_vs_applied`. Closed by a
-nullable `approach_theory_percent`.
 _Avoid_: theory rating, theoretical vs applied
 
 ### The community graph

--- a/apps/web/features/courses/components/course.tsx
+++ b/apps/web/features/courses/components/course.tsx
@@ -204,13 +204,14 @@ export async function Course({
                 key={review.id}
                 className="w-full max-w-full"
                 courseCode={details.courseCode}
-                wouldRecommend={review.wouldRecommend}
-                content={review.content}
-                examinationMethods={review.examinationMethods}
-                theoreticalVsApplied={review.theoreticalVsApplied}
-                workload={review.workload}
-                learningExperience={review.learningExperience}
-                likeCount={review.likeCount}
+                happyTook={review.happyTook}
+                message={review.message}
+                examinationDistribution={review.examinationDistribution}
+                approachTheoryPercent={review.approachTheoryPercent}
+                workloadScore={review.workloadScore}
+                learningScore={review.learningScore}
+                upvoteCount={review.upvoteCount}
+                downvoteCount={review.downvoteCount}
                 userVote={review.userVote}
                 postId={review.id}
               />

--- a/apps/web/features/reviews/api/mutations.ts
+++ b/apps/web/features/reviews/api/mutations.ts
@@ -20,12 +20,12 @@ export function useCreateReview() {
   );
 }
 
-export function useLikeReview(courseCode: string) {
+export function useVoteOnReview(courseCode: string) {
   const trpc = useTRPC();
   const queryClient = useQueryClient();
   const router = useRouter();
   return useMutation(
-    trpc.reviews.like.mutationOptions({
+    trpc.reviews.vote.mutationOptions({
       onSuccess: () => {
         void queryClient.invalidateQueries({
           queryKey: trpc.reviews.list.queryKey({ courseCode }),

--- a/apps/web/features/reviews/components/post-action-bar.tsx
+++ b/apps/web/features/reviews/components/post-action-bar.tsx
@@ -4,41 +4,45 @@ import { ThumbsDown, ThumbsUp } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { ButtonGroup } from "@/components/ui/button-group";
 import { cn } from "@/lib/utils";
+import type { ReviewVoteType } from "@/types";
 
 export type PostActionBarProps = {
   postId: string;
-  likeCount: number;
-  dislikeCount: number;
-  userVote: "like" | "dislike" | null;
-  onPostLike: (postId: string) => void;
-  onPostDislike: (postId: string) => void;
+  upvoteCount: number;
+  downvoteCount: number;
+  userVote: ReviewVoteType | null;
+  onVote: (postId: string, voteType: ReviewVoteType) => void;
 };
 
 export default function PostActionBar(props: Readonly<PostActionBarProps>) {
-  const isLiked = props.userVote === "like";
-  const isDisliked = props.userVote === "dislike";
+  const isUpvoted = props.userVote === "up";
+  const isDownvoted = props.userVote === "down";
 
   return (
     <ButtonGroup>
       <Button
-        variant={isLiked ? "secondary" : "ghost"}
-        onClick={() => props.onPostLike(props.postId)}
+        variant={isUpvoted ? "secondary" : "ghost"}
+        aria-pressed={isUpvoted}
+        aria-label="Upvote this review"
+        onClick={() => props.onVote(props.postId, "up")}
       >
         <ThumbsUp
           data-icon="inline-start"
-          className={cn(isLiked && "fill-current")}
+          className={cn(isUpvoted && "fill-current")}
         />
-        {props.likeCount}
+        {props.upvoteCount}
       </Button>
       <Button
-        variant={isDisliked ? "destructive" : "ghost"}
-        onClick={() => props.onPostDislike(props.postId)}
+        variant={isDownvoted ? "destructive" : "ghost"}
+        aria-pressed={isDownvoted}
+        aria-label="Downvote this review"
+        onClick={() => props.onVote(props.postId, "down")}
       >
         <ThumbsDown
           data-icon="inline-start"
-          className={cn(isDisliked && "fill-current")}
+          className={cn(isDownvoted && "fill-current")}
         />
-        {props.dislikeCount}
+        {props.downvoteCount}
       </Button>
     </ButtonGroup>
   );

--- a/apps/web/features/reviews/components/post.tsx
+++ b/apps/web/features/reviews/components/post.tsx
@@ -16,6 +16,7 @@ import type { ExaminationDistribution, ReviewVoteType } from "@/types";
 import {
   EXAMINATION_DISTRIBUTION_KEYS,
   EXAMINATION_DISTRIBUTION_LABELS,
+  MAX_REVIEW_SCORE,
 } from "@/types";
 import { useReviewVotes } from "../hooks/use-review-votes";
 import PostActionBar from "./post-action-bar";
@@ -85,9 +86,6 @@ function truncateHtmlAtWord(html: string, max: number) {
   return result;
 }
 
-/** Scores are stored on a 1-10 scale; see `planned-database-formats.md`. */
-const MAX_SCORE = 10;
-
 function scoreVariant(score: number) {
   if (score >= 8) return "default" as const;
   if (score >= 5) return "outline" as const;
@@ -100,13 +98,13 @@ type ScorePillProps = {
 };
 
 function ScorePill({ name, score }: Readonly<ScorePillProps>) {
-  const aria = `${name}: ${score} out of ${MAX_SCORE}`;
+  const aria = `${name}: ${score} out of ${MAX_REVIEW_SCORE}`;
 
   return (
     <div className="flex items-center gap-2" title={aria}>
       <span className="w-24 text-sm text-muted-foreground">{name}</span>
       <Badge variant={scoreVariant(score)}>
-        {score}/{MAX_SCORE}
+        {score}/{MAX_REVIEW_SCORE}
       </Badge>
     </div>
   );
@@ -156,22 +154,17 @@ type ExaminationSummaryProps = {
 function ExaminationSummary({
   distribution,
 }: Readonly<ExaminationSummaryProps>) {
-  const shares =
-    distribution === null
-      ? []
-      : EXAMINATION_DISTRIBUTION_KEYS.filter(
-          (key) => distribution[key] > 0,
-        ).map((key) => ({ key, share: distribution[key] }));
-
   return (
     <div className="flex flex-wrap items-center gap-2">
       <span className="w-24 text-sm text-muted-foreground">Examination</span>
-      {shares.length === 0 ? (
+      {distribution === null ? (
         <Badge variant="secondary">Not remembered</Badge>
       ) : (
-        shares.map(({ key, share }) => (
+        EXAMINATION_DISTRIBUTION_KEYS.filter(
+          (key) => distribution[key] > 0,
+        ).map((key) => (
           <Badge key={key} variant="outline">
-            {EXAMINATION_DISTRIBUTION_LABELS[key]} {share}%
+            {EXAMINATION_DISTRIBUTION_LABELS[key]} {distribution[key]}%
           </Badge>
         ))
       )}

--- a/apps/web/features/reviews/components/post.tsx
+++ b/apps/web/features/reviews/components/post.tsx
@@ -12,6 +12,11 @@ import {
 import { Separator } from "@/components/ui/separator";
 import { sanitizeHtml } from "@/lib/sanitize-html";
 import { cn } from "@/lib/utils";
+import type { ExaminationDistribution, ReviewVoteType } from "@/types";
+import {
+  EXAMINATION_DISTRIBUTION_KEYS,
+  EXAMINATION_DISTRIBUTION_LABELS,
+} from "@/types";
 import { useReviewVotes } from "../hooks/use-review-votes";
 import PostActionBar from "./post-action-bar";
 
@@ -80,91 +85,121 @@ function truncateHtmlAtWord(html: string, max: number) {
   return result;
 }
 
-function normalizeRating(r: number | undefined | null) {
-  if (typeof r !== "number" || Number.isNaN(r)) return null;
-  return Math.min(5, Math.max(0, Math.round(r)));
-}
+/** Scores are stored on a 1-10 scale; see `planned-database-formats.md`. */
+const MAX_SCORE = 10;
 
-function ratingLabel(rating: number | null) {
-  if (rating === null) return "N/A";
-  if (rating >= 5) return "Excellent";
-  if (rating >= 4) return "Good";
-  if (rating >= 3) return "Average";
-  if (rating >= 2) return "Poor";
-  if (rating >= 1) return "Bad";
-  return "Terrible";
-}
-
-function ratingVariant(rating: number | null) {
-  if (rating === null) return "secondary" as const;
-  if (rating >= 4) return "default" as const;
-  if (rating >= 3) return "outline" as const;
+function scoreVariant(score: number) {
+  if (score >= 8) return "default" as const;
+  if (score >= 5) return "outline" as const;
   return "destructive" as const;
 }
 
-type RatingPillProps = {
+type ScorePillProps = {
   name: string;
-  rating: number | null;
+  score: number;
 };
 
-function RatingPill({ name, rating }: Readonly<RatingPillProps>) {
-  const label = ratingLabel(rating);
-  const value = rating ?? "-";
-  const aria =
-    rating === null
-      ? `${name}: not available`
-      : `${name}: ${value} out of 5 (${label})`;
+function ScorePill({ name, score }: Readonly<ScorePillProps>) {
+  const aria = `${name}: ${score} out of ${MAX_SCORE}`;
 
   return (
     <div className="flex items-center gap-2" title={aria}>
-      <span className="w-20 text-sm text-muted-foreground">{name}</span>
-      <Badge variant={ratingVariant(rating)}>{value}</Badge>
+      <span className="w-24 text-sm text-muted-foreground">{name}</span>
+      <Badge variant={scoreVariant(score)}>
+        {score}/{MAX_SCORE}
+      </Badge>
     </div>
   );
 }
 
-type RecommendChipProps = {
-  wouldRecommend: boolean;
+type ApproachPillProps = {
+  /** `null` when the reviewer did not remember. */
+  percent: number | null;
 };
 
-function RecommendChip(props: Readonly<RecommendChipProps>) {
-  const label = props.wouldRecommend ? "Yes" : "No";
-  const aria = `Would recommend: ${label}`;
+function ApproachPill({ percent }: Readonly<ApproachPillProps>) {
+  const aria =
+    percent === null
+      ? "Approach: reviewer did not remember"
+      : `Approach: ${percent}% theory, ${100 - percent}% applied`;
+
   return (
     <div className="flex items-center gap-2" title={aria}>
-      <span className="w-20 text-sm text-muted-foreground">Recommend</span>
-      <Badge variant={props.wouldRecommend ? "default" : "secondary"}>
-        {label}
+      <span className="w-24 text-sm text-muted-foreground">Approach</span>
+      <Badge variant={percent === null ? "secondary" : "outline"}>
+        {percent === null ? "Not remembered" : `${percent}% theory`}
       </Badge>
+    </div>
+  );
+}
+
+type HappyTookChipProps = {
+  happyTook: boolean;
+};
+
+function HappyTookChip(props: Readonly<HappyTookChipProps>) {
+  const label = props.happyTook ? "Yes" : "No";
+  const aria = `Glad they took it: ${label}`;
+  return (
+    <div className="flex items-center gap-2" title={aria}>
+      <span className="w-24 text-sm text-muted-foreground">Glad they took</span>
+      <Badge variant={props.happyTook ? "default" : "secondary"}>{label}</Badge>
+    </div>
+  );
+}
+
+type ExaminationSummaryProps = {
+  /** `null` when the reviewer did not remember. */
+  distribution: ExaminationDistribution | null;
+};
+
+function ExaminationSummary({
+  distribution,
+}: Readonly<ExaminationSummaryProps>) {
+  const shares =
+    distribution === null
+      ? []
+      : EXAMINATION_DISTRIBUTION_KEYS.filter(
+          (key) => distribution[key] > 0,
+        ).map((key) => ({ key, share: distribution[key] }));
+
+  return (
+    <div className="flex flex-wrap items-center gap-2">
+      <span className="w-24 text-sm text-muted-foreground">Examination</span>
+      {shares.length === 0 ? (
+        <Badge variant="secondary">Not remembered</Badge>
+      ) : (
+        shares.map(({ key, share }) => (
+          <Badge key={key} variant="outline">
+            {EXAMINATION_DISTRIBUTION_LABELS[key]} {share}%
+          </Badge>
+        ))
+      )}
     </div>
   );
 }
 
 export type PostProps = {
   courseCode: string;
-  examinationMethods: number;
-  theoreticalVsApplied: number;
-  workload: number;
-  learningExperience: number;
-  wouldRecommend: boolean;
-  content: string;
-  likeCount?: number;
-  dislikeCount?: number;
-  userVote?: "like" | "dislike" | null;
+  examinationDistribution: ExaminationDistribution | null;
+  approachTheoryPercent: number | null;
+  workloadScore: number;
+  learningScore: number;
+  happyTook: boolean;
+  message: string | null;
+  upvoteCount?: number;
+  downvoteCount?: number;
+  userVote?: ReviewVoteType | null;
   postId?: string;
   /** Merged onto the outer `Card` (e.g. full-width on course detail). */
   className?: string;
 };
 
 export function Post(props: Readonly<PostProps>) {
-  const examinationMethods = normalizeRating(props.examinationMethods);
-  const theoreticalVsApplied = normalizeRating(props.theoreticalVsApplied);
-  const workload = normalizeRating(props.workload);
-  const learningExperience = normalizeRating(props.learningExperience);
-  const { like, dislike } = useReviewVotes(props.courseCode);
+  const { vote } = useReviewVotes(props.courseCode);
 
   const [expanded, setExpanded] = useState(false);
-  const content = props.content ?? "";
+  const content = props.message ?? "";
   const isLong = content.length > MAX_COLLAPSED_CHARS;
   const displayContent =
     expanded || !isLong
@@ -174,12 +209,14 @@ export function Post(props: Readonly<PostProps>) {
   return (
     <Card className={cn("w-[48rem] max-w-full", props.className)}>
       <CardHeader>
-        <div className="grid grid-cols-1 gap-2 md:grid-cols-2 lg:grid-cols-5">
-          <RatingPill name="Exam methods" rating={examinationMethods} />
-          <RatingPill name="Theory vs applied" rating={theoreticalVsApplied} />
-          <RatingPill name="Workload" rating={workload} />
-          <RatingPill name="Learning exp." rating={learningExperience} />
-          <RecommendChip wouldRecommend={props.wouldRecommend} />
+        <div className="grid grid-cols-1 gap-2 md:grid-cols-2 lg:grid-cols-3">
+          <ScorePill name="Workload" score={props.workloadScore} />
+          <ScorePill name="Learning" score={props.learningScore} />
+          <HappyTookChip happyTook={props.happyTook} />
+          <ApproachPill percent={props.approachTheoryPercent} />
+          <div className="md:col-span-2">
+            <ExaminationSummary distribution={props.examinationDistribution} />
+          </div>
         </div>
       </CardHeader>
 
@@ -204,11 +241,10 @@ export function Post(props: Readonly<PostProps>) {
         <CardFooter className="justify-end">
           <PostActionBar
             postId={props.postId}
-            likeCount={props.likeCount || 0}
-            dislikeCount={props.dislikeCount || 0}
-            userVote={props.userVote || null}
-            onPostLike={like}
-            onPostDislike={dislike}
+            upvoteCount={props.upvoteCount ?? 0}
+            downvoteCount={props.downvoteCount ?? 0}
+            userVote={props.userVote ?? null}
+            onVote={vote}
           />
         </CardFooter>
       )}

--- a/apps/web/features/reviews/components/review.tsx
+++ b/apps/web/features/reviews/components/review.tsx
@@ -35,11 +35,12 @@ import type { ExaminationDistribution } from "@/types";
 import {
   EXAMINATION_DISTRIBUTION_KEYS,
   EXAMINATION_DISTRIBUTION_LABELS,
+  examinationDistributionSchema,
+  MAX_REVIEW_SCORE,
+  percentSchema,
+  reviewScoreSchema,
 } from "@/types";
 import { useAddReview } from "../hooks/use-add-review";
-
-/** Both score axes are 1-10; see `docs/schema_docs/planned-database-formats.md`. */
-const MAX_SCORE = 10;
 
 export type ReviewFormData = {
   happyTook: boolean;
@@ -61,33 +62,8 @@ const EMPTY_DISTRIBUTION: ExaminationDistribution = {
   other: 0,
 };
 
-const scoreSchema = z
-  .number()
-  .int()
-  .min(1, "Select a score.")
-  .max(MAX_SCORE, `Scores go up to ${MAX_SCORE}.`);
-
-const percentageSchema = z.number().int().min(0).max(100);
-
-const distributionSchema = z
-  .object({
-    exam: percentageSchema,
-    assignments: percentageSchema,
-    labs: percentageSchema,
-    projects: percentageSchema,
-    seminars: percentageSchema,
-    other: percentageSchema,
-  })
-  .refine(
-    (value) =>
-      EXAMINATION_DISTRIBUTION_KEYS.reduce(
-        (total, key) => total + value[key],
-        0,
-      ) === 100,
-    "Shares must add up to 100%.",
-  )
-  .nullable();
-
+// The form shares the wire contract from `@/types` and adds only what is
+// specific to writing a review in a dialog: a message that is not just markup.
 const formSchema = z.object({
   happyTook: z.boolean(),
   message: z
@@ -96,10 +72,10 @@ const formSchema = z.object({
       (html) => html.replace(/<[^>]*>/g, "").trim().length > 0,
       "Write a review.",
     ),
-  examinationDistribution: distributionSchema,
-  approachTheoryPercent: percentageSchema.nullable(),
-  workloadScore: scoreSchema,
-  learningScore: scoreSchema,
+  examinationDistribution: examinationDistributionSchema.nullable(),
+  approachTheoryPercent: percentSchema.nullable(),
+  workloadScore: reviewScoreSchema,
+  learningScore: reviewScoreSchema,
 });
 
 const defaultValues: ReviewFormData = {
@@ -178,8 +154,8 @@ export function Review({
               <FieldSet>
                 <FieldLegend>Rate the Course</FieldLegend>
                 <FieldDescription>
-                  Two separate axes, each from 1 to {MAX_SCORE}. Neither is an
-                  overall verdict.
+                  Two separate axes, each from 1 to {MAX_REVIEW_SCORE}. Neither
+                  is an overall verdict.
                 </FieldDescription>
                 <FieldGroup>
                   <form.Field name="workloadScore">
@@ -196,9 +172,12 @@ export function Review({
                             value={field.state.value}
                             onValueChange={(value) => field.handleChange(value)}
                           >
-                            {Array.from({ length: MAX_SCORE }, (_, i) => (
-                              <RatingButton key={`workload-star-${i + 1}`} />
-                            ))}
+                            {Array.from(
+                              { length: MAX_REVIEW_SCORE },
+                              (_, i) => (
+                                <RatingButton key={`workload-star-${i + 1}`} />
+                              ),
+                            )}
                           </Rating>
                           {isInvalid && (
                             <FieldError errors={field.state.meta.errors} />
@@ -222,9 +201,12 @@ export function Review({
                             value={field.state.value}
                             onValueChange={(value) => field.handleChange(value)}
                           >
-                            {Array.from({ length: MAX_SCORE }, (_, i) => (
-                              <RatingButton key={`learning-star-${i + 1}`} />
-                            ))}
+                            {Array.from(
+                              { length: MAX_REVIEW_SCORE },
+                              (_, i) => (
+                                <RatingButton key={`learning-star-${i + 1}`} />
+                              ),
+                            )}
                           </Rating>
                           {isInvalid && (
                             <FieldError errors={field.state.meta.errors} />

--- a/apps/web/features/reviews/components/review.tsx
+++ b/apps/web/features/reviews/components/review.tsx
@@ -5,6 +5,7 @@ import { useEffect, useState } from "react";
 import { z } from "zod";
 import { RichTextEditor } from "@/components/RichEditor";
 import { Button } from "@/components/ui/button";
+import { Checkbox } from "@/components/ui/checkbox";
 import {
   Dialog,
   DialogClose,
@@ -24,44 +25,90 @@ import {
   FieldLegend,
   FieldSet,
 } from "@/components/ui/field";
+import { Input } from "@/components/ui/input";
 import { Rating, RatingButton } from "@/components/ui/shadcn-io/rating";
+import { Slider } from "@/components/ui/slider";
 import { Spinner } from "@/components/ui/spinner";
 import { Switch } from "@/components/ui/switch";
 import { useMe } from "@/features/auth";
+import type { ExaminationDistribution } from "@/types";
+import {
+  EXAMINATION_DISTRIBUTION_KEYS,
+  EXAMINATION_DISTRIBUTION_LABELS,
+} from "@/types";
 import { useAddReview } from "../hooks/use-add-review";
 
+/** Both score axes are 1-10; see `docs/schema_docs/planned-database-formats.md`. */
+const MAX_SCORE = 10;
+
 export type ReviewFormData = {
-  wouldRecommend: boolean;
-  content: string;
-  examinationMethods: number;
-  theoreticalVsApplied: number;
-  workload: number;
-  learningExperience: number;
+  happyTook: boolean;
+  message: string;
+  /** `null` is the stored answer for "I don't remember". */
+  examinationDistribution: ExaminationDistribution | null;
+  /** `null` is the stored answer for "I don't remember". */
+  approachTheoryPercent: number | null;
+  workloadScore: number;
+  learningScore: number;
 };
 
-const ratingSchema = z.number().int().min(1, "Select a rating.");
+const EMPTY_DISTRIBUTION: ExaminationDistribution = {
+  exam: 0,
+  assignments: 0,
+  labs: 0,
+  projects: 0,
+  seminars: 0,
+  other: 0,
+};
+
+const scoreSchema = z
+  .number()
+  .int()
+  .min(1, "Select a score.")
+  .max(MAX_SCORE, `Scores go up to ${MAX_SCORE}.`);
+
+const percentageSchema = z.number().int().min(0).max(100);
+
+const distributionSchema = z
+  .object({
+    exam: percentageSchema,
+    assignments: percentageSchema,
+    labs: percentageSchema,
+    projects: percentageSchema,
+    seminars: percentageSchema,
+    other: percentageSchema,
+  })
+  .refine(
+    (value) =>
+      EXAMINATION_DISTRIBUTION_KEYS.reduce(
+        (total, key) => total + value[key],
+        0,
+      ) === 100,
+    "Shares must add up to 100%.",
+  )
+  .nullable();
 
 const formSchema = z.object({
-  wouldRecommend: z.boolean(),
-  content: z
+  happyTook: z.boolean(),
+  message: z
     .string()
     .refine(
       (html) => html.replace(/<[^>]*>/g, "").trim().length > 0,
       "Write a review.",
     ),
-  examinationMethods: ratingSchema,
-  theoreticalVsApplied: ratingSchema,
-  workload: ratingSchema,
-  learningExperience: ratingSchema,
+  examinationDistribution: distributionSchema,
+  approachTheoryPercent: percentageSchema.nullable(),
+  workloadScore: scoreSchema,
+  learningScore: scoreSchema,
 });
 
 const defaultValues: ReviewFormData = {
-  wouldRecommend: false,
-  content: "",
-  examinationMethods: 0,
-  theoreticalVsApplied: 0,
-  workload: 0,
-  learningExperience: 0,
+  happyTook: false,
+  message: "",
+  examinationDistribution: null,
+  approachTheoryPercent: null,
+  workloadScore: 0,
+  learningScore: 0,
 };
 
 type ReviewProps = {
@@ -130,60 +177,12 @@ export function Review({
             <FieldGroup className="py-6">
               <FieldSet>
                 <FieldLegend>Rate the Course</FieldLegend>
+                <FieldDescription>
+                  Two separate axes, each from 1 to {MAX_SCORE}. Neither is an
+                  overall verdict.
+                </FieldDescription>
                 <FieldGroup>
-                  <form.Field name="examinationMethods">
-                    {(field) => {
-                      const isInvalid =
-                        field.state.meta.isTouched && !field.state.meta.isValid;
-                      return (
-                        <Field
-                          orientation="horizontal"
-                          data-invalid={isInvalid}
-                        >
-                          <FieldLabel>Examination methods</FieldLabel>
-                          <Rating
-                            value={field.state.value}
-                            onValueChange={(value) => field.handleChange(value)}
-                          >
-                            {Array.from({ length: 5 }, (_, i) => (
-                              <RatingButton key={`difficulty-star-${i + 1}`} />
-                            ))}
-                          </Rating>
-                          {isInvalid && (
-                            <FieldError errors={field.state.meta.errors} />
-                          )}
-                        </Field>
-                      );
-                    }}
-                  </form.Field>
-
-                  <form.Field name="theoreticalVsApplied">
-                    {(field) => {
-                      const isInvalid =
-                        field.state.meta.isTouched && !field.state.meta.isValid;
-                      return (
-                        <Field
-                          orientation="horizontal"
-                          data-invalid={isInvalid}
-                        >
-                          <FieldLabel>Theory vs applied</FieldLabel>
-                          <Rating
-                            value={field.state.value}
-                            onValueChange={(value) => field.handleChange(value)}
-                          >
-                            {Array.from({ length: 5 }, (_, i) => (
-                              <RatingButton key={`usefulness-star-${i + 1}`} />
-                            ))}
-                          </Rating>
-                          {isInvalid && (
-                            <FieldError errors={field.state.meta.errors} />
-                          )}
-                        </Field>
-                      );
-                    }}
-                  </form.Field>
-
-                  <form.Field name="workload">
+                  <form.Field name="workloadScore">
                     {(field) => {
                       const isInvalid =
                         field.state.meta.isTouched && !field.state.meta.isValid;
@@ -197,7 +196,7 @@ export function Review({
                             value={field.state.value}
                             onValueChange={(value) => field.handleChange(value)}
                           >
-                            {Array.from({ length: 5 }, (_, i) => (
+                            {Array.from({ length: MAX_SCORE }, (_, i) => (
                               <RatingButton key={`workload-star-${i + 1}`} />
                             ))}
                           </Rating>
@@ -209,7 +208,7 @@ export function Review({
                     }}
                   </form.Field>
 
-                  <form.Field name="learningExperience">
+                  <form.Field name="learningScore">
                     {(field) => {
                       const isInvalid =
                         field.state.meta.isTouched && !field.state.meta.isValid;
@@ -218,12 +217,12 @@ export function Review({
                           orientation="horizontal"
                           data-invalid={isInvalid}
                         >
-                          <FieldLabel>Learning experience</FieldLabel>
+                          <FieldLabel>Learning</FieldLabel>
                           <Rating
                             value={field.state.value}
                             onValueChange={(value) => field.handleChange(value)}
                           >
-                            {Array.from({ length: 5 }, (_, i) => (
+                            {Array.from({ length: MAX_SCORE }, (_, i) => (
                               <RatingButton key={`learning-star-${i + 1}`} />
                             ))}
                           </Rating>
@@ -238,8 +237,135 @@ export function Review({
               </FieldSet>
 
               <FieldSet>
-                <FieldLegend>Recommendation</FieldLegend>
-                <form.Field name="wouldRecommend">
+                <FieldLegend>Examination</FieldLegend>
+                <FieldDescription>
+                  How was assessment split across the course? Leave "I don't
+                  remember" checked if you are not sure — a guess helps nobody.
+                </FieldDescription>
+                <form.Field name="examinationDistribution">
+                  {(field) => {
+                    const distribution = field.state.value;
+                    const isInvalid =
+                      field.state.meta.isTouched && !field.state.meta.isValid;
+                    const total =
+                      distribution === null
+                        ? 0
+                        : EXAMINATION_DISTRIBUTION_KEYS.reduce(
+                            (sum, key) => sum + distribution[key],
+                            0,
+                          );
+                    return (
+                      <Field data-invalid={isInvalid}>
+                        <Field orientation="horizontal">
+                          <Checkbox
+                            id="examination-not-remembered"
+                            checked={distribution === null}
+                            onCheckedChange={(checked) =>
+                              field.handleChange(
+                                checked === true
+                                  ? null
+                                  : { ...EMPTY_DISTRIBUTION },
+                              )
+                            }
+                          />
+                          <FieldLabel htmlFor="examination-not-remembered">
+                            I don't remember
+                          </FieldLabel>
+                        </Field>
+
+                        {distribution !== null && (
+                          <>
+                            <div className="grid grid-cols-2 gap-3 md:grid-cols-3">
+                              {EXAMINATION_DISTRIBUTION_KEYS.map((key) => (
+                                <Field key={key}>
+                                  <FieldLabel
+                                    htmlFor={`examination-share-${key}`}
+                                  >
+                                    {EXAMINATION_DISTRIBUTION_LABELS[key]}
+                                  </FieldLabel>
+                                  <Input
+                                    id={`examination-share-${key}`}
+                                    type="number"
+                                    min={0}
+                                    max={100}
+                                    step={1}
+                                    value={distribution[key]}
+                                    onChange={(event) =>
+                                      field.handleChange({
+                                        ...distribution,
+                                        [key]:
+                                          Number.parseInt(
+                                            event.target.value,
+                                            10,
+                                          ) || 0,
+                                      })
+                                    }
+                                  />
+                                </Field>
+                              ))}
+                            </div>
+                            <FieldDescription>
+                              Total: {total}% (must be 100%)
+                            </FieldDescription>
+                          </>
+                        )}
+                        {isInvalid && (
+                          <FieldError errors={field.state.meta.errors} />
+                        )}
+                      </Field>
+                    );
+                  }}
+                </form.Field>
+              </FieldSet>
+
+              <FieldSet>
+                <FieldLegend>Approach</FieldLegend>
+                <FieldDescription>
+                  How theoretical rather than applied did you find the course?
+                </FieldDescription>
+                <form.Field name="approachTheoryPercent">
+                  {(field) => {
+                    const percent = field.state.value;
+                    return (
+                      <Field>
+                        <Field orientation="horizontal">
+                          <Checkbox
+                            id="approach-not-remembered"
+                            checked={percent === null}
+                            onCheckedChange={(checked) =>
+                              field.handleChange(checked === true ? null : 50)
+                            }
+                          />
+                          <FieldLabel htmlFor="approach-not-remembered">
+                            I don't remember
+                          </FieldLabel>
+                        </Field>
+                        {percent !== null && (
+                          <>
+                            <Slider
+                              aria-label="Percent theory"
+                              min={0}
+                              max={100}
+                              step={1}
+                              value={[percent]}
+                              onValueChange={([value]) =>
+                                field.handleChange(value)
+                              }
+                            />
+                            <FieldDescription>
+                              {percent}% theory / {100 - percent}% applied
+                            </FieldDescription>
+                          </>
+                        )}
+                      </Field>
+                    );
+                  }}
+                </form.Field>
+              </FieldSet>
+
+              <FieldSet>
+                <FieldLegend>Looking back</FieldLegend>
+                <form.Field name="happyTook">
                   {(field) => (
                     <Field orientation="horizontal">
                       <Switch
@@ -251,7 +377,7 @@ export function Review({
                         }
                       />
                       <FieldLabel htmlFor={field.name}>
-                        I would recommend this course
+                        I'm glad I took this course
                       </FieldLabel>
                     </Field>
                   )}
@@ -260,7 +386,7 @@ export function Review({
 
               <FieldSet>
                 <FieldLegend>Your Review</FieldLegend>
-                <form.Field name="content">
+                <form.Field name="message">
                   {(field) => {
                     const isInvalid =
                       field.state.meta.isTouched && !field.state.meta.isValid;

--- a/apps/web/features/reviews/hooks/use-add-review.ts
+++ b/apps/web/features/reviews/hooks/use-add-review.ts
@@ -14,7 +14,7 @@ export function useAddReview() {
       courseCode: string,
       reviewForm: ReviewFormData,
     ): Promise<boolean> => {
-      const plainText = reviewForm.content.replace(/<[^>]*>/g, " ");
+      const plainText = reviewForm.message.replace(/<[^>]*>/g, " ");
       const escapeRegex = (s: string) =>
         s.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
       const profoundMatches = profoundWords

--- a/apps/web/features/reviews/hooks/use-review-votes.ts
+++ b/apps/web/features/reviews/hooks/use-review-votes.ts
@@ -3,34 +3,26 @@
 import { useCallback } from "react";
 import { toast } from "sonner";
 import { useSessionData } from "@/features/auth";
-import { useLikeReview } from "../api/mutations";
+import type { ReviewVoteType } from "@/types";
+import { useVoteOnReview } from "../api/mutations";
 
 export function useReviewVotes(courseCode: string) {
   const { userId } = useSessionData();
-  const likeMutation = useLikeReview(courseCode);
+  const voteMutation = useVoteOnReview(courseCode);
 
-  const like = useCallback(
-    async (postId: string) => {
+  const vote = useCallback(
+    async (reviewId: string, voteType: ReviewVoteType) => {
       if (!userId) return;
       try {
-        await likeMutation.mutateAsync({ id: postId });
+        await voteMutation.mutateAsync({ id: reviewId, voteType });
       } catch {
         toast.error("Failed to update vote", {
           description: "Try again later",
         });
       }
     },
-    [likeMutation, userId],
+    [voteMutation, userId],
   );
 
-  const dislike = useCallback(
-    async (postId: string) => {
-      if (!userId) return;
-      void postId;
-      toast.info("Dislike is temporarily unavailable");
-    },
-    [userId],
-  );
-
-  return { like, dislike };
+  return { vote };
 }

--- a/apps/web/server/api/protected.spec.ts
+++ b/apps/web/server/api/protected.spec.ts
@@ -19,13 +19,19 @@ describe("protected procedures", () => {
     await expect(
       caller(null).reviews.create({
         courseCode: "DD2421",
-        examinationMethods: 3,
-        theoreticalVsApplied: 3,
-        workload: 3,
-        learningExperience: 3,
-        wouldRecommend: true,
-        content: "hi",
+        examinationDistribution: null,
+        approachTheoryPercent: null,
+        workloadScore: 3,
+        learningScore: 3,
+        happyTook: true,
+        message: "hi",
       }),
+    ).rejects.toMatchObject({ code: "UNAUTHORIZED" });
+  });
+
+  it("rejects visitors on reviews.vote", async () => {
+    await expect(
+      caller(null).reviews.vote({ id: "review-1", voteType: "up" }),
     ).rejects.toMatchObject({ code: "UNAUTHORIZED" });
   });
 

--- a/apps/web/server/api/trpc.ts
+++ b/apps/web/server/api/trpc.ts
@@ -1,6 +1,10 @@
 import { initTRPC, TRPCError } from "@trpc/server";
 import { getAuth } from "@/server/auth";
-import { ForbiddenError, NotFoundError } from "@/server/errors";
+import {
+  ForbiddenError,
+  NotFoundError,
+  ValidationError,
+} from "@/server/errors";
 
 export const createTRPCContext = async (opts: { headers: Headers }) => {
   const session = await getAuth().api.getSession({ headers: opts.headers });
@@ -20,6 +24,9 @@ const t = initTRPC
         return { ...shape, message: cause.message };
       }
       if (cause instanceof ForbiddenError) {
+        return { ...shape, message: cause.message };
+      }
+      if (cause instanceof ValidationError) {
         return { ...shape, message: cause.message };
       }
       return shape;
@@ -42,6 +49,13 @@ export const baseProcedure = t.procedure.use(async ({ next }) => {
     if (cause instanceof ForbiddenError) {
       throw new TRPCError({
         code: "FORBIDDEN",
+        message: cause.message,
+        cause,
+      });
+    }
+    if (cause instanceof ValidationError) {
+      throw new TRPCError({
+        code: "BAD_REQUEST",
         message: cause.message,
         cause,
       });

--- a/apps/web/server/db/drizzle/0006_target-schema.sql
+++ b/apps/web/server/db/drizzle/0006_target-schema.sql
@@ -199,7 +199,8 @@ SET
 	"happy_took" = "would_recommend",
 	"message" = NULLIF("content", '');--> statement-breakpoint
 
--- Keep old application writes valid until B switches the review repository.
+-- Keep old application writes valid until #75 switches the review repository.
+-- (Dropped in 0012_review_contract.sql.)
 CREATE FUNCTION "sync_legacy_review_fields_to_target"()
 RETURNS trigger
 LANGUAGE plpgsql

--- a/apps/web/server/db/drizzle/0009_volatile_kinsey_walden.sql
+++ b/apps/web/server/db/drizzle/0009_volatile_kinsey_walden.sql
@@ -1,7 +1,11 @@
 ALTER TABLE "reviews" ALTER COLUMN "happy_took" SET DEFAULT NULL;--> statement-breakpoint
 
--- Temporary expand/contract compatibility. B must drop these triggers and
--- functions after every repository writes the target tables and columns.
+-- Temporary expand/contract compatibility. Each trigger below is dropped by
+-- the issue that owns its domain, once that repository writes the target
+-- tables and columns: the review triggers (reviews_legacy_target_sync,
+-- review_likes_target_sync) belong to #75, user_favorites_target_sync to #64,
+-- and courses_explore_target_sync to the not-yet-filed courses/course_explore
+-- switch.
 CREATE OR REPLACE FUNCTION "sync_legacy_review_fields_to_target"()
 RETURNS trigger
 LANGUAGE plpgsql

--- a/apps/web/server/db/drizzle/0009_volatile_kinsey_walden.sql
+++ b/apps/web/server/db/drizzle/0009_volatile_kinsey_walden.sql
@@ -4,8 +4,7 @@ ALTER TABLE "reviews" ALTER COLUMN "happy_took" SET DEFAULT NULL;--> statement-b
 -- the issue that owns its domain, once that repository writes the target
 -- tables and columns: the review triggers (reviews_legacy_target_sync,
 -- review_likes_target_sync) belong to #75, user_favorites_target_sync to #64,
--- and courses_explore_target_sync to the not-yet-filed courses/course_explore
--- switch.
+-- and courses_explore_target_sync to #77.
 CREATE OR REPLACE FUNCTION "sync_legacy_review_fields_to_target"()
 RETURNS trigger
 LANGUAGE plpgsql

--- a/apps/web/server/db/drizzle/0012_review_contract.sql
+++ b/apps/web/server/db/drizzle/0012_review_contract.sql
@@ -15,8 +15,7 @@ BEGIN
 	SELECT count(*) INTO unscored
 	FROM "reviews"
 	WHERE "workload_score" IS NULL
-		OR "learning_score" IS NULL
-		OR "happy_took" IS NULL;
+		OR "learning_score" IS NULL;
 
 	IF unscored > 0 THEN
 		RAISE EXCEPTION
@@ -45,4 +44,6 @@ ALTER TABLE "reviews" DROP COLUMN "learning_experience";--> statement-breakpoint
 ALTER TABLE "reviews" DROP COLUMN "would_recommend";--> statement-breakpoint
 ALTER TABLE "reviews" DROP COLUMN "content";--> statement-breakpoint
 
-DROP TABLE "review_likes" CASCADE;
+-- No CASCADE: nothing should depend on this table any more, and if something
+-- does, aborting here is better than dropping it silently.
+DROP TABLE "review_likes";

--- a/apps/web/server/db/drizzle/0012_review_contract.sql
+++ b/apps/web/server/db/drizzle/0012_review_contract.sql
@@ -1,0 +1,48 @@
+-- Contract phase for the review domain (#75). The application now reads and
+-- writes only the target columns and `review_votes`, so the expand-phase
+-- compatibility triggers from 0006/0009 have no remaining writer and the
+-- legacy review columns and `review_likes` can go.
+--
+-- Fail before touching anything if a legacy row would be lost. `reviews` is
+-- empty today; if that has changed, a zero-valued legacy score never became a
+-- valid 1-10 target score and the abandoned `examination_methods` /
+-- `theoretical_vs_applied` integers do not convert. Both need a deliberate
+-- decision rather than a silent default.
+DO $$
+DECLARE
+	unscored bigint;
+BEGIN
+	SELECT count(*) INTO unscored
+	FROM "reviews"
+	WHERE "workload_score" IS NULL
+		OR "learning_score" IS NULL
+		OR "happy_took" IS NULL;
+
+	IF unscored > 0 THEN
+		RAISE EXCEPTION
+			'Cannot contract reviews: % row(s) have no target score. Decide how to score them before running this migration.',
+			unscored;
+	END IF;
+END;
+$$;--> statement-breakpoint
+
+DROP TRIGGER IF EXISTS "reviews_legacy_target_sync" ON "reviews";--> statement-breakpoint
+DROP FUNCTION IF EXISTS "sync_legacy_review_fields_to_target"();--> statement-breakpoint
+DROP TRIGGER IF EXISTS "review_likes_target_sync" ON "review_likes";--> statement-breakpoint
+DROP FUNCTION IF EXISTS "sync_review_likes_to_votes"();--> statement-breakpoint
+
+ALTER TABLE "reviews" ALTER COLUMN "workload_score" SET NOT NULL;--> statement-breakpoint
+ALTER TABLE "reviews" ALTER COLUMN "learning_score" SET NOT NULL;--> statement-breakpoint
+-- 0009 set this to DEFAULT NULL so the sync trigger could tell an omitted
+-- target value from an explicit one. With the trigger gone the column is
+-- simply required.
+ALTER TABLE "reviews" ALTER COLUMN "happy_took" DROP DEFAULT;--> statement-breakpoint
+
+ALTER TABLE "reviews" DROP COLUMN "examination_methods";--> statement-breakpoint
+ALTER TABLE "reviews" DROP COLUMN "theoretical_vs_applied";--> statement-breakpoint
+ALTER TABLE "reviews" DROP COLUMN "workload";--> statement-breakpoint
+ALTER TABLE "reviews" DROP COLUMN "learning_experience";--> statement-breakpoint
+ALTER TABLE "reviews" DROP COLUMN "would_recommend";--> statement-breakpoint
+ALTER TABLE "reviews" DROP COLUMN "content";--> statement-breakpoint
+
+DROP TABLE "review_likes" CASCADE;

--- a/apps/web/server/db/drizzle/meta/0012_snapshot.json
+++ b/apps/web/server/db/drizzle/meta/0012_snapshot.json
@@ -1,6 +1,6 @@
 {
-  "id": "7433d8fb-b358-4bcf-9c6c-feb0b654f7fb",
-  "prevId": "3642ca47-7c55-4c74-acb8-20c1d1dadc8d",
+  "id": "ab856fe0-aa82-400a-9c09-cc556bb9a8dd",
+  "prevId": "28130534-2068-45e7-bed5-7a3967dc4c19",
   "version": "7",
   "dialect": "postgresql",
   "tables": {
@@ -1181,62 +1181,6 @@
         "user_taken_courses_user_id_course_code_pk": {
           "name": "user_taken_courses_user_id_course_code_pk",
           "columns": ["user_id", "course_code"]
-        }
-      },
-      "uniqueConstraints": {},
-      "policies": {},
-      "checkConstraints": {},
-      "isRLSEnabled": false
-    },
-    "public.user_favorites": {
-      "name": "user_favorites",
-      "schema": "",
-      "columns": {
-        "user_id": {
-          "name": "user_id",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "fav_course_code": {
-          "name": "fav_course_code",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "created_at": {
-          "name": "created_at",
-          "type": "timestamp with time zone",
-          "primaryKey": false,
-          "notNull": true,
-          "default": "now()"
-        }
-      },
-      "indexes": {},
-      "foreignKeys": {
-        "user_favorites_user_id_users_id_fk": {
-          "name": "user_favorites_user_id_users_id_fk",
-          "tableFrom": "user_favorites",
-          "tableTo": "users",
-          "columnsFrom": ["user_id"],
-          "columnsTo": ["id"],
-          "onDelete": "cascade",
-          "onUpdate": "no action"
-        },
-        "user_favorites_fav_course_code_courses_code_fk": {
-          "name": "user_favorites_fav_course_code_courses_code_fk",
-          "tableFrom": "user_favorites",
-          "tableTo": "courses",
-          "columnsFrom": ["fav_course_code"],
-          "columnsTo": ["code"],
-          "onDelete": "cascade",
-          "onUpdate": "no action"
-        }
-      },
-      "compositePrimaryKeys": {
-        "user_favorites_user_id_fav_course_code_pk": {
-          "name": "user_favorites_user_id_fav_course_code_pk",
-          "columns": ["user_id", "fav_course_code"]
         }
       },
       "uniqueConstraints": {},

--- a/apps/web/server/db/drizzle/meta/0012_snapshot.json
+++ b/apps/web/server/db/drizzle/meta/0012_snapshot.json
@@ -1,0 +1,1860 @@
+{
+  "id": "7433d8fb-b358-4bcf-9c6c-feb0b654f7fb",
+  "prevId": "3642ca47-7c55-4c74-acb8-20c1d1dadc8d",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.collection_courses": {
+      "name": "collection_courses",
+      "schema": "",
+      "columns": {
+        "collection_id": {
+          "name": "collection_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "collection_user_id": {
+          "name": "collection_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "course_code": {
+          "name": "course_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "collection_courses_collection_owner_idx": {
+          "name": "collection_courses_collection_owner_idx",
+          "columns": [
+            {
+              "expression": "collection_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "collection_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "collection_courses_saved_course_idx": {
+          "name": "collection_courses_saved_course_idx",
+          "columns": [
+            {
+              "expression": "collection_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "course_code",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "collection_courses_collection_owner_fk": {
+          "name": "collection_courses_collection_owner_fk",
+          "tableFrom": "collection_courses",
+          "tableTo": "collections",
+          "columnsFrom": ["collection_id", "collection_user_id"],
+          "columnsTo": ["id", "user_id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "collection_courses_saved_course_fk": {
+          "name": "collection_courses_saved_course_fk",
+          "tableFrom": "collection_courses",
+          "tableTo": "user_saved_courses",
+          "columnsFrom": ["collection_user_id", "course_code"],
+          "columnsTo": ["user_id", "course_code"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "collection_courses_collection_id_course_code_pk": {
+          "name": "collection_courses_collection_id_course_code_pk",
+          "columns": ["collection_id", "course_code"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "position_nonnegative": {
+          "name": "position_nonnegative",
+          "value": "\"collection_courses\".\"position\" >= 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.collections": {
+      "name": "collections",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "collections_user_id_idx": {
+          "name": "collections_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "collections_user_id_users_id_fk": {
+          "name": "collections_user_id_users_id_fk",
+          "tableFrom": "collections",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "collections_id_user_id_unique": {
+          "name": "collections_id_user_id_unique",
+          "nullsNotDistinct": false,
+          "columns": ["id", "user_id"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.course_examinations": {
+      "name": "course_examinations",
+      "schema": "",
+      "columns": {
+        "course_code": {
+          "name": "course_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "exam_code": {
+          "name": "exam_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "credits": {
+          "name": "credits",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "grade_scale_code": {
+          "name": "grade_scale_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "course_examinations_course_code_courses_code_fk": {
+          "name": "course_examinations_course_code_courses_code_fk",
+          "tableFrom": "course_examinations",
+          "tableTo": "courses",
+          "columnsFrom": ["course_code"],
+          "columnsTo": ["code"],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "course_examinations_course_code_exam_code_pk": {
+          "name": "course_examinations_course_code_exam_code_pk",
+          "columns": ["course_code", "exam_code"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.course_explore": {
+      "name": "course_explore",
+      "schema": "",
+      "columns": {
+        "course_code": {
+          "name": "course_code",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "embedding": {
+          "name": "embedding",
+          "type": "vector(1536)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_hash": {
+          "name": "source_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "search_vector": {
+          "name": "search_vector",
+          "type": "tsvector",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "embedding_model": {
+          "name": "embedding_model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "embedded_at": {
+          "name": "embedded_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "course_explore_search_vector_idx": {
+          "name": "course_explore_search_vector_idx",
+          "columns": [
+            {
+              "expression": "search_vector",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        },
+        "course_explore_embedding_idx": {
+          "name": "course_explore_embedding_idx",
+          "columns": [
+            {
+              "expression": "embedding",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "vector_cosine_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "hnsw",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "course_explore_course_code_courses_code_fk": {
+          "name": "course_explore_course_code_courses_code_fk",
+          "tableFrom": "course_explore",
+          "tableTo": "courses",
+          "columnsFrom": ["course_code"],
+          "columnsTo": ["code"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.course_prerequisites": {
+      "name": "course_prerequisites",
+      "schema": "",
+      "columns": {
+        "course_code": {
+          "name": "course_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "prerequisite_course_code": {
+          "name": "prerequisite_course_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "course_prerequisites_prerequisite_course_code_idx": {
+          "name": "course_prerequisites_prerequisite_course_code_idx",
+          "columns": [
+            {
+              "expression": "prerequisite_course_code",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "course_prerequisites_course_code_courses_code_fk": {
+          "name": "course_prerequisites_course_code_courses_code_fk",
+          "tableFrom": "course_prerequisites",
+          "tableTo": "courses",
+          "columnsFrom": ["course_code"],
+          "columnsTo": ["code"],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "course_prerequisites_prerequisite_course_code_courses_code_fk": {
+          "name": "course_prerequisites_prerequisite_course_code_courses_code_fk",
+          "tableFrom": "course_prerequisites",
+          "tableTo": "courses",
+          "columnsFrom": ["prerequisite_course_code"],
+          "columnsTo": ["code"],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "course_prerequisites_course_code_prerequisite_course_code_pk": {
+          "name": "course_prerequisites_course_code_prerequisite_course_code_pk",
+          "columns": ["course_code", "prerequisite_course_code"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.course_rounds": {
+      "name": "course_rounds",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "course_code": {
+          "name": "course_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "start_term": {
+          "name": "start_term",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "study_pace": {
+          "name": "study_pace",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "schema_url": {
+          "name": "schema_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "language": {
+          "name": "language",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tutoring_form": {
+          "name": "tutoring_form",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tutoring_time_of_day": {
+          "name": "tutoring_time_of_day",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "formatted_periods_and_credits": {
+          "name": "formatted_periods_and_credits",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_pu": {
+          "name": "is_pu",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_vu": {
+          "name": "is_vu",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "course_rounds_course_code_idx": {
+          "name": "course_rounds_course_code_idx",
+          "columns": [
+            {
+              "expression": "course_code",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "course_rounds_course_code_courses_code_fk": {
+          "name": "course_rounds_course_code_courses_code_fk",
+          "tableFrom": "course_rounds",
+          "tableTo": "courses",
+          "columnsFrom": ["course_code"],
+          "columnsTo": ["code"],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "study_pace_range": {
+          "name": "study_pace_range",
+          "value": "\"course_rounds\".\"study_pace\" between 1 and 100"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.courses": {
+      "name": "courses",
+      "schema": "",
+      "columns": {
+        "code": {
+          "name": "code",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name_swedish": {
+          "name": "name_swedish",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name_english": {
+          "name": "name_english",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "state": {
+          "name": "state",
+          "type": "course_state",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "credits": {
+          "name": "credits",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "credit_unit": {
+          "name": "credit_unit",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "department_code": {
+          "name": "department_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "department": {
+          "name": "department",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "educational_level_code": {
+          "name": "educational_level_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "grade_scale_code": {
+          "name": "grade_scale_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "goals": {
+          "name": "goals",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "eligibility": {
+          "name": "eligibility",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "embedding": {
+          "name": "embedding",
+          "type": "vector(1536)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "embedding_hash": {
+          "name": "embedding_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "search_vector": {
+          "name": "search_vector",
+          "type": "tsvector",
+          "primaryKey": false,
+          "notNull": false,
+          "generated": {
+            "as": "to_tsvector('simple', coalesce(name_english, '') || ' ' || coalesce(name_swedish, '') || ' ' || coalesce(code, '') || ' ' || coalesce(goals, '') || ' ' || coalesce(content, ''))",
+            "type": "stored"
+          }
+        }
+      },
+      "indexes": {
+        "courses_search_vector_idx": {
+          "name": "courses_search_vector_idx",
+          "columns": [
+            {
+              "expression": "search_vector",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        },
+        "courses_embedding_idx": {
+          "name": "courses_embedding_idx",
+          "columns": [
+            {
+              "expression": "embedding",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "vector_cosine_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "hnsw",
+          "with": {}
+        },
+        "courses_name_trgm_idx": {
+          "name": "courses_name_trgm_idx",
+          "columns": [
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "gin_trgm_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        },
+        "courses_code_trgm_idx": {
+          "name": "courses_code_trgm_idx",
+          "columns": [
+            {
+              "expression": "code",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "gin_trgm_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.feedback_form": {
+      "name": "feedback_form",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "message": {
+          "name": "message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.review_votes": {
+      "name": "review_votes",
+      "schema": "",
+      "columns": {
+        "voter_user_id": {
+          "name": "voter_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "review_id": {
+          "name": "review_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "vote_type": {
+          "name": "vote_type",
+          "type": "review_vote_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "review_votes_review_id_idx": {
+          "name": "review_votes_review_id_idx",
+          "columns": [
+            {
+              "expression": "review_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "review_votes_voter_user_id_users_id_fk": {
+          "name": "review_votes_voter_user_id_users_id_fk",
+          "tableFrom": "review_votes",
+          "tableTo": "users",
+          "columnsFrom": ["voter_user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "review_votes_review_id_reviews_id_fk": {
+          "name": "review_votes_review_id_reviews_id_fk",
+          "tableFrom": "review_votes",
+          "tableTo": "reviews",
+          "columnsFrom": ["review_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "review_votes_voter_user_id_review_id_pk": {
+          "name": "review_votes_voter_user_id_review_id_pk",
+          "columns": ["voter_user_id", "review_id"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.reviews": {
+      "name": "reviews",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "course_code": {
+          "name": "course_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "examination_distribution": {
+          "name": "examination_distribution",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "approach_theory_percent": {
+          "name": "approach_theory_percent",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "workload_score": {
+          "name": "workload_score",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "learning_score": {
+          "name": "learning_score",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "happy_took": {
+          "name": "happy_took",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "message": {
+          "name": "message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "reviews_user_id_idx": {
+          "name": "reviews_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "reviews_course_code_idx": {
+          "name": "reviews_course_code_idx",
+          "columns": [
+            {
+              "expression": "course_code",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "reviews_user_id_users_id_fk": {
+          "name": "reviews_user_id_users_id_fk",
+          "tableFrom": "reviews",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "reviews_course_code_courses_code_fk": {
+          "name": "reviews_course_code_courses_code_fk",
+          "tableFrom": "reviews",
+          "tableTo": "courses",
+          "columnsFrom": ["course_code"],
+          "columnsTo": ["code"],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "approach_theory_percent_range": {
+          "name": "approach_theory_percent_range",
+          "value": "\"reviews\".\"approach_theory_percent\" between 0 and 100"
+        },
+        "workload_score_range": {
+          "name": "workload_score_range",
+          "value": "\"reviews\".\"workload_score\" between 1 and 10"
+        },
+        "learning_score_range": {
+          "name": "learning_score_range",
+          "value": "\"reviews\".\"learning_score\" between 1 and 10"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.user_saved_courses": {
+      "name": "user_saved_courses",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "course_code": {
+          "name": "course_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "user_saved_courses_course_code_idx": {
+          "name": "user_saved_courses_course_code_idx",
+          "columns": [
+            {
+              "expression": "course_code",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_saved_courses_user_id_users_id_fk": {
+          "name": "user_saved_courses_user_id_users_id_fk",
+          "tableFrom": "user_saved_courses",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "user_saved_courses_course_code_courses_code_fk": {
+          "name": "user_saved_courses_course_code_courses_code_fk",
+          "tableFrom": "user_saved_courses",
+          "tableTo": "courses",
+          "columnsFrom": ["course_code"],
+          "columnsTo": ["code"],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "user_saved_courses_user_id_course_code_pk": {
+          "name": "user_saved_courses_user_id_course_code_pk",
+          "columns": ["user_id", "course_code"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_taken_courses": {
+      "name": "user_taken_courses",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "course_code": {
+          "name": "course_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "attendance_periods": {
+          "name": "attendance_periods",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "attendance_year": {
+          "name": "attendance_year",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "grade": {
+          "name": "grade",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "earned_credits": {
+          "name": "earned_credits",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "transcript_imported_at": {
+          "name": "transcript_imported_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "user_taken_courses_course_code_idx": {
+          "name": "user_taken_courses_course_code_idx",
+          "columns": [
+            {
+              "expression": "course_code",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_taken_courses_user_id_users_id_fk": {
+          "name": "user_taken_courses_user_id_users_id_fk",
+          "tableFrom": "user_taken_courses",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "user_taken_courses_course_code_courses_code_fk": {
+          "name": "user_taken_courses_course_code_courses_code_fk",
+          "tableFrom": "user_taken_courses",
+          "tableTo": "courses",
+          "columnsFrom": ["course_code"],
+          "columnsTo": ["code"],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "user_taken_courses_user_id_course_code_pk": {
+          "name": "user_taken_courses_user_id_course_code_pk",
+          "columns": ["user_id", "course_code"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_favorites": {
+      "name": "user_favorites",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "fav_course_code": {
+          "name": "fav_course_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "user_favorites_user_id_users_id_fk": {
+          "name": "user_favorites_user_id_users_id_fk",
+          "tableFrom": "user_favorites",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "user_favorites_fav_course_code_courses_code_fk": {
+          "name": "user_favorites_fav_course_code_courses_code_fk",
+          "tableFrom": "user_favorites",
+          "tableTo": "courses",
+          "columnsFrom": ["fav_course_code"],
+          "columnsTo": ["code"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "user_favorites_user_id_fav_course_code_pk": {
+          "name": "user_favorites_user_id_fav_course_code_pk",
+          "columns": ["user_id", "fav_course_code"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users_graph_backbone_edges": {
+      "name": "users_graph_backbone_edges",
+      "schema": "",
+      "columns": {
+        "node_user_id": {
+          "name": "node_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "anchor_user_id": {
+          "name": "anchor_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "users_graph_backbone_edges_anchor_user_id_idx": {
+          "name": "users_graph_backbone_edges_anchor_user_id_idx",
+          "columns": [
+            {
+              "expression": "anchor_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "users_graph_backbone_edges_node_user_id_users_graph_nodes_user_id_fk": {
+          "name": "users_graph_backbone_edges_node_user_id_users_graph_nodes_user_id_fk",
+          "tableFrom": "users_graph_backbone_edges",
+          "tableTo": "users_graph_nodes",
+          "columnsFrom": ["node_user_id"],
+          "columnsTo": ["user_id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "users_graph_backbone_edges_anchor_user_id_users_graph_nodes_user_id_fk": {
+          "name": "users_graph_backbone_edges_anchor_user_id_users_graph_nodes_user_id_fk",
+          "tableFrom": "users_graph_backbone_edges",
+          "tableTo": "users_graph_nodes",
+          "columnsFrom": ["anchor_user_id"],
+          "columnsTo": ["user_id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "users_graph_backbone_edges_node_user_id_anchor_user_id_pk": {
+          "name": "users_graph_backbone_edges_node_user_id_anchor_user_id_pk",
+          "columns": ["node_user_id", "anchor_user_id"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "no_self_backbone_edge": {
+          "name": "no_self_backbone_edge",
+          "value": "\"users_graph_backbone_edges\".\"node_user_id\" <> \"users_graph_backbone_edges\".\"anchor_user_id\""
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.users_graph_nodes": {
+      "name": "users_graph_nodes",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "x": {
+          "name": "x",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "y": {
+          "name": "y",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "users_graph_nodes_user_id_users_id_fk": {
+          "name": "users_graph_nodes_user_id_users_id_fk",
+          "tableFrom": "users_graph_nodes",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users_node_profiles": {
+      "name": "users_node_profiles",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "color": {
+          "name": "color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'default'"
+        },
+        "style": {
+          "name": "style",
+          "type": "node_style",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'default'"
+        },
+        "signal_style": {
+          "name": "signal_style",
+          "type": "node_signal_style",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'default'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "users_node_profiles_user_id_users_id_fk": {
+          "name": "users_node_profiles_user_id_users_id_fk",
+          "tableFrom": "users_node_profiles",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.accounts": {
+      "name": "accounts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "issuer": {
+          "name": "issuer",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "accounts_issuer_accountId_uidx": {
+          "name": "accounts_issuer_accountId_uidx",
+          "columns": [
+            {
+              "expression": "issuer",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "accounts_userId_idx": {
+          "name": "accounts_userId_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "accounts_user_id_users_id_fk": {
+          "name": "accounts_user_id_users_id_fk",
+          "tableFrom": "accounts",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sessions": {
+      "name": "sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "sessions_userId_idx": {
+          "name": "sessions_userId_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "sessions_user_id_users_id_fk": {
+          "name": "sessions_user_id_users_id_fk",
+          "tableFrom": "sessions",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "sessions_token_unique": {
+          "name": "sessions_token_unique",
+          "nullsNotDistinct": false,
+          "columns": ["token"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "personalization_tier_earned": {
+          "name": "personalization_tier_earned",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "nullsNotDistinct": false,
+          "columns": ["email"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "personalization_tier_earned_range": {
+          "name": "personalization_tier_earned_range",
+          "value": "\"users\".\"personalization_tier_earned\" between 0 and 3"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.verifications": {
+      "name": "verifications",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "verifications_identifier_idx": {
+          "name": "verifications_identifier_idx",
+          "columns": [
+            {
+              "expression": "identifier",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.course_state": {
+      "name": "course_state",
+      "schema": "public",
+      "values": ["CANCELLED", "ESTABLISHED", "DEACTIVATED"]
+    },
+    "public.node_signal_style": {
+      "name": "node_signal_style",
+      "schema": "public",
+      "values": ["default"]
+    },
+    "public.node_style": {
+      "name": "node_style",
+      "schema": "public",
+      "values": ["default"]
+    },
+    "public.review_vote_type": {
+      "name": "review_vote_type",
+      "schema": "public",
+      "values": ["up", "down"]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/apps/web/server/db/drizzle/meta/_journal.json
+++ b/apps/web/server/db/drizzle/meta/_journal.json
@@ -61,7 +61,7 @@
     {
       "idx": 12,
       "version": "7",
-      "when": 1788477730000,
+      "when": 1788480553747,
       "tag": "0012_review_contract",
       "breakpoints": true
     }

--- a/apps/web/server/db/drizzle/meta/_journal.json
+++ b/apps/web/server/db/drizzle/meta/_journal.json
@@ -57,6 +57,13 @@
       "when": 1788477723351,
       "tag": "0011_saved_contract",
       "breakpoints": true
+    },
+    {
+      "idx": 12,
+      "version": "7",
+      "when": 1788477730000,
+      "tag": "0012_review_contract",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/web/server/db/schema.ts
+++ b/apps/web/server/db/schema.ts
@@ -19,6 +19,7 @@ import {
   vector,
 } from "drizzle-orm/pg-core";
 
+import type { ExaminationDistribution } from "@/types/review";
 import { users } from "./auth-schema";
 
 export * from "./auth-schema";
@@ -420,7 +421,7 @@ export type SelectUsersNodeProfile = typeof usersNodeProfiles.$inferSelect;
 
 // --- REVIEW / FORUM TABLES ----------------
 // table for reviews that references users (posters) and courses (reviewed)
-const reviewsTable = pgTable(
+export const reviews = pgTable(
   "reviews",
   {
     id: text("id").primaryKey(), // review id
@@ -434,25 +435,18 @@ const reviewsTable = pgTable(
         onUpdate: "no action",
       }), // foreign key to courses table
 
-    // scores
-    examinationMethods: integer("examination_methods").notNull().default(0), // 1-5
-    theoreticalVsApplied: integer("theoretical_vs_applied")
-      .notNull()
-      .default(0), // 1-5
-    workload: integer("workload").notNull().default(0), // 1-5
-    learningExperience: integer("learning_experience").notNull().default(0), // 1-5
-
-    wouldRecommend: boolean("would_recommend").notNull().default(false),
-    content: text("content").notNull(),
-
-    // Target fields coexist with the legacy fields until the review domain
-    // switches. Scores stay nullable during the expand phase because legacy
-    // zeroes do not represent valid target ratings.
-    examinationDistribution: jsonb("examination_distribution"),
+    // Self-reported recollection. Null is the stored answer for "I don't
+    // remember" — never a zero-filled distribution or a zero percentage.
+    examinationDistribution: jsonb(
+      "examination_distribution",
+    ).$type<ExaminationDistribution>(),
     approachTheoryPercent: integer("approach_theory_percent"),
-    workloadScore: integer("workload_score"),
-    learningScore: integer("learning_score"),
-    happyTook: boolean("happy_took").default(sql`NULL`).notNull(),
+
+    // Two separate axes, each 1-10. Neither is an overall verdict.
+    workloadScore: integer("workload_score").notNull(),
+    learningScore: integer("learning_score").notNull(),
+
+    happyTook: boolean("happy_took").notNull(),
     message: text("message"),
 
     // timestamps
@@ -475,31 +469,8 @@ const reviewsTable = pgTable(
   ],
 );
 
-type FullSelectReview = typeof reviewsTable.$inferSelect;
-type LegacyReviewKey =
-  | "id"
-  | "userId"
-  | "courseCode"
-  | "examinationMethods"
-  | "theoreticalVsApplied"
-  | "workload"
-  | "learningExperience"
-  | "wouldRecommend"
-  | "content"
-  | "createdAt"
-  | "updatedAt";
-
-// Temporary compatibility: current review services infer their read model from
-// this property. B removes the override when it switches to the target fields.
-export const reviews = reviewsTable as Omit<
-  typeof reviewsTable,
-  "$inferSelect"
-> & {
-  $inferSelect: Pick<FullSelectReview, LegacyReviewKey>;
-};
-
-export type InsertReview = typeof reviewsTable.$inferInsert;
-export type SelectReview = Pick<FullSelectReview, LegacyReviewKey>;
+export type InsertReview = typeof reviews.$inferInsert;
+export type SelectReview = typeof reviews.$inferSelect;
 
 export const reviewVotes = pgTable(
   "review_votes",
@@ -533,24 +504,6 @@ export const reviewVotes = pgTable(
 export type InsertReviewVote = typeof reviewVotes.$inferInsert;
 export type SelectReviewVote = typeof reviewVotes.$inferSelect;
 
-// junction table for tracking user likes/dislikes on reviews
-export const reviewLikes = pgTable(
-  "review_likes",
-  {
-    userId: text("user_id")
-      .notNull()
-      .references(() => users.id, { onDelete: "cascade" }),
-    reviewId: text("review_id")
-      .notNull()
-      .references(() => reviews.id, { onDelete: "cascade" }),
-    voteType: text("vote_type").notNull(), // "like" or "dislike"
-    createdAt: timestamp("created_at", { withTimezone: true })
-      .defaultNow()
-      .notNull(),
-  },
-  (table) => [primaryKey({ columns: [table.userId, table.reviewId] })],
-);
-
 // --- FEEDBACK / FORM TABLES ----------------
 export const feedback_form = pgTable("feedback_form", {
   id: text("id").primaryKey(),
@@ -566,5 +519,3 @@ export type InsertFeedbackForm = typeof feedback_form.$inferInsert;
 export type SelectFeedbackMessage = typeof feedback_form.$inferSelect;
 export type InsertUser = typeof users.$inferInsert;
 export type SelectUser = typeof users.$inferSelect;
-export type InsertReviewLike = typeof reviewLikes.$inferInsert;
-export type SelectReviewLike = typeof reviewLikes.$inferSelect;

--- a/apps/web/server/db/schema.ts
+++ b/apps/web/server/db/schema.ts
@@ -19,6 +19,10 @@ import {
   vector,
 } from "drizzle-orm/pg-core";
 
+// Type-only, and must stay type-only: `@/types/review` also defines the zod
+// schemas the router, service and review form share, and drizzle-kit loads
+// this file. TypeScript erases the import before drizzle-kit ever evaluates
+// that module, so no runtime dependency reaches the migration tooling.
 import type { ExaminationDistribution } from "@/types/review";
 import { users } from "./auth-schema";
 

--- a/apps/web/server/errors.ts
+++ b/apps/web/server/errors.ts
@@ -13,3 +13,12 @@ export class ForbiddenError extends Error {
     this.name = "ForbiddenError";
   }
 }
+
+/** A domain rule a service enforces beyond the router's input schema. */
+export class ValidationError extends Error {
+  readonly code = "BAD_REQUEST" as const;
+  constructor(message: string) {
+    super(message);
+    this.name = "ValidationError";
+  }
+}

--- a/apps/web/server/reviews/repository.ts
+++ b/apps/web/server/reviews/repository.ts
@@ -117,32 +117,24 @@ export async function findVote(
   return vote;
 }
 
-export async function insertVote(
-  reviewId: string,
-  voterUserId: string,
-  voteType: ReviewVoteType,
-) {
-  await db.insert(schema.reviewVotes).values({
-    voterUserId,
-    reviewId,
-    voteType,
-  });
-}
-
-export async function updateVote(
+/**
+ * Sets this voter's vote on this review, whether or not they had one. It is a
+ * single conflict-aware statement rather than a read then a write: two
+ * requests racing on a first vote (a double-click is enough) would otherwise
+ * have one of them rejected by the composite primary key.
+ */
+export async function upsertVote(
   reviewId: string,
   voterUserId: string,
   voteType: ReviewVoteType,
 ) {
   await db
-    .update(schema.reviewVotes)
-    .set({ voteType, updatedAt: sql`now()` })
-    .where(
-      and(
-        eq(schema.reviewVotes.reviewId, reviewId),
-        eq(schema.reviewVotes.voterUserId, voterUserId),
-      ),
-    );
+    .insert(schema.reviewVotes)
+    .values({ voterUserId, reviewId, voteType })
+    .onConflictDoUpdate({
+      target: [schema.reviewVotes.voterUserId, schema.reviewVotes.reviewId],
+      set: { voteType, updatedAt: sql`now()` },
+    });
 }
 
 export async function deleteVote(reviewId: string, voterUserId: string) {

--- a/apps/web/server/reviews/repository.ts
+++ b/apps/web/server/reviews/repository.ts
@@ -1,16 +1,25 @@
 import { and, eq, sql } from "drizzle-orm";
+import type { ExaminationDistribution, ReviewVoteType } from "@/types/review";
 import { db } from "../db";
 import * as schema from "../db/schema";
 
 export type ReviewRecord = typeof schema.reviews.$inferSelect;
 
+/** The reviewer-supplied half of a review; the rest is identity and clock. */
 export type ReviewWrite = {
-  examinationMethods: number;
-  theoreticalVsApplied: number;
-  workload: number;
-  learningExperience: number;
-  wouldRecommend: boolean;
-  content: string;
+  examinationDistribution: ExaminationDistribution | null;
+  approachTheoryPercent: number | null;
+  workloadScore: number;
+  learningScore: number;
+  happyTook: boolean;
+  message: string | null;
+};
+
+/** A review row joined with its vote tallies and the caller's own vote. */
+export type ReviewWithVotes = ReviewRecord & {
+  upvoteCount: number | string | null;
+  downvoteCount: number | string | null;
+  userVote: ReviewVoteType | null;
 };
 
 export async function insertReview(
@@ -20,43 +29,49 @@ export async function insertReview(
   return inserted;
 }
 
-export async function listReviews(courseCode?: string, userId?: string) {
+export async function listReviews(
+  courseCode?: string,
+  userId?: string,
+): Promise<ReviewWithVotes[]> {
   const baseQuery = db
     .select({
       id: schema.reviews.id,
       userId: schema.reviews.userId,
       courseCode: schema.reviews.courseCode,
-      examinationMethods: schema.reviews.examinationMethods,
-      theoreticalVsApplied: schema.reviews.theoreticalVsApplied,
-      workload: schema.reviews.workload,
-      learningExperience: schema.reviews.learningExperience,
-      wouldRecommend: schema.reviews.wouldRecommend,
-      content: schema.reviews.content,
+      examinationDistribution: schema.reviews.examinationDistribution,
+      approachTheoryPercent: schema.reviews.approachTheoryPercent,
+      workloadScore: schema.reviews.workloadScore,
+      learningScore: schema.reviews.learningScore,
+      happyTook: schema.reviews.happyTook,
+      message: schema.reviews.message,
       createdAt: schema.reviews.createdAt,
       updatedAt: schema.reviews.updatedAt,
-      likeCount: sql<number>`COALESCE(like_counts.like_count, 0)`,
-      userVote: schema.reviewLikes.voteType,
+      upvoteCount: sql<number>`COALESCE(vote_counts.upvote_count, 0)`,
+      downvoteCount: sql<number>`COALESCE(vote_counts.downvote_count, 0)`,
+      userVote: schema.reviewVotes.voteType,
     })
     .from(schema.reviews)
     .leftJoin(
       sql`(
-          SELECT review_id, COUNT(*) as like_count 
-          FROM ${schema.reviewLikes} 
-          WHERE vote_type = 'like' 
+          SELECT
+            review_id,
+            COUNT(*) FILTER (WHERE vote_type = 'up') AS upvote_count,
+            COUNT(*) FILTER (WHERE vote_type = 'down') AS downvote_count
+          FROM ${schema.reviewVotes}
           GROUP BY review_id
-        ) as like_counts`,
-      eq(schema.reviews.id, sql`like_counts.review_id`),
+        ) as vote_counts`,
+      eq(schema.reviews.id, sql`vote_counts.review_id`),
     )
     .leftJoin(
-      schema.reviewLikes,
+      schema.reviewVotes,
       userId
         ? and(
-            eq(schema.reviewLikes.reviewId, schema.reviews.id),
-            eq(schema.reviewLikes.userId, userId),
+            eq(schema.reviewVotes.reviewId, schema.reviews.id),
+            eq(schema.reviewVotes.voterUserId, userId),
           )
         : sql`false`,
     )
-    .orderBy(sql`created_at DESC`);
+    .orderBy(sql`${schema.reviews.createdAt} DESC`);
 
   return courseCode
     ? await baseQuery.where(eq(schema.reviews.courseCode, courseCode))
@@ -92,14 +107,17 @@ export async function deleteById(id: string) {
   return deleted;
 }
 
-export async function findVote(reviewId: string, userId: string) {
+export async function findVote(
+  reviewId: string,
+  voterUserId: string,
+): Promise<schema.SelectReviewVote | undefined> {
   const [vote] = await db
     .select()
-    .from(schema.reviewLikes)
+    .from(schema.reviewVotes)
     .where(
       and(
-        eq(schema.reviewLikes.reviewId, reviewId),
-        eq(schema.reviewLikes.userId, userId),
+        eq(schema.reviewVotes.reviewId, reviewId),
+        eq(schema.reviewVotes.voterUserId, voterUserId),
       ),
     )
     .limit(1);
@@ -108,11 +126,11 @@ export async function findVote(reviewId: string, userId: string) {
 
 export async function insertVote(
   reviewId: string,
-  userId: string,
-  voteType: "like" | "dislike",
+  voterUserId: string,
+  voteType: ReviewVoteType,
 ) {
-  await db.insert(schema.reviewLikes).values({
-    userId,
+  await db.insert(schema.reviewVotes).values({
+    voterUserId,
     reviewId,
     voteType,
   });
@@ -120,27 +138,27 @@ export async function insertVote(
 
 export async function updateVote(
   reviewId: string,
-  userId: string,
-  voteType: "like" | "dislike",
+  voterUserId: string,
+  voteType: ReviewVoteType,
 ) {
   await db
-    .update(schema.reviewLikes)
-    .set({ voteType })
+    .update(schema.reviewVotes)
+    .set({ voteType, updatedAt: sql`now()` })
     .where(
       and(
-        eq(schema.reviewLikes.reviewId, reviewId),
-        eq(schema.reviewLikes.userId, userId),
+        eq(schema.reviewVotes.reviewId, reviewId),
+        eq(schema.reviewVotes.voterUserId, voterUserId),
       ),
     );
 }
 
-export async function deleteVote(reviewId: string, userId: string) {
+export async function deleteVote(reviewId: string, voterUserId: string) {
   await db
-    .delete(schema.reviewLikes)
+    .delete(schema.reviewVotes)
     .where(
       and(
-        eq(schema.reviewLikes.reviewId, reviewId),
-        eq(schema.reviewLikes.userId, userId),
+        eq(schema.reviewVotes.reviewId, reviewId),
+        eq(schema.reviewVotes.voterUserId, voterUserId),
       ),
     );
 }

--- a/apps/web/server/reviews/repository.ts
+++ b/apps/web/server/reviews/repository.ts
@@ -1,19 +1,12 @@
 import { and, eq, sql } from "drizzle-orm";
-import type { ExaminationDistribution, ReviewVoteType } from "@/types/review";
+import type { ReviewInput, ReviewVoteType } from "@/types/review";
 import { db } from "../db";
 import * as schema from "../db/schema";
 
 export type ReviewRecord = typeof schema.reviews.$inferSelect;
 
 /** The reviewer-supplied half of a review; the rest is identity and clock. */
-export type ReviewWrite = {
-  examinationDistribution: ExaminationDistribution | null;
-  approachTheoryPercent: number | null;
-  workloadScore: number;
-  learningScore: number;
-  happyTook: boolean;
-  message: string | null;
-};
+export type ReviewWrite = ReviewInput;
 
 /** A review row joined with its vote tallies and the caller's own vote. */
 export type ReviewWithVotes = ReviewRecord & {

--- a/apps/web/server/reviews/router.ts
+++ b/apps/web/server/reviews/router.ts
@@ -13,13 +13,30 @@ import {
   updateReview,
 } from "./service";
 
+const percentage = z.number().int().min(0).max(100);
+
+/**
+ * `null` is the stored answer for "I don't remember"; the service rejects a
+ * distribution that does not add up to 100.
+ */
+const examinationDistribution = z
+  .object({
+    exam: percentage,
+    assignments: percentage,
+    labs: percentage,
+    projects: percentage,
+    seminars: percentage,
+    other: percentage,
+  })
+  .nullable();
+
 const reviewInput = z.object({
-  examinationMethods: z.number().int(),
-  theoreticalVsApplied: z.number().int(),
-  workload: z.number().int(),
-  learningExperience: z.number().int(),
-  wouldRecommend: z.boolean(),
-  content: z.string(),
+  examinationDistribution,
+  approachTheoryPercent: percentage.nullable(),
+  workloadScore: z.number().int(),
+  learningScore: z.number().int(),
+  happyTook: z.boolean(),
+  message: z.string().nullable(),
 });
 
 export const reviewsRouter = createTRPCRouter({
@@ -46,9 +63,14 @@ export const reviewsRouter = createTRPCRouter({
   delete: protectedProcedure
     .input(z.object({ id: z.string().min(1) }))
     .mutation(({ ctx, input }) => removeReview(input.id, ctx.session.user.id)),
-  like: protectedProcedure
-    .input(z.object({ id: z.string().min(1) }))
+  vote: protectedProcedure
+    .input(
+      z.object({
+        id: z.string().min(1),
+        voteType: z.enum(["up", "down"]),
+      }),
+    )
     .mutation(({ ctx, input }) =>
-      toggleVote(input.id, ctx.session.user.id, "like"),
+      toggleVote(input.id, ctx.session.user.id, input.voteType),
     ),
 });

--- a/apps/web/server/reviews/router.ts
+++ b/apps/web/server/reviews/router.ts
@@ -1,4 +1,5 @@
 import { z } from "zod";
+import { reviewInputSchema, reviewVoteTypeSchema } from "@/types";
 import {
   baseProcedure,
   createTRPCRouter,
@@ -13,32 +14,6 @@ import {
   updateReview,
 } from "./service";
 
-const percentage = z.number().int().min(0).max(100);
-
-/**
- * `null` is the stored answer for "I don't remember"; the service rejects a
- * distribution that does not add up to 100.
- */
-const examinationDistribution = z
-  .object({
-    exam: percentage,
-    assignments: percentage,
-    labs: percentage,
-    projects: percentage,
-    seminars: percentage,
-    other: percentage,
-  })
-  .nullable();
-
-const reviewInput = z.object({
-  examinationDistribution,
-  approachTheoryPercent: percentage.nullable(),
-  workloadScore: z.number().int(),
-  learningScore: z.number().int(),
-  happyTook: z.boolean(),
-  message: z.string().nullable(),
-});
-
 export const reviewsRouter = createTRPCRouter({
   list: baseProcedure
     .input(z.object({ courseCode: z.string().optional() }))
@@ -49,13 +24,13 @@ export const reviewsRouter = createTRPCRouter({
     .input(z.object({ id: z.string().min(1) }))
     .query(({ input }) => findOneReview(input.id)),
   create: protectedProcedure
-    .input(reviewInput.extend({ courseCode: z.string().min(1) }))
+    .input(reviewInputSchema.extend({ courseCode: z.string().min(1) }))
     .mutation(({ ctx, input }) => {
       const { courseCode, ...reviewData } = input;
       return createReview(courseCode, ctx.session.user.id, reviewData);
     }),
   update: protectedProcedure
-    .input(reviewInput.extend({ id: z.string().min(1) }))
+    .input(reviewInputSchema.extend({ id: z.string().min(1) }))
     .mutation(({ ctx, input }) => {
       const { id, ...reviewData } = input;
       return updateReview(id, ctx.session.user.id, reviewData);
@@ -67,7 +42,7 @@ export const reviewsRouter = createTRPCRouter({
     .input(
       z.object({
         id: z.string().min(1),
-        voteType: z.enum(["up", "down"]),
+        voteType: reviewVoteTypeSchema,
       }),
     )
     .mutation(({ ctx, input }) =>

--- a/apps/web/server/reviews/service.spec.ts
+++ b/apps/web/server/reviews/service.spec.ts
@@ -231,7 +231,7 @@ describe("reviews", () => {
 
     const result = await toggleVote("review-123", "voter-1", "up");
 
-    expect(reviewsRepo.insertVote).toHaveBeenCalledWith(
+    expect(reviewsRepo.upsertVote).toHaveBeenCalledWith(
       "review-123",
       "voter-1",
       "up",
@@ -250,7 +250,7 @@ describe("reviews", () => {
 
     const result = await toggleVote("review-123", "voter-1", "down");
 
-    expect(reviewsRepo.updateVote).toHaveBeenCalledWith(
+    expect(reviewsRepo.upsertVote).toHaveBeenCalledWith(
       "review-123",
       "voter-1",
       "down",
@@ -274,6 +274,33 @@ describe("reviews", () => {
       "voter-1",
     );
     expect(result).toEqual({ action: "removed", voteType: null });
+  });
+
+  it("two concurrent first votes both succeed", async () => {
+    // A double-click is enough to get two requests past the same `findVote`.
+    // A plain insert of the second would hit the composite primary key; the
+    // conflict-aware set must not.
+    const stored = new Map<string, string>();
+    const key = (reviewId: string, voterUserId: string) =>
+      `${voterUserId}:${reviewId}`;
+
+    vi.mocked(reviewsRepo.findVote).mockResolvedValue(undefined);
+    vi.mocked(reviewsRepo.upsertVote).mockImplementation(
+      async (reviewId, voterUserId, voteType) => {
+        stored.set(key(reviewId, voterUserId), voteType);
+      },
+    );
+
+    const results = await Promise.all([
+      toggleVote("review-123", "voter-1", "up"),
+      toggleVote("review-123", "voter-1", "up"),
+    ]);
+
+    expect(results).toEqual([
+      { action: "added", voteType: "up" },
+      { action: "added", voteType: "up" },
+    ]);
+    expect([...stored.values()]).toEqual(["up"]);
   });
 
   it("findAllReviews tallies upvotes and downvotes separately", async () => {

--- a/apps/web/server/reviews/service.spec.ts
+++ b/apps/web/server/reviews/service.spec.ts
@@ -1,7 +1,13 @@
-import { describe, expect, it, vi } from "vitest";
-import { ForbiddenError, NotFoundError } from "../errors";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { ForbiddenError, NotFoundError, ValidationError } from "../errors";
 import * as reviewsRepo from "./repository";
-import { findOneReview, updateReview } from "./service";
+import {
+  createReview,
+  findAllReviews,
+  findOneReview,
+  toggleVote,
+  updateReview,
+} from "./service";
 
 vi.mock("./repository");
 
@@ -9,17 +15,28 @@ const review = {
   id: "review-123",
   userId: "user-456",
   courseCode: "SF1625",
-  examinationMethods: 4,
-  theoreticalVsApplied: 5,
-  workload: 3,
-  learningExperience: 4,
-  wouldRecommend: true,
-  content: "Great course content!",
+  examinationDistribution: {
+    exam: 50,
+    assignments: 20,
+    labs: 10,
+    projects: 10,
+    seminars: 5,
+    other: 5,
+  },
+  approachTheoryPercent: 70,
+  workloadScore: 8,
+  learningScore: 9,
+  happyTook: true,
+  message: "Great course content!",
   createdAt: new Date("2023-01-01"),
   updatedAt: new Date("2023-01-01"),
 };
 
 describe("reviews", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
   it("findOneReview throws when missing", async () => {
     vi.mocked(reviewsRepo.findById).mockResolvedValue(undefined);
 
@@ -33,13 +50,248 @@ describe("reviews", () => {
 
     await expect(
       updateReview("review-123", "other-user", {
-        examinationMethods: 1,
-        theoreticalVsApplied: 1,
-        workload: 1,
-        learningExperience: 1,
-        wouldRecommend: false,
-        content: "nope",
+        examinationDistribution: null,
+        approachTheoryPercent: null,
+        workloadScore: 1,
+        learningScore: 1,
+        happyTook: false,
+        message: "nope",
       }),
     ).rejects.toBeInstanceOf(ForbiddenError);
+  });
+
+  it("createReview round-trips a review through the target columns only", async () => {
+    vi.mocked(reviewsRepo.insertReview).mockResolvedValue(review);
+
+    const created = await createReview("SF1625", "user-456", {
+      examinationDistribution: review.examinationDistribution,
+      approachTheoryPercent: 70,
+      workloadScore: 8,
+      learningScore: 9,
+      happyTook: true,
+      message: "Great course content!",
+    });
+
+    expect(
+      vi.mocked(reviewsRepo.insertReview).mock.calls[0]?.[0],
+    ).toMatchObject({
+      courseCode: "SF1625",
+      userId: "user-456",
+      examinationDistribution: review.examinationDistribution,
+      approachTheoryPercent: 70,
+      workloadScore: 8,
+      learningScore: 9,
+      happyTook: true,
+      message: "Great course content!",
+    });
+    expect(created).toEqual({
+      id: "review-123",
+      userId: "user-456",
+      courseCode: "SF1625",
+      examinationDistribution: review.examinationDistribution,
+      approachTheoryPercent: 70,
+      workloadScore: 8,
+      learningScore: 9,
+      happyTook: true,
+      message: "Great course content!",
+      createdAt: "2023-01-01T00:00:00.000Z",
+      updatedAt: "2023-01-01T00:00:00.000Z",
+      upvoteCount: 0,
+      downvoteCount: 0,
+      userVote: null,
+    });
+  });
+
+  it("createReview keeps an unremembered distribution and percent null", async () => {
+    const forgetful = {
+      ...review,
+      examinationDistribution: null,
+      approachTheoryPercent: null,
+    };
+    vi.mocked(reviewsRepo.insertReview).mockResolvedValue(forgetful);
+
+    const created = await createReview("SF1625", "user-456", {
+      examinationDistribution: null,
+      approachTheoryPercent: null,
+      workloadScore: 8,
+      learningScore: 9,
+      happyTook: true,
+      message: "Great course content!",
+    });
+
+    const written = vi.mocked(reviewsRepo.insertReview).mock.calls[0]?.[0];
+    expect(written?.examinationDistribution).toBeNull();
+    expect(written?.approachTheoryPercent).toBeNull();
+    expect(created.examinationDistribution).toBeNull();
+    expect(created.approachTheoryPercent).toBeNull();
+  });
+
+  it("updateReview keeps an unremembered distribution and percent null", async () => {
+    const forgetful = {
+      ...review,
+      examinationDistribution: null,
+      approachTheoryPercent: null,
+    };
+    vi.mocked(reviewsRepo.findById).mockResolvedValue(review);
+    vi.mocked(reviewsRepo.updateById).mockResolvedValue(forgetful);
+
+    const updated = await updateReview("review-123", "user-456", {
+      examinationDistribution: null,
+      approachTheoryPercent: null,
+      workloadScore: 3,
+      learningScore: 4,
+      happyTook: false,
+      message: null,
+    });
+
+    const written = vi.mocked(reviewsRepo.updateById).mock.calls[0]?.[1];
+    expect(written?.examinationDistribution).toBeNull();
+    expect(written?.approachTheoryPercent).toBeNull();
+    expect(updated.examinationDistribution).toBeNull();
+    expect(updated.approachTheoryPercent).toBeNull();
+  });
+
+  it("createReview rejects a zero-filled distribution", async () => {
+    await expect(
+      createReview("SF1625", "user-456", {
+        examinationDistribution: {
+          exam: 0,
+          assignments: 0,
+          labs: 0,
+          projects: 0,
+          seminars: 0,
+          other: 0,
+        },
+        approachTheoryPercent: 0,
+        workloadScore: 8,
+        learningScore: 9,
+        happyTook: true,
+        message: "Great course content!",
+      }),
+    ).rejects.toBeInstanceOf(ValidationError);
+    expect(reviewsRepo.insertReview).not.toHaveBeenCalled();
+  });
+
+  it("createReview rejects a distribution that does not add up to 100", async () => {
+    await expect(
+      createReview("SF1625", "user-456", {
+        examinationDistribution: {
+          ...review.examinationDistribution,
+          exam: 40,
+        },
+        approachTheoryPercent: null,
+        workloadScore: 8,
+        learningScore: 9,
+        happyTook: true,
+        message: null,
+      }),
+    ).rejects.toBeInstanceOf(ValidationError);
+    expect(reviewsRepo.insertReview).not.toHaveBeenCalled();
+  });
+
+  it.each([0, 11, 5.5])(
+    "createReview rejects %s as a score outside 1-10",
+    async (score) => {
+      await expect(
+        createReview("SF1625", "user-456", {
+          examinationDistribution: null,
+          approachTheoryPercent: null,
+          workloadScore: score,
+          learningScore: 9,
+          happyTook: true,
+          message: null,
+        }),
+      ).rejects.toBeInstanceOf(ValidationError);
+      expect(reviewsRepo.insertReview).not.toHaveBeenCalled();
+    },
+  );
+
+  it("createReview stores a blank message as null", async () => {
+    vi.mocked(reviewsRepo.insertReview).mockResolvedValue({
+      ...review,
+      message: null,
+    });
+
+    await createReview("SF1625", "user-456", {
+      examinationDistribution: null,
+      approachTheoryPercent: null,
+      workloadScore: 8,
+      learningScore: 9,
+      happyTook: true,
+      message: "   ",
+    });
+
+    expect(vi.mocked(reviewsRepo.insertReview).mock.calls[0]?.[0].message).toBe(
+      null,
+    );
+  });
+
+  it("toggleVote records an upvote when the reviewer has not voted", async () => {
+    vi.mocked(reviewsRepo.findVote).mockResolvedValue(undefined);
+
+    const result = await toggleVote("review-123", "voter-1", "up");
+
+    expect(reviewsRepo.insertVote).toHaveBeenCalledWith(
+      "review-123",
+      "voter-1",
+      "up",
+    );
+    expect(result).toEqual({ action: "added", voteType: "up" });
+  });
+
+  it("toggleVote flips an existing upvote to a downvote", async () => {
+    vi.mocked(reviewsRepo.findVote).mockResolvedValue({
+      voterUserId: "voter-1",
+      reviewId: "review-123",
+      voteType: "up",
+      createdAt: new Date("2023-01-01"),
+      updatedAt: new Date("2023-01-01"),
+    });
+
+    const result = await toggleVote("review-123", "voter-1", "down");
+
+    expect(reviewsRepo.updateVote).toHaveBeenCalledWith(
+      "review-123",
+      "voter-1",
+      "down",
+    );
+    expect(result).toEqual({ action: "updated", voteType: "down" });
+  });
+
+  it("toggleVote removes a vote repeated in the same direction", async () => {
+    vi.mocked(reviewsRepo.findVote).mockResolvedValue({
+      voterUserId: "voter-1",
+      reviewId: "review-123",
+      voteType: "down",
+      createdAt: new Date("2023-01-01"),
+      updatedAt: new Date("2023-01-01"),
+    });
+
+    const result = await toggleVote("review-123", "voter-1", "down");
+
+    expect(reviewsRepo.deleteVote).toHaveBeenCalledWith(
+      "review-123",
+      "voter-1",
+    );
+    expect(result).toEqual({ action: "removed", voteType: null });
+  });
+
+  it("findAllReviews tallies upvotes and downvotes separately", async () => {
+    vi.mocked(reviewsRepo.listReviews).mockResolvedValue([
+      {
+        ...review,
+        upvoteCount: "3",
+        downvoteCount: "1",
+        userVote: "down",
+      },
+    ]);
+
+    const [first] = await findAllReviews("SF1625", "voter-1");
+
+    expect(first).toMatchObject({
+      upvoteCount: 3,
+      downvoteCount: 1,
+      userVote: "down",
+    });
   });
 });

--- a/apps/web/server/reviews/service.ts
+++ b/apps/web/server/reviews/service.ts
@@ -107,6 +107,13 @@ export async function removeReview(id: string, userId: string) {
   return serializeReview(deleted);
 }
 
+/**
+ * Voting the same way twice takes the vote back; voting the other way flips
+ * it. The read only decides which of those the caller meant — the write itself
+ * is a set or a remove, both idempotent, so two racing requests agree instead
+ * of one of them failing on the composite key. `planned-database-formats.md`
+ * asks for exactly that: "idempotent set/remove operations".
+ */
 export async function toggleVote(
   reviewId: string,
   voterUserId: string,
@@ -114,17 +121,16 @@ export async function toggleVote(
 ) {
   const existingVote = await reviewsRepo.findVote(reviewId, voterUserId);
 
-  if (existingVote) {
-    if (existingVote.voteType === voteType) {
-      await reviewsRepo.deleteVote(reviewId, voterUserId);
-      return { action: "removed" as const, voteType: null };
-    }
-    await reviewsRepo.updateVote(reviewId, voterUserId, voteType);
-    return { action: "updated" as const, voteType };
+  if (existingVote?.voteType === voteType) {
+    await reviewsRepo.deleteVote(reviewId, voterUserId);
+    return { action: "removed" as const, voteType: null };
   }
 
-  await reviewsRepo.insertVote(reviewId, voterUserId, voteType);
-  return { action: "added" as const, voteType };
+  await reviewsRepo.upsertVote(reviewId, voterUserId, voteType);
+  return {
+    action: existingVote ? ("updated" as const) : ("added" as const),
+    voteType,
+  };
 }
 
 async function assertAuthor(reviewId: string, userId: string) {

--- a/apps/web/server/reviews/service.ts
+++ b/apps/web/server/reviews/service.ts
@@ -1,35 +1,103 @@
 import { nanoid } from "nanoid";
-import type { Review } from "@/types";
-import { ForbiddenError, NotFoundError } from "../errors";
+import type { ExaminationDistribution, Review, ReviewVoteType } from "@/types";
+import { EXAMINATION_DISTRIBUTION_KEYS } from "@/types";
+import { ForbiddenError, NotFoundError, ValidationError } from "../errors";
 import * as reviewsRepo from "./repository";
 
 export type ReviewInput = reviewsRepo.ReviewWrite;
+
+/** Both score axes are 1-10, matching the database check constraints. */
+const MIN_SCORE = 1;
+const MAX_SCORE = 10;
 
 function toIso(value: Date | string): string {
   return value instanceof Date ? value.toISOString() : value;
 }
 
 function serializeReview(
-  row: reviewsRepo.ReviewRecord & {
-    likeCount?: number | string | null;
-    userVote?: string | null;
-  },
+  row: reviewsRepo.ReviewRecord & Partial<reviewsRepo.ReviewWithVotes>,
 ): Review {
-  const userVote = row.userVote;
   return {
     id: row.id,
     userId: row.userId,
     courseCode: row.courseCode,
-    examinationMethods: row.examinationMethods,
-    theoreticalVsApplied: row.theoreticalVsApplied,
-    workload: row.workload,
-    learningExperience: row.learningExperience,
-    wouldRecommend: row.wouldRecommend,
-    content: row.content,
+    examinationDistribution: row.examinationDistribution ?? null,
+    approachTheoryPercent: row.approachTheoryPercent ?? null,
+    workloadScore: row.workloadScore,
+    learningScore: row.learningScore,
+    happyTook: row.happyTook,
+    message: row.message ?? null,
     createdAt: toIso(row.createdAt),
     updatedAt: toIso(row.updatedAt),
-    likeCount: Number(row.likeCount ?? 0),
-    userVote: userVote === "like" || userVote === "dislike" ? userVote : null,
+    upvoteCount: Number(row.upvoteCount ?? 0),
+    downvoteCount: Number(row.downvoteCount ?? 0),
+    userVote: row.userVote ?? null,
+  };
+}
+
+function assertScore(name: string, value: number) {
+  if (!Number.isInteger(value) || value < MIN_SCORE || value > MAX_SCORE) {
+    throw new ValidationError(
+      `${name} must be a whole number between ${MIN_SCORE} and ${MAX_SCORE}`,
+    );
+  }
+}
+
+/**
+ * A distribution the reviewer did supply must be complete and add up to 100.
+ * `null` is left alone: it is how "I don't remember" is stored, and turning it
+ * into zeroes would claim the reviewer answered.
+ */
+function assertExaminationDistribution(
+  distribution: ExaminationDistribution | null,
+) {
+  if (distribution === null) return;
+
+  let total = 0;
+  for (const key of EXAMINATION_DISTRIBUTION_KEYS) {
+    const share = distribution[key];
+    if (!Number.isInteger(share) || share < 0 || share > 100) {
+      throw new ValidationError(
+        `Examination distribution "${key}" must be a whole percentage between 0 and 100`,
+      );
+    }
+    total += share;
+  }
+  if (total !== 100) {
+    throw new ValidationError(
+      `Examination distribution must add up to 100, got ${total}`,
+    );
+  }
+}
+
+function assertApproachTheoryPercent(percent: number | null) {
+  if (percent === null) return;
+  if (!Number.isInteger(percent) || percent < 0 || percent > 100) {
+    throw new ValidationError(
+      "Approach theory percent must be a whole number between 0 and 100",
+    );
+  }
+}
+
+/**
+ * Normalizes what the form sends into what the target columns store. An
+ * unanswered recollection stays `null`; an empty message becomes `null` rather
+ * than an empty string.
+ */
+function validateReviewInput(input: ReviewInput): ReviewInput {
+  assertScore("Workload score", input.workloadScore);
+  assertScore("Learning score", input.learningScore);
+  assertExaminationDistribution(input.examinationDistribution);
+  assertApproachTheoryPercent(input.approachTheoryPercent);
+
+  const message = input.message?.trim();
+  return {
+    examinationDistribution: input.examinationDistribution,
+    approachTheoryPercent: input.approachTheoryPercent,
+    workloadScore: input.workloadScore,
+    learningScore: input.learningScore,
+    happyTook: input.happyTook,
+    message: message ? input.message : null,
   };
 }
 
@@ -42,7 +110,7 @@ export async function createReview(
     id: nanoid(),
     userId,
     courseCode,
-    ...reviewData,
+    ...validateReviewInput(reviewData),
   });
   return serializeReview(inserted);
 }
@@ -67,7 +135,10 @@ export async function updateReview(
   reviewData: ReviewInput,
 ) {
   await assertAuthor(id, userId);
-  const updated = await reviewsRepo.updateById(id, reviewData);
+  const updated = await reviewsRepo.updateById(
+    id,
+    validateReviewInput(reviewData),
+  );
   if (!updated) throw new NotFoundError(`Review with id ${id} not found`);
   return serializeReview(updated);
 }
@@ -81,21 +152,21 @@ export async function removeReview(id: string, userId: string) {
 
 export async function toggleVote(
   reviewId: string,
-  userId: string,
-  voteType: "like" | "dislike",
+  voterUserId: string,
+  voteType: ReviewVoteType,
 ) {
-  const existingVote = await reviewsRepo.findVote(reviewId, userId);
+  const existingVote = await reviewsRepo.findVote(reviewId, voterUserId);
 
   if (existingVote) {
     if (existingVote.voteType === voteType) {
-      await reviewsRepo.deleteVote(reviewId, userId);
+      await reviewsRepo.deleteVote(reviewId, voterUserId);
       return { action: "removed" as const, voteType: null };
     }
-    await reviewsRepo.updateVote(reviewId, userId, voteType);
+    await reviewsRepo.updateVote(reviewId, voterUserId, voteType);
     return { action: "updated" as const, voteType };
   }
 
-  await reviewsRepo.insertVote(reviewId, userId, voteType);
+  await reviewsRepo.insertVote(reviewId, voterUserId, voteType);
   return { action: "added" as const, voteType };
 }
 

--- a/apps/web/server/reviews/service.ts
+++ b/apps/web/server/reviews/service.ts
@@ -37,6 +37,12 @@ function serializeReview(
  * message to `null`. A `null` recollection is left alone: that is how "I don't
  * remember" is stored, and filling it with zeroes would claim an answer the
  * reviewer never gave.
+ *
+ * The router already fed the same `reviewInputSchema` to `.input()`, so over
+ * tRPC this parse is deliberately redundant. It stays because the service is
+ * the enforcement point `planned-database-formats.md` names, and because the
+ * service is called directly by tests and by any future caller that is not a
+ * tRPC procedure. One schema, checked twice — not two sources of truth.
  */
 function validateReviewInput(input: ReviewInput): ReviewInput {
   const parsed = reviewInputSchema.safeParse(input);

--- a/apps/web/server/reviews/service.ts
+++ b/apps/web/server/reviews/service.ts
@@ -1,14 +1,10 @@
 import { nanoid } from "nanoid";
-import type { ExaminationDistribution, Review, ReviewVoteType } from "@/types";
-import { EXAMINATION_DISTRIBUTION_KEYS } from "@/types";
+import type { Review, ReviewInput, ReviewVoteType } from "@/types";
+import { reviewInputSchema } from "@/types";
 import { ForbiddenError, NotFoundError, ValidationError } from "../errors";
 import * as reviewsRepo from "./repository";
 
-export type ReviewInput = reviewsRepo.ReviewWrite;
-
-/** Both score axes are 1-10, matching the database check constraints. */
-const MIN_SCORE = 1;
-const MAX_SCORE = 10;
+export type { ReviewInput };
 
 function toIso(value: Date | string): string {
   return value instanceof Date ? value.toISOString() : value;
@@ -35,69 +31,24 @@ function serializeReview(
   };
 }
 
-function assertScore(name: string, value: number) {
-  if (!Number.isInteger(value) || value < MIN_SCORE || value > MAX_SCORE) {
-    throw new ValidationError(
-      `${name} must be a whole number between ${MIN_SCORE} and ${MAX_SCORE}`,
-    );
-  }
-}
-
 /**
- * A distribution the reviewer did supply must be complete and add up to 100.
- * `null` is left alone: it is how "I don't remember" is stored, and turning it
- * into zeroes would claim the reviewer answered.
- */
-function assertExaminationDistribution(
-  distribution: ExaminationDistribution | null,
-) {
-  if (distribution === null) return;
-
-  let total = 0;
-  for (const key of EXAMINATION_DISTRIBUTION_KEYS) {
-    const share = distribution[key];
-    if (!Number.isInteger(share) || share < 0 || share > 100) {
-      throw new ValidationError(
-        `Examination distribution "${key}" must be a whole percentage between 0 and 100`,
-      );
-    }
-    total += share;
-  }
-  if (total !== 100) {
-    throw new ValidationError(
-      `Examination distribution must add up to 100, got ${total}`,
-    );
-  }
-}
-
-function assertApproachTheoryPercent(percent: number | null) {
-  if (percent === null) return;
-  if (!Number.isInteger(percent) || percent < 0 || percent > 100) {
-    throw new ValidationError(
-      "Approach theory percent must be a whole number between 0 and 100",
-    );
-  }
-}
-
-/**
- * Normalizes what the form sends into what the target columns store. An
- * unanswered recollection stays `null`; an empty message becomes `null` rather
- * than an empty string.
+ * The last gate before the target columns. It enforces the shared contract —
+ * 1-10 scores, a distribution that adds up to 100 — and normalizes a blank
+ * message to `null`. A `null` recollection is left alone: that is how "I don't
+ * remember" is stored, and filling it with zeroes would claim an answer the
+ * reviewer never gave.
  */
 function validateReviewInput(input: ReviewInput): ReviewInput {
-  assertScore("Workload score", input.workloadScore);
-  assertScore("Learning score", input.learningScore);
-  assertExaminationDistribution(input.examinationDistribution);
-  assertApproachTheoryPercent(input.approachTheoryPercent);
+  const parsed = reviewInputSchema.safeParse(input);
+  if (!parsed.success) {
+    throw new ValidationError(
+      parsed.error.issues[0]?.message ?? "Invalid review",
+    );
+  }
 
-  const message = input.message?.trim();
   return {
-    examinationDistribution: input.examinationDistribution,
-    approachTheoryPercent: input.approachTheoryPercent,
-    workloadScore: input.workloadScore,
-    learningScore: input.learningScore,
-    happyTook: input.happyTook,
-    message: message ? input.message : null,
+    ...parsed.data,
+    message: parsed.data.message?.trim() ? parsed.data.message : null,
   };
 }
 

--- a/apps/web/server/search/repository.ts
+++ b/apps/web/server/search/repository.ts
@@ -96,10 +96,15 @@ export async function searchByEmbedding(
   }));
 }
 
+/**
+ * The crude blended score behind the `minRating` filter. It used to average
+ * four legacy review columns; #75 dropped those, so it now averages the two
+ * surviving 1-10 axes. Real aggregation over the target columns is #67's.
+ */
 export async function averageRatings(codes: string[]) {
   const ratingRows = await db.execute(
     sql`SELECT course_code,
-            ROUND((AVG(examination_methods) + AVG(theoretical_vs_applied) + AVG(workload) + AVG(learning_experience))/4) AS rating
+            ROUND((AVG(workload_score) + AVG(learning_score))/2) AS rating
             FROM ${schema.reviews}
             WHERE ${inArray(schema.reviews.courseCode, codes)}
             GROUP BY course_code`,

--- a/apps/web/server/search/router.ts
+++ b/apps/web/server/search/router.ts
@@ -10,7 +10,9 @@ export const searchRouter = createTRPCRouter({
         page: z.number().int().positive().optional(),
         size: z.number().int().positive().optional(),
         department: z.string().optional(),
-        minRating: z.number().optional(),
+        // Stars, as the filter dropdown renders them. The service converts
+        // this to the 1-10 scale review scores are stored on.
+        minRating: z.number().int().min(1).max(5).optional(),
       }),
     )
     .query(async ({ input }) => {

--- a/apps/web/server/search/service.spec.ts
+++ b/apps/web/server/search/service.spec.ts
@@ -1,0 +1,73 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { CourseSummary } from "@/types";
+import { getSummariesByCodes } from "../course/service";
+import { averageRatings, searchByKeyword } from "./repository";
+import { searchCourses } from "./service";
+
+vi.mock("./repository");
+vi.mock("../course/service");
+vi.mock("../ai", () => ({
+  embedSingle: vi.fn().mockRejectedValue(new Error("no embeddings in tests")),
+}));
+
+function summary(courseCode: string): CourseSummary {
+  return {
+    courseCode,
+    titleEng: courseCode,
+    currentStatus: "ESTABLISHED",
+    credits: 7.5,
+    creditUnit: "hp",
+    department: "EECS",
+    startTerms: [20252],
+    examTypes: null,
+    languages: ["English"],
+    updatedAt: "2026-01-01T00:00:00.000Z",
+  };
+}
+
+describe("searchCourses minimum-rating filter", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(searchByKeyword).mockResolvedValue([
+      { courseCode: "SF1625", score: 1 },
+      { courseCode: "DD2421", score: 0.9 },
+    ]);
+    vi.mocked(getSummariesByCodes).mockImplementation(async (codes: string[]) =>
+      codes.map(summary),
+    );
+  });
+
+  it("reads the star filter on its 1-5 scale, not the stored 1-10 one", async () => {
+    // 4/10 stored is a poor course; a four-star filter must not return it.
+    vi.mocked(averageRatings).mockResolvedValue(
+      new Map([
+        ["SF1625", 4],
+        ["DD2421", 9],
+      ]),
+    );
+
+    const results = await searchCourses("maths", 10, { minRating: 4 });
+
+    expect(results.map((r) => r.courseCode)).toEqual(["DD2421"]);
+  });
+
+  it("keeps a course whose stored score clears the converted threshold", async () => {
+    vi.mocked(averageRatings).mockResolvedValue(
+      new Map([
+        ["SF1625", 6],
+        ["DD2421", 5],
+      ]),
+    );
+
+    const results = await searchCourses("maths", 10, { minRating: 3 });
+
+    expect(results.map((r) => r.courseCode)).toEqual(["SF1625"]);
+  });
+
+  it("does not filter when no minimum rating is asked for", async () => {
+    const results = await searchCourses("maths", 10);
+
+    expect(results.map((r) => r.courseCode)).toEqual(["SF1625", "DD2421"]);
+    expect(averageRatings).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/server/search/service.ts
+++ b/apps/web/server/search/service.ts
@@ -11,6 +11,14 @@ import {
 
 export type { SearchHit };
 
+/**
+ * The search filter asks for a minimum in stars, 1-5, because that is how the
+ * dropdown renders. Review scores are stored 1-10. Convert the threshold up
+ * rather than the averages down: the comparison then happens in the scale the
+ * columns actually use, and no rounding is invented on the way.
+ */
+const SCORE_POINTS_PER_STAR = 2;
+
 const embeddingCache = new Map<string, number[]>();
 const embeddingInflight = new Map<string, Promise<number[]>>();
 let embeddingSearchFailures = 0;
@@ -96,6 +104,7 @@ async function searchWithEmbedding(
 export async function searchCourses(
   query: string,
   size = 10,
+  /** `minRating` is in stars (1-5), not in stored score points (1-10). */
   filters?: { department?: string; minRating?: number },
 ): Promise<CourseSummary[]> {
   if (!query?.trim()) return [];
@@ -121,7 +130,8 @@ export async function searchCourses(
   const minRating = filters?.minRating;
   if (minRating) {
     const ratingByCode = await averageRatings(codes);
-    codes = codes.filter((c) => (ratingByCode.get(c) ?? 0) >= minRating);
+    const threshold = minRating * SCORE_POINTS_PER_STAR;
+    codes = codes.filter((c) => (ratingByCode.get(c) ?? 0) >= threshold);
   }
 
   codes = codes.slice(0, size);

--- a/apps/web/types/review.ts
+++ b/apps/web/types/review.ts
@@ -1,17 +1,4 @@
-/**
- * A reviewer's recollection of how assessment was split across a course, as
- * whole percentages that add up to 100. It is memory, not source data — see
- * `course_examinations` for what KOPPS reports. "I don't remember" is an
- * answer and is stored as `null`, never as a zero-filled distribution.
- */
-export interface ExaminationDistribution {
-  exam: number;
-  assignments: number;
-  labs: number;
-  projects: number;
-  seminars: number;
-  other: number;
-}
+import { z } from "zod";
 
 /** The keys of an examination distribution, in the order the form asks them. */
 export const EXAMINATION_DISTRIBUTION_KEYS = [
@@ -21,14 +8,14 @@ export const EXAMINATION_DISTRIBUTION_KEYS = [
   "projects",
   "seminars",
   "other",
-] as const satisfies readonly (keyof ExaminationDistribution)[];
+] as const;
 
 /**
  * Display names for the distribution keys. The broad labels come from the
  * examination-method taxonomy in `docs/schema_docs/planned-database-formats.md`.
  */
 export const EXAMINATION_DISTRIBUTION_LABELS: Record<
-  keyof ExaminationDistribution,
+  (typeof EXAMINATION_DISTRIBUTION_KEYS)[number],
   string
 > = {
   exam: "Exam",
@@ -39,22 +26,75 @@ export const EXAMINATION_DISTRIBUTION_LABELS: Record<
   other: "Other",
 };
 
+/**
+ * Both review score axes are 1-10. The range governs the database check
+ * constraints and service validation alike — see
+ * `docs/schema_docs/planned-database-formats.md`.
+ */
+export const MIN_REVIEW_SCORE = 1;
+export const MAX_REVIEW_SCORE = 10;
+
+export const reviewScoreSchema = z
+  .number()
+  .int()
+  .min(MIN_REVIEW_SCORE)
+  .max(MAX_REVIEW_SCORE);
+
+export const percentSchema = z.number().int().min(0).max(100);
+
+/**
+ * A reviewer's recollection of how assessment was split across a course, as
+ * whole percentages that add up to 100. It is memory, not source data — see
+ * `course_examinations` for what KOPPS reports. "I don't remember" is an
+ * answer and is stored as `null`, never as a zero-filled distribution.
+ */
+export const examinationDistributionSchema = z
+  .object({
+    exam: percentSchema,
+    assignments: percentSchema,
+    labs: percentSchema,
+    projects: percentSchema,
+    seminars: percentSchema,
+    other: percentSchema,
+  })
+  .refine(
+    (value) =>
+      EXAMINATION_DISTRIBUTION_KEYS.reduce(
+        (total, key) => total + value[key],
+        0,
+      ) === 100,
+    "Examination shares must add up to 100%.",
+  );
+
+export type ExaminationDistribution = z.infer<
+  typeof examinationDistributionSchema
+>;
+
+/** The reviewer-supplied half of a review; the rest is identity and clock. */
+export const reviewInputSchema = z.object({
+  /** `null` is the stored answer for "I don't remember". */
+  examinationDistribution: examinationDistributionSchema.nullable(),
+  /** `null` is the stored answer for "I don't remember". */
+  approachTheoryPercent: percentSchema.nullable(),
+  workloadScore: reviewScoreSchema,
+  learningScore: reviewScoreSchema,
+  happyTook: z.boolean(),
+  /** `null` when the reviewer wrote nothing, never an empty string. */
+  message: z.string().nullable(),
+});
+
+export type ReviewInput = z.infer<typeof reviewInputSchema>;
+
 /** An app user's judgement that a review was or was not worth reading. */
-export type ReviewVoteType = "up" | "down";
+export const reviewVoteTypeSchema = z.enum(["up", "down"]);
+
+export type ReviewVoteType = z.infer<typeof reviewVoteTypeSchema>;
 
 /** Review as exposed over the API (timestamps serialized as ISO strings). */
-export interface Review {
+export interface Review extends ReviewInput {
   id: string;
   userId: string;
   courseCode: string;
-  examinationDistribution: ExaminationDistribution | null;
-  approachTheoryPercent: number | null;
-  /** 1-10. */
-  workloadScore: number;
-  /** 1-10. */
-  learningScore: number;
-  happyTook: boolean;
-  message: string | null;
   createdAt: string;
   updatedAt: string;
   upvoteCount: number;

--- a/apps/web/types/review.ts
+++ b/apps/web/types/review.ts
@@ -1,16 +1,63 @@
+/**
+ * A reviewer's recollection of how assessment was split across a course, as
+ * whole percentages that add up to 100. It is memory, not source data — see
+ * `course_examinations` for what KOPPS reports. "I don't remember" is an
+ * answer and is stored as `null`, never as a zero-filled distribution.
+ */
+export interface ExaminationDistribution {
+  exam: number;
+  assignments: number;
+  labs: number;
+  projects: number;
+  seminars: number;
+  other: number;
+}
+
+/** The keys of an examination distribution, in the order the form asks them. */
+export const EXAMINATION_DISTRIBUTION_KEYS = [
+  "exam",
+  "assignments",
+  "labs",
+  "projects",
+  "seminars",
+  "other",
+] as const satisfies readonly (keyof ExaminationDistribution)[];
+
+/**
+ * Display names for the distribution keys. The broad labels come from the
+ * examination-method taxonomy in `docs/schema_docs/planned-database-formats.md`.
+ */
+export const EXAMINATION_DISTRIBUTION_LABELS: Record<
+  keyof ExaminationDistribution,
+  string
+> = {
+  exam: "Exam",
+  assignments: "Assignments",
+  labs: "Labs",
+  projects: "Projects",
+  seminars: "Seminars",
+  other: "Other",
+};
+
+/** An app user's judgement that a review was or was not worth reading. */
+export type ReviewVoteType = "up" | "down";
+
 /** Review as exposed over the API (timestamps serialized as ISO strings). */
 export interface Review {
   id: string;
   userId: string;
   courseCode: string;
-  examinationMethods: number;
-  theoreticalVsApplied: number;
-  workload: number;
-  learningExperience: number;
-  wouldRecommend: boolean;
-  content: string;
+  examinationDistribution: ExaminationDistribution | null;
+  approachTheoryPercent: number | null;
+  /** 1-10. */
+  workloadScore: number;
+  /** 1-10. */
+  learningScore: number;
+  happyTook: boolean;
+  message: string | null;
   createdAt: string;
   updatedAt: string;
-  likeCount?: number;
-  userVote?: "like" | "dislike" | null;
+  upvoteCount: number;
+  downvoteCount: number;
+  userVote: ReviewVoteType | null;
 }


### PR DESCRIPTION
Closes #75.

## Before merging

**#64 has merged (PR #79) and this branch is rebased on it.** The dependency that section used to describe is discharged:

- `0011_saved_contract` is #64's; `0012_review_contract` is this PR's. The journal's `idx` is now contiguous — the gap this branch was holding open is closed, and `0012`'s `when` is strictly after `0011`'s (drizzle-orm's migrator orders by that timestamp, so an earlier one would have applied `0012` first).
- `meta/0012_snapshot.json` is **regenerated on top of `0011`**. `bun run db:generate` reports "No schema changes, nothing to migrate", and the migration it would otherwise emit is the hand-written `0012` this PR already carries.

**Heads-up for whoever rebases #65 (PR #78) and #66 onto this:** this PR adds a `ValidationError` class to `apps/web/server/errors.ts` and two `instanceof` branches in `apps/web/server/api/trpc.ts`. The change is purely additive, but both files are shared across wave 1, so expect a small conflict there. Raised by #64's agent — see the ownership note further down.

**This migration has not been applied to any database.** No Neon connection was made. `0012_review_contract.sql`, its journal entry and `meta/0012_snapshot.json` are committed SQL only — please apply them to a Neon branch and run Schema Diff before merging.

## What this does

`reviews` holds 0 rows today, so the review half of the expand/contract migration lands with no data to convert. This PR takes that window.

**Write path.** `server/reviews/{router,service,repository}.ts`, `types/review.ts` and the tRPC input all use the target names: `examinationDistribution`, `approachTheoryPercent`, `workloadScore`, `learningScore`, `happyTook`, `message`. Nothing in the app reads or writes a legacy review column or `review_likes` any more.

**The two unwired columns now have a writer.** The review form collects an examination distribution (six whole percentages that must add up to 100) and an approach-theory percentage. Both offer "I don't remember", and that answer **stores `null`, never zeroes** — the invariant `CONTEXT.md` names, defended by tests at the service seam.

**Votes.** Reads and writes move from `review_likes` (`vote_type` text `"like"`/`"dislike"`) to `review_votes` (`voter_user_id`, `up`/`down` enum). Downvoting works again instead of showing "Dislike is temporarily unavailable". The list query tallies `upvoteCount` and `downvoteCount` separately.

A vote is an **idempotent set or remove**, as `planned-database-formats.md` asks. The read only decides which of those the caller meant; the write is a single `INSERT ... ON CONFLICT (voter_user_id, review_id) DO UPDATE` or a delete. Greptile caught the earlier read-then-insert losing a race on a first vote (a double-click was enough to make one request fail with a duplicate-key error after the vote had been saved); a test now races two first votes through a repository double that enforces the primary key the way Postgres does.

**Contract migration `0012_review_contract.sql`.** Drops `reviews_legacy_target_sync` + `sync_legacy_review_fields_to_target` and `review_likes_target_sync` + `sync_review_likes_to_votes`; sets `workload_score` and `learning_score` `NOT NULL`; drops `happy_took`'s temporary `DEFAULT NULL` (0009 added it only so the trigger could tell an omitted target value from an explicit one); drops the six legacy review columns; drops `review_likes`. A `DO $$` pre-flight aborts with a readable message if any row still lacks a target score, rather than letting `SET NOT NULL` fail opaquely. `review_likes` is dropped **without** `CASCADE` so an unexpected dependant aborts the migration instead of being dropped with it.

**Declared target restored.** `schema.ts` declares `workloadScore` / `learningScore` `.notNull()` again, matching `planned-schema-lucid.json`. `meta/0012_snapshot.json` reproduces the `reviews` entry exactly: 11 columns, correct nullability, all three check constraints.

**Scores stay 1–10.** No conversion, no scale parameter. The design's 1–5 is a rendering choice and belongs to #68.

## Please read: things outside this issue's stated file ownership

Two changes were necessary but fall outside `apps/web/server/reviews/**`:

1. **`server/search` — `averageRatings` and the star filter.** `averageRatings` computed `(AVG(examination_methods) + AVG(theoretical_vs_applied) + AVG(workload) + AVG(learning_experience)) / 4`. All four columns are dropped by `0012`, so leaving it would break search at runtime. It now averages the two surviving axes: `(AVG(workload_score) + AVG(learning_score)) / 2`.

   That moved the aggregate from the legacy 1–5 scale to the stored 1–10 one, while the "Minimum Rating" dropdown still sends **stars, 1–5**. Greptile caught the resulting bug (a four-star search returning courses averaging 4/10) and it is fixed: `searchCourses` converts the star threshold up to score points before comparing, so the comparison happens in the scale the columns actually use, and `search/router.ts` bounds `minRating` to 1–5 so the boundary says which scale it speaks. `server/search/service.spec.ts` covers it.

   **What it measures is still a two-axis blend rather than a four-axis one**, and it was already a dubious metric — it averages workload in, and `CONTEXT.md` is explicit that workload is *not* an overall verdict. I preserved its shape rather than redesign it, because aggregation is **#67**'s. #67 should decide what that filter ought to measure.

2. **`server/errors.ts` + `server/api/trpc.ts` — a new `ValidationError`.** The service needs a typed error for "distribution does not add up to 100" / "score out of 1–10" that maps to `BAD_REQUEST`. Both files are shared with the other wave-1 PRs; the change is purely additive (one class, two `instanceof` branches) but **#65 (PR #78) and #66 should expect a small conflict here when they rebase**. Flagged in "Before merging" above too.

## For #67

Your inputs are unchanged from the plan — `examination_distribution`, `approach_theory_percent`, `workload_score`, `learning_score`, `happy_took` keep exactly the names and shapes `planned-schema-lucid.json` specifies. One thing the plan left open that I had to settle:

**`examination_distribution` is a JSON object keyed `{exam, assignments, labs, projects, seminars, other}`, each a whole percentage 0–100, all six summing to exactly 100.** The keys are the broad examination-method labels from `planned-database-formats.md` ("Exam, Assignments, Labs, Projects, Seminars/participation, Other/unspecified"), so a reviewer's remembered mix is comparable to a classified `course_examinations` row. The shape is validated in the service, per that doc's "Validate the JSON shape and total in the service until a database-level JSON constraint is deliberately specified". If you want a different shape, say so before this merges — the table is empty, so it is free to change now and expensive later.

## For #65

`reviews.created_at` and `reviews_user_id_idx` are untouched, as agreed.

## Housekeeping

- The three stale "B" ownership pointers are corrected. `0006` and `0009` now name #75 (and `0009` names #64 for `user_favorites_target_sync` and the unfiled courses/`course_explore` switch for the third trigger). **Comments only — no executable line in an already-applied migration was touched.** The `schema.ts:513` pointer is gone entirely: the temporary `$inferSelect` override it described no longer exists.
- The five review `_Today_` lines are deleted from `CONTEXT.md` (Upvote/Downvote, Happy took, Workload/Learning score, Examination distribution, Approach theory percent). No others.
- Reviews stay readable by visitors: `list` and `byId` are `baseProcedure`; `create`, `update`, `delete` and `vote` are `protectedProcedure` and take the user from `ctx.session`, never from input.

## Hands off to #77

`courses` → `course_explore` is now filed as **#77** ("H: Move search and ingest onto course_explore, then contract the courses table"). `courses.name`, `embedding`, `search_vector` and `embedding_hash` remain live and synced by `courses_explore_target_sync`, which #77 drops.

**#77 inherits the `server/search/**` changes in this PR** — the rewritten `averageRatings` and the star-to-score threshold conversion — so it should rebase on this before moving search onto `course_explore`.

## Tests

`server/reviews/service.spec.ts` drives the seam with the repository mocked, never the database. It covers a review round-tripping through target columns only, `null` `examinationDistribution` / `approachTheoryPercent` surviving as `null` on both create and update, a zero-filled distribution being rejected, a distribution that does not total 100 being rejected, scores outside 1–10 being rejected, a blank message stored as `null`, votes mapping to `up` / `down` (add, flip, and remove-on-repeat), and two concurrent first votes both succeeding. `server/api/protected.spec.ts` gains a visitor check on `reviews.vote`, and `server/search/service.spec.ts` is new (see the star-scale fix above).

Gates: `bun run test:web` (90 passed, this PR's and #64's together), `npx tsc --noEmit`, `bun run lint` all pass. The 12 lint warnings are pre-existing `noImgElement` warnings in `Topbar.tsx` / `app-sidebar.tsx`, untouched by this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01D3d7V2JceJZvtJED18HXFJ
