### PR TITLE
F0: mirror the Claude Design project and extract the card fixtures

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -20,3 +20,8 @@
 # Lockfiles are generated; keep them out of diffs.
 bun.lock          -diff linguist-generated
 package-lock.json -diff linguist-generated
+
+# A read-only mirror of the Claude Design project. Never reformat it and keep it
+# out of diffs: lefthook runs `biome check --write` on staged files, which
+# silently rewrote support.js once already.
+docs/design/** -diff linguist-generated

--- a/.gitattributes
+++ b/.gitattributes
@@ -25,3 +25,7 @@ package-lock.json -diff linguist-generated
 # out of diffs: lefthook runs `biome check --write` on staged files, which
 # silently rewrote support.js once already.
 docs/design/** -diff linguist-generated
+
+# ...except the README, which is ours rather than mirrored and has to stay
+# readable in diffs and reviews.
+docs/design/README.md diff -linguist-generated

--- a/apps/web/app/globals.css
+++ b/apps/web/app/globals.css
@@ -66,6 +66,11 @@
   --color-cc-btn: var(--cc-btn);
   --color-cc-btn-fg: var(--cc-btn-fg);
   --color-cc-info: var(--cc-info);
+  --color-cc-warn: var(--cc-warn);
+  --color-cc-warn-border: var(--cc-warn-border);
+  --color-cc-warn-ink: var(--cc-warn-ink);
+  --color-cc-warn-btn: var(--cc-warn-btn);
+  --color-cc-warn-btn-fg: var(--cc-warn-btn-fg);
 }
 
 :root {
@@ -110,7 +115,9 @@
      pill chips and tracks  rail the sidebar (brand blue in both themes)
      ink primary text  ink2 secondary  muted supporting  dim/dim2 labels and hints
      chip-ink text on a pill  rule/2/3 hairline, border, strong border
-     hov hover border  brand links and brand text  btn/btn-fg filled button */
+     hov hover border  brand links and brand text  btn/btn-fg filled button
+     warn/warn-border/warn-ink the nudge to write a review, and
+     warn-btn/warn-btn-fg its call to action — amber in dark, blue in light */
   --cc-pg: #faf8f1;
   --cc-surface: #ffffff;
   --cc-inset: #faf8f1;
@@ -130,6 +137,11 @@
   --cc-btn: #1751a6;
   --cc-btn-fg: #ffffff;
   --cc-info: rgba(23, 81, 166, 0.07);
+  --cc-warn: #fdf7ea;
+  --cc-warn-border: #f0e6d2;
+  --cc-warn-ink: #7a5309;
+  --cc-warn-btn: #1751a6;
+  --cc-warn-btn-fg: #ffffff;
 }
 
 .dark {
@@ -188,6 +200,13 @@
   --cc-btn: #f4eee2;
   --cc-btn-fg: #1751a6;
   --cc-info: rgba(226, 236, 251, 0.1);
+  /* The warn button is amber here where light is blue. That hue change is the
+     design's, not a mistake: on the dark blue surface a blue button vanishes. */
+  --cc-warn: rgba(223, 165, 60, 0.16);
+  --cc-warn-border: rgba(223, 165, 60, 0.3);
+  --cc-warn-ink: #f2c879;
+  --cc-warn-btn: #dfa53c;
+  --cc-warn-btn-fg: #1a1305;
 }
 
 @layer base {

--- a/apps/web/data/course-card-sample.ts
+++ b/apps/web/data/course-card-sample.ts
@@ -1,0 +1,245 @@
+/**
+ * Course card fixtures, extracted from the design.
+ *
+ * Source: `docs/design/Course Community - Course Card.dc.html` — the
+ * `SAMPLE_GEO` / `SAMPLE_COURSE` literals in its trailing
+ * `<script type="text/x-dc">` block, and that tag's `data-props` attribute,
+ * which names `c: CourseCardModel` and `geo: CardGeometry`.
+ *
+ * **Regenerate from the artboard; do not hand-edit.** Values are copied
+ * verbatim so a card built against this shape needs no reshaping when the real
+ * aggregation lands. Nothing here is invented, renamed or tidied — including
+ * the things that are plainly wrong (see "Known divergences" below).
+ *
+ * These are fixtures, not data. The card takes typed props and the *screen*
+ * maps tRPC output onto them, so a server change touches one mapping function
+ * rather than the card.
+ *
+ * ## Known divergences from the schema — do not "fix" them here
+ *
+ * - `workload: "3.8"` / `learning: "4.2"` are on the artboard's 1–5 scale.
+ *   Scores are **1–10 displayed raw** (issue #68); a 7.6 renders `"7.6"` and
+ *   the bar width is `value / 10`, which is the same width the artboard draws.
+ * - `comparisons` / `hasComparisons` are the design's word for **collections**.
+ *   Code says `Collection` everywhere; the fixture keeps the artboard's name
+ *   because fidelity is the point of this file.
+ * - `keywords` and `summary` have no schema backing at all. The card renders
+ *   their headers with empty sections until a writer exists (issue #68).
+ * - `prereqCourses` entries carry `inCatalog` in the sample but the markup
+ *   reads `taken`. Prerequisite ticks are display-only and never cascade.
+ *
+ * `apps/web/data/courseCardMockData.ts` is the older, unrelated mock that
+ * existing components still use. This file does not replace it.
+ */
+
+/** One prerequisite chip. */
+export interface PrerequisiteCourse {
+  code: string;
+  name: string;
+  /** Whether the prerequisite is itself a course we hold. */
+  inCatalog: boolean;
+  /**
+   * The artboard markup reads these; the sample literal does not set them.
+   * `taken` draws the checkmark — display-only, never inferred.
+   */
+  taken?: boolean;
+  gap?: string;
+  padding?: string;
+  radius?: string;
+  bg?: string;
+}
+
+/** One row of the collection picker. The artboard calls it a comparison. */
+export interface CourseCardComparison {
+  name: string;
+  /** SVG `fill` for the checkbox glyph. */
+  fill: string;
+  /** SVG `path` `d` for the checkbox tick. */
+  tick: string;
+  onClick?: () => void;
+}
+
+/**
+ * The card's `c` prop. `data-props` types it `CourseCardModel`.
+ *
+ * Presentation is precomputed by the parent: the model carries strings and
+ * booleans, not numbers to format or conditions to evaluate. `hasX` / `noX`
+ * pairs are the artboard's two `sc-if` branches and are not complements —
+ * both may be false while a third state renders.
+ */
+export interface CourseCardModel {
+  title: string;
+  /** Credits, department and level, already joined for display. */
+  meta: string;
+  /** Comma-separated; the card chips the first two and counts the rest. */
+  keywords: string;
+  /** Comma-separated prerequisite codes, already joined for display. */
+  prereq: string;
+  prereqCourses: PrerequisiteCourse[];
+  hasPrereq: boolean;
+  noPrereq: boolean;
+  summary: string;
+  /** The summary as the card shows it, clipped to `geo.summaryMax`. */
+  summaryClipped: string;
+  hasStats: boolean;
+  noStats: boolean;
+  /** Top examination contributors, e.g. `"Labs 60% · Exam 40%"`. */
+  examLabel: string;
+  /** Mean workload, preformatted. */
+  workload: string;
+  /** Mean learning, preformatted. */
+  learning: string;
+  /** Workload bar width, as a CSS percentage. */
+  wlW: string;
+  /** Learning bar width, as a CSS percentage. */
+  leW: string;
+  /** Share of reviewers glad they took the course, as a CSS percentage. */
+  happyPct: string;
+  hasReviewStats: boolean;
+  noReviewStats: boolean;
+  /** Taken count, abbreviated for display. */
+  statTaken: string;
+  /** Review count, as a string. */
+  statReviews: string;
+
+  // Per-instance colours the parent resolves. Components style against the
+  // `--cc-*` tokens; these exist because the artboard has no token for a
+  // value that changes with card state.
+  borderColor: string;
+  takenTitle: string;
+  takenCountFg: string;
+  takenBg: string;
+  takenFill: string;
+  takenStroke: string;
+  saveLabel: string;
+  saveFg: string;
+  saveBg: string;
+  saveBorder: string;
+  saveFill: string;
+
+  pickerOpen: boolean;
+  creating: boolean;
+  notCreating: boolean;
+  hasComparisons: boolean;
+  comparisons: CourseCardComparison[];
+
+  // Referenced by the artboard markup but absent from the sample literal.
+  /** Hover fill for the taken pill. */
+  takenHoverBg?: string;
+  /** Whether the guest sign-up prompt over the taken pill is open. */
+  takenPickerOpen?: boolean;
+  /** Accessible name for the picker trigger in the `"add"` action. */
+  addLabel?: string;
+  /** Accessible name and tooltip for the remove button. */
+  removeLabel?: string;
+  onOpen?: () => void;
+  onTaken?: () => void;
+  onReview?: () => void;
+  onSave?: () => void;
+  onPicker?: () => void;
+  onNewComparison?: () => void;
+  onRemove?: () => void;
+  onSignUp?: () => void;
+  onLogIn?: () => void;
+}
+
+/**
+ * The card's `geo` prop. `data-props` types it `CardGeometry`.
+ *
+ * Geometry arrives as one object so the **parent** owns the collapse ramp:
+ * Explore interpolates it from the results column width, Saved pins it to the
+ * fully collapsed end. Every value is a CSS string the card drops straight
+ * into a style, which is why widths and paddings are not numbers.
+ */
+export interface CardGeometry {
+  /** CSS `transition` shorthand, or `"none"` while dragging the ramp. */
+  tween: string;
+  titleSize: string;
+  cardGap: string;
+  cardPad: string;
+  factsGap: string;
+  reviewPad: string;
+  labelMax: string;
+  labelOpacity: number;
+  saveW: string;
+  savePad: string;
+  railW: string;
+  railPad: string;
+  summaryMax: string;
+  summaryOpacity: number;
+  reviewFlex: string;
+  saveFlex: string;
+  showLabel: boolean;
+  cardHeight: string;
+}
+
+/** The fully expanded end of the collapse ramp. */
+export const SAMPLE_GEO: CardGeometry = {
+  tween: "none",
+  titleSize: "17px",
+  cardGap: "10px",
+  cardPad: "18px",
+  factsGap: "14px",
+  reviewPad: "0 12px",
+  labelMax: "120px",
+  labelOpacity: 1,
+  saveW: "126px",
+  savePad: "12px",
+  railW: "224px",
+  railPad: "18px 16px",
+  summaryMax: "38px",
+  summaryOpacity: 1,
+  reviewFlex: "0 1 132px",
+  saveFlex: "0 1 158px",
+  showLabel: true,
+  cardHeight: "236px",
+};
+
+/**
+ * Stand-in course used only when the artboard is opened on its own, so the
+ * preview matches what Explore and Saved courses render.
+ */
+export const SAMPLE_COURSE: CourseCardModel = {
+  title: "DD2380 Artificial Intelligence",
+  meta: "6.0 credits · EECS · Advanced",
+  keywords: "search, planning, probabilistic reasoning, agents",
+  prereq: "DD1337, SF1918",
+  prereqCourses: [
+    { code: "DD1337", name: "Programming", inCatalog: true },
+    { code: "SF1918", name: "Probability and Statistics", inCatalog: true },
+  ],
+  hasPrereq: true,
+  noPrereq: false,
+  summary:
+    "A broad first course in AI: search, planning and reasoning under uncertainty, taught through three programming labs.",
+  summaryClipped:
+    "A broad first course in AI: search, planning and reasoning under uncertainty, taught through three programming labs.",
+  hasStats: true,
+  noStats: false,
+  examLabel: "Labs 60% · Exam 40%",
+  workload: "3.8",
+  learning: "4.2",
+  wlW: "76%",
+  leW: "84%",
+  happyPct: "87%",
+  hasReviewStats: true,
+  noReviewStats: false,
+  statTaken: "1.2k",
+  statReviews: "148",
+  borderColor: "#e5e0d2",
+  takenTitle: "1.2k students have taken this course · click to mark as taken",
+  takenCountFg: "#5c6570",
+  takenBg: "transparent",
+  takenFill: "none",
+  takenStroke: "#8a857a",
+  saveLabel: "Save course",
+  saveFg: "#1751a6",
+  saveBg: "#fff",
+  saveBorder: "#ddd8c9",
+  saveFill: "none",
+  pickerOpen: false,
+  creating: false,
+  notCreating: true,
+  hasComparisons: false,
+  comparisons: [],
+};

--- a/apps/web/data/course-card-sample.ts
+++ b/apps/web/data/course-card-sample.ts
@@ -20,11 +20,18 @@
  * - `workload: "3.8"` / `learning: "4.2"` are on the artboard's 1–5 scale.
  *   Scores are **1–10 displayed raw** (issue #68); a 7.6 renders `"7.6"` and
  *   the bar width is `value / 10`, which is the same width the artboard draws.
- * - `comparisons` / `hasComparisons` are the design's word for **collections**.
- *   Code says `Collection` everywhere; the fixture keeps the artboard's name
- *   because fidelity is the point of this file.
- * - `keywords` and `summary` have no schema backing at all. The card renders
- *   their headers with empty sections until a writer exists (issue #68).
+ * - `comparisons`, `hasComparisons` and `onNewComparison` are the design's word
+ *   for **collections**. `CONTEXT.md` bans "comparison" in identifiers and #68
+ *   settles the concept as Collection, so the card and everything downstream of
+ *   it say `Collection`; these three field names are the one place that word
+ *   survives, because #97 requires this file to quote the artboard verbatim.
+ *   Every identifier this file coins itself — `CollectionPickerRow` — follows
+ *   the glossary instead.
+ * - `summary` is `courses.content` in the design's own store, so it does have a
+ *   column behind it. `keywords` does not: the store reads a `searchTerms`
+ *   field on `course_explore` that the table has no column for, and nothing in
+ *   `server/` writes one. Until that is settled the card renders the header
+ *   with an empty section (issue #68).
  * - `prereqCourses` entries carry `inCatalog` in the sample but the markup
  *   reads `taken`. Prerequisite ticks are display-only and never cascade.
  *
@@ -39,18 +46,31 @@ export interface PrerequisiteCourse {
   /** Whether the prerequisite is itself a course we hold. */
   inCatalog: boolean;
   /**
-   * The artboard markup reads these; the sample literal does not set them.
-   * `taken` draws the checkmark — display-only, never inferred.
+   * Whether the viewer has separately marked this course taken, which draws
+   * the chip's checkmark. Display-only: marking a course taken never cascades
+   * into its prerequisites (#68).
+   *
+   * The artboard markup reads this; the sample literal does not set it.
    */
   taken?: boolean;
+  /**
+   * Per-chip metrics the parent interpolates alongside `geo`, so the chips
+   * shrink with the card. Markup-only, like `taken`.
+   */
   gap?: string;
   padding?: string;
   radius?: string;
   bg?: string;
 }
 
-/** One row of the collection picker. The artboard calls it a comparison. */
-export interface CourseCardComparison {
+/**
+ * One row of the collection picker.
+ *
+ * The artboard's own field is `c.comparisons`, kept verbatim below. This type
+ * is not the artboard's, so it takes the glossary's word: `CONTEXT.md` bans
+ * "comparison" in identifiers and #68 settles the concept as **Collection**.
+ */
+export interface CollectionPickerRow {
   name: string;
   /** SVG `fill` for the checkbox glyph. */
   fill: string;
@@ -121,7 +141,7 @@ export interface CourseCardModel {
   creating: boolean;
   notCreating: boolean;
   hasComparisons: boolean;
-  comparisons: CourseCardComparison[];
+  comparisons: CollectionPickerRow[];
 
   // Referenced by the artboard markup but absent from the sample literal.
   /** Hover fill for the taken pill. */

--- a/apps/web/data/course-card-sample.ts
+++ b/apps/web/data/course-card-sample.ts
@@ -122,9 +122,11 @@ export interface CourseCardModel {
   /** Review count, as a string. */
   statReviews: string;
 
-  // Per-instance colours the parent resolves. Components style against the
-  // `--cc-*` tokens; these exist because the artboard has no token for a
-  // value that changes with card state.
+  // Per-instance presentation the parent resolves: colours that change with
+  // card state, plus the taken pill's tooltip. Components style against the
+  // `--cc-*` tokens; these fields exist because the artboard has no token for
+  // a value that varies per card. Order is the artboard's, so the tooltip
+  // sits among the colours.
   borderColor: string;
   takenTitle: string;
   takenCountFg: string;

--- a/biome.json
+++ b/biome.json
@@ -14,7 +14,8 @@
       "!dist",
       "!build",
       "!migrations",
-      "!drizzle"
+      "!drizzle",
+      "!docs/design"
     ]
   },
   "formatter": {

--- a/docs/design/Course Community - About.dc.html
+++ b/docs/design/Course Community - About.dc.html
@@ -1,0 +1,125 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<script src="./support.js"></script>
+</head>
+<body>
+<x-dc>
+<helmet data-dc-atomics><link rel="preconnect" href="https://fonts.googleapis.com"><link rel="preconnect" href="https://fonts.gstatic.com" crossorigin><link href="https://fonts.googleapis.com/css2?family=Geist:wght@400;500;600;700&family=Geist+Mono:wght@400;500&display=swap" rel="stylesheet"><link rel="stylesheet" href="cc-theme.css"><style>body{background:var(--pg);color:var(--ink)}html,body{margin:0;height:100%;background:var(--pg);font-family:Geist,system-ui,sans-serif;color:var(--ink)}a{color:#1751a6}a:hover{color:#10386f}*{box-sizing:border-box}input,button,textarea{font-family:Geist,system-ui,sans-serif}@keyframes rise{from{opacity:0;transform:translateY(6px)}to{opacity:1;transform:none}}</style></helmet>
+
+<div style="position:relative;display:flex;height:900px;background:var(--pg);color:var(--ink);font-size:14px">
+<div style="position:absolute;top:0;left:0;right:0;height:66px;z-index:1;box-sizing:border-box;display:flex;align-items:center;justify-content:flex-end;gap:8px;padding:0 28px;border-bottom:1px solid var(--rule);background:var(--pg)">
+<div onClick="{{ onTheme }}" role="button" tabIndex="0" title="{{ themeTitle }}" aria-label="{{ themeTitle }}" style="width:34px;height:34px;display:flex;align-items:center;justify-content:center;border-radius:8px;color:var(--chipInk);cursor:pointer" style-hover="background:rgba(125,145,175,.14)">
+<sc-if value="{{ notNight }}" hint-placeholder-val="{{ true }}"><svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><path d="M20.5 14.5A8.5 8.5 0 1 1 9.5 3.5a7 7 0 0 0 11 11z"></path></svg></sc-if>
+<sc-if value="{{ night }}" hint-placeholder-val="{{ false }}"><svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round"><circle cx="12" cy="12" r="4.2"></circle><path d="M12 3v2M12 19v2M3 12h2M19 12h2M5.6 5.6l1.4 1.4M17 17l1.4 1.4M18.4 5.6 17 7M7 17l-1.4 1.4"></path></svg></sc-if>
+</div>
+</div>
+
+<div style="position:relative;z-index:2;box-sizing:border-box;width:236px;flex:none;display:flex;flex-direction:column;gap:6px;padding:14px 10px;background:#1751a6;color:#fff">
+<a href="Course Community - Landing.dc.html" style="display:flex;align-items:center;gap:10px;padding:6px 8px 14px;color:#fff;text-decoration:none">
+<img src="assets/ais-symbol-white.png" alt="KTH AI Society" style="height:34px;width:34px;object-fit:contain">
+<div style="width:1px;height:28px;background:rgba(255,255,255,.35)"></div>
+<div style="font-size:15px;font-weight:600;line-height:1.15">Course<br>Community</div>
+</a>
+<div style="display:flex;flex-direction:column;gap:2px;margin-top:14px">
+<a href="Course Community - Explore.dc.html" style="display:flex;align-items:center;gap:10px;padding:9px 10px;border-radius:8px;background:transparent;font-weight:400;color:#fff;text-decoration:none" style-hover="background:rgba(255,255,255,.1)"><svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="#fff" stroke-width="2.4" stroke-linecap="round"><circle cx="11" cy="11" r="7"></circle><line x1="16.5" y1="16.5" x2="21" y2="21"></line></svg><span style="flex:1">Explore</span></a>
+<a href="Course Community - Saved.dc.html" style="display:flex;align-items:center;gap:10px;padding:9px 10px;border-radius:8px;background:transparent;font-weight:400;color:#fff;text-decoration:none" style-hover="background:rgba(255,255,255,.1)"><svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="#fff" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="m19 21-7-4-7 4V5a2 2 0 0 1 2-2h10a2 2 0 0 1 2 2z"></path></svg><span style="flex:1">Saved courses</span></a>
+<a href="Course Community - My Page.dc.html" style="display:flex;align-items:center;gap:10px;padding:9px 10px;border-radius:8px;background:transparent;font-weight:400;color:#fff;text-decoration:none" style-hover="background:rgba(255,255,255,.1)"><svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="#fff" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="8" r="4"></circle><path d="M5.5 21a6.5 6.5 0 0 1 13 0"></path></svg><span style="flex:1">My Page</span></a>
+<a href="Course Community - Taken Courses.dc.html" style="display:flex;align-items:center;gap:10px;padding:9px 10px;border-radius:8px;background:transparent;font-weight:400;color:#fff;text-decoration:none" style-hover="background:rgba(255,255,255,.1)"><svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="#fff" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="10"></circle><path d="m9 12 2 2 4-4"></path></svg><span style="flex:1">Taken courses</span></a>
+</div>
+<div style="margin-top:auto;display:flex;flex-direction:column;gap:2px">
+<div style="display:flex;align-items:center;gap:10px;padding:9px 10px;border-radius:8px;background:rgba(255,255,255,.16);font-weight:600;color:#fff"><svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="#fff" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M12 7v14"></path><path d="M3 18a1 1 0 0 1-1-1V4a1 1 0 0 1 1-1h5a4 4 0 0 1 4 4 4 4 0 0 1 4-4h5a1 1 0 0 1 1 1v13a1 1 0 0 1-1 1h-6a3 3 0 0 0-3 3 3 3 0 0 0-3-3z"></path></svg>About &amp; contact</div>
+<sc-if value="{{ isMember }}" hint-placeholder-val="{{ false }}">
+<div style="display:flex;align-items:center;gap:10px;padding:10px;margin-top:8px;border-radius:8px;background:rgba(255,255,255,.1)">
+<div style="width:34px;height:34px;flex:none;border-radius:50%;background:#7ea6d8;color:#0d2f5e;display:flex;align-items:center;justify-content:center;font-weight:700;font-size:13px">EL</div>
+<div style="flex:1;min-width:0;font-size:13px;font-weight:500">Elsa Lindqvist</div>
+<div onClick="{{ onSignOut }}" role="button" tabIndex="0" aria-label="Sign out" title="Sign out" style="flex:none;width:28px;height:28px;display:flex;align-items:center;justify-content:center;border-radius:7px;color:rgba(255,255,255,.75);cursor:pointer" style-hover="background:rgba(255,255,255,.16);color:#fff"><svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.9" stroke-linecap="round" stroke-linejoin="round"><path d="M9 21H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h4"></path><path d="M16 17l5-5-5-5"></path><path d="M21 12H9"></path></svg></div>
+</div>
+</sc-if>
+<sc-if value="{{ isGuest }}" hint-placeholder-val="{{ true }}">
+<div style="margin-top:8px;padding-top:12px;border-top:1px solid rgba(255,255,255,.2)">
+<div style="font-size:11.5px;line-height:1.45;color:rgba(255,255,255,.78)">Browsing as a guest. Saving courses and posting reviews need an account.</div>
+<div onClick="{{ onSignUp }}" role="button" tabIndex="0" style="margin-top:10px;display:flex;align-items:center;justify-content:center;height:34px;border-radius:8px;background:#fff;color:#12417f;font-size:13px;font-weight:600;cursor:pointer">Sign up</div>
+<div onClick="{{ onLogIn }}" role="button" tabIndex="0" style="margin-top:6px;display:flex;align-items:center;justify-content:center;height:34px;border-radius:8px;border:1px solid rgba(255,255,255,.4);font-size:13px;font-weight:500;color:#fff;cursor:pointer">Log in</div>
+</div>
+</sc-if>
+</div>
+</div>
+
+<div style="position:relative;flex:1;min-width:0;min-height:0;margin-top:66px;display:flex;flex-direction:column;overflow-y:auto;overflow-x:hidden">
+<div style="width:100%;max-width:{{ pageMaxWidth }};box-sizing:border-box;margin:0 auto;padding:0 {{ pageSidePadding }} 60px;display:flex;flex-direction:column">
+
+<dc-import name="Course Community - Page Header" title="About &amp; contact" subtitle="Course Community is built by KTH AI Society to help students pick courses using the reviews and experience of the students before them." hint-size="100%,90px"></dc-import>
+
+<div style="padding:0 28px">
+<div style="margin-top:30px;border:1px solid var(--rule);border-radius:12px;background:var(--surface);padding:20px 22px">
+<div style="display:flex;align-items:center;gap:10px">
+<div style="flex:none;width:34px;height:34px;border-radius:9px;background:var(--pill);display:flex;align-items:center;justify-content:center"><svg width="18" height="18" viewBox="0 0 24 24" fill="currentColor" style="color:var(--brand)"><path d="M12 2C6.48 2 2 6.58 2 12.25c0 4.53 2.87 8.37 6.84 9.73.5.1.68-.22.68-.49 0-.24-.01-1.05-.01-1.9-2.78.62-3.37-1.22-3.37-1.22-.45-1.18-1.11-1.49-1.11-1.49-.9-.64.07-.63.07-.63 1 .07 1.53 1.05 1.53 1.05.89 1.56 2.34 1.11 2.91.85.09-.66.34-1.11.62-1.36-2.22-.26-4.56-1.14-4.56-5.06 0-1.12.38-2.03 1.02-2.75-.1-.26-.44-1.31.1-2.73 0 0 .84-.28 2.75 1.05a9.3 9.3 0 0 1 5 0c1.9-1.33 2.74-1.05 2.74-1.05.55 1.42.21 2.47.1 2.73.65.72 1.02 1.63 1.02 2.75 0 3.93-2.35 4.8-4.58 5.05.36.32.68.95.68 1.92 0 1.39-.01 2.51-.01 2.85 0 .27.18.6.69.49A10.02 10.02 0 0 0 22 12.25C22 6.58 17.52 2 12 2z"></path></svg></div>
+<div>
+<div style="font-size:15px;font-weight:600">Open source, on GitHub</div>
+<div style="margin-top:2px;font-size:12.5px;color:var(--muted)">The code is out there. So are we.</div>
+</div>
+</div>
+<div style="margin-top:14px;font-size:13.5px;line-height:1.6;color:var(--ink2)">Every part of this — the reviews, the ratings, the way courses are matched — is open for anyone to read, fork, or improve. If something looks wrong or you'd rather build it differently, open an issue or send a pull request.</div>
+<a href="https://github.com" target="_blank" style="margin-top:14px;display:inline-flex;align-items:center;gap:8px;height:38px;padding:0 15px;border-radius:9px;border:1px solid var(--rule3);background:var(--pg);font-size:13px;font-weight:500;color:var(--ink);text-decoration:none" style-hover="border-color:var(--hov)"><svg width="15" height="15" viewBox="0 0 24 24" fill="currentColor"><path d="M12 2C6.48 2 2 6.58 2 12.25c0 4.53 2.87 8.37 6.84 9.73.5.1.68-.22.68-.49 0-.24-.01-1.05-.01-1.9-2.78.62-3.37-1.22-3.37-1.22-.45-1.18-1.11-1.49-1.11-1.49-.9-.64.07-.63.07-.63 1 .07 1.53 1.05 1.53 1.05.89 1.56 2.34 1.11 2.91.85.09-.66.34-1.11.62-1.36-2.22-.26-4.56-1.14-4.56-5.06 0-1.12.38-2.03 1.02-2.75-.1-.26-.44-1.31.1-2.73 0 0 .84-.28 2.75 1.05a9.3 9.3 0 0 1 5 0c1.9-1.33 2.74-1.05 2.74-1.05.55 1.42.21 2.47.1 2.73.65.72 1.02 1.63 1.02 2.75 0 3.93-2.35 4.8-4.58 5.05.36.32.68.95.68 1.92 0 1.39-.01 2.51-.01 2.85 0 .27.18.6.69.49A10.02 10.02 0 0 0 22 12.25C22 6.58 17.52 2 12 2z"></path></svg>View the repository</a>
+</div>
+
+<div style="margin-top:26px">
+<dc-import name="Course Community - Contact Form" store-module="{{ workspaceStore }}" hint-size="100%,320px"></dc-import>
+</div>
+
+</div>
+
+</div>
+</div>
+</div>
+
+</x-dc>
+<script type="text/x-dc" data-dc-script data-props="{&quot;$preview&quot;:{&quot;width&quot;:1440,&quot;height&quot;:900},&quot;session&quot;:{&quot;editor&quot;:&quot;enum&quot;,&quot;default&quot;:&quot;guest&quot;,&quot;options&quot;:[&quot;guest&quot;,&quot;member&quot;],&quot;tsType&quot;:&quot;string&quot;}}">
+let STORE = null;
+
+class Component extends DCLogic {
+  state = { signedIn: undefined };
+
+  componentDidMount() {
+    this.ccApplyTheme();
+    import("./cc-store.js").then((mod) => { STORE = mod; this.forceUpdate(); });
+  }
+
+  /* Theme choice is shared across the pages through one storage key. */
+  ccDark() {
+    if (this.state.ccNight !== undefined) return this.state.ccNight === true;
+    try { return window.localStorage.getItem("cc:theme") === "dark"; } catch (e) { return false; }
+  }
+
+  ccSetDark(next) {
+    document.documentElement.setAttribute("data-cc-theme", next ? "dark" : "light");
+    try { window.localStorage.setItem("cc:theme", next ? "dark" : "light"); } catch (e) { /* storage off */ }
+    this.setState({ ccNight: next });
+  }
+
+  renderVals() {
+    const s = this.state;
+    const night = this.ccDark();
+    const signedIn = s.signedIn !== undefined ? s.signedIn : this.props.session !== "guest";
+    const guest = !signedIn;
+    return {
+      night, notNight: !night,
+      themeTitle: night ? "Switch to day" : "Switch to night",
+      onTheme: () => this.ccSetDark(!this.ccDark()),
+      isGuest: guest, isMember: !guest,
+      onSignUp: () => this.setState({ signedIn: true }),
+      onLogIn: () => this.setState({ signedIn: true }),
+      onSignOut: () => this.setState({ signedIn: false }),
+      pageMaxWidth: STORE ? STORE.PAGE_MAX_WIDTH : "1216px",
+      pageSidePadding: STORE ? STORE.PAGE_SIDE_PADDING : "20px",
+      workspaceStore: STORE
+    };
+  }
+}
+
+</script>
+</body>
+</html>

--- a/docs/design/Course Community - Collections.dc.html
+++ b/docs/design/Course Community - Collections.dc.html
@@ -1,0 +1,513 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<script src="./support.js"></script>
+</head>
+<body>
+<x-dc>
+<div style="position:relative;display:flex;flex-direction:column;gap:14px">
+
+<sc-if value="{{ authOpen }}" hint-placeholder-val="{{ false }}">
+<div style="position:fixed;inset:0;z-index:80;display:flex;align-items:center;justify-content:center;padding:24px;background:rgba(20,30,45,.34)">
+<div style="width:392px;max-width:100%;box-sizing:border-box;padding:24px;border-radius:14px;background:var(--surface);box-shadow:0 18px 48px rgba(20,30,45,.24)">
+<div style="display:flex;align-items:center;justify-content:space-between;gap:12px">
+<div style="font-size:11px;font-weight:600;letter-spacing:.06em;text-transform:uppercase;color:var(--brand)">One step left</div>
+<div onClick="{{ onAuthCancel }}" title="Close" style="width:26px;height:26px;display:flex;align-items:center;justify-content:center;border-radius:7px;color:var(--dim);font-size:17px;line-height:1;cursor:pointer" style-hover="background:var(--pill)">×</div>
+</div>
+<div style="margin-top:8px;font-size:19px;font-weight:600;line-height:1.25">Sign in to build a comparison</div>
+<div style="margin-top:6px;font-size:13.5px;line-height:1.5;color:var(--muted)">Collections, AI comparisons, and syncing saved courses across devices need an account.</div>
+<div style="margin-top:16px;display:flex;flex-direction:column;gap:8px">
+<div onClick="{{ onAuthCancel }}" style="display:flex;align-items:center;justify-content:center;gap:9px;height:42px;border-radius:9px;background:var(--btn);color:var(--btnFg);font-size:13.5px;font-weight:600;cursor:pointer" style-hover="background:var(--btn)">Continue with KTH account</div>
+<div onClick="{{ onAuthCancel }}" style="display:flex;align-items:center;justify-content:center;height:42px;border-radius:9px;border:1px solid var(--rule3);background:var(--surface);font-size:13.5px;font-weight:500;color:var(--ink);cursor:pointer" style-hover="border-color:var(--hov)">Sign up with email</div>
+</div>
+<div onClick="{{ onAuthCancel }}" style="margin-top:14px;text-align:center;font-size:12.5px;font-weight:500;color:var(--brand);cursor:pointer" style-hover="text-decoration:underline">Back</div>
+</div>
+</div>
+</sc-if>
+
+<sc-if value="{{ hasNote }}" hint-placeholder-val="{{ false }}">
+<div style="display:flex;align-items:center;gap:8px;padding:9px 13px;border-radius:9px;border:1px solid var(--rule2);background:var(--pill);font-size:12.5px;color:var(--brand)">
+<svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="#1751a6" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round"><path d="M20 6 9 17l-5-5"></path></svg>{{ note }}
+</div>
+</sc-if>
+
+<sc-if value="{{ isGuest }}" hint-placeholder-val="{{ true }}">
+<div>
+<h2 style="margin:0;font-size:16px;font-weight:600">Collections</h2>
+<div style="margin-top:4px;font-size:12.5px;color:var(--muted)">Group courses you want to compare.</div>
+<div style="margin-top:14px;max-width:520px;padding:16px 17px;border:1px solid var(--rule2);border-radius:11px;background:var(--surface)">
+<div style="display:flex;align-items:center;gap:8px">
+<svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="#6b6355" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><rect x="4" y="10.5" width="16" height="10.5" rx="2.5"></rect><path d="M8 10.5V7.5a4 4 0 0 1 8 0v3"></path></svg>
+<div style="font-size:13.5px;font-weight:600">Organize your saved courses</div>
+</div>
+<div style="margin-top:6px;font-size:12.5px;line-height:1.5;color:var(--muted)">Sign up or log in to create collections, compare courses with AI, and sync across devices.</div>
+<div style="margin-top:11px;display:flex;gap:7px">
+<div onClick="{{ onSignUp }}" role="button" tabIndex="0" style="display:flex;align-items:center;justify-content:center;height:32px;padding:0 14px;border-radius:8px;background:var(--btn);color:var(--btnFg);font-size:12.5px;font-weight:600;cursor:pointer" style-hover="background:var(--btn)">Sign up</div>
+<div onClick="{{ onLogIn }}" role="button" tabIndex="0" style="display:flex;align-items:center;justify-content:center;height:32px;padding:0 14px;border-radius:8px;border:1px solid var(--rule3);background:var(--surface);font-size:12.5px;font-weight:500;color:var(--brand);cursor:pointer" style-hover="border-color:var(--hov)">Log in</div>
+</div>
+</div>
+</div>
+</sc-if>
+
+<sc-if value="{{ isMember }}" hint-placeholder-val="{{ false }}">
+
+<sc-if value="{{ inDetail }}" hint-placeholder-val="{{ false }}">
+<div style="display:flex;flex-direction:column;gap:16px">
+<div onClick="{{ onBackToGrid }}" role="button" tabIndex="0" style="align-self:flex-start;display:flex;align-items:center;gap:6px;font-size:12.5px;font-weight:500;color:var(--brand);cursor:pointer" style-hover="text-decoration:underline">← All comparisons</div>
+<div style="display:flex;align-items:flex-start;justify-content:space-between;gap:16px;flex-wrap:wrap">
+<div>
+<sc-if value="{{ detailRenaming }}" hint-placeholder-val="{{ false }}">
+<input value="{{ renameDraft }}" onChange="{{ onRenameChange }}" onBlur="{{ onRenameCommit }}" onKeyDown="{{ onRenameKey }}" autoFocus="{{ true }}" aria-label="Comparison name" style="box-sizing:border-box;height:34px;padding:0 10px;border-radius:8px;border:1px solid var(--brand);outline:none;font-family:Geist,system-ui,sans-serif;font-size:20px;font-weight:600;color:var(--ink)">
+</sc-if>
+<sc-if value="{{ notRenamingDetail }}" hint-placeholder-val="{{ true }}">
+<h2 style="margin:0;font-size:21px;font-weight:600;letter-spacing:-.015em">{{ detailName }}</h2>
+</sc-if>
+<div style="margin-top:5px;font-size:12.5px;color:var(--muted)">{{ detailCount }}</div>
+</div>
+<div style="display:flex;align-items:center;gap:7px">
+<div onClick="{{ onDetailRename }}" role="button" tabIndex="0" style="height:32px;display:flex;align-items:center;padding:0 11px;border-radius:8px;border:1px solid var(--rule3);background:var(--surface);font-size:12.5px;font-weight:500;color:var(--ink);cursor:pointer" style-hover="border-color:var(--hov)">Rename</div>
+<sc-if value="{{ canAdd }}" hint-placeholder-val="{{ true }}">
+<div style="position:relative">
+<div onClick="{{ onToggleAdd }}" role="button" tabIndex="0" aria-haspopup="true" style="height:32px;display:flex;align-items:center;padding:0 11px;border-radius:8px;border:1px solid var(--rule3);background:var(--surface);font-size:12.5px;font-weight:500;color:var(--ink);cursor:pointer" style-hover="border-color:var(--hov)">Add course</div>
+<sc-if value="{{ addOpen }}" hint-placeholder-val="{{ false }}">
+<div style="position:absolute;top:36px;right:0;z-index:20;box-sizing:border-box;width:250px;padding:5px;border-radius:10px;border:1px solid var(--rule2);background:var(--surface);box-shadow:0 8px 24px rgba(20,30,45,.14)">
+<sc-for list="{{ detailAddable }}" as="a" hint-placeholder-count="3">
+<div onClick="{{ a.onAdd }}" role="button" tabIndex="0" style="display:flex;align-items:baseline;gap:8px;padding:8px 9px;border-radius:7px;font-size:12.5px;color:var(--ink2);cursor:pointer" style-hover="background:var(--pill)"><span style="font-family:'Geist Mono',ui-monospace,monospace;font-size:11.5px;color:var(--dim)">{{ a.code }}</span><span style="flex:1;overflow:hidden;text-overflow:ellipsis;white-space:nowrap">{{ a.title }}</span></div>
+</sc-for>
+</div>
+</sc-if>
+</div>
+</sc-if>
+<div onClick="{{ onDetailDelete }}" role="button" tabIndex="0" style="height:32px;display:flex;align-items:center;padding:0 11px;border-radius:8px;border:1px solid #ecd9d2;background:var(--surface);font-size:12.5px;font-weight:500;color:#a4402a;cursor:pointer" style-hover="border-color:#d9a08c">Delete</div>
+</div>
+</div>
+
+<div style="display:flex;flex-direction:column;gap:8px">
+<sc-for list="{{ detailRows }}" as="r" hint-placeholder-count="3">
+<div style="display:flex;align-items:center;gap:12px;padding:12px 14px;border:1px solid var(--rule);border-radius:10px;background:var(--surface)">
+<span style="font-family:'Geist Mono',ui-monospace,monospace;font-size:12px;font-weight:500;color:var(--brand)">{{ r.code }}</span>
+<span style="flex:1;min-width:0;font-size:13.5px;font-weight:500;overflow:hidden;text-overflow:ellipsis;white-space:nowrap">{{ r.title }}</span>
+<span style="font-size:12px;color:var(--muted);white-space:nowrap">{{ r.meta }}</span>
+<div onClick="{{ r.onRemove }}" role="button" tabIndex="0" aria-label="{{ r.removeLabel }}" title="{{ r.removeLabel }}" style="flex:none;width:28px;height:28px;display:flex;align-items:center;justify-content:center;border-radius:7px;color:var(--dim);cursor:pointer" style-hover="background:var(--pill)"><svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"><path d="M6 6l12 12M18 6 6 18"></path></svg></div>
+</div>
+</sc-for>
+</div>
+
+<div style="padding:16px 17px;border:1px solid var(--rule);border-radius:11px;background:var(--surface)">
+<div style="display:flex;align-items:center;justify-content:space-between;gap:12px;flex-wrap:wrap">
+<div>
+<div style="font-size:14.5px;font-weight:600">AI comparison</div>
+<div style="margin-top:4px;font-size:12.5px;color:var(--muted)">Mock result for the prototype — no request is made.</div>
+</div>
+<sc-if value="{{ aiIdle }}" hint-placeholder-val="{{ true }}">
+<div onClick="{{ onGenerate }}" role="button" tabIndex="0" style="height:36px;display:flex;align-items:center;padding:0 14px;border-radius:9px;background:var(--btn);color:var(--btnFg);font-size:13px;font-weight:600;cursor:pointer" style-hover="background:var(--btn)">Generate AI comparison</div>
+</sc-if>
+</div>
+
+<sc-if value="{{ aiShort }}" hint-placeholder-val="{{ false }}">
+<div role="note" style="margin-top:13px;display:flex;align-items:center;gap:8px;padding:11px 13px;border-radius:9px;background:var(--pg);border:1px solid var(--rule2);font-size:12.5px;color:var(--dim)">
+<svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="#6b6355" stroke-width="1.9" stroke-linecap="round"><circle cx="12" cy="12" r="9.5"></circle><path d="M12 8v5M12 16h.01"></path></svg>Add at least 2 courses before generating a comparison.
+</div>
+</sc-if>
+
+<sc-if value="{{ aiLoading }}" hint-placeholder-val="{{ false }}">
+<div aria-live="polite" style="margin-top:13px;display:flex;align-items:center;gap:10px;padding:12px 13px;border-radius:9px;background:var(--pill);border:1px solid var(--rule2);font-size:12.5px;color:var(--brand)">
+<span style="flex:none;width:14px;height:14px;border-radius:50%;border:2px solid var(--hov);border-top-color:var(--brand);animation:om-spin .9s linear infinite"></span>
+Comparing course content, workload, assessment, and student feedback…
+</div>
+</sc-if>
+
+<sc-if value="{{ aiError }}" hint-placeholder-val="{{ false }}">
+<div role="alert" style="margin-top:13px;display:flex;align-items:center;gap:10px;padding:12px 13px;border-radius:9px;background:#fdf3ef;border:1px solid #ecd9d2;font-size:12.5px;color:#8f3a24">
+<svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="#a4402a" stroke-width="2" stroke-linecap="round"><circle cx="12" cy="12" r="9.5"></circle><path d="M12 7.5v5.5M12 16.5h.01"></path></svg>
+<span style="flex:1">The comparison could not be generated. Nothing was saved.</span>
+<span onClick="{{ onRetry }}" role="button" tabIndex="0" style="font-weight:600;color:var(--brand);cursor:pointer" style-hover="text-decoration:underline">Try again</span>
+</div>
+</sc-if>
+
+<sc-if value="{{ aiDone }}" hint-placeholder-val="{{ false }}">
+<div aria-live="polite" style="margin-top:14px">
+<div style="display:inline-flex;align-items:center;gap:6px;padding:2px 8px;border-radius:6px;background:var(--pill);font-size:10.5px;font-weight:600;letter-spacing:.06em;text-transform:uppercase;color:var(--dim)">Mock result</div>
+<div style="margin-top:11px;overflow:auto">
+<table style="width:100%;border-collapse:collapse;font-size:12.5px">
+<thead>
+<tr>
+<th style="text-align:left;padding:8px 10px;border-bottom:1px solid var(--rule);font-size:11px;font-weight:600;letter-spacing:.07em;text-transform:uppercase;color:var(--dim)">Field</th>
+<sc-for list="{{ aiHeads }}" as="h" hint-placeholder-count="3">
+<th style="text-align:left;padding:8px 10px;border-bottom:1px solid var(--rule);font-family:'Geist Mono',ui-monospace,monospace;font-size:11.5px;font-weight:500;color:var(--brand)">{{ h.code }}</th>
+</sc-for>
+</tr>
+</thead>
+<tbody>
+<sc-for list="{{ aiRows }}" as="row" hint-placeholder-count="7">
+<tr>
+<td style="padding:9px 10px;border-bottom:1px solid #f2efe6;font-weight:500;color:var(--chipInk);white-space:nowrap">{{ row.label }}</td>
+<sc-for list="{{ row.cells }}" as="cell" hint-placeholder-count="3">
+<td style="padding:9px 10px;border-bottom:1px solid #f2efe6;color:var(--ink2);line-height:1.45">{{ cell.text }}</td>
+</sc-for>
+</tr>
+</sc-for>
+</tbody>
+</table>
+</div>
+<sc-if value="{{ hasGaps }}" hint-placeholder-val="{{ false }}">
+<div style="margin-top:12px;padding:11px 13px;border-radius:9px;background:var(--pg);border:1px solid var(--rule2)">
+<div style="font-size:11px;font-weight:600;letter-spacing:.07em;text-transform:uppercase;color:var(--dim)">Missing data</div>
+<sc-for list="{{ aiGaps }}" as="g" hint-placeholder-count="1">
+<div style="margin-top:6px;font-size:12.5px;color:var(--muted)">{{ g.text }}</div>
+</sc-for>
+</div>
+</sc-if>
+</div>
+</sc-if>
+</div>
+</div>
+</sc-if>
+
+<sc-if value="{{ notInDetail }}" hint-placeholder-val="{{ true }}">
+<div>
+<h2 style="margin:0;font-size:16px;font-weight:600">Collections</h2>
+<div style="margin-top:4px;font-size:12.5px;color:var(--muted)">Group courses you want to compare.</div>
+
+<sc-if value="{{ compact }}" hint-placeholder-val="{{ false }}">
+<div style="margin-top:14px;display:flex;flex-wrap:wrap;gap:8px">
+<div onClick="{{ onOpenDlg }}" role="button" tabIndex="0" style="flex:none;box-sizing:border-box;height:40px;display:flex;align-items:center;gap:6px;padding:0 13px;border:1px dashed #9dbfe4;border-radius:9px;background:rgba(23,81,166,.06);cursor:pointer;white-space:nowrap" style-hover="border-color:var(--brand);background:rgba(23,81,166,.11)">
+<svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="#1751a6" stroke-width="2.2" stroke-linecap="round"><path d="M5 12h14"></path><path d="M12 5v14"></path></svg><span style="font-size:13px;font-weight:600;color:var(--brand);white-space:nowrap">New collection</span>
+</div>
+<sc-for list="{{ collections }}" as="col" hint-placeholder-count="3">
+<div onClick="{{ col.onOpen }}" role="button" tabIndex="0" aria-label="{{ col.openLabel }}" style="flex:none;position:relative;box-sizing:border-box;height:40px;display:flex;align-items:center;gap:9px;padding:0 12px;border:1px solid var(--rule);border-radius:9px;background:var(--surface);cursor:pointer;white-space:nowrap" style-hover="border-color:var(--hov)">
+<sc-if value="{{ col.renaming }}" hint-placeholder-val="{{ false }}">
+<input value="{{ renameDraft }}" onChange="{{ onRenameChange }}" onBlur="{{ onRenameCommit }}" onKeyDown="{{ onRenameKey }}" onClick="{{ stop }}" autoFocus="{{ true }}" aria-label="Comparison name" style="box-sizing:border-box;width:120px;height:26px;padding:0 7px;border-radius:6px;border:1px solid var(--brand);outline:none;font-family:Geist,system-ui,sans-serif;font-size:13px;font-weight:600;color:var(--ink)">
+</sc-if>
+<sc-if value="{{ col.notRenaming }}" hint-placeholder-val="{{ true }}">
+<span style="font-size:13px;font-weight:600;overflow:hidden;text-overflow:ellipsis;white-space:nowrap;max-width:160px">{{ col.name }}</span>
+</sc-if>
+<span style="font-size:12px;color:var(--dim2);white-space:nowrap">{{ col.count }}</span>
+<div onClick="{{ col.onMenu }}" role="button" tabIndex="0" aria-label="{{ col.menuLabel }}" title="{{ col.menuLabel }}" style="flex:none;width:22px;height:22px;display:flex;align-items:center;justify-content:center;border-radius:6px;color:var(--dim);cursor:pointer" style-hover="background:var(--pill)">⋯</div>
+<sc-if value="{{ col.menuOpen }}" hint-placeholder-val="{{ false }}">
+<div style="position:absolute;top:42px;right:0;z-index:20;width:150px;padding:4px;border-radius:9px;border:1px solid var(--rule2);background:var(--surface);box-shadow:0 8px 24px rgba(20,30,45,.14)">
+<div onClick="{{ col.onRename }}" role="button" tabIndex="0" style="padding:8px 9px;border-radius:6px;font-size:12.5px;color:var(--ink2);cursor:pointer" style-hover="background:var(--pill)">Rename</div>
+<div onClick="{{ col.onDelete }}" role="button" tabIndex="0" style="padding:8px 9px;border-radius:6px;font-size:12.5px;color:#a4402a;cursor:pointer" style-hover="background:#fdf3ef">Delete</div>
+</div>
+</sc-if>
+</div>
+</sc-for>
+</div>
+</sc-if>
+
+<sc-if value="{{ notCompact }}" hint-placeholder-val="{{ true }}">
+<div style="margin-top:14px;display:grid;grid-template-columns:repeat(auto-fill,minmax(240px,1fr));gap:12px">
+<div onClick="{{ onOpenDlg }}" role="button" tabIndex="0" style="box-sizing:border-box;min-height:150px;display:flex;flex-direction:column;align-items:center;justify-content:center;gap:7px;padding:15px 16px;border:1px dashed #9dbfe4;border-radius:11px;background:rgba(23,81,166,.06);cursor:pointer" style-hover="border-color:var(--brand);background:rgba(23,81,166,.11)">
+<div style="display:flex;align-items:center;gap:8px;font-size:16px;font-weight:600;color:var(--brand)"><svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="#1751a6" stroke-width="2.2" stroke-linecap="round"><path d="M5 12h14"></path><path d="M12 5v14"></path></svg>New comparison</div>
+<div style="font-size:12px;line-height:1.5;color:var(--muted);text-align:center;max-width:190px">Group specific courses and compare them side by side.</div>
+</div>
+<sc-for list="{{ collections }}" as="col" hint-placeholder-count="3">
+<div onClick="{{ col.onOpen }}" role="button" tabIndex="0" aria-label="{{ col.openLabel }}" style="position:relative;box-sizing:border-box;min-height:150px;display:flex;flex-direction:column;gap:9px;padding:14px 15px;border:1px solid var(--rule);border-radius:11px;background:var(--surface);cursor:pointer" style-hover="border-color:var(--hov)">
+<div style="display:flex;align-items:flex-start;justify-content:space-between;gap:8px">
+<div style="min-width:0">
+<sc-if value="{{ col.renaming }}" hint-placeholder-val="{{ false }}">
+<input value="{{ renameDraft }}" onChange="{{ onRenameChange }}" onBlur="{{ onRenameCommit }}" onKeyDown="{{ onRenameKey }}" onClick="{{ stop }}" autoFocus="{{ true }}" aria-label="Comparison name" style="box-sizing:border-box;width:100%;height:28px;padding:0 8px;border-radius:6px;border:1px solid var(--brand);outline:none;font-family:Geist,system-ui,sans-serif;font-size:13.5px;font-weight:600;color:var(--ink)">
+</sc-if>
+<sc-if value="{{ col.notRenaming }}" hint-placeholder-val="{{ true }}">
+<div style="font-size:14px;font-weight:600;line-height:1.3;overflow:hidden;text-overflow:ellipsis;white-space:nowrap">{{ col.name }}</div>
+</sc-if>
+</div>
+<div onClick="{{ col.onMenu }}" role="button" tabIndex="0" aria-label="{{ col.menuLabel }}" title="{{ col.menuLabel }}" style="flex:none;width:26px;height:26px;display:flex;align-items:center;justify-content:center;border-radius:7px;color:var(--dim);cursor:pointer" style-hover="background:var(--pill)">⋯</div>
+</div>
+<div style="display:flex;flex-direction:column;gap:3px">
+<sc-for list="{{ col.previews }}" as="p" hint-placeholder-count="3">
+<div style="display:flex;align-items:baseline;gap:7px;font-size:11.5px;color:var(--ink2)"><span style="font-family:'Geist Mono',ui-monospace,monospace;font-size:11px;color:var(--dim)">{{ p.code }}</span><span style="flex:1;min-width:0;overflow:hidden;text-overflow:ellipsis;white-space:nowrap">{{ p.title }}</span></div>
+</sc-for>
+<sc-if value="{{ col.overflow }}" hint-placeholder-val="{{ false }}">
+<div style="font-size:11.5px;font-weight:500;color:var(--brand)">{{ col.overflowLabel }}</div>
+</sc-if>
+</div>
+<div style="margin-top:auto;display:flex;align-items:baseline;justify-content:space-between;gap:10px;font-size:11px;color:var(--dim2)"><span>{{ col.updated }}</span><span>{{ col.count }}</span></div>
+<sc-if value="{{ col.menuOpen }}" hint-placeholder-val="{{ false }}">
+<div style="position:absolute;top:38px;right:12px;z-index:20;width:150px;padding:4px;border-radius:9px;border:1px solid var(--rule2);background:var(--surface);box-shadow:0 8px 24px rgba(20,30,45,.14)">
+<div onClick="{{ col.onRename }}" role="button" tabIndex="0" style="padding:8px 9px;border-radius:6px;font-size:12.5px;color:var(--ink2);cursor:pointer" style-hover="background:var(--pill)">Rename</div>
+<div onClick="{{ col.onDelete }}" role="button" tabIndex="0" style="padding:8px 9px;border-radius:6px;font-size:12.5px;color:#a4402a;cursor:pointer" style-hover="background:#fdf3ef">Delete</div>
+</div>
+</sc-if>
+</div>
+</sc-for>
+</div>
+</sc-if>
+
+<sc-if value="{{ noCollections }}" hint-placeholder-val="{{ false }}">
+<div style="margin-top:14px;padding:24px;border:1px solid var(--rule);border-radius:11px;background:var(--surface);text-align:center">
+<div style="font-size:14.5px;font-weight:600">No comparisons yet</div>
+<div style="margin-top:5px;font-size:12.5px;color:var(--muted)">Create a comparison to organize courses you are considering together.</div>
+<div onClick="{{ onOpenDlg }}" role="button" tabIndex="0" style="margin:13px auto 0;width:max-content;height:34px;display:flex;align-items:center;padding:0 14px;border-radius:9px;background:var(--btn);color:var(--btnFg);font-size:13px;font-weight:600;cursor:pointer" style-hover="background:var(--btn)">Create comparison</div>
+</div>
+</sc-if>
+</div>
+</sc-if>
+
+<sc-if value="{{ dlgOpen }}" hint-placeholder-val="{{ false }}">
+<div onClick="{{ onCloseDlg }}" style="position:fixed;inset:0;z-index:75;display:flex;align-items:center;justify-content:center;padding:24px;background:rgba(20,30,45,.34)">
+<div onClick="{{ stop }}" onKeyDown="{{ onDlgKey }}" role="dialog" aria-modal="true" aria-label="New comparison" style="width:440px;max-width:100%;box-sizing:border-box;padding:22px;border-radius:14px;background:var(--surface);box-shadow:0 18px 48px rgba(20,30,45,.24)">
+<div style="display:flex;align-items:center;justify-content:space-between;gap:12px">
+<div style="font-size:18px;font-weight:600">New comparison</div>
+<div onClick="{{ onCloseDlg }}" role="button" tabIndex="0" aria-label="Cancel" style="width:26px;height:26px;display:flex;align-items:center;justify-content:center;border-radius:7px;color:var(--dim);font-size:17px;cursor:pointer" style-hover="background:var(--pill)">×</div>
+</div>
+<input value="{{ dlgName }}" onChange="{{ onDlgName }}" autoFocus="{{ true }}" placeholder="Comparison name" aria-label="Comparison name" style="margin-top:14px;box-sizing:border-box;width:100%;height:38px;padding:0 12px;border-radius:9px;border:1px solid var(--rule3);outline:none;font-family:Geist,system-ui,sans-serif;font-size:13.5px;color:var(--ink)">
+<input value="{{ dlgQuery }}" onChange="{{ onDlgQuery }}" placeholder="Filter saved courses" aria-label="Filter saved courses" style="margin-top:8px;box-sizing:border-box;width:100%;height:34px;padding:0 12px;border-radius:9px;border:1px solid var(--rule);background:var(--pg);outline:none;font-family:Geist,system-ui,sans-serif;font-size:12.5px;color:var(--ink)">
+<div style="margin-top:10px;max-height:210px;overflow:auto;border:1px solid var(--rule);border-radius:9px">
+<sc-for list="{{ dlgList }}" as="p" hint-placeholder-count="5">
+<div onClick="{{ p.onToggle }}" role="checkbox" tabIndex="0" aria-checked="{{ p.checked }}" style="display:flex;align-items:center;gap:10px;padding:9px 11px;border-bottom:1px solid #f2efe6;cursor:pointer" style-hover="background:var(--pg)">
+<span style="flex:none;width:16px;height:16px;border-radius:4px;border:1px solid {{ p.boxBorder }};background:{{ p.boxBg }};display:flex;align-items:center;justify-content:center"><svg width="11" height="11" viewBox="0 0 24 24" fill="none" stroke="#fff" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"><path d="{{ p.tick }}"></path></svg></span>
+<span style="font-family:'Geist Mono',ui-monospace,monospace;font-size:11.5px;color:var(--dim)">{{ p.code }}</span>
+<span style="flex:1;min-width:0;font-size:13px;overflow:hidden;text-overflow:ellipsis;white-space:nowrap">{{ p.title }}</span>
+</div>
+</sc-for>
+</div>
+<div style="margin-top:9px;display:flex;align-items:center;justify-content:space-between;gap:12px">
+<div style="font-size:12px;color:var(--muted)">{{ dlgPickedLabel }}</div>
+<sc-if value="{{ hasDlgError }}" hint-placeholder-val="{{ false }}">
+<div role="alert" style="font-size:12px;font-weight:500;color:#a4402a">{{ dlgError }}</div>
+</sc-if>
+</div>
+<div style="margin-top:14px;display:flex;gap:8px">
+<div onClick="{{ onDlgCreate }}" role="button" tabIndex="0" style="flex:1;display:flex;align-items:center;justify-content:center;height:40px;border-radius:9px;background:var(--btn);color:var(--btnFg);font-size:13.5px;font-weight:600;cursor:pointer" style-hover="background:var(--btn)">Create comparison</div>
+<div onClick="{{ onCloseDlg }}" role="button" tabIndex="0" style="display:flex;align-items:center;justify-content:center;height:40px;padding:0 16px;border-radius:9px;border:1px solid var(--rule3);background:var(--surface);font-size:13.5px;font-weight:500;color:var(--ink);cursor:pointer" style-hover="border-color:var(--hov)">Cancel</div>
+</div>
+</div>
+</div>
+</sc-if>
+
+</sc-if>
+</div>
+
+</x-dc>
+<script type="text/x-dc" data-dc-script data-props="{&quot;$preview&quot;:{&quot;width&quot;:900,&quot;height&quot;:620},&quot;storeModule&quot;:{&quot;editor&quot;:null,&quot;tsType&quot;:&quot;any&quot;},&quot;courses&quot;:{&quot;editor&quot;:null,&quot;tsType&quot;:&quot;any[]&quot;},&quot;savedCodes&quot;:{&quot;editor&quot;:null,&quot;tsType&quot;:&quot;string[]&quot;},&quot;isGuest&quot;:{&quot;editor&quot;:&quot;boolean&quot;,&quot;default&quot;:false,&quot;tsType&quot;:&quot;boolean&quot;},&quot;compact&quot;:{&quot;editor&quot;:&quot;boolean&quot;,&quot;default&quot;:false,&quot;tsType&quot;:&quot;boolean&quot;},&quot;onChange&quot;:{&quot;editor&quot;:null,&quot;tsType&quot;:&quot;() =&gt; void&quot;},&quot;onDetailChange&quot;:{&quot;editor&quot;:null,&quot;tsType&quot;:&quot;(id: string | null) =&gt; void&quot;}}">
+const libOfFrom = (courses, code) => courses.find((c) => c.code === code) || null;
+
+class Component extends DCLogic {
+  state = {
+    detail: null, dlg: false, dlgName: "", dlgPicked: [], dlgQuery: "", dlgError: "",
+    menuFor: null, renameId: null, renameDraft: "", addOpen: false,
+    aiState: "idle", note: null, authOpen: false
+  };
+
+  stop = (e) => e.stopPropagation();
+
+  onDocDown = (e) => {
+    if (e.target.closest && e.target.closest("[data-pop]")) return;
+    if (this.state.menuFor || this.state.addOpen) this.setState({ menuFor: null, addOpen: false });
+  };
+
+  componentDidMount() {
+    document.addEventListener("pointerdown", this.onDocDown, true);
+  }
+  componentWillUnmount() {
+    document.removeEventListener("pointerdown", this.onDocDown, true);
+  }
+
+  clearNote() {
+    clearTimeout(this.noteTimer);
+    this.noteTimer = setTimeout(() => this.setState({ note: null }), 3000);
+  }
+
+  renderVals() {
+    const s = this.state;
+    const STORE = this.props.storeModule;
+    const courses = this.props.courses || [];
+    const savedCodes = this.props.savedCodes || [];
+    const isGuest = Boolean(this.props.isGuest);
+    const isMember = !isGuest;
+    const collections = (STORE && STORE.collections) || [];
+    const libOf = (code) => libOfFrom(courses, code);
+
+    const detail = collections.find((c) => c.id === s.detail) || null;
+
+    const collectionCard = (c) => {
+      const shown = c.codes.slice(0, 3).map((code) => {
+        const lc = libOf(code) || { code: code, title: code };
+        return { code: lc.code, title: lc.title };
+      });
+      return {
+        id: c.id, name: c.name, updated: c.updated,
+        previews: shown,
+        overflow: c.codes.length > 3,
+        overflowLabel: "+" + (c.codes.length - 3) + " more",
+        count: c.codes.length + (c.codes.length === 1 ? " course" : " courses"),
+        onOpen: () => { this.setState({ detail: c.id, aiState: "idle", menuFor: null }); if (this.props.onDetailChange) this.props.onDetailChange(c.id); },
+        openLabel: "Open comparison " + c.name,
+        menuOpen: s.menuFor === c.id,
+        notRenaming: s.renameId !== c.id,
+        onMenu: (ev) => { ev.stopPropagation(); this.setState({ menuFor: s.menuFor === c.id ? null : c.id }); },
+        menuLabel: "More actions for " + c.name,
+        onRename: (ev) => { ev.stopPropagation(); this.setState({ renameId: c.id, renameDraft: c.name, menuFor: null }); },
+        onDelete: (ev) => {
+          ev.stopPropagation();
+          if (STORE) STORE.deleteCollection(c.id);
+          this.setState({ menuFor: null, note: "Comparison deleted" });
+          this.clearNote();
+          notify();
+        },
+        renaming: s.renameId === c.id
+      };
+    };
+
+    const pickable = savedCodes.map((code) => {
+      const c = libOf(code) || { code: code, title: code };
+      const on = s.dlgPicked.indexOf(code) >= 0;
+      const q = s.dlgQuery.trim().toLowerCase();
+      return {
+        code: c.code, title: c.title, checked: on,
+        boxBorder: on ? "var(--brand)" : "var(--rule3)",
+        boxBg: on ? "var(--brand)" : "transparent",
+        tick: on ? "M20 6 9 17l-5-5" : "",
+        onToggle: () => this.setState({
+          dlgPicked: on ? s.dlgPicked.filter((k) => k !== code) : s.dlgPicked.concat([code]),
+          dlgError: ""
+        }),
+        _match: !q || (c.code + " " + c.title).toLowerCase().indexOf(q) >= 0
+      };
+    }).filter((p) => p._match);
+
+    const detailRows = detail ? detail.codes.map((code) => {
+      const c = libOf(code) || { code: code, title: code };
+      return {
+        code: code, title: c.title, meta: (c.hp || "") + " · " + (c.period || "") + " · " + (c.school || ""),
+        onRemove: () => {
+          if (STORE) STORE.removeCourseFromCollection(detail.id, code);
+          this.forceUpdate();
+          notify();
+        },
+        removeLabel: "Remove " + code + " from this comparison"
+      };
+    }) : [];
+
+    const addable = detail ? savedCodes.filter((k) => detail.codes.indexOf(k) < 0).map((code) => {
+      const c = libOf(code) || { code: code, title: code };
+      return {
+        code: code, title: c.title,
+        onAdd: () => {
+          if (STORE) STORE.addCourseToCollection(detail.id, code);
+          this.setState({ addOpen: false });
+          notify();
+        }
+      };
+    }) : [];
+
+    const aiRows = detail ? [
+      { label: "Credits", vals: detail.codes.map((k) => (libOf(k) || {}).hp || "—") },
+      { label: "Study period", vals: detail.codes.map((k) => (libOf(k) || {}).period || "—") },
+      { label: "Prerequisites", vals: detail.codes.map((k) => (libOf(k) || {}).prereq || "—") },
+      { label: "Workload", vals: detail.codes.map((k) => (libOf(k) || {}).workload || "—") },
+      { label: "Assessment", vals: detail.codes.map((k) => (libOf(k) || {}).assessment || "—") },
+      { label: "Content", vals: detail.codes.map((k) => (libOf(k) || {}).content || "—") },
+      { label: "Review themes", vals: detail.codes.map((k) => (libOf(k) || {}).themes || "—") }
+    ].map((r) => ({ label: r.label, cells: r.vals.map((t) => ({ text: t })) })) : [];
+
+    const gaps = detail ? detail.codes.map((k) => (libOf(k) || {}).missing).filter(Boolean) : [];
+
+    const notify = () => { if (this.props.onChange) this.props.onChange(); };
+
+    return {
+      compact: Boolean(this.props.compact),
+      notCompact: !this.props.compact,
+      isGuest, isMember,
+      onSignUp: () => this.setState({ authOpen: true }),
+      onLogIn: () => this.setState({ authOpen: true }),
+      authOpen: s.authOpen,
+      onAuthCancel: () => this.setState({ authOpen: false }),
+
+      hasNote: Boolean(s.note),
+      note: s.note,
+
+      inDetail: Boolean(detail),
+      notInDetail: !detail,
+
+      collections: collections.map(collectionCard),
+      noCollections: collections.length === 0,
+      onOpenDlg: () => this.setState({ dlg: true, dlgName: "", dlgPicked: [], dlgQuery: "", dlgError: "" }),
+
+      renameDraft: s.renameDraft,
+      onRenameChange: (ev) => this.setState({ renameDraft: ev.target.value }),
+      onRenameCommit: () => {
+        const name = (s.renameDraft || "").trim();
+        if (STORE && s.renameId) STORE.renameCollection(s.renameId, name);
+        this.setState({ renameId: null, renameDraft: "" });
+      },
+      onRenameKey: (ev) => {
+        if (ev.key === "Enter") ev.target.blur();
+        if (ev.key === "Escape") this.setState({ renameId: null, renameDraft: "" });
+      },
+
+      dlgOpen: s.dlg,
+      dlgName: s.dlgName,
+      onDlgName: (ev) => this.setState({ dlgName: ev.target.value, dlgError: "" }),
+      dlgQuery: s.dlgQuery,
+      onDlgQuery: (ev) => this.setState({ dlgQuery: ev.target.value }),
+      dlgList: pickable,
+      dlgPickedLabel: s.dlgPicked.length + " selected",
+      hasDlgError: Boolean(s.dlgError),
+      dlgError: s.dlgError,
+      onCloseDlg: () => this.setState({ dlg: false, dlgError: "" }),
+      onDlgKey: (ev) => { if (ev.key === "Escape") this.setState({ dlg: false, dlgError: "" }); },
+      onDlgCreate: () => {
+        const name = (s.dlgName || "").trim();
+        if (!name) return this.setState({ dlgError: "Give this comparison a name" });
+        if (!STORE) return;
+        const col = STORE.createCollection(name, s.dlgPicked);
+        this.setState({ dlg: false, dlgName: "", dlgPicked: [], dlgQuery: "", dlgError: "", note: "Comparison \u201C" + name + "\u201D created", detail: col.id, aiState: "idle" });
+        this.clearNote();
+        notify();
+        if (this.props.onDetailChange) this.props.onDetailChange(col.id);
+      },
+      stop: this.stop,
+
+      detailName: detail ? detail.name : "",
+      detailCount: detail ? detail.codes.length + (detail.codes.length === 1 ? " course" : " courses") : "",
+      detailRenaming: Boolean(detail) && s.renameId === (detail && detail.id),
+      notRenamingDetail: !(detail && s.renameId === detail.id),
+      onDetailRename: () => { if (detail) this.setState({ renameId: detail.id, renameDraft: detail.name }); },
+      onDetailDelete: () => {
+        if (!detail) return;
+        if (STORE) STORE.deleteCollection(detail.id);
+        this.setState({ detail: null, note: "Comparison deleted" });
+        this.clearNote();
+        notify();
+        if (this.props.onDetailChange) this.props.onDetailChange(null);
+      },
+      onBackToGrid: () => { this.setState({ detail: null, addOpen: false, aiState: "idle" }); if (this.props.onDetailChange) this.props.onDetailChange(null); },
+      canAdd: addable.length > 0,
+      onToggleAdd: () => this.setState({ addOpen: !s.addOpen }),
+      addOpen: s.addOpen,
+      detailAddable: addable,
+      detailRows: detailRows,
+
+      aiIdle: s.aiState === "idle" && Boolean(detail) && detail.codes.length > 1,
+      aiShort: s.aiState === "short" || (Boolean(detail) && detail.codes.length < 2),
+      aiLoading: s.aiState === "loading",
+      aiDone: s.aiState === "done",
+      aiError: s.aiState === "error",
+      aiHeads: detail ? detail.codes.map((k) => ({ code: k })) : [],
+      aiRows: aiRows,
+      hasGaps: gaps.length > 0,
+      aiGaps: gaps.map((g) => ({ text: g })),
+      onGenerate: () => {
+        if (!detail || detail.codes.length < 2) return this.setState({ aiState: "short" });
+        this.setState({ aiState: "loading" });
+        clearTimeout(this.aiTimer);
+        this.aiTimer = setTimeout(() => {
+          this.setState({ aiState: detail.id === "c2" ? "error" : "done" });
+        }, 1800);
+      },
+      onRetry: () => {
+        this.setState({ aiState: "loading" });
+        clearTimeout(this.aiTimer);
+        this.aiTimer = setTimeout(() => this.setState({ aiState: "done" }), 1200);
+      }
+    };
+  }
+}
+
+</script>
+</body>
+</html>

--- a/docs/design/Course Community - Contact Form.dc.html
+++ b/docs/design/Course Community - Contact Form.dc.html
@@ -1,0 +1,79 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<script src="./support.js"></script>
+</head>
+<body>
+<x-dc>
+<div>
+<h2 style="margin:0;font-size:18px;font-weight:600">Get in touch</h2>
+<div style="margin-top:6px;font-size:13px;line-height:1.55;color:var(--muted)">Bug, idea, or just want to say hi — we read everything.</div>
+
+<sc-if value="{{ isSent }}" hint-placeholder-val="{{ false }}">
+<div style="margin-top:16px;display:flex;align-items:flex-start;gap:11px;padding:15px 16px;border-radius:12px;border:1px solid #cfe4de;background:#e9f3ef;animation:rise .2s ease-out">
+<svg width="17" height="17" viewBox="0 0 24 24" fill="none" stroke="#1c6b60" stroke-width="2.1" stroke-linecap="round" stroke-linejoin="round" style="flex:none;margin-top:1px"><circle cx="12" cy="12" r="9.5"></circle><path d="m8.5 12.2 2.4 2.4 4.6-5"></path></svg>
+<div>
+<div style="font-size:14px;font-weight:600;color:#1c6b60">Message sent</div>
+<div style="margin-top:3px;font-size:12.5px;color:#2b6a60">Thanks — we'll get back to you at {{ sentEmail }}.</div>
+</div>
+</div>
+</sc-if>
+
+<sc-if value="{{ isForm }}" hint-placeholder-val="{{ true }}">
+<div style="margin-top:16px;max-width:480px;display:flex;flex-direction:column;gap:14px">
+<div>
+<label style="display:block;margin-bottom:6px;font-size:12.5px;font-weight:500;color:var(--ink2)">Name</label>
+<input value="{{ name }}" onChange="{{ onNameChange }}" placeholder="Your name" style="box-sizing:border-box;width:100%;height:40px;padding:0 12px;border-radius:9px;border:1px solid var(--rule3);background:var(--surface);outline:none;font-size:14px;color:var(--ink)">
+</div>
+<div>
+<label style="display:block;margin-bottom:6px;font-size:12.5px;font-weight:500;color:var(--ink2)">Email</label>
+<input value="{{ email }}" onChange="{{ onEmailChange }}" placeholder="you@kth.se" style="box-sizing:border-box;width:100%;height:40px;padding:0 12px;border-radius:9px;border:1px solid var(--rule3);background:var(--surface);outline:none;font-size:14px;color:var(--ink)">
+</div>
+<div>
+<label style="display:block;margin-bottom:6px;font-size:12.5px;font-weight:500;color:var(--ink2)">Message</label>
+<textarea value="{{ message }}" onChange="{{ onMessageChange }}" placeholder="What's on your mind?" rows="5" style="box-sizing:border-box;width:100%;padding:10px 12px;border-radius:9px;border:1px solid var(--rule3);background:var(--surface);outline:none;font-size:14px;line-height:1.5;color:var(--ink);resize:vertical;font-family:inherit"></textarea>
+</div>
+<div>
+<div onClick="{{ onSubmit }}" role="button" tabIndex="0" style="display:inline-flex;align-items:center;height:42px;padding:0 20px;border-radius:9px;background:{{ submitBg }};color:var(--btnFg);font-size:13.5px;font-weight:600;cursor:{{ submitCursor }}" style-hover="opacity:.88">Send message</div>
+<sc-if value="{{ hasError }}" hint-placeholder-val="{{ false }}">
+<div style="margin-top:8px;font-size:12.5px;color:#a3452a">{{ errorText }}</div>
+</sc-if>
+</div>
+</div>
+</sc-if>
+</div>
+
+</x-dc>
+<script type="text/x-dc" data-dc-script data-props="{&quot;$preview&quot;:{&quot;width&quot;:480,&quot;height&quot;:420},&quot;storeModule&quot;:{&quot;editor&quot;:null,&quot;tsType&quot;:&quot;any&quot;}}">
+class Component extends DCLogic {
+  state = { name: "", email: "", message: "", sent: false, error: "" };
+
+  renderVals() {
+    const s = this.state;
+    const STORE = this.props.storeModule;
+    const canSubmit = s.name.trim() && s.email.trim() && s.message.trim();
+    return {
+      isSent: s.sent, isForm: !s.sent,
+      sentEmail: s.email,
+      name: s.name, email: s.email, message: s.message,
+      onNameChange: (e) => this.setState({ name: e.target.value }),
+      onEmailChange: (e) => this.setState({ email: e.target.value }),
+      onMessageChange: (e) => this.setState({ message: e.target.value }),
+      hasError: Boolean(s.error), errorText: s.error,
+      submitBg: canSubmit ? "var(--btn)" : "var(--pill)",
+      submitCursor: canSubmit ? "pointer" : "not-allowed",
+      onSubmit: () => {
+        if (!s.name.trim() || !s.message.trim()) { this.setState({ error: "Name and message are required." }); return; }
+        if (!/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(s.email.trim())) { this.setState({ error: "Enter a valid email." }); return; }
+        if (STORE) STORE.submitFeedback({ name: s.name.trim(), email: s.email.trim(), message: s.message.trim() });
+        this.setState({ sent: true, error: "" });
+      }
+    };
+  }
+}
+
+</script>
+</body>
+</html>

--- a/docs/design/Course Community - Course Card.dc.html
+++ b/docs/design/Course Community - Course Card.dc.html
@@ -1,0 +1,290 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<script src="./support.js"></script>
+</head>
+<body>
+<x-dc>
+<helmet data-dc-atomics><link rel="preconnect" href="https://fonts.googleapis.com"><link rel="preconnect" href="https://fonts.gstatic.com" crossorigin><link href="https://fonts.googleapis.com/css2?family=Geist:wght@400;500;600;700&display=swap" rel="stylesheet"><link rel="stylesheet" href="cc-theme.css"><style>body{margin:0;background:var(--pg);font-family:Geist,system-ui,sans-serif;font-size:14px;color:var(--ink)}input{font-family:Geist,system-ui,sans-serif}a{color:var(--brand)}a:hover{color:#10386f}</style></helmet>
+
+<div onClick="{{ c.onOpen }}" style="display:flex;height:{{ geo.cardHeight }};flex:none;border-radius:12px;border:1px solid {{ c.borderColor }};background:var(--surface);box-shadow:0 1px 2px rgba(20,30,45,.05);cursor:pointer" style-hover="border-color:var(--hov);box-shadow:0 2px 8px rgba(20,30,45,.09)">
+<div style="box-sizing:border-box;flex:1;min-width:0;display:flex;flex-direction:column;gap:{{ geo.cardGap }};padding:{{ geo.cardPad }};transition:{{ geo.tween }}">
+<div style="flex:none;display:flex;align-items:flex-start;justify-content:space-between;gap:10px">
+<div style="min-width:0;flex:1">
+<div title="{{ c.title }}" style="font-size:{{ geo.titleSize }};font-weight:600;line-height:1.2;color:var(--brand);max-width:100%;white-space:nowrap;overflow:hidden;text-overflow:ellipsis;transition:{{ geo.tween }}" style-hover="text-decoration:underline">{{ c.title }}</div>
+<div style="margin-top:3px;font-size:13px;color:var(--muted);overflow:hidden;text-overflow:ellipsis;white-space:nowrap">{{ c.meta }}</div>
+</div>
+<div data-pop="taken" onClick="{{ stopClick }}" style="position:relative;flex:none">
+<div onClick="{{ c.onTaken }}" title="{{ c.takenTitle }}" style="height:26px;flex:none;display:flex;align-items:center;gap:6px;padding:0 8px 0 5px;border-radius:7px;background:{{ c.takenBg }};color:{{ c.takenCountFg }};font-size:12px;cursor:pointer" style-hover="background:{{ c.takenHoverBg }}">
+<svg width="16" height="16" viewBox="0 0 24 24" fill="{{ c.takenFill }}" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="10"></circle><path d="m9 12 2 2 4-4"></path></svg>
+<span style="font-variant-numeric:tabular-nums">{{ c.statTaken }}</span>
+</div>
+<sc-if value="{{ c.takenPickerOpen }}" hint-placeholder-val="{{ false }}">
+<div data-pop-panel="taken" style="position:absolute;top:30px;right:0;z-index:25;box-sizing:border-box;width:250px;padding:11px 11px 10px;border-radius:10px;border:1px solid var(--rule2);background:var(--surface);box-shadow:0 8px 24px rgba(20,30,45,.14)">
+<div style="display:flex;align-items:center;gap:8px">
+<svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="#6b6355" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><rect x="4" y="10.5" width="16" height="10.5" rx="2.5"></rect><path d="M8 10.5V7.5a4 4 0 0 1 8 0v3"></path></svg>
+<div style="font-size:13.5px;font-weight:600">Track courses you've taken</div>
+</div>
+<div style="margin-top:6px;font-size:12.5px;line-height:1.5;color:var(--muted)">Sign up or log in to mark courses as taken and build your profile.</div>
+<div style="margin-top:11px;display:flex;gap:7px">
+<div onClick="{{ c.onSignUp }}" role="button" tabIndex="0" style="flex:1;display:flex;align-items:center;justify-content:center;height:32px;border-radius:8px;background:var(--btn);color:var(--btnFg);font-size:12.5px;font-weight:600;cursor:pointer" style-hover="background:var(--btn)">Sign up</div>
+<div onClick="{{ c.onLogIn }}" role="button" tabIndex="0" style="flex:1;display:flex;align-items:center;justify-content:center;height:32px;border-radius:8px;border:1px solid var(--rule3);background:var(--surface);font-size:12.5px;font-weight:500;color:var(--ink);cursor:pointer" style-hover="border-color:var(--hov)">Log in</div>
+</div>
+</div>
+</sc-if>
+</div>
+</div>
+<div style="flex:none;display:flex;flex-wrap:wrap;gap:{{ geo.factsGap }};padding:2px 0;transition:{{ geo.tween }}">
+<sc-if value="{{ notHideKeywords }}" hint-placeholder-val="{{ true }}">
+<div style="flex:1 1 150px;min-width:0">
+<div style="font-size:11px;font-weight:500;color:var(--muted);margin-bottom:4px">Keywords</div>
+<div title="{{ c.keywords }}" style="display:flex;flex-wrap:nowrap;gap:5px;height:20px;overflow:hidden">
+<sc-for list="{{ keywordTags }}" as="k" hint-placeholder-count="3">
+<span style="display:inline-flex;align-items:center;flex:{{ k.flex }};min-width:0;box-sizing:border-box;font-size:11.5px;color:var(--muted);white-space:nowrap;overflow:hidden;text-overflow:ellipsis">{{ k.label }}</span>
+</sc-for>
+</div>
+</div>
+</sc-if>
+<div style="flex:1 1 150px;min-width:0">
+<div style="font-size:11px;font-weight:500;color:var(--muted);margin-bottom:4px">Prerequisites</div>
+<sc-if value="{{ c.hasPrereq }}" hint-placeholder-val="{{ true }}">
+<div style="display:flex;flex-wrap:nowrap;gap:5px;height:20px;overflow:hidden">
+<sc-for list="{{ c.prereqCourses }}" as="p" hint-placeholder-count="2">
+<span title="{{ p.name }}" style="display:inline-flex;align-items:center;gap:{{ p.gap }};flex:none;box-sizing:border-box;height:20px;padding:{{ p.padding }};border-radius:{{ p.radius }};background:{{ p.bg }};font:500 11.5px Geist Mono,ui-monospace,monospace;color:var(--brand);white-space:nowrap"><svg width="11" height="11" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round" style="flex:none"><circle cx="12" cy="12" r="10"></circle><sc-if value="{{ p.taken }}" hint-placeholder-val="{{ false }}"><path d="m9 12 2 2 4-4"></path></sc-if></svg>{{ p.code }}</span>
+</sc-for>
+</div>
+</sc-if>
+<sc-if value="{{ c.noPrereq }}" hint-placeholder-val="{{ false }}">
+<div style="font-size:13px;color:var(--dim2);line-height:19px">None listed</div>
+</sc-if>
+</div>
+</div>
+<div style="flex:1 1 auto;min-height:0;max-height:{{ geo.summaryMax }};opacity:{{ geo.summaryOpacity }};overflow:hidden;transition:{{ geo.tween }}">
+<div style="font-size:13px;color:var(--muted);line-height:19px;overflow:hidden">{{ c.summaryClipped }}</div>
+</div>
+<div style="flex:none;display:flex;gap:8px;margin-top:auto;padding-top:2px;min-width:0">
+<div onClick="{{ c.onReview }}" title="Write a review" style="display:flex;align-items:center;justify-content:center;gap:7px;flex:{{ geo.reviewFlex }};min-width:40px;overflow:hidden;box-sizing:border-box;height:34px;padding:0 10px;border-radius:8px;background:var(--warnBtn);color:var(--warnBtnFg);font-size:13px;font-weight:500;cursor:pointer" style-hover="background:var(--warnBtn)"><svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="var(--warnBtnFg)" stroke-width="2" stroke-linejoin="round" style="flex:none"><path d="M21 12a8 8 0 0 1-8 8H4l2-3.2A8 8 0 1 1 21 12z"></path></svg><sc-if value="{{ geo.showLabel }}" hint-placeholder-val="{{ true }}"><span style="min-width:0;flex:1;overflow:hidden;white-space:nowrap">Write a review</span></sc-if></div>
+
+<div data-pop="compare" onClick="{{ stopClick }}" style="position:relative;flex:{{ geo.saveFlex }};min-width:44px">
+
+<sc-if value="{{ isSaveAction }}" hint-placeholder-val="{{ true }}">
+<div style="display:flex;align-items:stretch;box-sizing:border-box;height:34px;max-width:100%;border-radius:8px;border:1px solid {{ c.saveBorder }};background:{{ c.saveBg }};overflow:hidden">
+<div onClick="{{ c.onSave }}" style="display:flex;align-items:center;gap:7px;flex:1;min-width:0;overflow:hidden;box-sizing:border-box;padding:0 10px;color:{{ c.saveFg }};font-size:13px;cursor:pointer" style-hover="background:rgba(23,81,166,.06)">
+<svg width="15" height="15" viewBox="0 0 24 24" fill="{{ c.saveFill }}" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round" style="flex:none"><path d="m19 21-7-4-7 4V5a2 2 0 0 1 2-2h10a2 2 0 0 1 2 2z"></path></svg><sc-if value="{{ geo.showLabel }}" hint-placeholder-val="{{ true }}"><span style="min-width:0;overflow:hidden;white-space:nowrap">{{ c.saveLabel }}</span></sc-if>
+</div>
+<div style="flex:none;width:1px;background:{{ c.saveBorder }}"></div>
+<div onClick="{{ c.onPicker }}" title="Add to collections" style="flex:none;display:flex;align-items:center;padding:0 9px;color:{{ c.saveFg }};font-size:10px;cursor:pointer" style-hover="background:rgba(23,81,166,.06)">▾</div>
+</div>
+</sc-if>
+
+<sc-if value="{{ isAddAction }}" hint-placeholder-val="{{ false }}">
+<div onClick="{{ c.onPicker }}" role="button" tabIndex="0" aria-haspopup="true" aria-label="{{ c.addLabel }}" style="display:flex;align-items:center;gap:7px;box-sizing:border-box;height:34px;padding:0 10px;border-radius:8px;border:1px solid var(--rule3);background:var(--surface);color:var(--ink);font-size:13px;overflow:hidden;cursor:pointer" style-hover="border-color:var(--hov);background:rgba(23,81,166,.06)">
+<svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="#16202b" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round" style="flex:none"><rect x="3" y="5" width="14" height="14" rx="2.5"></rect><path d="M8.5 12h5M11 9.5v5"></path></svg><sc-if value="{{ geo.showLabel }}" hint-placeholder-val="{{ true }}"><span style="min-width:0;overflow:hidden;white-space:nowrap">Add to comparison</span></sc-if>
+</div>
+</sc-if>
+
+<sc-if value="{{ c.pickerOpen }}" hint-placeholder-val="{{ false }}">
+<div data-pop-panel="compare" style="position:absolute;top:{{ pickerTop }};bottom:{{ pickerBottom }};left:0;z-index:25;box-sizing:border-box;width:266px;padding:5px;border-radius:10px;border:1px solid var(--rule2);background:var(--surface);box-shadow:0 8px 24px rgba(20,30,45,.14)">
+
+<sc-if value="{{ isGuest }}" hint-placeholder-val="{{ false }}">
+<div style="padding:11px 11px 10px">
+<div style="display:flex;align-items:center;gap:8px">
+<svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="#6b6355" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><rect x="4" y="10.5" width="16" height="10.5" rx="2.5"></rect><path d="M8 10.5V7.5a4 4 0 0 1 8 0v3"></path></svg>
+<div style="font-size:13.5px;font-weight:600">Organize your saved courses</div>
+</div>
+<div style="margin-top:6px;font-size:12.5px;line-height:1.5;color:var(--muted)">Sign up or log in to create collections, compare courses with AI, and sync across devices.</div>
+<div style="margin-top:11px;display:flex;gap:7px">
+<div onClick="{{ onSignUp }}" role="button" tabIndex="0" style="flex:1;display:flex;align-items:center;justify-content:center;height:32px;border-radius:8px;background:var(--btn);color:var(--btnFg);font-size:12.5px;font-weight:600;cursor:pointer" style-hover="background:var(--btn)">Sign up</div>
+<div onClick="{{ onLogIn }}" role="button" tabIndex="0" style="flex:1;display:flex;align-items:center;justify-content:center;height:32px;border-radius:8px;border:1px solid var(--rule3);background:var(--surface);font-size:12.5px;font-weight:500;color:var(--brand);cursor:pointer" style-hover="border-color:var(--hov)">Log in</div>
+</div>
+</div>
+</sc-if>
+
+<sc-if value="{{ isMember }}" hint-placeholder-val="{{ true }}">
+<div>
+<div style="padding:8px 9px 6px;font-size:10.5px;font-weight:600;letter-spacing:.09em;text-transform:uppercase;color:var(--dim)">Add to collections</div>
+<sc-if value="{{ c.creating }}" hint-placeholder-val="{{ false }}">
+<div style="display:flex;align-items:center;gap:9px;padding:2px 9px 6px">
+<span style="width:16px;flex:none;display:flex;justify-content:center"><svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="#1751a6" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M5 12h14"></path><path d="M12 5v14"></path></svg></span>
+<input value="{{ draftName }}" onChange="{{ onDraftChange }}" onFocus="{{ onDraftFocus }}" onKeyDown="{{ onDraftKey }}" onBlur="{{ onDraftCommit }}" autoFocus="{{ true }}" style="flex:1;min-width:0;box-sizing:border-box;height:28px;padding:0 8px;border-radius:6px;border:1px solid var(--brand);outline:none;font-family:Geist,system-ui,sans-serif;font-size:13px;color:var(--ink)">
+</div>
+</sc-if>
+<sc-if value="{{ c.notCreating }}" hint-placeholder-val="{{ true }}">
+<div onClick="{{ c.onNewComparison }}" role="button" tabIndex="0" style="display:flex;align-items:center;gap:9px;padding:8px 9px;border-radius:7px;font-size:13px;font-weight:500;color:var(--brand);cursor:pointer" style-hover="background:var(--pill)">
+<span style="width:16px;flex:none;display:flex;justify-content:center"><svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="#1751a6" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M5 12h14"></path><path d="M12 5v14"></path></svg></span>{{ newLabel }}
+</div>
+</sc-if>
+<sc-if value="{{ c.hasComparisons }}" hint-placeholder-val="{{ true }}">
+<div style="height:1px;margin:4px 6px;background:var(--pill)"></div>
+</sc-if>
+<sc-for list="{{ c.comparisons }}" as="k" hint-placeholder-count="2">
+<div onClick="{{ k.onClick }}" role="button" tabIndex="0" style="display:flex;align-items:center;gap:9px;padding:8px 9px;border-radius:7px;font-size:13px;color:var(--ink2);cursor:pointer" style-hover="background:var(--pill)">
+<span style="width:16px;flex:none;display:flex;justify-content:center"><svg width="16" height="16" viewBox="0 0 24 24" fill="{{ k.fill }}" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="5" width="14" height="14" rx="2.5"></rect><path d="{{ k.tick }}"></path></svg></span>
+<span style="flex:1;overflow:hidden;text-overflow:ellipsis;white-space:nowrap">{{ k.name }}</span>
+</div>
+</sc-for>
+</div>
+</sc-if>
+
+</div>
+</sc-if>
+</div>
+
+
+
+<sc-if value="{{ hasRemove }}" hint-placeholder-val="{{ false }}">
+<div onClick="{{ c.onRemove }}" role="button" tabIndex="0" aria-label="{{ c.removeLabel }}" title="{{ c.removeLabel }}" style="margin-left:auto;flex:none;width:34px;height:34px;display:flex;align-items:center;justify-content:center;border-radius:8px;border:1px solid var(--rule3);background:var(--surface);color:var(--dim);cursor:pointer" style-hover="border-color:#d9a08c;color:#a4402a"><svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.9" stroke-linecap="round" stroke-linejoin="round"><path d="M4 7h16"></path><path d="M6 7V5a2 2 0 0 1 2-2h8a2 2 0 0 1 2 2v2"></path><path d="M6 7l1 13a2 2 0 0 0 2 2h6a2 2 0 0 0 2-2l1-13"></path><path d="M10 11v6"></path><path d="M14 11v6"></path></svg></div>
+</sc-if>
+</div>
+</div>
+<div style="box-sizing:border-box;width:{{ geo.railW }};flex:none;display:flex;flex-direction:column;justify-content:space-between;gap:10px;padding:{{ geo.railPad }};transition:{{ geo.tween }};border-left:1px solid var(--rule);background:var(--inset);border-radius:0 11px 11px 0">
+<div style="display:flex;flex-direction:column;gap:11px">
+<div style="display:flex;justify-content:flex-end">
+<sc-if value="{{ c.hasStats }}" hint-placeholder-val="{{ true }}">
+<div style="padding:3px 9px;border-radius:6px;background:var(--pill);color:var(--muted);font-size:11.5px;white-space:nowrap;overflow:hidden;text-overflow:ellipsis">{{ c.examLabel }}</div>
+</sc-if>
+<sc-if value="{{ c.noStats }}" hint-placeholder-val="{{ false }}">
+<div style="padding:3px 9px;border-radius:6px;background:var(--pill);color:var(--dim);font-size:11.5px;white-space:nowrap">No reviews yet</div>
+</sc-if>
+</div>
+<div>
+<sc-if value="{{ c.hasReviewStats }}" hint-placeholder-val="{{ true }}">
+<div style="margin-top:2px"><span style="font-size:26px;font-weight:600;line-height:1;letter-spacing:-.02em;color:var(--brand);font-variant-numeric:tabular-nums">{{ c.happyPct }}</span></div>
+<div style="margin-top:3px;font-size:11px;line-height:1.3;color:var(--muted)">of {{ c.statReviews }} reviewers are happy they took the course</div>
+</sc-if>
+<sc-if value="{{ c.noReviewStats }}" hint-placeholder-val="{{ false }}">
+<div style="margin-top:2px;font-size:15px;font-weight:600;color:var(--dim)">No reviews yet</div>
+<sc-if value="{{ notCompact }}" hint-placeholder-val="{{ true }}">
+<div style="margin-top:3px;font-size:11px;line-height:1.3;color:var(--muted)">Be the first to say how it went.</div>
+</sc-if>
+</sc-if>
+</div>
+<div style="display:flex;flex-direction:column;gap:8px">
+<div>
+<div style="display:flex;justify-content:space-between;font-size:11.5px;color:var(--muted);margin-bottom:3px"><span>Workload</span><span style="font-weight:600;color:var(--ink)">{{ c.workload }}</span></div>
+<div style="height:5px;border-radius:3px;background:var(--pill);overflow:hidden"><div style="height:100%;width:{{ c.wlW }};background:#dfa53c"></div></div>
+</div>
+<div>
+<div style="display:flex;justify-content:space-between;font-size:11.5px;color:var(--muted);margin-bottom:3px"><span>Learning</span><span style="font-weight:600;color:var(--ink)">{{ c.learning }}</span></div>
+<div style="height:5px;border-radius:3px;background:var(--pill);overflow:hidden"><div style="height:100%;width:{{ c.leW }};background:var(--btn)"></div></div>
+</div>
+</div>
+</div>
+<sc-if value="{{ notCompact }}" hint-placeholder-val="{{ true }}">
+<div style="display:flex;justify-content:flex-end;gap:8px;font-size:12px;color:var(--muted)">
+<span style="display:flex;align-items:center;gap:4px" title="Number of reviews"><svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="#5c6570" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><path d="M22 17a2 2 0 0 1-2 2H6l-4 4V4a2 2 0 0 1 2-2h16a2 2 0 0 1 2 2z"></path></svg>{{ c.statReviews }}</span>
+</div>
+</sc-if>
+</div>
+</div>
+</x-dc>
+<script type="text/x-dc" data-dc-script data-props="{&quot;$preview&quot;:{&quot;width&quot;:620,&quot;height&quot;:260},&quot;c&quot;:{&quot;editor&quot;:null,&quot;tsType&quot;:&quot;CourseCardModel&quot;},&quot;geo&quot;:{&quot;editor&quot;:null,&quot;tsType&quot;:&quot;CardGeometry&quot;},&quot;action&quot;:{&quot;editor&quot;:&quot;enum&quot;,&quot;default&quot;:&quot;save&quot;,&quot;options&quot;:[&quot;save&quot;,&quot;add&quot;],&quot;tsType&quot;:&quot;\&quot;save\&quot; | \&quot;add\&quot;&quot;},&quot;pickerAbove&quot;:{&quot;editor&quot;:&quot;boolean&quot;,&quot;default&quot;:false,&quot;tsType&quot;:&quot;boolean&quot;},&quot;newLabel&quot;:{&quot;editor&quot;:&quot;text&quot;,&quot;default&quot;:&quot;Create new collection&quot;,&quot;tsType&quot;:&quot;string&quot;},&quot;isGuest&quot;:{&quot;editor&quot;:&quot;boolean&quot;,&quot;default&quot;:false,&quot;tsType&quot;:&quot;boolean&quot;},&quot;isMember&quot;:{&quot;editor&quot;:&quot;boolean&quot;,&quot;default&quot;:true,&quot;tsType&quot;:&quot;boolean&quot;},&quot;onSignUp&quot;:{&quot;editor&quot;:null,&quot;tsType&quot;:&quot;() =&gt; void&quot;},&quot;onLogIn&quot;:{&quot;editor&quot;:null,&quot;tsType&quot;:&quot;() =&gt; void&quot;},&quot;draftName&quot;:{&quot;editor&quot;:&quot;text&quot;,&quot;default&quot;:&quot;&quot;,&quot;tsType&quot;:&quot;string&quot;},&quot;onDraftChange&quot;:{&quot;editor&quot;:null,&quot;tsType&quot;:&quot;(e: Event) =&gt; void&quot;},&quot;onDraftFocus&quot;:{&quot;editor&quot;:null,&quot;tsType&quot;:&quot;(e: Event) =&gt; void&quot;},&quot;onDraftKey&quot;:{&quot;editor&quot;:null,&quot;tsType&quot;:&quot;(e: Event) =&gt; void&quot;},&quot;onDraftCommit&quot;:{&quot;editor&quot;:null,&quot;tsType&quot;:&quot;(e: Event) =&gt; void&quot;},&quot;hideFacts&quot;:{&quot;editor&quot;:&quot;boolean&quot;,&quot;default&quot;:false,&quot;tsType&quot;:&quot;boolean&quot;}}">
+/* The course card, shared by Explore and Saved courses.
+
+   Geometry arrives as one `geo` object so the parent owns the collapse ramp —
+   Explore interpolates it from the results column width, Saved pins it to the
+   fully collapsed end. The only structural difference between the two pages is
+   the action control: Explore's split Save button, or Saved's Add to comparison. */
+const SAMPLE_GEO = {
+  tween: "none",
+  titleSize: "17px",
+  cardGap: "10px",
+  cardPad: "18px",
+  factsGap: "14px",
+  reviewPad: "0 12px",
+  labelMax: "120px",
+  labelOpacity: 1,
+  saveW: "126px",
+  savePad: "12px",
+  railW: "224px",
+  railPad: "18px 16px",
+  summaryMax: "38px",
+  summaryOpacity: 1,
+  reviewFlex: "0 1 132px",
+  saveFlex: "0 1 158px",
+  showLabel: true,
+  cardHeight: "236px"
+};
+
+/* Stand-in course used only when the page is opened on its own, so the preview
+   matches what Explore and Saved courses render. */
+const SAMPLE_COURSE = {
+  title: "DD2380 Artificial Intelligence",
+  meta: "6.0 credits · EECS · Advanced",
+  keywords: "search, planning, probabilistic reasoning, agents",
+  prereq: "DD1337, SF1918",
+  prereqCourses: [
+    { code: "DD1337", name: "Programming", inCatalog: true },
+    { code: "SF1918", name: "Probability and Statistics", inCatalog: true }
+  ],
+  hasPrereq: true,
+  noPrereq: false,
+  summary: "A broad first course in AI: search, planning and reasoning under uncertainty, taught through three programming labs.",
+  summaryClipped: "A broad first course in AI: search, planning and reasoning under uncertainty, taught through three programming labs.",
+  hasStats: true,
+  noStats: false,
+  examLabel: "Labs 60% · Exam 40%",
+  workload: "3.8",
+  learning: "4.2",
+  wlW: "76%",
+  leW: "84%",
+  happyPct: "87%",
+  hasReviewStats: true,
+  noReviewStats: false,
+  statTaken: "1.2k",
+  statReviews: "148",
+  borderColor: "#e5e0d2",
+  takenTitle: "1.2k students have taken this course · click to mark as taken",
+  takenCountFg: "#5c6570",
+  takenBg: "transparent",
+  takenFill: "none",
+  takenStroke: "#8a857a",
+  saveLabel: "Save course",
+  saveFg: "#1751a6",
+  saveBg: "#fff",
+  saveBorder: "#ddd8c9",
+  saveFill: "none",
+  pickerOpen: false,
+  creating: false,
+  notCreating: true,
+  hasComparisons: false,
+  comparisons: []
+};
+
+class Component extends DCLogic {
+  /* One row of chips only: the row is exactly 20px, so a wrapped second row is
+     clipped whole rather than cut through, and what did not fit is counted. */
+  tagsFor(raw) {
+    const all = String(raw || "").split(",").map((s) => s.trim()).filter(Boolean);
+    const SHOWN = 2;
+    const out = all.slice(0, SHOWN).map((s) => ({ label: s, flex: "0 1 auto" }));
+    if (all.length > SHOWN) out.push({ label: "+" + (all.length - SHOWN), flex: "none" });
+    return out;
+  }
+
+  renderVals() {
+    const p = this.props;
+    const action = p.action || "save";
+    return {
+      // Props win when the card is embedded; the sample only fills a bare preview.
+      c: p.c || SAMPLE_COURSE,
+      keywordTags: this.tagsFor((p.c || SAMPLE_COURSE).keywords),
+      notHideKeywords: !p.hideFacts,
+      notCompact: !p.compact,
+      geo: p.geo || SAMPLE_GEO,
+      isSaveAction: action === "save",
+      isAddAction: action === "add",
+      // Explore's card sits in a scrolling column, Saved's near the page bottom.
+      pickerTop: p.pickerAbove ? "auto" : "38px",
+      pickerBottom: p.pickerAbove ? "38px" : "auto",
+      newLabel: p.newLabel || "Create new collection",
+      hasRemove: Boolean(p.c && p.c.onRemove),
+      stopClick: (ev) => ev.stopPropagation()
+    };
+  }
+}
+</script>
+</body>
+</html>

--- a/docs/design/Course Community - Explore.dc.html
+++ b/docs/design/Course Community - Explore.dc.html
@@ -1,0 +1,1662 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<script src="./support.js"></script>
+</head>
+<body>
+<x-dc>
+<helmet data-dc-atomics><link rel="preconnect" href="https://fonts.googleapis.com"><link rel="preconnect" href="https://fonts.gstatic.com" crossorigin><link href="https://fonts.googleapis.com/css2?family=Geist:wght@400;500;600;700&family=Geist+Mono:wght@400;500&display=swap" rel="stylesheet"><link rel="stylesheet" href="cc-theme.css"><style>body{background:var(--pg);color:var(--ink)}body{margin:0;background:var(--pg);color:var(--ink);font-family:Geist,system-ui,sans-serif}a{color:#1751a6}a:hover{color:#10386f}.dv-turn{padding:40px 44px 32px;border-bottom:1px solid rgba(0,0,0,.08);scroll-margin-top:16px}.dv-thd{display:flex;align-items:baseline;gap:10px;margin:0 0 20px}.dv-tid{font:600 10px ui-monospace,Menlo,monospace;padding:3px 7px;background:#16202b;color:#fff;border-radius:4px;text-decoration:none}.dv-tname{font:600 13px/1.2 Geist,system-ui,sans-serif;color:var(--ink)}.dv-opts{display:flex;flex-wrap:wrap;gap:28px;align-items:flex-start}.dv-opt{flex:none;display:flex;flex-direction:column;gap:9px;scroll-margin-top:16px}.dv-oid{font:600 10.5px ui-monospace,Menlo,monospace;padding:3px 7px;background:rgba(0,0,0,.08);color:var(--ink);border-radius:5px;text-decoration:none}.dv-olabel{display:flex;align-items:baseline;gap:8px;font:400 11px/1.3 Geist,system-ui,sans-serif;color:rgba(0,0,0,.55)}.dv-card{max-width:100%;background:var(--surface);border:1px solid rgba(0,0,0,.08);border-radius:8px;box-shadow:0 1px 3px rgba(0,0,0,.06);overflow:hidden}.dv-opt:target .dv-oid{background:var(--btn);color:#fff}.dv-next{margin:22px 0 0;font:12px/1.5 Geist,system-ui,sans-serif;color:rgba(0,0,0,.5)}@keyframes om-spin{to{transform:rotate(360deg)}}@keyframes pulse{0%,100%{opacity:.45}50%{opacity:1}}</style></helmet>
+
+<div data-cc-page="explore" style="position:relative;display:flex;height:900px;background:var(--pg);color:var(--ink);font-size:14px">
+<div data-cc-topbar="1" data-cc-fade="1" style="position:absolute;top:0;left:0;right:0;height:66px;z-index:1;box-sizing:border-box;display:flex;align-items:center;justify-content:flex-end;gap:8px;padding:0 28px;border-bottom:1px solid var(--rule);background:var(--pg)">
+<div onClick="{{ onTheme }}" role="button" tabIndex="0" title="{{ themeTitle }}" aria-label="{{ themeTitle }}" style="width:34px;height:34px;display:flex;align-items:center;justify-content:center;border-radius:8px;color:var(--chipInk);cursor:pointer" style-hover="background:rgba(125,145,175,.14)">
+<sc-if value="{{ notNight }}" hint-placeholder-val="{{ true }}"><svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><path d="M20.5 14.5A8.5 8.5 0 1 1 9.5 3.5a7 7 0 0 0 11 11z"></path></svg></sc-if>
+<sc-if value="{{ night }}" hint-placeholder-val="{{ false }}"><svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round"><circle cx="12" cy="12" r="4.2"></circle><path d="M12 3v2M12 19v2M3 12h2M19 12h2M5.6 5.6l1.4 1.4M17 17l1.4 1.4M18.4 5.6 17 7M7 17l-1.4 1.4"></path></svg></sc-if>
+</div>
+</div>
+
+
+<div data-cc-sidebar="1" data-cc-fade="1" style="position:relative;z-index:2;box-sizing:border-box;width:236px;flex:none;display:flex;flex-direction:column;gap:6px;padding:14px 10px;background:#1751a6;color:#fff">
+<a href="Course Community - Landing.dc.html" style="display:flex;align-items:center;gap:10px;padding:6px 8px 14px;color:#fff;text-decoration:none">
+<img src="assets/ais-symbol-white.png" alt="KTH AI Society" style="height:34px;width:34px;object-fit:contain">
+<div style="width:1px;height:28px;background:rgba(255,255,255,.35)"></div>
+<div style="font-size:15px;font-weight:600;line-height:1.15">Course<br>Community</div>
+</a>
+<div style="display:flex;flex-direction:column;gap:2px;margin-top:14px">
+<a href="Course Community - Explore.dc.html" style="display:flex;align-items:center;gap:10px;padding:9px 10px;border-radius:8px;background:rgba(255,255,255,.16);font-weight:600;color:#fff;text-decoration:none" style-hover="background:rgba(255,255,255,.1)"><svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="#fff" stroke-width="2.4" stroke-linecap="round"><circle cx="11" cy="11" r="7"></circle><line x1="16.5" y1="16.5" x2="21" y2="21"></line></svg><span style="flex:1">Explore</span></a>
+<a href="Course Community - Saved.dc.html" style="display:flex;align-items:center;gap:10px;padding:9px 10px;border-radius:8px;background:transparent;font-weight:400;color:#fff;text-decoration:none" style-hover="background:rgba(255,255,255,.1)"><svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="#fff" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="m19 21-7-4-7 4V5a2 2 0 0 1 2-2h10a2 2 0 0 1 2 2z"></path></svg><span style="flex:1">Saved courses</span><sc-if value="{{ hasSavedCount }}" hint-placeholder-val="{{ true }}"><span style="padding:1px 7px;border-radius:9px;background:rgba(255,255,255,.22);font-size:11.5px;font-weight:600">{{ savedCountLabel }}</span></sc-if></a>
+<a href="Course Community - My Page.dc.html" style="display:flex;align-items:center;gap:10px;padding:9px 10px;border-radius:8px;background:transparent;font-weight:400;color:#fff;text-decoration:none" style-hover="background:rgba(255,255,255,.1)"><svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="#fff" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="8" r="4"></circle><path d="M5.5 21a6.5 6.5 0 0 1 13 0"></path></svg><span style="flex:1">My Page</span></a>
+<a href="Course Community - Taken Courses.dc.html" style="display:flex;align-items:center;gap:10px;padding:9px 10px;border-radius:8px;background:transparent;font-weight:400;color:#fff;text-decoration:none" style-hover="background:rgba(255,255,255,.1)"><svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="#fff" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="10"></circle><path d="m9 12 2 2 4-4"></path></svg><span style="flex:1">Taken courses</span></a>
+</div>
+<div style="margin-top:auto;display:flex;flex-direction:column;gap:2px">
+<a href="Course Community - About.dc.html" style="display:flex;align-items:center;gap:10px;padding:9px 10px;border-radius:8px;color:rgba(255,255,255,.82);text-decoration:none" style-hover="background:rgba(255,255,255,.1)"><svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="#fff" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M12 7v14"></path><path d="M3 18a1 1 0 0 1-1-1V4a1 1 0 0 1 1-1h5a4 4 0 0 1 4 4 4 4 0 0 1 4-4h5a1 1 0 0 1 1 1v13a1 1 0 0 1-1 1h-6a3 3 0 0 0-3 3 3 3 0 0 0-3-3z"></path></svg>About &amp; contact</a>
+<sc-if value="{{ isMember }}" hint-placeholder-val="{{ false }}">
+<div style="display:flex;align-items:center;gap:10px;padding:10px;margin-top:8px;border-radius:8px;background:rgba(255,255,255,.1)">
+<div style="width:34px;height:34px;flex:none;border-radius:50%;background:#7ea6d8;color:#0d2f5e;display:flex;align-items:center;justify-content:center;font-weight:700;font-size:13px">EL</div>
+<div style="flex:1;min-width:0;font-size:13px;font-weight:500">Elsa Lindqvist</div>
+<div onClick="{{ onSignOut }}" role="button" tabIndex="0" aria-label="Sign out" title="Sign out" style="flex:none;width:28px;height:28px;display:flex;align-items:center;justify-content:center;border-radius:7px;color:rgba(255,255,255,.75);cursor:pointer" style-hover="background:rgba(255,255,255,.16);color:#fff"><svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.9" stroke-linecap="round" stroke-linejoin="round"><path d="M9 21H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h4"></path><path d="M16 17l5-5-5-5"></path><path d="M21 12H9"></path></svg></div>
+</div>
+</sc-if>
+<sc-if value="{{ isGuest }}" hint-placeholder-val="{{ true }}">
+<div style="margin-top:8px;padding-top:12px;border-top:1px solid rgba(255,255,255,.2)">
+<div style="font-size:11.5px;line-height:1.45;color:rgba(255,255,255,.78)">Browsing as a guest. Saving courses and posting reviews need an account.</div>
+<div onClick="{{ onSignUp }}" role="button" tabIndex="0" style="margin-top:10px;display:flex;align-items:center;justify-content:center;height:34px;border-radius:8px;background:#fff;color:#12417f;font-size:13px;font-weight:600;cursor:pointer">Sign up</div>
+<div onClick="{{ onLogIn }}" role="button" tabIndex="0" style="margin-top:6px;display:flex;align-items:center;justify-content:center;height:34px;border-radius:8px;border:1px solid rgba(255,255,255,.4);font-size:13px;font-weight:500;color:#fff;cursor:pointer">Log in</div>
+</div>
+</sc-if>
+</div>
+</div>
+
+<div style="position:relative;flex:1;min-width:0;min-height:0;margin-top:{{ paneTop }};display:flex;flex-direction:column;overflow-y:auto;overflow-x:hidden">
+
+<sc-if value="{{ authOpen }}" hint-placeholder-val="{{ false }}">
+<div style="position:absolute;inset:0;z-index:60;display:flex;align-items:center;justify-content:center;padding:24px;background:rgba(20,30,45,.34)">
+<div style="width:392px;box-sizing:border-box;padding:24px;border-radius:14px;background:var(--surface);box-shadow:0 18px 48px rgba(20,30,45,.24)">
+<div style="display:flex;align-items:center;justify-content:space-between;gap:12px">
+<div style="font-size:11px;font-weight:600;letter-spacing:.06em;text-transform:uppercase;color:var(--brand)">One step left</div>
+<div onClick="{{ onAuthCancel }}" title="Back to my draft" style="width:26px;height:26px;display:flex;align-items:center;justify-content:center;border-radius:7px;color:var(--dim);font-size:17px;line-height:1;cursor:pointer" style-hover="background:var(--pill)">×</div>
+</div>
+<div style="margin-top:8px;font-size:19px;font-weight:600;line-height:1.25">Sign in to publish your review</div>
+<div style="margin-top:6px;font-size:13.5px;line-height:1.5;color:var(--muted)">Your draft is saved as it is — text, scores and the course all stay put. Nothing is published until you confirm.</div>
+<div style="margin-top:16px;display:flex;flex-direction:column;gap:8px">
+<div onClick="{{ onAuthDone }}" style="display:flex;align-items:center;justify-content:center;gap:9px;height:42px;border-radius:9px;background:var(--btn);color:var(--btnFg);font-size:13.5px;font-weight:600;cursor:pointer" style-hover="background:var(--btn)">Continue with KTH account</div>
+<div onClick="{{ onAuthDone }}" style="display:flex;align-items:center;justify-content:center;height:42px;border-radius:9px;border:1px solid var(--rule3);background:var(--surface);font-size:13.5px;font-weight:500;color:var(--ink);cursor:pointer" style-hover="border-color:var(--hov)">Sign up with email</div>
+</div>
+<div onClick="{{ onAuthCancel }}" style="margin-top:14px;text-align:center;font-size:12.5px;font-weight:500;color:var(--brand);cursor:pointer" style-hover="text-decoration:underline">Back to my draft</div>
+</div>
+</div>
+</sc-if>
+
+
+
+<sc-if value="{{ isSavedView }}" hint-placeholder-val="{{ false }}">
+<div style="position:absolute;inset:0;z-index:40;overflow:auto;background:var(--pg);color:var(--ink)">
+<div style="width:100%;max-width:{{ pageMaxWidth }};box-sizing:border-box;margin:0 auto;padding:26px {{ pageSidePadding }} 40px;display:flex;flex-direction:column;gap:22px">
+
+<div aria-live="polite" style="position:sticky;top:0;z-index:5;display:flex;flex-direction:column;gap:8px">
+<sc-if value="{{ hasNote }}" hint-placeholder-val="{{ false }}">
+<div style="display:flex;align-items:center;gap:8px;padding:9px 13px;border-radius:9px;border:1px solid var(--rule2);background:var(--pill);font-size:12.5px;color:var(--brand)">
+<svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="#1751a6" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round"><path d="M20 6 9 17l-5-5"></path></svg>{{ note }}
+</div>
+</sc-if>
+</div>
+
+<div style="display:flex;flex-direction:column;gap:12px">
+<div>
+<h1 style="margin:0;font-size:26px;font-weight:600;letter-spacing:-.02em">Saved courses</h1>
+<div style="margin-top:6px;font-size:13.5px;line-height:1.5;color:var(--muted)">Keep track of courses you are interested in and organize them into groups for comparison.</div>
+</div>
+</div>
+
+<div style="display:flex;flex-direction:column;gap:26px">
+
+<sc-if value="{{ importRunning }}" hint-placeholder-val="{{ false }}">
+<div aria-live="polite" style="display:flex;align-items:center;gap:10px;padding:12px 14px;border-radius:10px;border:1px solid var(--rule2);background:var(--pill);font-size:12.5px;color:var(--brand)">
+<span style="flex:none;width:14px;height:14px;border-radius:50%;border:2px solid var(--hov);border-top-color:var(--brand);animation:om-spin .9s linear infinite"></span>
+Adding the courses saved in this browser to your account…
+</div>
+</sc-if>
+<sc-if value="{{ importDone }}" hint-placeholder-val="{{ false }}">
+<div aria-live="polite" style="display:flex;align-items:center;gap:10px;padding:12px 14px;border-radius:10px;border:1px solid var(--rule2);background:var(--pill);font-size:12.5px;color:var(--brand)">
+<svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="#1751a6" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round"><path d="M20 6 9 17l-5-5"></path></svg>
+<span style="flex:1">{{ importMsg }}</span>
+<span onClick="{{ onDismissImport }}" role="button" tabIndex="0" aria-label="Dismiss" style="cursor:pointer;color:var(--muted)">×</span>
+</div>
+</sc-if>
+<sc-if value="{{ importDupes }}" hint-placeholder-val="{{ false }}">
+<div aria-live="polite" style="display:flex;align-items:center;gap:10px;padding:12px 14px;border-radius:10px;border:1px solid var(--rule2);background:var(--pg);font-size:12.5px;color:var(--muted)">
+<svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="#6b6355" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M20 6 9 17l-5-5"></path></svg>
+<span style="flex:1">Your saved courses are already up to date</span>
+<span onClick="{{ onDismissImport }}" role="button" tabIndex="0" aria-label="Dismiss" style="cursor:pointer">×</span>
+</div>
+</sc-if>
+<sc-if value="{{ pendingImport }}" hint-placeholder-val="{{ false }}">
+<div style="display:flex;align-items:center;gap:12px;padding:12px 14px;border-radius:10px;border:1px solid var(--rule2);background:var(--surface);font-size:12.5px;color:var(--chipInk)">
+<span style="flex:1">{{ pendingImportMsg }}</span>
+<div onClick="{{ onRunImport }}" role="button" tabIndex="0" style="height:30px;display:flex;align-items:center;padding:0 12px;border-radius:8px;background:var(--btn);color:var(--btnFg);font-size:12.5px;font-weight:600;cursor:pointer" style-hover="background:var(--btn)">Add to my account</div>
+</div>
+</sc-if>
+
+<dc-import name="Course Community - Collections" store-module="{{ workspaceStore }}" courses="{{ collectionsCourses }}" saved-codes="{{ savedCodesForCollections }}" is-guest="{{ isGuest }}" on-change="{{ onCollectionsChanged }}" on-detail-change="{{ onCollectionsDetailChange }}" hint-size="100%,320px"></dc-import>
+
+<sc-if value="{{ showSavedSection }}" hint-placeholder-val="{{ true }}">
+<div>
+<h2 style="margin:0;font-size:16px;font-weight:600">Saved courses</h2>
+<div style="margin-top:4px;font-size:12.5px;color:var(--muted)">Courses you have saved but not yet added to a comparison.</div>
+
+<sc-if value="{{ hasUnorganized }}" hint-placeholder-val="{{ true }}">
+<div style="margin-top:14px;display:grid;grid-template-columns:repeat(auto-fill,minmax(300px,1fr));gap:12px">
+<sc-for list="{{ unorganized }}" as="c" hint-placeholder-count="4">
+<div style="position:relative;box-sizing:border-box;display:flex;flex-direction:column;gap:10px;padding:14px 15px;border:1px solid var(--rule);border-radius:11px;background:var(--surface)" style-hover="border-color:var(--hov)">
+<div>
+<div style="display:flex;align-items:baseline;gap:8px">
+<span style="font-family:'Geist Mono',ui-monospace,monospace;font-size:12px;font-weight:500;color:var(--brand)">{{ c.code }}</span>
+<span style="font-size:11.5px;color:var(--dim2)">{{ c.period }}</span>
+</div>
+<div style="margin-top:4px;font-size:14px;font-weight:600;line-height:1.3">{{ c.title }}</div>
+<div style="margin-top:4px;font-size:11.5px;color:var(--muted)">{{ c.meta }}</div>
+</div>
+<div style="display:flex;flex-wrap:wrap;gap:10px;font-size:11.5px;color:var(--muted)">
+<span>Workload: {{ c.workload }}</span>
+<span>{{ c.assessment }}</span>
+</div>
+<div style="margin-top:auto;display:flex;align-items:center;gap:7px">
+<div onClick="{{ c.onOpen }}" role="button" tabIndex="0" aria-label="{{ c.openLabel }}" style="height:30px;display:flex;align-items:center;padding:0 11px;border-radius:8px;border:1px solid var(--rule3);background:var(--surface);font-size:12px;font-weight:500;color:var(--ink);cursor:pointer" style-hover="border-color:var(--hov)">Open</div>
+<div style="position:relative">
+<div onClick="{{ c.onAdd }}" role="button" tabIndex="0" aria-haspopup="true" aria-label="{{ c.addLabel }}" style="height:30px;display:flex;align-items:center;gap:6px;padding:0 11px;border-radius:8px;border:1px solid var(--rule3);background:var(--surface);font-size:12px;font-weight:500;color:var(--ink);cursor:pointer" style-hover="border-color:var(--hov)">Add to comparison ▾</div>
+<sc-if value="{{ c.pickerOpen }}" hint-placeholder-val="{{ false }}">
+<div style="position:absolute;bottom:34px;left:0;z-index:25;box-sizing:border-box;width:262px;padding:5px;border-radius:10px;border:1px solid var(--rule2);background:var(--surface);box-shadow:0 8px 24px rgba(20,30,45,.14)">
+<sc-if value="{{ isGuest }}" hint-placeholder-val="{{ true }}">
+<div style="padding:11px 11px 10px">
+<div style="display:flex;align-items:center;gap:8px">
+<svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="#6b6355" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><rect x="4" y="10.5" width="16" height="10.5" rx="2.5"></rect><path d="M8 10.5V7.5a4 4 0 0 1 8 0v3"></path></svg>
+<div style="font-size:13.5px;font-weight:600">Organize your saved courses</div>
+</div>
+<div style="margin-top:6px;font-size:12.5px;line-height:1.5;color:var(--muted)">Sign up or log in to create collections, compare courses with AI, and sync across devices.</div>
+<div style="margin-top:11px;display:flex;gap:7px">
+<div onClick="{{ onSignUp }}" role="button" tabIndex="0" style="flex:1;display:flex;align-items:center;justify-content:center;height:32px;border-radius:8px;background:var(--btn);color:var(--btnFg);font-size:12.5px;font-weight:600;cursor:pointer" style-hover="background:var(--btn)">Sign up</div>
+<div onClick="{{ onLogIn }}" role="button" tabIndex="0" style="flex:1;display:flex;align-items:center;justify-content:center;height:32px;border-radius:8px;border:1px solid var(--rule3);background:var(--surface);font-size:12.5px;font-weight:500;color:var(--brand);cursor:pointer" style-hover="border-color:var(--hov)">Log in</div>
+</div>
+</div>
+</sc-if>
+<sc-if value="{{ isMember }}" hint-placeholder-val="{{ false }}">
+<div>
+<div style="padding:8px 9px 6px;font-size:10.5px;font-weight:600;letter-spacing:.09em;text-transform:uppercase;color:var(--dim)">Add to collections</div>
+<div onClick="{{ onOpenDlg }}" role="button" tabIndex="0" style="display:flex;align-items:center;gap:9px;padding:8px 9px;border-radius:7px;font-size:13px;font-weight:500;color:var(--brand);cursor:pointer" style-hover="background:var(--pill)"><svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="#1751a6" stroke-width="2" stroke-linecap="round"><path d="M5 12h14"></path><path d="M12 5v14"></path></svg>Create new comparison</div>
+<div style="height:1px;margin:4px 6px;background:#eae6da"></div>
+<sc-for list="{{ collectionsForPicker }}" as="k" hint-placeholder-count="3">
+<div onClick="{{ k.onPick }}" role="button" tabIndex="0" style="padding:8px 9px;border-radius:7px;font-size:13px;color:var(--ink2);cursor:pointer;overflow:hidden;text-overflow:ellipsis;white-space:nowrap" style-hover="background:var(--pill)">{{ k.name }}</div>
+</sc-for>
+</div>
+</sc-if>
+</div>
+</sc-if>
+</div>
+<div onClick="{{ c.onRemove }}" role="button" tabIndex="0" aria-label="{{ c.removeLabel }}" title="{{ c.removeLabel }}" style="margin-left:auto;width:30px;height:30px;display:flex;align-items:center;justify-content:center;border-radius:8px;color:var(--dim);cursor:pointer" style-hover="background:var(--pill)"><svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"><path d="M6 6l12 12M18 6 6 18"></path></svg></div>
+</div>
+</div>
+</sc-for>
+</div>
+</sc-if>
+
+<sc-if value="{{ noSaved }}" hint-placeholder-val="{{ false }}">
+<div style="margin-top:14px;padding:24px;border:1px solid var(--rule);border-radius:11px;background:var(--surface);text-align:center">
+<div style="font-size:14.5px;font-weight:600">No saved courses yet</div>
+<div style="margin-top:5px;font-size:12.5px;color:var(--muted)">Explore courses and save the ones you want to revisit.</div>
+<div onClick="{{ onOpenExplore }}" role="button" tabIndex="0" style="margin:13px auto 0;width:max-content;height:34px;display:flex;align-items:center;padding:0 14px;border-radius:9px;background:var(--btn);color:var(--btnFg);font-size:13px;font-weight:600;cursor:pointer" style-hover="background:var(--btn)">Explore courses</div>
+</div>
+</sc-if>
+</div>
+</sc-if>
+
+</div>
+
+</div>
+
+</div>
+</sc-if>
+
+<div style="width:100%;max-width:{{ pageMaxWidth }};box-sizing:border-box;margin:0 auto;padding:0 {{ pageSidePadding }}">
+<dc-import name="Course Community - Page Header" title="Explore courses" subtitle="Search the KTH catalogue and see what students said about a course before you pick it." hint-size="100%,90px"></dc-import>
+
+<div style="display:flex;align-items:center;justify-content:center;gap:12px;padding:18px 24px 14px;margin-right:{{ searchBarMargin }}">
+<div ref="{{ barRef }}" style="width:100%;max-width:560px;box-sizing:border-box;display:flex;align-items:center;gap:10px;height:42px;padding:0 14px;border-radius:10px;border:1px solid var(--rule3);background:var(--surface)">
+<svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="#5c6570" stroke-width="2" stroke-linecap="round"><circle cx="11" cy="11" r="7"></circle><line x1="16.5" y1="16.5" x2="21" y2="21"></line></svg>
+<input value="{{ q }}" onChange="{{ onQ }}" placeholder="Search a course, code or subject" style="flex:1;min-width:0;border:none;outline:none;background:transparent;font-family:Geist,system-ui,sans-serif;font-size:14px;color:var(--ink)">
+</div>
+</div>
+
+<div ref="{{ rowRef }}" data-cc-fade="1" style="display:flex;flex:1;min-height:0;gap:18px;padding:0 20px 20px">
+
+<sc-if value="{{ resultsShown }}" hint-placeholder-val="{{ true }}">
+<div data-cc-results="1" style="flex:1;min-width:{{ resultsFloor }};max-width:{{ resultsMax }};margin:0 auto;display:flex;flex-direction:column;gap:14px;overflow:hidden">
+<div style="display:flex;align-items:baseline;gap:8px;padding-left:2px;font-size:12px;color:var(--muted)">
+<span>{{ resultsLabel }}</span>
+<sc-if value="{{ hasQuery }}" hint-placeholder-val="{{ false }}">
+<span onClick="{{ onClearQuery }}" style="font-weight:500;color:var(--brand);cursor:pointer" style-hover="text-decoration:underline">Clear search</span>
+</sc-if>
+</div>
+<sc-if value="{{ resultsLoading }}" hint-placeholder-val="{{ false }}">
+<sc-for list="{{ skeletonCards }}" as="k" hint-placeholder-count="3">
+<div style="flex:none;display:flex;height:236px;border-radius:12px;border:1px solid var(--rule2);background:var(--surface)">
+<div style="flex:1;min-width:0;display:flex;flex-direction:column;gap:14px;padding:14px">
+<div style="height:15px;width:46%;border-radius:5px;background:#eae6da;animation:pulse 1.2s ease-in-out infinite"></div>
+<div style="height:11px;width:30%;border-radius:4px;background:var(--pill);animation:pulse 1.2s ease-in-out infinite"></div>
+<div style="height:11px;width:{{ k.w }};border-radius:4px;background:var(--pill);animation:pulse 1.2s ease-in-out infinite"></div>
+<div style="height:11px;width:64%;border-radius:4px;background:var(--pill);animation:pulse 1.2s ease-in-out infinite"></div>
+<div style="margin-top:auto;display:flex;gap:8px"><div style="height:34px;width:96px;border-radius:8px;background:var(--pill);animation:pulse 1.2s ease-in-out infinite"></div><div style="height:34px;width:128px;border-radius:8px;background:var(--pill);animation:pulse 1.2s ease-in-out infinite"></div></div>
+</div>
+<div style="width:152px;flex:none;display:flex;flex-direction:column;gap:12px;padding:14px;border-left:1px solid var(--rule);background:var(--pg);border-radius:0 11px 11px 0">
+<div style="height:11px;width:80%;align-self:flex-end;border-radius:4px;background:var(--pill);animation:pulse 1.2s ease-in-out infinite"></div>
+<div style="height:26px;width:56%;border-radius:5px;background:#eae6da;animation:pulse 1.2s ease-in-out infinite"></div>
+<div style="height:5px;width:100%;border-radius:3px;background:var(--pill);animation:pulse 1.2s ease-in-out infinite"></div>
+<div style="height:5px;width:100%;border-radius:3px;background:var(--pill);animation:pulse 1.2s ease-in-out infinite"></div>
+</div>
+</div>
+</sc-for>
+</sc-if>
+
+<sc-if value="{{ resultsError }}" hint-placeholder-val="{{ false }}">
+<div style="padding:26px 22px;border-radius:12px;border:1px solid #f0d7cf;background:var(--surface);text-align:center">
+<span style="display:inline-flex;width:34px;height:34px;border-radius:50%;background:#fbeceb;align-items:center;justify-content:center"><svg width="17" height="17" viewBox="0 0 24 24" fill="none" stroke="#a3452a" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round"><path d="M12 8v5"></path><path d="M12 16.5h.01"></path></svg></span>
+<div style="margin-top:12px;font-size:15.5px;font-weight:600">{{ resultsErrorTitle }}</div>
+<div style="margin-top:6px;font-size:13px;line-height:1.5;color:var(--muted)">{{ resultsErrorBody }}</div>
+<div onClick="{{ onRetryResults }}" style="margin-top:15px;display:inline-flex;align-items:center;gap:8px;height:38px;padding:0 16px;border-radius:9px;background:var(--btn);color:var(--btnFg);font-size:13px;font-weight:600;cursor:pointer" style-hover="background:var(--btn)"><svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="#fff" stroke-width="1.9" stroke-linecap="round" stroke-linejoin="round"><path d="M20 12a8 8 0 1 1-2.6-5.9"></path><path d="M20 4v4h-4"></path></svg>Try again</div>
+</div>
+</sc-if>
+
+<sc-if value="{{ noResults }}" hint-placeholder-val="{{ false }}">
+<div style="padding:26px 22px;border-radius:12px;border:1px dashed var(--rule3);background:var(--surface);text-align:center">
+<div style="font-size:14.5px;font-weight:600">No courses match “{{ q }}”</div>
+<div style="margin-top:5px;font-size:13px;color:var(--muted)">Try a course code, a subject, or <span onClick="{{ onClearQuery }}" style="font-weight:500;color:var(--brand);cursor:pointer" style-hover="text-decoration:underline">clear the search</span>.</div>
+</div>
+</sc-if>
+
+<sc-for list="{{ courses }}" as="c" hint-placeholder-count="3">
+<dc-import name="Course Community - Course Card" c="{{ c }}" geo="{{ geo }}" action="save" is-guest="{{ isGuest }}" is-member="{{ isMember }}" on-sign-up="{{ onSignUp }}" on-log-in="{{ onLogIn }}" draft-name="{{ draftName }}" on-draft-change="{{ onDraftChange }}" on-draft-focus="{{ onDraftFocus }}" on-draft-key="{{ onDraftKey }}" on-draft-commit="{{ onDraftCommit }}" hint-size="100%,236px" style="flex:none"></dc-import>
+</sc-for>
+
+<sc-if value="{{ hasPager }}" hint-placeholder-val="{{ false }}">
+<div style="display:flex;align-items:center;justify-content:center;gap:14px;padding:6px 0 4px">
+<div onClick="{{ onPrevPage }}" role="button" tabIndex="0" style="display:flex;align-items:center;height:34px;padding:0 14px;border-radius:8px;border:1px solid var(--rule3);background:var(--surface);font-size:12.5px;font-weight:500;color:{{ prevColor }};cursor:{{ prevCursor }}" style-hover="border-color:var(--hov)">← Previous</div>
+<span style="font-size:12.5px;color:var(--muted);font-variant-numeric:tabular-nums">{{ pageLabel }}</span>
+<div onClick="{{ onNextPage }}" role="button" tabIndex="0" style="display:flex;align-items:center;height:34px;padding:0 14px;border-radius:8px;border:1px solid var(--rule3);background:var(--surface);font-size:12.5px;font-weight:500;color:{{ nextColor }};cursor:{{ nextCursor }}" style-hover="border-color:var(--hov)">Next →</div>
+</div>
+</sc-if>
+</div>
+
+</sc-if>
+
+<sc-if value="{{ hasTabs }}" hint-placeholder-val="{{ true }}">
+<div style="display:flex;flex:{{ paneGrow }};min-width:0;min-height:0;margin-left:-14px">
+<div onPointerDown="{{ onPaneDrag }}" onDoubleClick="{{ onPaneReset }}" title="Drag to resize · double-click to reset" style="flex:none;width:11px;margin-right:3px;display:flex;align-items:center;justify-content:center;cursor:{{ dragCursor }}">
+<div style="width:2px;height:34px;border-radius:2px;background:#ddd8c9"></div>
+</div>
+<dc-import name="Course Community - Workspace Pane" pane-width="{{ paneWidth }}" pane-grow="{{ paneGrow }}" courses="{{ workspaceCourses }}" store-module="{{ workspaceStore }}" locale="{{ workspaceLocale }}" is-guest="{{ isGuest }}" open-signal="{{ openSignal }}" on-tabs-change="{{ onTabsChange }}" on-authed="{{ onWorkspaceAuthed }}" hint-size="504px,100%"></dc-import>
+</div>
+</sc-if>
+
+</div>
+</div>
+
+</div>
+
+</x-dc>
+<script type="text/x-dc" data-dc-script data-props="{&quot;$preview&quot;:{&quot;width&quot;:1440,&quot;height&quot;:900},&quot;session&quot;:{&quot;editor&quot;:&quot;enum&quot;,&quot;default&quot;:&quot;guest&quot;,&quot;options&quot;:[&quot;guest&quot;,&quot;member&quot;],&quot;tsType&quot;:&quot;\&quot;guest\&quot; | \&quot;member\&quot;&quot;,&quot;section&quot;:&quot;Session&quot;},&quot;scenario&quot;:{&quot;editor&quot;:&quot;enum&quot;,&quot;default&quot;:&quot;populated&quot;,&quot;options&quot;:[&quot;populated&quot;,&quot;empty&quot;,&quot;loading&quot;,&quot;error&quot;,&quot;edge-case&quot;],&quot;tsType&quot;:&quot;string&quot;,&quot;section&quot;:&quot;Prototype state&quot;},&quot;locale&quot;:{&quot;editor&quot;:&quot;enum&quot;,&quot;default&quot;:&quot;en&quot;,&quot;options&quot;:[&quot;en&quot;,&quot;sv&quot;],&quot;tsType&quot;:&quot;\&quot;en\&quot; | \&quot;sv\&quot;&quot;,&quot;section&quot;:&quot;Prototype state&quot;},&quot;onAuthed&quot;:{&quot;editor&quot;:null,&quot;tsType&quot;:&quot;() =&gt; void&quot;,&quot;section&quot;:&quot;Session&quot;}}">
+/* No course data lives on this page. Cards are built by the shared selector
+   `catalogCardView`, so Explore and Saved cannot drift apart. */
+let STORE = null;
+let COURSES = [];
+
+/* ---------------------------------------------------------------------------
+   MOCK FIXTURES — Saved courses prototype only. No backend, no real auth, no
+   real AI. Everything below is frontend sample data for review purposes.
+--------------------------------------------------------------------------- */
+const libOf = (code) => COURSES.find((c) => c.code === code) || null;
+
+let MOCK_ACCOUNT_SAVES = [];
+let MOCK_LOCAL_SAVES = [];
+
+/* The five canonical data conditions. Session is a separate axis. */
+const FIXTURES = [
+  { key: "populated", label: "Populated" },
+  { key: "empty", label: "Empty" },
+  { key: "loading", label: "Loading" },
+  { key: "error", label: "Error" },
+  { key: "edge-case", label: "Edge case" }
+];
+
+// `ink` is the label colour that clears AA on that segment's own fill.
+/* The examination categories are the schema's five keys, so a review draft
+   writes an examinationDistribution the store can hold as-is. */
+const METHODS = [
+  { key: "exam", label: "On-campus exam", short: "Exam", color: "var(--brand)", ink: "var(--btnFg)" },
+  { key: "assignments", label: "Assignments", short: "Assign.", color: "#dfa53c", ink: "#3a2a06" },
+  { key: "labs", label: "Labs", short: "Labs", color: "#2f9e8e", ink: "#06251f" },
+  { key: "projects", label: "Project", short: "Project", color: "#6a4ea8", ink: "var(--btnFg)" },
+  { key: "other", label: "Other", short: "Other", color: "#57646f", ink: "var(--btnFg)" }
+];
+
+const COMPARE_CAP = 4;
+const SAVED_KEY = "kth-cc:saved-courses";
+
+const countOf = (v) => parseInt(String(v).replace(/\D/g, ""), 10) || 0;
+const fmtCount = (n) => String(n).replace(/\B(?=(\d{3})+(?!\d))/g, "\u2009");
+
+const EMPTY_DRAFT = {
+  overall: null, picked: [], pcts: [], theory: null,
+  workload: null, learning: null, recommend: null, reviewText: ""
+};
+
+/** Even split across n segments in 5% steps; the remainder lands on the last. */
+function evenSplit(n) {
+  if (n === 0) return [];
+  const base = Math.max(5, Math.round(100 / n / 5) * 5);
+  const out = new Array(n).fill(base);
+  out[n - 1] = 100 - base * (n - 1);
+  return out;
+}
+
+/** Card-level summary of an examination split: "Only X" / "Mainly X" / "Mixed".
+    Takes the store's segments, which carry their own labels — never an array
+    position matched against a local name list. */
+function examLabel(segments) {
+  if (!segments || segments.length === 0) return null;
+  const total = segments.reduce((a, x) => a + (x.percent || 0), 0);
+  if (total === 0) return null;
+  let top = 0;
+  for (let i = 1; i < segments.length; i++) if (segments[i].percent > segments[top].percent) top = i;
+  const share = (segments[top].percent / total) * 100;
+  if (share === 100) return "Only " + segments[top].label;
+  if (share > 50) return "Mainly " + segments[top].label;
+  return "Mixed Evaluation Methods";
+}
+
+function mixLabel(theoretical) {
+  if (theoretical == null) return null;
+  if (theoretical >= 60) return "mostly theoretical";
+  if (theoretical <= 40) return "mostly applied";
+  return "balanced";
+}
+
+class Component extends DCLogic {
+  /* Theme choice is shared across the pages through one storage key. */
+  ccDark() {
+    if (this.state.ccNight !== undefined) return this.state.ccNight === true;
+    try { return window.localStorage.getItem("cc:theme") === "dark"; } catch (e) { return false; }
+  }
+
+  ccSetDark(next) {
+    document.documentElement.setAttribute("data-cc-theme", next ? "dark" : "light");
+    try { window.localStorage.setItem("cc:theme", next ? "dark" : "light"); } catch (e) { /* storage off */ }
+    this.setState({ ccNight: next });
+  }
+
+  ccApplyTheme() {
+    document.documentElement.setAttribute("data-cc-theme", this.ccDark() ? "dark" : "light");
+  }
+
+  state = {
+    tab: 0,
+    collectionsOpenDetail: null,
+    // One draft per course code — nothing exists until that student answers something.
+    drafts: {},
+    flags: { DD2421: { compare: true }, DD2380: { saved: true } },
+    tabs: [],
+    workspaceTabCount: 0,
+    openSignal: null,
+    compareMenu: null,
+    takenMenu: null,
+    creatingFor: null,
+    draftTouched: false,
+    confirmDelete: null,
+    failedRow: null,
+    draftName: "",
+    overflowOpen: false,
+    contentOpen: false,
+    reviewsOpen: false,
+    q: "machine learning",
+    page: 0,
+    guest: true,
+    authOpen: false,
+    justAuthed: false,
+    posted: false,
+    compareHelpOpen: false,
+    dragging: false,
+    paneW: 504,
+    rowW: 0
+  };
+
+  /* One global "open surface" at a time; every trigger and panel is tagged
+     data-pop, so dismissal is a single containment test. */
+  closeAll = (extra) => {
+    // A half-typed collection is abandoned with the surface, never committed behind it.
+    this.setState({ compareMenu: null, takenMenu: null, overflowOpen: false, confirmDelete: null, creatingFor: null, ...(extra || {}) });
+  };
+
+  onDocDown = (e) => {
+    if (e.target.closest && e.target.closest("[data-pop]")) return;
+    if (this.state.compareMenu || this.state.takenMenu || this.state.overflowOpen) this.closeAll();
+  };
+
+  onDocKey = (e) => {
+    if (e.key !== "Escape") return;
+    if (this.state.compareMenu || this.state.takenMenu || this.state.overflowOpen) this.closeAll();
+  };
+
+  onDocScroll = (e) => {
+    if (e.target.closest && e.target.closest("[data-pop-panel]")) return;
+    if (this.state.compareMenu || this.state.takenMenu || this.state.overflowOpen) this.closeAll();
+  };
+
+  measure = () => {
+    const row = this.rowRef.current;
+    if (row && row.clientWidth !== this.state.rowW) this.setState({ rowW: row.clientWidth });
+  };
+
+  componentDidMount() {
+    this.ccApplyTheme();
+    // Guest saves have nowhere else to live, so they are kept under our own key.
+    try {
+      const raw = window.localStorage.getItem(SAVED_KEY);
+      const codes = raw ? JSON.parse(raw) : [];
+      if (Array.isArray(codes) && codes.length) {
+        const flags = { ...this.state.flags };
+        codes.forEach((code) => { flags[code] = { ...(flags[code] || {}), saved: true }; });
+        this.setState({ flags });
+      }
+    } catch (e) { /* storage unavailable */ }
+    document.addEventListener("pointerdown", this.onDocDown, true);
+    document.addEventListener("keydown", this.onDocKey, true);
+    window.addEventListener("resize", this.measure);
+    // The row's own box drives the collapse, so watch it rather than the window.
+    if (typeof ResizeObserver === "function" && this.rowRef.current) {
+      this.rowRO = new ResizeObserver(this.measure);
+      this.rowRO.observe(this.rowRef.current);
+    }
+    this.measure();
+    // The landing page hands its query over in the URL, so it survives a refresh.
+    const q = new URLSearchParams(window.location.search).get("q");
+    if (q) this.setState({ q: q });
+    document.addEventListener("scroll", this.onDocScroll, true);
+    this.ccHydrate();
+    this.pickUpSharedBar();
+    import("./cc-store.js").then((mod) => {
+      STORE = mod;
+      this.seenHarness = this.harnessKey();
+      this.applyFixture(this.props.scenario);
+    });
+  }
+
+  componentDidUpdate() {
+    if (!STORE) return;
+    if (this.harnessKey() !== this.seenHarness) {
+      this.seenHarness = this.harnessKey();
+      this.applyFixture(this.props.scenario);
+    }
+  }
+
+  componentWillUnmount() {
+    document.removeEventListener("pointerdown", this.onDocDown, true);
+    document.removeEventListener("keydown", this.onDocKey, true);
+    window.removeEventListener("resize", this.measure);
+    document.removeEventListener("scroll", this.onDocScroll, true);
+    if (this.rowRO) this.rowRO.disconnect();
+  }
+
+  rowRef = React.createRef();
+  paneScrollRef = React.createRef();
+  reviewsRef = React.createRef();
+
+  /** Opens the review list and brings it into view inside the pane's own scroller. */
+  revealReviews() {
+    this.setState({ reviewsOpen: true }, () => {
+      requestAnimationFrame(() => {
+        const box = this.paneScrollRef.current;
+        const head = this.reviewsRef.current;
+        if (!box || !head) return;
+        const top = head.getBoundingClientRect().top - box.getBoundingClientRect().top + box.scrollTop;
+        box.scrollTo({ top: Math.max(0, top - 12), behavior: "smooth" });
+      });
+    });
+  }
+
+
+  // The floors the layout is pinned to. The results column's floor is the one
+  // that must hold: a crushed card is unreadable, a narrower pane is merely tight.
+  RESULTS_FLOOR = 396;   // the cropped card's own minimum
+  PANE_FLOOR = 440;      // comfortable pane
+  PANE_MIN = 356;        // as narrow as the pane goes before the row stacks
+  GUTTERS = 58;          // row padding (40) + column gap (18)
+
+  /** What the row can actually give the two columns at its current width. */
+  paneBounds(rowW) {
+    const row = this.rowRef.current;
+    // The live DOM width is always current; the cached state only backs it
+    // up before the ref is attached, so a stale measurement can never win.
+    const w = (row && row.clientWidth) || rowW || window.innerWidth;
+    const avail = w - this.GUTTERS;
+    const roomForPane = avail - this.RESULTS_FLOOR;
+    // Both floors fit: the pane may range from comfortable up to whatever is left.
+    if (roomForPane >= this.PANE_FLOOR) return { min: this.PANE_FLOOR, max: roomForPane, stack: false };
+    // Only by giving the pane less than comfortable — the results column keeps its floor.
+    if (roomForPane >= this.PANE_MIN) return { min: this.PANE_MIN, max: roomForPane, stack: true };
+    // Neither floor can be honoured side by side, so the pane takes the row alone.
+    return { min: Math.max(this.PANE_MIN, avail), max: Math.max(this.PANE_MIN, avail), stack: true, solo: true };
+  }
+
+  maxPane() {
+    return this.paneBounds().max;
+  }
+
+  examTrackRef = React.createRef();
+
+  drag(onMove) {
+    const move = (ev) => onMove(ev);
+    const up = () => {
+      window.removeEventListener("pointermove", move);
+      window.removeEventListener("pointerup", up);
+      document.body.style.cursor = "";
+      document.body.style.userSelect = "";
+    };
+    window.addEventListener("pointermove", move);
+    window.addEventListener("pointerup", up);
+    document.body.style.cursor = "ew-resize";
+    document.body.style.userSelect = "none";
+  }
+
+  draftFor(code) {
+    return this.state.drafts[code] || EMPTY_DRAFT;
+  }
+
+  patchDraft(code, patch) {
+    const drafts = { ...this.state.drafts };
+    drafts[code] = { ...this.draftFor(code), ...patch };
+    this.setState({ drafts });
+  }
+
+  /* The controls take a value plus a setter, so the draft panel and the
+     standalone demos can share them without sharing state. */
+  dividerDown(i, rect, pcts, setPcts) {
+    const before = pcts.slice(0, i).reduce((a, p) => a + p, 0);
+    const pair = pcts[i] + pcts[i + 1];
+    this.drag((ev) => {
+      let x = ((ev.clientX - rect.left) / rect.width) * 100 - before;
+      x = Math.round(x / 5) * 5;
+      x = Math.max(5, Math.min(pair - 5, x));
+      const next = pcts.slice();
+      next[i] = x;
+      next[i + 1] = pair - x;
+      setPcts(next);
+    });
+  }
+
+  bump(i, delta, pcts, setPcts) {
+    const next = pcts.slice();
+    const j = (i + 1) % next.length;
+    if (i === j) return;
+    if (next[i] + delta < 5 || next[j] - delta < 5) return;
+    next[i] += delta;
+    next[j] -= delta;
+    setPcts(next);
+  }
+
+  toggleMethod(method, picked, setBoth) {
+    const next = picked.slice();
+    const at = next.indexOf(method);
+    if (at >= 0) next.splice(at, 1); else next.push(method);
+    // Re-splitting evenly keeps the bar honest when the segment count changes.
+    setBoth(next, evenSplit(next.length));
+  }
+
+  startPct(e, scale, apply) {
+    const rect = e.currentTarget.getBoundingClientRect();
+    const run = (ev) => {
+      const raw = ((ev.clientX - rect.left) / rect.width) * 100;
+      apply(scale === 100
+        ? Math.round(Math.max(5, Math.min(95, raw)))
+        : Math.round(Math.max(1, Math.min(10, raw / 10))));
+    };
+    run(e);
+    this.drag(run);
+  }
+
+  /* ---------- Saved courses (mock prototype) ---------- */
+
+  savedState = {
+    view: "explore",
+    localSaves: MOCK_LOCAL_SAVES.slice(),
+    acctSaves: MOCK_ACCOUNT_SAVES.slice(),
+    importState: null, importCount: 0,
+    note: null, fixture: "populated", pickerFor: null,
+    loading: false, error: false
+  };
+
+  sv(patch, then) {
+    this.savedState = { ...this.savedState, ...patch };
+    this.ccPersist();
+    this.forceUpdate();
+    if (then) then();
+  }
+  CC_KEYS = { member: "cc:member", saves: "cc:saves", badge: "cc:savedBadge" };
+
+  ccRead(key, fallback) {
+    try {
+      const raw = window.localStorage.getItem(key);
+      return raw === null ? fallback : JSON.parse(raw);
+    } catch (e) { return fallback; }
+  }
+
+  ccWrite(key, value) {
+    try { window.localStorage.setItem(key, JSON.stringify(value)); } catch (e) { /* storage unavailable */ }
+  }
+
+  /** Pull session + library from storage on mount; each page starts where the last left off. */
+  ccHydrate() {
+    const member = this.ccRead(this.CC_KEYS.member, null);
+    const saves = this.ccRead(this.CC_KEYS.saves, null);
+    if (saves) this.savedState.acctSaves = saves;
+    if (member !== null && member !== !this.state.guest) this.setState({ guest: !member });
+    else this.forceUpdate();
+  }
+
+  ccPersist() {
+    this.ccWrite(this.CC_KEYS.member, !this.state.guest);
+    this.ccWrite(this.CC_KEYS.saves, this.savedState.acctSaves);
+    // The count the sidebar shows, for the session in force right now.
+    this.ccWrite(this.CC_KEYS.badge, this.savedCodes().length);
+  }
+
+
+  savedMember() {
+    // The scenario seeds the session; anything the user does afterwards wins.
+    return !this.state.guest;
+  }
+
+  /** Everything saved, account list or browser list depending on the session. */
+  savedCodes() {
+    const v = this.savedState;
+    return this.savedMember() ? v.acctSaves : v.localSaves;
+  }
+
+  /** Collections are groupings — a course in one is still in the library. */
+  unorganizedCodes() {
+    const v = this.savedState;
+    const codes = this.savedCodes();
+    if (!this.savedMember()) return codes.slice();
+    const grouped = {};
+    ((STORE && STORE.collections) || []).forEach((c) => c.codes.forEach((k) => { grouped[k] = 1; }));
+    return codes.filter((k) => !grouped[k]);
+  }
+
+  harnessKey() {
+    return [this.props.session, this.props.scenario, this.props.locale].join("|");
+  }
+
+  locale() {
+    return this.props.locale === "sv" ? "sv" : "en";
+  }
+
+  /* Session (guest | member) and scenario (populated | empty | loading | error |
+     edge-case) are the shared axes. A scenario only poses what is on screen; it
+     never writes to the store. */
+  applyFixture(key) {
+    if (!STORE) return;
+    const h = STORE.resolveHarness({
+      session: this.props.session,
+      scenario: STORE.SCENARIOS.indexOf(key) >= 0 ? key : this.props.scenario
+    });
+    COURSES = STORE.catalogCards({ locale: this.locale() });
+    MOCK_ACCOUNT_SAVES = STORE.savedCourses.account.slice();
+    MOCK_LOCAL_SAVES = STORE.savedCourses.local.slice();
+
+    const base = {
+      fixture: h.scenario, importState: null, importCount: 0, note: null, pickerFor: null,
+      localSaves: [], acctSaves: [], loading: false, error: false
+    };
+    if (h.isLoading) {
+      base.loading = true;
+      base.acctSaves = h.isGuest ? [] : MOCK_ACCOUNT_SAVES.slice();
+    } else if (h.isError) {
+      base.error = true;
+    } else if (h.isEdgeCase) {
+      // Everything waiting to be imported is already in the account.
+      base.localSaves = ["DD2421", "DD2380"];
+      base.acctSaves = MOCK_ACCOUNT_SAVES.slice();
+    } else {
+      base.localSaves = h.isGuest ? MOCK_LOCAL_SAVES.slice() : [];
+      base.acctSaves = MOCK_ACCOUNT_SAVES.slice();
+    }
+    this.savedState = { ...this.savedState, ...base };
+    if (h.isGuest !== this.state.guest) {
+      this.setState({ guest: h.isGuest }, () => this.afterPose(h));
+    } else {
+      this.forceUpdate();
+      this.afterPose(h);
+    }
+  }
+
+  /** A member arriving with local saves gets the merge run for them. */
+  afterPose(h) {
+    if (h.isMember && h.isPopulated && this.savedState.localSaves.length) this.runImport(true);
+  }
+
+  /** Simulated merge: dedupe by course code, never by title; collections untouched. */
+  runImport(silentIfEmpty) {
+    const v = this.savedState;
+    const local = v.localSaves.slice();
+    if (!local.length) { if (!silentIfEmpty) this.sv({ importState: null }); return; }
+    this.sv({ importState: "running" });
+    clearTimeout(this.importTimer);
+    this.importTimer = setTimeout(() => {
+      const acct = this.savedState.acctSaves.slice();
+      const fresh = local.filter((code) => acct.indexOf(code) < 0);
+      const merged = acct.concat(fresh);
+      this.sv({
+        acctSaves: merged,
+        localSaves: [],           // the browser hand-off is cleared only now
+        importState: fresh.length ? "done" : "dupes",
+        importCount: fresh.length
+      });
+      try { window.localStorage.removeItem(SAVED_KEY); } catch (e) { /* storage unavailable */ }
+    }, 1400);
+  }
+
+  toggleSaved(code) {
+    const v = this.savedState;
+    const key = this.savedMember() ? "acctSaves" : "localSaves";
+    const list = v[key];
+    const next = list.indexOf(code) >= 0 ? list.filter((k) => k !== code) : list.concat([code]);
+    this.sv({ [key]: next, note: list.indexOf(code) >= 0 ? "Removed from saved courses" : "Saved" });
+    if (!this.savedMember()) {
+      try { window.localStorage.setItem(SAVED_KEY, JSON.stringify(next)); } catch (e) { /* storage unavailable */ }
+    }
+    this.clearNote();
+  }
+
+  clearNote() {
+    clearTimeout(this.noteTimer);
+    this.noteTimer = setTimeout(() => this.sv({ note: null }), 3000);
+  }
+
+  savedVals(guest) {
+    const v = this.savedState;
+    const member = !guest;
+    const saved = this.savedCodes();
+    const unorganized = this.unorganizedCodes();
+
+    const card = (code, extra) => {
+      const c = libOf(code) || { code: code, title: code, hp: "", school: "", period: "" };
+      return {
+        code: c.code, title: c.title, meta: c.hp + " · " + c.code + " · " + c.school,
+        period: c.period, workload: c.workload || "—", assessment: c.assessment || "—",
+        onOpen: () => this.sv({ note: "Opening " + c.code + " (mock)" }, () => this.clearNote()),
+        onRemove: () => this.toggleSaved(c.code),
+        onAdd: () => this.sv({ pickerFor: v.pickerFor === c.code ? null : c.code }),
+        pickerOpen: v.pickerFor === c.code,
+        removeLabel: "Remove " + c.code + " from saved courses",
+        addLabel: "Add " + c.code + " to a comparison",
+        openLabel: "Open " + c.code,
+        ...(extra || {})
+      };
+    };
+
+    return {
+      stop: (ev) => ev.stopPropagation(),
+      pageMaxWidth: STORE.PAGE_MAX_WIDTH,
+      pageSidePadding: STORE.PAGE_SIDE_PADDING,
+      isSavedView: v.view === "saved",
+      isExploreView: v.view === "explore",
+      savedCount: saved.length,
+      savedCountLabel: String(saved.length),
+      hasSavedCount: saved.length > 0,
+      savedNavBg: v.view === "saved" ? "rgba(255,255,255,.16)" : "transparent",
+      savedNavWeight: v.view === "saved" ? "600" : "400",
+      exploreNavBg: v.view === "explore" ? "rgba(255,255,255,.16)" : "transparent",
+      exploreNavWeight: v.view === "explore" ? "600" : "400",
+      onOpenSaved: () => { window.location.href = "Course Community - Saved.dc.html"; },
+      onOpenExplore: () => { window.location.href = "Course Community - Explore.dc.html"; },
+      onSignOut: () => {
+        this.ccWrite(this.CC_KEYS.member, false);
+        this.setState({ guest: true });
+      },
+
+      fixtures: FIXTURES.map((f) => ({
+        key: f.key, label: f.label,
+        bg: v.fixture === f.key ? "var(--ink)" : "var(--surface)",
+        fg: v.fixture === f.key ? "var(--btnFg)" : "var(--chipInk)",
+        onPick: () => this.applyFixture(f.key)
+      })),
+
+      importRunning: v.importState === "running",
+      importDone: v.importState === "done",
+      importDupes: v.importState === "dupes",
+      importMsg: v.importCount + (v.importCount === 1 ? " saved course added to your account" : " saved courses added to your account"),
+      pendingImport: member && v.localSaves.length > 0 && v.importState !== "running",
+      pendingImportMsg: v.localSaves.length + " course" + (v.localSaves.length === 1 ? "" : "s") + " saved in this browser are ready to add to your account.",
+      onRunImport: () => this.runImport(false),
+      onDismissImport: () => this.sv({ importState: null }),
+
+      unorganized: unorganized.map((code) => card(code)),
+      hasUnorganized: unorganized.length > 0,
+      noSaved: saved.length === 0,
+      collectionsForPicker: ((STORE && STORE.collections) || []).map((c) => ({
+        name: c.name,
+        onPick: () => {
+          const code = v.pickerFor;
+          if (STORE) STORE.addCourseToCollection(c.id, code);
+          this.sv({ pickerFor: null, note: code + " added to “" + c.name + "”" }, () => this.clearNote());
+        }
+      })),
+
+      collectionsCourses: COURSES,
+      savedCodesForCollections: saved,
+      onCollectionsChanged: () => this.forceUpdate(),
+      onCollectionsDetailChange: (id) => this.setState({ collectionsOpenDetail: id }),
+      showSavedSection: !this.state.collectionsOpenDetail,
+
+      note: v.note,
+      hasNote: !!v.note
+    };
+  }
+
+  HANDOFF_KEY = "cc:searchHandoff";
+  barRef = React.createRef();
+
+  reducedMotion() {
+    return typeof window.matchMedia === "function"
+      && window.matchMedia("(prefers-reduced-motion: reduce)").matches;
+  }
+
+  /** Continue the landing page's search bar from where it was left, so the bar
+      reads as one element across the navigation. Position and size only. */
+  pickUpSharedBar() {
+    let from = null;
+    try {
+      const raw = window.sessionStorage.getItem(this.HANDOFF_KEY);
+      window.sessionStorage.removeItem(this.HANDOFF_KEY);
+      if (raw) from = JSON.parse(raw);
+    } catch (e) { return; }
+    if (!from || Date.now() - from.t > 4000) return;
+    if (this.reducedMotion()) return;
+
+    const bar = this.barRef.current;
+    if (!bar) return;
+    const to = bar.getBoundingClientRect();
+    if (!to.width || !to.height) return;
+    const dx = from.x - to.left;
+    const dy = from.y - to.top;
+    const sx = from.w / to.width;
+    const sy = from.h / to.height;
+    if (Math.abs(dx) < 1 && Math.abs(dy) < 1 && Math.abs(sx - 1) < 0.01) return;
+
+    // Translate only — scaling a bordered box distorts its border and its
+    // contents mid-flight, which is what makes a handoff look synthetic.
+    bar.style.transformOrigin = "left top";
+    bar.style.transition = "none";
+    bar.style.transform = "translate(" + dx + "px," + dy + "px)";
+    bar.style.willChange = "transform";
+
+    // Surroundings fade in behind the bar while it travels — except the sidebar,
+    // which slides in from the left on the bar's own curve and duration, so the
+    // two movements read as one gesture.
+    const fade = [];
+    const root = bar.closest("[data-cc-page]") || document.body;
+    root.querySelectorAll("[data-cc-fade]").forEach((el) => {
+      el.style.transition = "none";
+      el.style.opacity = "0";
+      fade.push(el);
+    });
+    const rail = root.querySelector("[data-cc-sidebar]");
+    if (rail) {
+      rail.style.transition = "none";
+      rail.style.transform = "translateX(-100%)";
+      rail.style.opacity = "1";
+      rail.style.willChange = "transform";
+    }
+    // Results arrive last, one after another, so the eye lands on content
+    // instead of on the whole page appearing at once.
+    const col = root.querySelector("[data-cc-results]");
+    const cards = col ? Array.prototype.slice.call(col.children) : [];
+    cards.forEach((el) => {
+      el.style.transition = "none";
+      el.style.opacity = "0";
+      el.style.transform = "translateY(6px)";
+    });
+
+    // Released on whichever fires first — rAF is throttled in background frames,
+    // and the styles must come off either way.
+    let released = false;
+    const release = () => {
+      if (released) return;
+      released = true;
+      // One easing family for everything entering; the rail travels less, so a
+      // shorter duration lands it a touch ahead of the bar rather than in step.
+      const EASE = "cubic-bezier(.32,.72,0,1)";
+      bar.style.transition = "transform 280ms " + EASE;
+      bar.style.transform = "none";
+      if (rail) {
+        rail.style.transition = "transform 240ms " + EASE;
+        rail.style.transform = "none";
+      }
+      fade.forEach((el) => {
+        if (el === rail) return;
+        el.style.transition = "opacity 200ms " + EASE + " 120ms";
+        el.style.opacity = "1";
+      });
+      cards.forEach((el, i) => {
+        const wait = 200 + i * 36;
+        el.style.transition = "opacity 220ms " + EASE + " " + wait + "ms, transform 220ms " + EASE + " " + wait + "ms";
+        el.style.opacity = "1";
+        el.style.transform = "none";
+      });
+      const done = 200 + cards.length * 36 + 260;
+      setTimeout(() => {
+        bar.style.transition = "";
+        bar.style.transform = "";
+        bar.style.transformOrigin = "";
+        bar.style.willChange = "";
+        if (rail) {
+          rail.style.transition = "";
+          rail.style.transform = "";
+          rail.style.opacity = "";
+          rail.style.willChange = "";
+        }
+        fade.forEach((el) => { el.style.transition = ""; el.style.opacity = ""; });
+        cards.forEach((el) => { el.style.transition = ""; el.style.opacity = ""; el.style.transform = ""; });
+      }, done);
+    };
+    requestAnimationFrame(release);
+    setTimeout(release, 32);
+
+    // The field the user was typing in keeps the caret across the navigation.
+    // The store import re-renders the tree once after mount, which steals focus
+    // back to the body, so the claim is re-asserted until it sticks.
+    this.holdBarFocus();
+  }
+
+  holdBarFocus() {
+    let tries = 0;
+    const claim = () => {
+      const bar = this.barRef.current;
+      const input = bar && bar.querySelector("input");
+      const act = document.activeElement;
+      // The user moving on to another control wins over the claim.
+      if (act && act !== input && act !== document.body
+        && act.closest && act.closest('input,textarea,select,a,[role="button"]')) return;
+      if (input && input.focus) {
+        if (document.activeElement !== input) {
+          input.focus({ preventScroll: true });
+          const n = (input.value || "").length;
+          if (input.setSelectionRange) {
+            try { input.setSelectionRange(n, n); } catch (e) { /* type has no range */ }
+          }
+        }
+      }
+      if (++tries < 12) this.focusTimer = setTimeout(claim, 60);
+    };
+    claim();
+  }
+
+  renderVals() {
+    const s = this.state;
+    // Seeded from the shared session, then owned by whatever the user does here.
+    const guest = s.guest;
+    const active = s.tabs[s.tab] || s.tabs[0] || { kind: "none", code: "" };
+    const course = COURSES.find((c) => c.code === active.code) || COURSES[0];
+
+    // Every open pane lives in one dropdown; the trigger is just a count.
+    const indexed = s.tabs.map((t, i) => ({ ...t, i }));
+
+    const d = this.draftFor(active.code);
+    const setDraft = (patch) => this.patchDraft(active.code, patch);
+
+    const buildMix = (keys, pcts, ref, setPcts, setBoth) => {
+      const items = keys.map((k) => METHODS.find((m) => m.key === k)).filter(Boolean);
+      let acc = 0;
+      const cuts = [];
+      for (let i = 0; i < items.length - 1; i++) { acc += pcts[i] || 0; cuts.push(acc); }
+      return {
+        items,
+        segs: items.map((m, i) => {
+          const p = pcts[i] || 0;
+          return {
+            label: m.label, short: m.short, color: m.color, ink: m.ink,
+            width: p + "%", pctLabel: p + "%",
+            // Name in the slice when it fits, then the abbreviation, then nothing.
+            slotLabel: p >= 24 ? m.label : p >= 13 ? m.short : ""
+          };
+        }),
+        dividers: cuts.map((left, i) => ({
+          left: left + "%",
+          onDown: (e) => {
+            e.preventDefault();
+            const el = ref.current;
+            if (el) this.dividerDown(i, el.getBoundingClientRect(), pcts, setPcts);
+          }
+        })),
+        rows: items.map((m, i) => ({
+          label: m.label, color: m.color, pctLabel: (pcts[i] || 0) + "%",
+          onMinus: () => this.bump(i, -5, pcts, setPcts),
+          onPlus: () => this.bump(i, 5, pcts, setPcts)
+        })),
+        chips: METHODS.map((m) => {
+          const on = keys.indexOf(m.key) >= 0;
+          return {
+            label: m.label,
+            dot: on ? m.color : "#ded8c8",
+            bg: on ? "var(--pill)" : "var(--surface)",
+            fg: on ? "var(--ink)" : "var(--muted)",
+            border: on ? "var(--brand)" : "var(--rule3)",
+            onClick: () => this.toggleMethod(m.key, keys, setBoth)
+          };
+        })
+      };
+    };
+
+    const draftMix = buildMix(d.picked, d.pcts, this.examTrackRef,
+      (pcts) => setDraft({ pcts }),
+      (picked, pcts) => setDraft({ picked, pcts }));
+
+    const chosen = draftMix.items;
+    // One search, whether it arrived in the URL or was typed here.
+    const busy = this.savedState.loading || this.savedState.error;
+    const query = s.q.trim().toLowerCase();
+    const matches = busy ? [] : query
+      ? COURSES.filter((c) => STORE.matchesQuery(c.code, query, this.locale()))
+      : COURSES;
+    const PAGE_SIZE = 10;
+    const pageCount = Math.max(1, Math.ceil(matches.length / PAGE_SIZE));
+    const page = Math.min(s.page || 0, pageCount - 1);
+    const paged = matches.slice(page * PAGE_SIZE, page * PAGE_SIZE + PAGE_SIZE);
+    // The results column keeps its floor; the pane yields, and gives up the row
+    // entirely when even the narrow pane and the floor cannot both fit.
+    const rowW = s.rowW || window.innerWidth;
+    const bounds = this.paneBounds(rowW);
+    const paneSolo = (s.workspaceTabCount || 0) > 0 && Boolean(bounds.solo);
+    const paneW = Math.max(bounds.min, Math.min(s.paneW, bounds.max));
+    // 0 = the cropped card's floor, 1 = full width; everything in between lerps.
+    const resultsW = (s.workspaceTabCount || 0) === 0 ? Infinity
+      : paneSolo ? this.RESULTS_FLOOR : rowW - this.GUTTERS - paneW;
+    const t = Math.max(0, Math.min(1, (resultsW - 470) / 170));
+    const px = (a, b, k) => Math.round((a + (b - a) * (k === undefined ? t : k)) * 10) / 10 + "px";
+    const ramp = (from) => Math.max(0, Math.min(1, (t - from) / (1 - from)));
+    // The buttons only give way in the last stretch, where the column really is tight.
+    const late = Math.max(0, Math.min(1, t / 0.22));
+    // Cut away earlier and in three steps, so the summary shrinks gradually
+    // instead of jumping straight from full to gone.
+    const summaryLines = t >= 0.62 ? 2 : t >= 0.38 ? 1 : 0;
+    // -webkit-line-clamp does not survive the style pipeline, so the strings are cut here.
+    const colW = resultsW === Infinity ? Infinity : resultsW - (134 + 90 * t) - 2 * (14 + 4 * t);
+    const perLine = colW === Infinity ? Infinity : Math.floor(colW / 6.45);
+    const clip = (str, lines) => {
+      if (lines === 0) return "";
+      const max = perLine * lines;
+      if (!str || max === Infinity || str.length <= max) return str;
+      const cut = str.slice(0, Math.max(0, max - 1));
+      const space = cut.lastIndexOf(" ");
+      return (space > max * 0.6 ? cut.slice(0, space) : cut).replace(/[,;·\s]+$/, "") + "…";
+    };
+    const factsW = colW === Infinity ? Infinity : (colW >= 320 ? colW / 2 - 7 : colW);
+    const factsPerLine = factsW === Infinity ? Infinity : Math.floor(factsW / 6.45);
+    const clipFacts = (str) => {
+      const max = factsPerLine * 2;
+      if (!str || max === Infinity || str.length <= max) return str;
+      const cut = str.slice(0, Math.max(0, max - 1));
+      const space = cut.lastIndexOf(" ");
+      return (space > max * 0.6 ? cut.slice(0, space) : cut).replace(/[,;·\s]+$/, "") + "…";
+    };
+    // One pill per answer group, and a fresh draft starts at zero.
+    const doneCount = [
+      d.picked.length > 0 && d.theory != null,
+      d.workload != null && d.learning != null,
+      d.recommend != null && Boolean(d.reviewText.trim())
+    ].filter(Boolean).length;
+    const untouched = doneCount === 0 && d.recommend == null && !d.reviewText.trim();
+
+
+    return {
+      courses: paged.map((c) => {
+        const saved = Boolean((s.flags[c.code] || {}).saved);
+        return {
+        title: c.title, meta: c.meta, keywords: c.keywords, prereq: c.prereq, summary: c.summary,
+        hasStats: Boolean(examLabel(c.exSegments)),
+        noStats: !examLabel(c.exSegments),
+        examLabel: examLabel(c.exSegments),
+        mixLabel: mixLabel(c.th),
+        hasReviewStats: c.happy != null,
+        noReviewStats: c.happy == null,
+        workload: c.wl != null ? (c.wl / 10).toFixed(1) : "—",
+        learning: c.le != null ? (c.le / 10).toFixed(1) : "—",
+        thLeftW: c.th + "%",
+        thRightW: (100 - c.th) + "%",
+        // Narrow segments drop the word and keep the number so the label still fits.
+        thLeftLabel: c.th >= 30 ? "Theoretical" : "",
+        thRightLabel: 100 - c.th >= 30 ? "Applied" : "",
+        wlW: (c.wl || 0) + "%",
+        leW: (c.le || 0) + "%",
+        statRecommend: c.stats[0],
+        // Share of reviewers, not of everyone who took it.
+        happyPct: c.happy != null ? c.happy + "%" : "—",
+        // Your own mark counts toward the total the card shows.
+        summaryClipped: clip(c.summary, summaryLines),
+        keywordsClipped: clipFacts(c.keywords),
+        prereqClipped: c.prereq || "None listed",
+        prereqCourses: (c.prereqCourses || []).map((p) => {
+          const taken = this.isTaken(p.code);
+          return {
+          code: p.code, name: p.name, taken: taken,
+          bg: taken ? "rgba(23,81,166,.08)" : "transparent",
+          radius: taken ? "999px" : "6px",
+          padding: taken ? "0 8px 0 5px" : "0 8px 0 5px",
+          gap: "5px"
+          };
+        }),
+        hasPrereq: Boolean(c.prereqCourses && c.prereqCourses.length),
+        noPrereq: !(c.prereqCourses && c.prereqCourses.length),
+        statTaken: fmtCount(countOf(c.stats[1]) + (this.isTaken(c.code) ? 1 : 0)),
+        statReviews: c.stats[2],
+        borderColor: active.code === c.code ? "var(--brand)" : "var(--rule2)",
+        takenLabel: this.isTaken(c.code) ? "Marked as taken" : "Mark as taken",
+        takenTitle: fmtCount(countOf(c.stats[1]) + (this.isTaken(c.code) ? 1 : 0))
+          + " students have taken this course · "
+          + (this.isTaken(c.code) ? "you marked it as taken" : "click to mark as taken"),
+        takenCountFg: this.isTaken(c.code) ? "var(--brand)" : "var(--muted)",
+        takenBg: this.isTaken(c.code) ? "rgba(23,81,166,.08)" : "transparent",
+        takenHoverBg: this.isTaken(c.code) ? "rgba(23,81,166,.14)" : "var(--pill)",
+        takenFill: "none",
+        takenStroke: "currentColor",
+        onTaken: (e) => { e.stopPropagation(); if (guest) { this.setState({ takenMenu: s.takenMenu === c.code ? null : c.code, compareMenu: null }); return; } this.toggleFlag(e, c.code, "taken"); },
+        takenPickerOpen: s.takenMenu === c.code,
+        onSignUp: (e) => { e.stopPropagation(); this.closeAll({ authOpen: true }); },
+        onLogIn: (e) => { e.stopPropagation(); this.closeAll({ authOpen: true }); },
+        saveLabel: saved ? "Saved" : "Save course",
+        saveBg: saved ? "rgba(23,81,166,.08)" : "transparent",
+        saveBorder: saved ? "var(--brand)" : "var(--rule3)",
+        saveFg: saved ? "var(--brand)" : "var(--chipInk)",
+        saveFill: "none",
+        // Saving is never gated; a guest's list lives locally until they sign in.
+        onSave: (e) => this.toggleFlag(e, c.code, "saved"),
+        compareOpen: s.compareMenu === c.code,
+        pickerOpen: s.compareMenu === c.code,
+        onPicker: (e) => {
+          e.stopPropagation();
+          this.closeAll({ compareMenu: s.compareMenu === c.code ? null : c.code });
+        },
+        onCompare: (e) => {
+          e.stopPropagation();
+          this.closeAll({ compareMenu: s.compareMenu === c.code ? null : c.code });
+        },
+        hasComparisons: ((STORE && STORE.collections) || []).length > 0,
+        creating: s.creatingFor === c.code,
+        notCreating: s.creatingFor !== c.code,
+        comparisons: ((STORE && STORE.collections) || []).map((k) => {
+          const on = k.codes.indexOf(c.code) >= 0;
+          const full = false;
+          return {
+            name: k.name,
+            count: full
+              ? k.codes.length + "/" + COMPARE_CAP + " courses"
+              : k.codes.length === 0 ? "Empty"
+              : k.codes.length === 1 ? "1 course"
+              : k.codes.length + " courses",
+            fill: on ? "currentColor" : "none",
+            stroke: on ? "currentColor" : full ? "#c6c0b2" : "currentColor",
+            fg: full ? "#b3ada0" : "var(--ink2)",
+            cursor: full ? "not-allowed" : "pointer",
+            tooltip: full ? "Comparison is full" : "",
+            tick: on ? "m8.5 12 2.4 2.4 4.6-4.9" : "",
+            confirming: s.confirmDelete === k.id,
+            onAskDelete: (e) => { e.stopPropagation(); this.setState({ confirmDelete: k.id }); },
+            onCancelDelete: (e) => { e.stopPropagation(); this.setState({ confirmDelete: null }); },
+            onConfirmDelete: (e) => {
+              e.stopPropagation();
+              if (STORE) STORE.deleteCollection(k.id);
+              this.setState({ confirmDelete: null });
+            },
+            failed: s.failedRow === k.id + ":" + c.code,
+            onClick: (e) => {
+              if (full) { e.stopPropagation(); return; }
+              this.toggleInComparison(e, k.id, c.code);
+            }
+          };
+        }),
+        onNewComparison: (e) => {
+          e.stopPropagation();
+          this.setState({
+            creatingFor: c.code,
+            draftName: "Collection " + (((STORE && STORE.collections) || []).length + 1),
+            draftTouched: false
+          });
+        },
+        onOpen: () => { this.closeAll(); this.openTab(c.code, "c"); },
+        onReview: (e) => { e.stopPropagation(); this.closeAll(); this.openTab(c.code, "r"); }
+        };
+      }),
+      workspaceCourses: COURSES,
+      workspaceStore: STORE,
+      workspaceLocale: this.locale(),
+      openSignal: s.openSignal,
+      onTabsChange: (count) => {
+        if (count === 0) { this.setState({ workspaceTabCount: 0, openSignal: null }); return; }
+        if (count !== s.workspaceTabCount) this.setState({ workspaceTabCount: count });
+      },
+      onWorkspaceAuthed: () => {},
+      // Tabs tighten in three steps instead of scrolling or growing a "+N".
+      tabGap: indexed.length > 8 ? "2px" : "4px",
+      caretBg: s.overflowOpen ? "#eae6da" : "var(--pill)",
+      tabItems: indexed.map((t) => {
+        const on = t.i === s.tab;
+        const tight = indexed.length > 8;
+        const medium = !tight && indexed.length > 4;
+        const width = tight ? (on ? 44 : 30) : medium ? (on ? 90 : 68) : (on ? 104 : 88);
+        return {
+          title: t.label,
+          label: tight ? "" : medium ? t.code.slice(2) : t.code,
+          labelFlex: tight ? "0 0 0" : "1",
+          justify: tight ? "center" : "flex-start",
+          width: width + "px",
+          padding: tight ? "0" : on ? "0 8px 0 9px" : "0 9px",
+          dot: tight ? "8px" : "7px",
+          accent: t.kind === "r" ? "#dfa53c" : "#1751a6",
+          bg: on ? "var(--surface)" : "var(--pill)",
+          fg: on ? "var(--ink)" : "var(--dim)",
+          weight: on ? "600" : "500",
+          z: on ? "1" : "0",
+          dip: on ? "-1px" : "0",
+          isActive: on,
+          onClick: () => this.setState({ tab: t.i, overflowOpen: false }),
+          onClose: (e) => this.closeTab(e, t.i)
+        };
+      }),
+      reviewsOpen: s.reviewsOpen,
+      reviewsCaret: s.reviewsOpen ? "▴" : "▾",
+      reviewsTabBorder: s.reviewsOpen ? "var(--brand)" : "transparent",
+      reviewsTabFg: s.reviewsOpen ? "#1751a6" : "#5c6570",
+      onToggleReviews: () => this.setState({ reviewsOpen: !s.reviewsOpen }),
+      paneScrollRef: this.paneScrollRef,
+      reviewsRef: this.reviewsRef,
+      onExpandReviews: () => this.revealReviews(),
+      compareHelpOpen: s.compareHelpOpen,
+      compareHelpBg: s.compareHelpOpen ? "#eae6da" : "transparent",
+      onToggleCompareHelp: (e) => {
+        e.stopPropagation();
+        this.setState({ compareHelpOpen: !s.compareHelpOpen });
+      },
+      barRef: this.barRef,
+      q: s.q,
+      onQ: (e) => this.setState({ q: e.target.value, page: 0 }),
+      onClearQuery: () => this.setState({ q: "", page: 0 }),
+      hasQuery: Boolean(query),
+      noResults: !busy && Boolean(query) && matches.length === 0,
+      resultsLoading: this.savedState.loading,
+      resultsError: this.savedState.error,
+      onRetryResults: () => this.applyFixture("populated"),
+      resultsErrorTitle: "The course catalogue did not answer",
+      resultsErrorBody: "Search is unavailable right now. Your saved courses and collections are untouched.",
+      skeletonCards: [1, 2, 3].map((n) => ({ w: (86 - n * 9) + "%" })),
+      resultsLabel: this.savedState.loading
+        ? "Loading courses…"
+        : this.savedState.error
+          ? "Catalogue unavailable"
+          : query
+            ? matches.length + (matches.length === 1 ? " course matches " : " courses match ") + "“" + s.q.trim() + "”"
+            : COURSES.length + " courses",
+      hasPager: pageCount > 1,
+      pageLabel: "Page " + (page + 1) + " of " + pageCount,
+      onPrevPage: () => { if (page > 0) this.setState({ page: page - 1 }); },
+      onNextPage: () => { if (page < pageCount - 1) this.setState({ page: page + 1 }); },
+      prevDisabled: page === 0,
+      nextDisabled: page >= pageCount - 1,
+      prevColor: page === 0 ? "var(--dim2)" : "var(--ink)",
+      nextColor: page >= pageCount - 1 ? "var(--dim2)" : "var(--ink)",
+      prevCursor: page === 0 ? "not-allowed" : "pointer",
+      nextCursor: page >= pageCount - 1 ? "not-allowed" : "pointer",
+      authOpen: s.authOpen,
+      justAuthed: s.justAuthed && !s.posted,
+      posted: s.posted,
+      postLabel: s.posted ? "Published" : s.justAuthed ? "Publish review" : "Post review",
+      happyNotSet: d.recommend == null,
+      postBg: (d.recommend != null && d.workload != null && d.learning != null) ? "var(--btn)" : "var(--pill)",
+      postCursor: (d.recommend != null && d.workload != null && d.learning != null) ? "pointer" : "not-allowed",
+      postHint: (d.recommend != null && d.workload != null && d.learning != null) ? "" : "Answer happy, workload and learning to publish — the write-up is the only optional part",
+      onPostReview: () => {
+        // Happy/workload/learning are required to publish; only the write-up is optional.
+        if (d.recommend == null || d.workload == null || d.learning == null) return;
+        // A guest writes the whole review; only publishing needs an account.
+        if (guest) { this.setState({ authOpen: true }); return; }
+        // Publishing implies the course was taken — add it to user_taken_courses
+        // if it wasn't already there, and write the review itself so My Page
+        // and the course's own review list pick it up immediately.
+        if (!STORE.userTakenCourses.some((r) => r.userId === "u1" && r.courseCode === active.code)) {
+          const now = new Date().toISOString();
+          STORE.userTakenCourses.push({
+            userId: "u1", courseCode: active.code, attendancePeriods: [], attendanceYear: null,
+            grade: null, earnedCredits: null, transcriptImportedAt: null,
+            createdAt: now, updatedAt: now
+          });
+        }
+        STORE.reviews.push({
+          id: "r" + Date.now(), userId: "u1", courseCode: active.code,
+          examinationDistribution: STORE.examinationDistributionFrom(draftMix.items, d.pcts),
+          approachTheoryPercent: d.theory == null ? 50 : d.theory,
+          workloadScore: d.workload, learningScore: d.learning,
+          happyTook: d.recommend,
+          message: d.reviewText || "",
+          createdAt: new Date().toISOString(), updatedAt: new Date().toISOString()
+        });
+        this.setState({ posted: true, justAuthed: false });
+      },
+      // When a host owns the session, tell it — otherwise the two disagree.
+      onAuthDone: () => {
+        this.setState({ guest: false, authOpen: false, justAuthed: true });
+        if (this.props.onAuthed) this.props.onAuthed();
+      },
+      onAuthCancel: () => this.setState({ authOpen: false }),
+      isGuest: guest,
+      isMember: !guest,
+      night: this.ccDark(),
+      notNight: !this.ccDark(),
+      themeTitle: this.ccDark() ? "Switch to light mode" : "Switch to dark mode",
+      onTheme: () => this.ccSetDark(!this.ccDark()),
+      paneTop: "66px",
+      ...this.savedVals(guest),
+      onSignUp: (e) => { e.stopPropagation(); this.closeAll({ authOpen: true }); },
+      onLogIn: (e) => { e.stopPropagation(); this.closeAll({ authOpen: true }); },
+      hasTabs: Boolean(s.openSignal) || (s.workspaceTabCount || 0) > 0,
+      resultsMax: Boolean(s.openSignal) || (s.workspaceTabCount || 0) > 0 ? "none" : "1148px",
+      searchBarMargin: (Boolean(s.openSignal) || (s.workspaceTabCount || 0) > 0) ? "236px" : "0",
+      rowRef: this.rowRef,
+      paneW: paneW + "px",
+      // Below the combined floor the row stacks: the pane alone, results stood down.
+      resultsHidden: paneSolo,
+      resultsShown: !paneSolo,
+      resultsFloor: Boolean(s.openSignal) || (s.workspaceTabCount || 0) > 0 ? this.RESULTS_FLOOR + "px" : "0px",
+      // Full triple: a bare `flex:0` would zero the basis and collapse the pane.
+      paneGrow: paneSolo ? "1 1 auto" : "0 0 auto",
+      paneWidth: paneSolo ? "auto" : paneW + "px",
+      dragCursor: paneSolo ? "default" : "col-resize",
+      onPaneDrag: (e) => {
+        e.preventDefault();
+        const startX = e.clientX;
+        const startW = paneW;
+        const bounds = this.paneBounds();
+        const min = bounds.min;
+        const max = bounds.max;
+        // Transitions off mid-drag, so the card tracks the handle exactly.
+        this.setState({ dragging: true });
+        window.addEventListener("pointerup", () => this.setState({ dragging: false }), { once: true });
+        this.drag((ev) => {
+          const next = Math.round(Math.max(min, Math.min(max, startW - (ev.clientX - startX))));
+          if (next !== this.state.paneW) this.setState({ paneW: next });
+        });
+      },
+      onPaneReset: () => this.setState({ paneW: 504 }),
+
+      // Every width in the card is interpolated from t, so no state is binary.
+      geo: {
+        tween: s.dragging
+          ? "none"
+          : "padding .18s ease-out, width .18s ease-out, gap .18s ease-out, max-height .18s ease-out, max-width .18s ease-out, opacity .14s ease-out, font-size .18s ease-out",
+        titleSize: px(15.5, 17),
+        cardGap: px(8, 10),
+        cardPad: px(14, 18),
+        factsGap: px(10, 14),
+        reviewPad: "0 " + px(10, 13, late),
+        saveW: px(96, 126, late),
+        savePad: px(10, 12, late),
+        railW: px(134, 224),
+        railPad: px(14, 18) + " " + px(12, 16),
+        summaryMax: summaryLines * 19 + "px",
+        summaryOpacity: summaryLines === 0 ? 0 : 1,
+        labelMax: px(0, 120, late),
+        labelOpacity: late,
+        // At the tightest collapse the label text would just get clipped —
+        // better to drop it and show the icon-only button/split-button.
+        showLabel: t > 0.02,
+        reviewFlex: t > 0.02 ? "0 1 132px" : "0 0 34px",
+        saveFlex: t > 0.02 ? "0 1 158px" : "0 0 68px",
+        cardHeight: "236px"
+      },
+      tween: s.dragging
+        ? "none"
+        : "padding .18s ease-out, width .18s ease-out, gap .18s ease-out, max-height .18s ease-out, max-width .18s ease-out, opacity .14s ease-out, font-size .18s ease-out",
+      titleSize: px(15.5, 17),
+      cardGap: px(8, 10),
+      cardPad: px(14, 18),
+      factsGap: px(10, 14),
+      reviewPad: "0 " + px(10, 13, late),
+      saveW: px(96, 126, late),
+      savePad: px(10, 12, late),
+      railW: px(134, 224),
+      railPad: px(14, 18) + " " + px(12, 16),
+      // Whole 19px line boxes only, so a partial line can never be sliced.
+      summaryLines: String(Math.max(1, summaryLines)),
+      summaryMax: summaryLines * 19 + "px",
+      summaryOpacity: summaryLines === 0 ? 0 : 1,
+      labelMax: px(0, 120, late),
+      labelOpacity: late,
+      openCountLabel: (s.workspaceTabCount || 0) + " open",
+      noTabs: (s.workspaceTabCount || 0) === 0,
+      overflowOpen: s.overflowOpen,
+      onToggleOverflow: (e) => {
+        e.stopPropagation();
+        this.closeAll({ overflowOpen: !s.overflowOpen });
+      },
+      switcherItems: indexed.map((t) => ({
+        label: t.label,
+        accent: t.kind === "r" ? "#dfa53c" : "#1751a6",
+        bg: t.i === s.tab ? "var(--pill)" : "transparent",
+        fg: t.i === s.tab ? "var(--brand)" : "var(--ink2)",
+        weight: t.i === s.tab ? "600" : "400",
+        onClick: () => this.setState({ tab: t.i, overflowOpen: false }),
+        onClose: (e) => this.closeTab(e, t.i)
+      })),
+      isDetails: active.kind === "c",
+      isReview: active.kind === "r",
+      // The pane reads one course, so every figure in it follows the open tab.
+      noOfferings: !((STORE.getCourse(active.code) || { rounds: [] }).rounds || []).length,
+      detail: (() => {
+        const known = COURSES.find((x) => x.code === active.code);
+        // Codes outside the sample set stand in as unreviewed courses.
+        const c = known || {
+          code: active.code, title: active.code, meta: "7.5 hp · " + active.code + " · SCI",
+          summary: "No description on file yet. Open the course on KTH.se for the official syllabus.",
+          keywords: "", exSegments: [], th: null, wl: 0, le: 0, happy: 0, stats: ["0", "0", "0"]
+        };
+        const segs = c.exSegments || [];
+        const rounds = (STORE.getCourse(active.code) || { rounds: [] }).rounds || [];
+        return {
+          title: c.title, meta: c.meta, content: c.summary,
+          // course_rounds.formatted_periods_and_credits, as stored. The year is
+          // not shown: an offering repeats, the periods are what differs.
+          offerings: rounds.map((r, i) => ({
+            key: r.roundCode || String(i),
+            periods: r.formattedPeriodsAndCredits || r.periodLabel || "—",
+            language: r.language || "—",
+            tutoring: r.tutoringForm || "—"
+          })),
+          hasOfferings: rounds.length > 0,
+          reviews: c.stats[2], hp: c.meta.split(" · ")[0],
+          reviewed: Boolean(known), unreviewed: !known,
+          happy: c.happy + "%",
+          reviewCards: STORE.reviewsByCourse(active.code).map((r) => STORE.reviewView(r, { locale: this.locale() })).map((rv) => ({
+            code: rv.courseCode, name: rv.name, term: rv.startTermLabel,
+            author: rv.author, date: rv.createdAtLabel, likes: rv.helpfulCount,
+            message: rv.message, workloadScore: rv.workloadScore, happyTook: rv.happyTook
+          })),
+          hasReviewCards: STORE.reviewsByCourse(active.code).length > 0,
+          noReviewCards: STORE.reviewsByCourse(active.code).length === 0,
+          summaryLine: known
+            ? "Reviewers single out " + c.keywords.split(", ")[0] + " as the part of the course that sticks, and flag "
+              + (c.wl >= 80 ? "the workload as the thing to plan around." : "the pace as brisk but manageable.")
+            : "",
+          examSegments: segs.map((x) => ({ w: x.percent + "%", color: x.color })),
+          hasExam: segs.length > 0,
+          noExam: segs.length === 0,
+          exSplit: segs.length ? segs.map((x) => x.percent).join(" / ") : "—",
+          exNames: segs.length ? segs.map((x) => x.label).join(" · ") : "No examination breakdown yet",
+          thW: (c.th || 0) + "%", apW: (c.th == null ? 0 : 100 - c.th) + "%",
+          thSplit: c.th == null ? "—" : c.th + " / " + (100 - c.th),
+          wl: c.wl != null ? (c.wl / 10).toFixed(1) : "—", wlW: (c.wl || 0) + "%",
+          le: c.le != null ? (c.le / 10).toFixed(1) : "—", leW: (c.le || 0) + "%",
+          hasReviewStats: c.happy != null, noReviewStats: c.happy == null
+        };
+      })(),
+      onOpenReviewTab: () => this.openTab(active.code, "r"),
+
+      examTrackRef: this.examTrackRef,
+      examSegs: draftMix.segs,
+      examSplitLabel: chosen.length ? chosen.map((m, i) => d.pcts[i] || 0).join(" / ") : "Not set",
+      examEmpty: chosen.length === 0,
+      savedLabel: untouched ? "Not saved yet" : "Saved just now",
+      examDividers: draftMix.dividers,
+      methodChips: draftMix.chips,
+
+      theoryW1: (d.theory == null ? 50 : d.theory) + "%",
+      theoryW2: (d.theory == null ? 50 : 100 - d.theory) + "%",
+      theoryFill1: d.theory == null ? "#ded8c8" : "#12417f",
+      theoryFill2: d.theory == null ? "#ded8c8" : "#a9c8ec",
+      theoryInk1: d.theory == null ? "#6b6355" : "#fff",
+      theoryInk2: d.theory == null ? "#6b6355" : "#12417f",
+      theorySet: d.theory != null,
+      theoryUnset: d.theory == null,
+      theoryLabel: d.theory == null ? "Not set" : d.theory + " / " + (100 - d.theory),
+      onTheoryDown: (e) => this.startPct(e, 100, (v) => setDraft({ theory: v })),
+
+      workloadW: (d.workload == null ? 0 : d.workload * 10) + "%",
+      workloadSet: d.workload != null,
+      workloadLabel: d.workload == null ? "Not set" : d.workload + " / 10",
+      onWorkloadDown: (e) => this.startPct(e, 10, (v) => setDraft({ workload: v })),
+      learningW: (d.learning == null ? 0 : d.learning * 10) + "%",
+      learningSet: d.learning != null,
+      learningLabel: d.learning == null ? "Not set" : d.learning + " / 10",
+      onLearningDown: (e) => this.startPct(e, 10, (v) => setDraft({ learning: v })),
+
+      overallOpts: ["Bad", "Poor", "Okay", "Good", "Great"].map((label, i) => {
+        const v = i + 1;
+        const on = d.overall === v;
+        return {
+          value: v, label,
+          bg: on ? "var(--btn)" : "var(--surface)",
+          fg: on ? "var(--btnFg)" : "var(--muted)",
+          border: on ? "var(--brand)" : "#dde7f4",
+          onClick: () => setDraft({ overall: v })
+        };
+      }),
+
+      reviewText: d.reviewText,
+      onReviewChange: (e) => setDraft({ reviewText: e.target.value }),
+      promptChips: [
+        ["What surprised you?", "One thing that surprised me was "],
+        ["Who is it for?", "This course is a great fit if you "],
+        ["Time it really took?", "Budget more time than you think for "]
+      ].map(([label, starter]) => ({
+        label,
+        onClick: () => setDraft({
+          reviewText: d.reviewText ? d.reviewText.replace(/\s*$/, "") + "\n" + starter : starter
+        })
+      })),
+      progressLabel: doneCount + " of 3 sections done",
+      progressSegs: [0, 1, 2].map((i) => ({ bg: i < doneCount ? "var(--btn)" : "var(--pill)" })),
+
+      stopClick: (e) => e.stopPropagation(),
+      draftName: s.draftName,
+      onDraftChange: (e) => this.setState({ draftName: e.target.value, draftTouched: true }),
+      onDraftFocus: (e) => e.target.select(),
+      onDraftKey: (e) => {
+        if (e.key === "Enter") this.commitDraft();
+        if (e.key === "Escape") this.setState({ creatingFor: null });
+      },
+      onDraftCommit: () => this.commitDraft(),
+
+      contentClamp: s.contentOpen ? "unset" : "3",
+      contentToggleLabel: s.contentOpen ? "Show less" : "Read more",
+      onToggleContent: () => this.setState({ contentOpen: !s.contentOpen }),
+
+      happyOpts: [[true, "Yes, I am"], [false, "No, I am not"]].map(([v, label]) => {
+        const on = d.recommend === v;
+        return {
+          label,
+          bg: on ? "var(--pill)" : "var(--surface)",
+          fg: on ? "var(--brand)" : "var(--chipInk)",
+          border: on ? "var(--brand)" : "var(--rule3)",
+          weight: on ? "600" : "500",
+          dot: on ? "#1751a6" : "transparent",
+          dotBorder: on ? "var(--brand)" : "#c8c2b2",
+          onClick: () => setDraft({ recommend: v })
+        };
+      }),
+      recommendBg: d.recommend ? "var(--btn)" : "#cfc9b8",
+      recommendJustify: d.recommend ? "flex-end" : "flex-start",
+      recommendLabel: d.recommend == null
+        ? "I would recommend this course — not answered yet"
+        : d.recommend ? "Yes, I would recommend this course" : "No, I would not recommend this course",
+      onToggleRecommend: () => setDraft({ recommend: !d.recommend })
+    };
+  }
+
+  commitDraft() {
+    const s = this.state;
+    const name = (s.draftName || "").trim();
+    if (!s.creatingFor) return;
+    if (!name || !s.draftTouched) { this.setState({ creatingFor: null }); return; }
+    if (STORE) STORE.createCollection(name, [s.creatingFor]);
+    const flags = { ...s.flags };
+    flags[s.creatingFor] = { ...(flags[s.creatingFor] || {}), saved: true };
+    this.setState({ flags, creatingFor: null });
+    this.persistSaved(flags);
+  }
+
+  toggleInComparison(e, id, code) {
+    e.stopPropagation();
+    // Picking a collection implies saving, so the two never disagree.
+    const flags = { ...this.state.flags };
+    flags[code] = { ...(flags[code] || {}), saved: true };
+    this.setState({ flags });
+    this.persistSaved(flags);
+    if (STORE) {
+      const col = STORE.collections.find((k) => k.id === id);
+      if (col && col.codes.indexOf(code) >= 0) STORE.removeCourseFromCollection(id, code);
+      else STORE.addCourseToCollection(id, code);
+    }
+    this.forceUpdate();
+  }
+
+  toggleFlag(e, code, key) {
+    e.stopPropagation();
+    if (key === "taken") { this.toggleTaken(code); return; }
+    const flags = { ...this.state.flags };
+    const cur = { ...(flags[code] || {}) };
+    cur[key] = !cur[key];
+    flags[code] = cur;
+    this.setState({ flags });
+    if (key === "saved") this.persistSaved(flags);
+  }
+
+  /** "Taken" lives in user_taken_courses, not the local flags cache, so
+      every card that lists this course (including as a prerequisite)
+      agrees the moment it changes. */
+  toggleTaken(code) {
+    const rows = STORE.userTakenCourses;
+    const at = rows.findIndex((r) => r.userId === "u1" && r.courseCode === code);
+    if (at >= 0) rows.splice(at, 1);
+    else {
+      const now = new Date().toISOString();
+      rows.push({ userId: "u1", courseCode: code, attendancePeriods: [], attendanceYear: null,
+        grade: null, earnedCredits: null, transcriptImportedAt: null, createdAt: now, updatedAt: now });
+    }
+    this.forceUpdate();
+  }
+
+  isTaken(code) {
+    return STORE.userTakenCourses.some((r) => r.userId === "u1" && r.courseCode === code);
+  }
+
+  /** Writes only our own key, so nothing else in storage is touched. */
+  persistSaved(flags) {
+    try {
+      const codes = Object.keys(flags).filter((code) => flags[code] && flags[code].saved);
+      window.localStorage.setItem(SAVED_KEY, JSON.stringify(codes));
+    } catch (e) { /* storage unavailable */ }
+  }
+
+  closeTab(e, i) {
+    e.stopPropagation();
+    const tabs = this.state.tabs.slice();
+    tabs.splice(i, 1);
+    let tab = this.state.tab;
+    if (i < tab) tab -= 1;
+    if (tab >= tabs.length) tab = tabs.length - 1;
+    this.setState({ tabs, tab: Math.max(0, tab) });
+  }
+
+  openTab(code, kind) {
+    this.setState({ openSignal: { code, kind, nonce: Date.now() } });
+  }
+}
+</script>
+</body>
+</html>

--- a/docs/design/Course Community - Landing.dc.html
+++ b/docs/design/Course Community - Landing.dc.html
@@ -1,0 +1,1602 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<script src="./support.js"></script>
+</head>
+<body>
+<x-dc>
+<helmet data-dc-atomics><link rel="preconnect" href="https://fonts.googleapis.com"><link rel="preconnect" href="https://fonts.gstatic.com" crossorigin><link href="https://fonts.googleapis.com/css2?family=Geist:wght@400;500;600;700&display=swap" rel="stylesheet"><link rel="stylesheet" href="cc-theme.css"><style>.omx-th *{transition:background-color .34s ease,color .34s ease,border-color .34s ease}body{margin:0;background:var(--pg);font-family:Geist,system-ui,sans-serif;transition:background-color .34s ease}a{color:#1751a6}a:hover{color:#10386f}input{font-family:Geist,system-ui,sans-serif}.omx-app{position:absolute;inset:0;overflow:hidden}.omx-app .dv-turn{padding:0!important;border:none!important}.omx-app .dv-thd,.omx-app .dv-olabel{display:none!important}.omx-app .dv-opts,.omx-app .dv-opt{display:block!important;gap:0!important}.omx-app .dv-card{max-width:none!important;border:none!important;border-radius:0!important;box-shadow:none!important;overflow:visible!important}.omx-app div:has(> input[placeholder="Search a course, code or subject"]){opacity:0!important}@keyframes omxShimmer{0%{background-position:-320px 0}100%{background-position:320px 0}}.omx-skel{background:linear-gradient(90deg,#f2efe6 0%,#faf8f1 50%,#f2efe6 100%);background-size:320px 100%;animation:omxShimmer 1.1s linear infinite;border-radius:6px}
+[data-cc-landing-container="1"]{container-type:inline-size}
+@container (max-width:500px){[data-cc-hero-title="1"]{font-size:30px!important}[data-cc-searchbar="desktop"]{display:none!important}[data-cc-searchbar="mobile"]{display:flex!important}[data-cc-hero-gap="1"]{height:24px!important}[data-cc-header-actions="1"]{display:none!important}[data-cc-landing-header="1"]{padding:0 16px!important}[data-cc-mark="1"]{display:none!important}[data-cc-wordmark="1"]{display:none!important}[data-cc-landing-root="1"]{height:auto!important;overflow:visible!important;position:static!important}[data-cc-landing-scroll="1"]{position:static!important;height:auto!important;overflow:visible!important;transform:none!important}}</style></helmet>
+
+<div data-cc-landing-container="1">
+<div data-cc-theme="{{ theme }}" data-cc-landing-root="1" style="position:relative;width:100%;height:900px;overflow:hidden;background:var(--pg);color:var(--ink);font-size:14px;transition:background-color .34s ease,color .34s ease">
+
+
+<div data-cc-landing-scroll="1" class="omx-th" ref="{{ landingRef }}" style="position:absolute;inset:0;z-index:20;overflow:auto;background:var(--pg);clip-path:inset({{ curtain }} 0 0 0);opacity:{{ landingOpacity }};transform:translateY({{ landingShift }});transition:{{ landingTween }};pointer-events:{{ landingPointer }}">
+
+<div data-cc-landing-header="1" style="display:flex;align-items:center;justify-content:space-between;gap:20px;height:66px;padding:0 28px;box-sizing:border-box;position:relative;z-index:2;border-bottom:1px solid var(--rule);background:var(--pg);color:{{ headFg }}">
+<div onClick="{{ onHome }}" style="display:flex;align-items:center;gap:10px;cursor:pointer">
+<div data-cc-mark="1" style="width:34px;height:34px;flex:none;border-radius:9px;background:#1751a6;display:flex;align-items:center;justify-content:center"><img src="assets/ais-symbol-white.png" alt="KTH AI Society" style="height:22px;width:22px;object-fit:contain"></div>
+<div data-cc-wordmark-line="1" style="width:1px;height:28px;background:var(--rule3)"></div>
+<div data-cc-wordmark="1" style="font-size:15px;font-weight:600;line-height:1.15;color:var(--ink)">Course<br>Community</div>
+</div>
+<div style="flex:1"></div>
+<div data-cc-header-actions="1" style="display:flex;align-items:center;gap:6px">
+<div onClick="{{ onTheme }}" onKeyDown="{{ onThemeKey }}" role="button" tabIndex="0" title="{{ themeTitle }}" aria-label="{{ themeTitle }}" style="width:34px;height:34px;display:flex;align-items:center;justify-content:center;border-radius:8px;color:{{ headMuted }};cursor:pointer" style-hover="background:rgba(125,145,175,.16)">
+<sc-if value="{{ notNight }}" hint-placeholder-val="{{ true }}"><svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><path d="M20.5 14.5A8.5 8.5 0 1 1 9.5 3.5a7 7 0 0 0 11 11z"></path></svg></sc-if>
+<sc-if value="{{ night }}" hint-placeholder-val="{{ false }}"><svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round"><circle cx="12" cy="12" r="4.2"></circle><path d="M12 3v2M12 19v2M3 12h2M19 12h2M5.6 5.6l1.4 1.4M17 17l1.4 1.4M18.4 5.6 17 7M7 17l-1.4 1.4"></path></svg></sc-if>
+</div>
+<sc-if value="{{ isGuest }}" hint-placeholder-val="{{ true }}">
+<div style="display:flex;align-items:center;gap:8px">
+<div onClick="{{ onLogIn }}" style="display:flex;align-items:center;height:34px;padding:0 13px;border-radius:8px;border:{{ loginBorder }};background:{{ loginBg }};font-size:13px;font-weight:500;color:{{ loginFg }};cursor:pointer">Log in</div>
+<div onClick="{{ onSignUp }}" style="display:flex;align-items:center;height:34px;padding:0 15px;border-radius:8px;background:{{ signupBg }};color:{{ signupFg }};font-size:13px;font-weight:600;cursor:pointer">Sign up</div>
+</div>
+</sc-if>
+<sc-if value="{{ isMember }}" hint-placeholder-val="{{ false }}">
+<div style="display:flex;align-items:center;gap:9px">
+<div style="display:flex;align-items:center;gap:8px;height:34px;padding:0 11px 0 5px;border-radius:8px;background:{{ chipBg }}">
+<span style="width:24px;height:24px;border-radius:50%;background:#7ea6d8;color:#0d2f5e;display:flex;align-items:center;justify-content:center;font-size:10px;font-weight:700">EL</span>
+<span style="font-size:13px;font-weight:500;color:{{ headFg }}">Elsa Lindqvist</span>
+</div>
+<div onClick="{{ onLogOut }}" role="button" tabIndex="0" style="display:flex;align-items:center;height:34px;padding:0 11px;border-radius:8px;font-size:13px;font-weight:500;color:{{ headMuted }};cursor:pointer" style-hover="background:rgba(125,145,175,.16)">Log out</div>
+</div>
+</sc-if>
+</div>
+</div>
+
+<div style="position:absolute;left:0;right:0;top:66px;height:600px;z-index:0;pointer-events:none">
+<canvas ref="{{ vizRef }}" aria-hidden="true" style="display:block;width:100%;height:100%"></canvas>
+</div>
+
+<div style="position:relative;z-index:1">
+<div style="height:600px;display:flex;flex-direction:column;align-items:center;justify-content:center;padding:0 28px;box-sizing:border-box">
+<div style="width:100%;max-width:720px;display:flex;flex-direction:column;align-items:center;text-align:center">
+<div data-om-clear="1" style="margin-top:70px;font-size:11px;font-weight:600;letter-spacing:.09em;text-transform:uppercase;color:var(--dim)">Run by students at KTH</div>
+<div data-cc-hero-title="1" data-om-clear="1" style="margin-top:14px;font-size:44px;font-weight:600;line-height:1.08;letter-spacing:-.025em;text-wrap:balance">Find the Course You Will Be Happy You Took</div>
+
+<div data-cc-searchbar="mobile" class="omx-th" data-om-clear="1" style="display:none;margin-top:16px;width:100%;box-sizing:border-box;align-items:center;gap:10px;height:42px;padding:0 14px;border-radius:10px;border:1px solid var(--rule3);background:var(--surface)">
+<svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" style="color:var(--muted);flex:none"><circle cx="11" cy="11" r="7"></circle><line x1="16.5" y1="16.5" x2="21" y2="21"></line></svg>
+<input value="{{ q }}" onChange="{{ onQ }}" onKeyDown="{{ onKey }}" onFocus="{{ onFocusSearch }}" placeholder="Search a course, code or subject" style="flex:1;min-width:0;border:none;outline:none;background:transparent;font-size:14px;color:var(--ink)">
+</div>
+
+<div data-cc-hero-gap="1" style="height:97px"></div>
+<div data-om-clear="1" style="display:flex;align-items:center;gap:7px;flex-wrap:wrap;justify-content:center">
+<span style="font-size:12px;color:var(--dim)">Try</span>
+<div onClick="{{ onTry1 }}" style="height:28px;display:flex;align-items:center;padding:0 11px;border-radius:14px;border:1px solid var(--rule2);background:var(--surface);font-size:12.5px;color:var(--chipInk);cursor:pointer" style-hover="border-color:var(--hov)">deep learning</div>
+<div onClick="{{ onTry2 }}" style="height:28px;display:flex;align-items:center;padding:0 11px;border-radius:14px;border:1px solid var(--rule2);background:var(--surface);font-size:12.5px;color:var(--chipInk);cursor:pointer" style-hover="border-color:var(--hov)">machine learning</div>
+<div onClick="{{ onTry3 }}" style="height:28px;display:flex;align-items:center;padding:0 11px;border-radius:14px;border:1px solid var(--rule2);background:var(--surface);font-size:12.5px;color:var(--chipInk);cursor:pointer" style-hover="border-color:var(--hov)">DD2380</div>
+</div>
+<div data-om-clear="1" style="margin-top:20px;display:flex;align-items:center;gap:5px;font-size:12.5px;color:var(--dim)"><span>Already a member?</span><span onClick="{{ onFindDot }}" role="button" tabIndex="0" style="font-weight:500;color:var(--muted);text-decoration:underline;text-underline-offset:2px;cursor:pointer" style-hover="color:var(--brand)">Find your dot.</span></div>
+</div>
+</div>
+<div style="border-top:1px solid var(--rule);background:var(--surface);padding:34px 28px">
+<div style="max-width:960px;margin:0 auto;display:{{ sectionsDisplay }};flex-direction:column;grid-template-columns:repeat(3,1fr);gap:22px">
+<div>
+<div style="font-size:10.5px;font-weight:600;letter-spacing:.09em;text-transform:uppercase;color:var(--dim)">Search</div>
+<div style="margin-top:7px;font-size:15px;font-weight:600">Every KTH course, one field</div>
+<div style="margin-top:5px;font-size:13.5px;line-height:1.5;color:var(--muted)">Filter by school, credits or rating. Open as many courses as you like side by side.</div>
+</div>
+<div>
+<div style="font-size:10.5px;font-weight:600;letter-spacing:.09em;text-transform:uppercase;color:var(--dim)">Read</div>
+<div style="margin-top:7px;font-size:15px;font-weight:600">Numbers, not vibes</div>
+<div style="margin-top:5px;font-size:13.5px;line-height:1.5;color:var(--muted)">Examination mix, theoretical versus applied, workload and learning — aggregated per course.</div>
+</div>
+<div>
+<div style="font-size:10.5px;font-weight:600;letter-spacing:.09em;text-transform:uppercase;color:var(--dim)">Review</div>
+<div style="margin-top:7px;font-size:15px;font-weight:600">Write first, sign in last</div>
+<div style="margin-top:5px;font-size:13.5px;line-height:1.5;color:var(--muted)">Fill in a review as a guest. You only need an account at the moment you post it.</div>
+</div>
+</div>
+</div>
+</div>
+
+
+
+</div>
+
+<sc-if value="{{ showBottomAuth }}" hint-placeholder-val="{{ false }}">
+<div style="padding:20px 20px 36px">
+<div style="border-radius:11px;background:var(--surface);border:1px solid var(--rule2);padding:20px 19px">
+<div style="font-size:11px;font-weight:600;letter-spacing:.06em;text-transform:uppercase;color:var(--brand)">{{ authKicker }}</div>
+<div style="margin-top:8px;font-size:17px;font-weight:600;line-height:1.25">{{ authTitle }}</div>
+<div style="margin-top:6px;font-size:13px;line-height:1.5;color:var(--muted)">{{ authBody }}</div>
+<div style="margin-top:16px;display:flex;flex-direction:column;gap:8px">
+<div tabIndex="0" onClick="{{ onAuthDone }}" style="display:flex;align-items:center;justify-content:center;height:42px;border-radius:9px;background:var(--btn);color:var(--btnFg);font-size:13.5px;font-weight:600;cursor:pointer">Continue with KTH account</div>
+<div tabIndex="0" onClick="{{ onAuthDone }}" style="display:flex;align-items:center;justify-content:center;height:42px;border-radius:9px;border:1px solid var(--rule3);background:var(--surface);font-size:13.5px;font-weight:500;color:var(--ink);cursor:pointer">Sign up with email</div>
+</div>
+<div onClick="{{ onSwitchReason }}" style="margin-top:12px;text-align:center;font-size:12.5px;font-weight:500;color:var(--brand);cursor:pointer">{{ authSwitchLabel }}</div>
+</div>
+</div>
+</sc-if>
+
+<sc-if value="{{ loading }}" hint-placeholder-val="{{ false }}">
+<div style="position:absolute;left:256px;right:20px;top:76px;bottom:20px;z-index:22;display:flex;flex-direction:column;gap:14px;overflow:hidden">
+<div class="omx-skel" style="width:104px;height:12px;border-radius:6px"></div>
+<div class="omx-skel" style="height:236px;border-radius:12px"></div>
+<div class="omx-skel" style="height:236px;border-radius:12px"></div>
+<div class="omx-skel" style="height:236px;border-radius:12px"></div>
+</div>
+</sc-if>
+
+<div data-cc-searchbar="desktop" style="position:{{ barPosition }};left:0;right:0;top:{{ barTop }};z-index:30;display:flex;justify-content:center;opacity:{{ barOpacity }};transition:{{ barTween }};pointer-events:{{ barPointer }}">
+<div class="omx-th" ref="{{ barRef }}" data-om-clear="1" style="width:{{ barWidth }};box-sizing:border-box;display:flex;align-items:center;gap:10px;height:42px;padding:0 14px;border-radius:10px;border:1px solid var(--rule3);background:var(--surface)">
+<svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" style="color:var(--muted);flex:none"><circle cx="11" cy="11" r="7"></circle><line x1="16.5" y1="16.5" x2="21" y2="21"></line></svg>
+<input ref="{{ inputRef }}" value="{{ q }}" onChange="{{ onQ }}" onKeyDown="{{ onKey }}" onFocus="{{ onFocusSearch }}" placeholder="Search a course, code or subject" style="flex:1;min-width:0;border:none;outline:none;background:transparent;font-size:14px;color:var(--ink)">
+</div>
+</div>
+
+<div style="position:absolute;left:0;top:0;bottom:0;z-index:35;box-sizing:border-box;width:236px;padding:6px 12px 14px;display:flex;flex-direction:column;background:#1751a6;color:#fff;transform:translateX({{ railShift }});transition:{{ railTween }};pointer-events:{{ railPointer }}">
+<div onClick="{{ onHome }}" style="display:flex;align-items:center;gap:10px;padding:6px 8px 14px;cursor:pointer">
+<img src="assets/ais-symbol-white.png" alt="KTH AI Society" style="height:34px;width:34px;object-fit:contain">
+<div style="width:1px;height:28px;background:rgba(255,255,255,.35)"></div>
+<div style="font-size:15px;font-weight:600;line-height:1.15">Course<br>Community</div>
+</div>
+<div style="display:flex;flex-direction:column;gap:2px;margin-top:14px;font-size:14px">
+<div style="display:flex;align-items:center;gap:10px;padding:9px 10px;border-radius:8px;background:rgba(255,255,255,.16);font-weight:600"><svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="#fff" stroke-width="2.4" stroke-linecap="round"><circle cx="11" cy="11" r="7"></circle><line x1="16.5" y1="16.5" x2="21" y2="21"></line></svg>Explore</div>
+<div style="display:flex;align-items:center;gap:10px;padding:9px 10px;border-radius:8px;color:rgba(255,255,255,.82)" style-hover="background:rgba(255,255,255,.1)"><svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="#fff" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="m19 21-7-4-7 4V5a2 2 0 0 1 2-2h10a2 2 0 0 1 2 2z"></path></svg>Saved courses</div>
+<div style="display:flex;align-items:center;gap:10px;padding:9px 10px;border-radius:8px;color:rgba(255,255,255,.82)" style-hover="background:rgba(255,255,255,.1)"><svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="#fff" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M11.525 2.295a.53.53 0 0 1 .95 0l2.31 4.679a2.123 2.123 0 0 0 1.595 1.16l5.166.756a.53.53 0 0 1 .294.904l-3.736 3.638a2.123 2.123 0 0 0-.611 1.878l.882 5.14a.53.53 0 0 1-.771.56l-4.618-2.428a2.122 2.122 0 0 0-1.973 0L6.396 21.11a.53.53 0 0 1-.77-.56l.881-5.139a2.122 2.122 0 0 0-.611-1.879L2.16 9.795a.53.53 0 0 1 .294-.906l5.165-.755a2.122 2.122 0 0 0 1.597-1.16z"></path></svg>My reviews</div>
+</div>
+<div style="margin-top:auto;display:flex;flex-direction:column;gap:2px;font-size:14px">
+<div style="display:flex;align-items:center;gap:10px;padding:9px 10px;border-radius:8px;color:rgba(255,255,255,.82)"><svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="#fff" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M12 7v14"></path><path d="M3 18a1 1 0 0 1-1-1V4a1 1 0 0 1 1-1h5a4 4 0 0 1 4 4 4 4 0 0 1 4-4h5a1 1 0 0 1 1 1v13a1 1 0 0 1-1 1h-6a3 3 0 0 0-3 3 3 3 0 0 0-3-3z"></path></svg>About</div>
+<div style="display:flex;align-items:center;gap:10px;padding:9px 10px;border-radius:8px;color:rgba(255,255,255,.82)"><svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="#fff" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M12 17h.01"></path><path d="M9.09 9a3 3 0 0 1 5.83 1c0 2-3 3-3 3"></path><circle cx="12" cy="12" r="10"></circle></svg>Contact</div>
+</div>
+<div style="margin-top:12px;padding-top:12px;border-top:1px solid rgba(255,255,255,.2)">
+<div style="font-size:11.5px;line-height:1.45;color:rgba(255,255,255,.78)">Browsing as a guest. Saving courses and posting reviews need an account.</div>
+<div onClick="{{ onSignUp }}" style="margin-top:10px;display:flex;align-items:center;justify-content:center;height:34px;border-radius:8px;background:#fff;color:#12417f;font-size:13px;font-weight:600;cursor:pointer">Sign up</div>
+<div onClick="{{ onLogIn }}" style="margin-top:6px;display:flex;align-items:center;justify-content:center;height:34px;border-radius:8px;border:1px solid rgba(255,255,255,.4);font-size:13px;font-weight:500;color:#fff;cursor:pointer" style-hover="background:rgba(255,255,255,.12)">Log in</div>
+</div>
+</div>
+
+<sc-if value="{{ toast }}" hint-placeholder-val="{{ false }}">
+<div style="position:absolute;left:50%;bottom:26px;z-index:70;transform:translateX(-50%);display:flex;align-items:center;gap:9px;padding:11px 15px;border-radius:10px;background:#16202b;color:#fff;font-size:13px;box-shadow:0 10px 30px rgba(20,30,45,.28)">
+<svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="#8fd4c4" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M20 6 9 17l-5-5"></path></svg>{{ toast }}
+</div>
+</sc-if>
+
+<sc-if value="{{ dotOpen }}" hint-placeholder-val="{{ false }}">
+<div onClick="{{ onDotClose }}" style="position:absolute;inset:0;z-index:60;display:flex;align-items:{{ dotAlign }};justify-content:center;padding:0 0 {{ dotPadBottom }};box-sizing:border-box;background:{{ dotScrim }};transition:background .3s ease">
+<div onClick="{{ stop }}" class="omx-th" role="dialog" aria-modal="true" aria-label="Find your place in the community" style="width:396px;box-sizing:border-box;padding:24px;border-radius:14px;background:var(--surface);border:1px solid var(--rule2);box-shadow:0 20px 56px rgba(14,26,44,.26)">
+
+<sc-if value="{{ isDotForm }}" hint-placeholder-val="{{ true }}">
+<div>
+<div style="display:flex;align-items:flex-start;justify-content:space-between;gap:12px">
+<div style="font-size:19px;font-weight:600;line-height:1.2;letter-spacing:-.012em">Find your place in the community</div>
+<div onClick="{{ onDotClose }}" role="button" aria-label="Close" style="flex:none;width:26px;height:26px;display:flex;align-items:center;justify-content:center;border-radius:7px;color:var(--dim);font-size:17px;cursor:pointer" style-hover="background:var(--pill)">×</div>
+</div>
+<div style="margin-top:9px;font-size:13.5px;line-height:1.55;color:var(--muted)">Enter your email and we’ll send you a private link to reveal your dot.</div>
+<input value="{{ dotEmail }}" onChange="{{ onDotEmail }}" onKeyDown="{{ onDotKey }}" type="email" placeholder="you@kth.se" aria-label="Email address" style="margin-top:16px;width:100%;box-sizing:border-box;height:40px;padding:0 12px;border-radius:9px;border:{{ dotErrBorder }};background:var(--inset);font-family:inherit;font-size:13.5px;color:var(--ink);outline:none">
+<sc-if value="{{ dotErr }}" hint-placeholder-val="{{ false }}">
+<div role="alert" style="margin-top:8px;font-size:12.5px;color:#c2410c">Enter a valid email address.</div>
+</sc-if>
+<div onClick="{{ onDotSubmit }}" role="button" tabIndex="0" style="margin-top:14px;height:40px;display:flex;align-items:center;justify-content:center;border-radius:9px;background:var(--btn);color:var(--btnFg);font-size:13.5px;font-weight:600;cursor:pointer" style-hover="opacity:.88">Send private link</div>
+</div>
+</sc-if>
+
+<sc-if value="{{ isDotBusy }}" hint-placeholder-val="{{ false }}">
+<div>
+<div style="font-size:19px;font-weight:600;line-height:1.2;letter-spacing:-.012em">Find your place in the community</div>
+<div style="margin-top:9px;font-size:13.5px;line-height:1.55;color:var(--muted)">Enter your email and we’ll send you a private link to reveal your dot.</div>
+<div style="margin-top:16px;width:100%;box-sizing:border-box;height:40px;display:flex;align-items:center;padding:0 12px;border-radius:9px;border:1px solid var(--rule2);background:var(--inset);font-size:13.5px;color:var(--dim2)">{{ dotEmail }}</div>
+<div aria-live="polite" style="margin-top:14px;height:40px;display:flex;align-items:center;justify-content:center;gap:8px;border-radius:9px;background:var(--btn);color:var(--btnFg);font-size:13.5px;font-weight:600;opacity:.7">Sending…</div>
+</div>
+</sc-if>
+
+<sc-if value="{{ isDotSent }}" hint-placeholder-val="{{ false }}">
+<div>
+<div style="display:flex;align-items:flex-start;justify-content:space-between;gap:12px">
+<div style="font-size:19px;font-weight:600;line-height:1.2;letter-spacing:-.012em">Check your inbox</div>
+<div onClick="{{ onDotClose }}" role="button" aria-label="Close" style="flex:none;width:26px;height:26px;display:flex;align-items:center;justify-content:center;border-radius:7px;color:var(--dim);font-size:17px;cursor:pointer" style-hover="background:var(--pill)">×</div>
+</div>
+<div aria-live="polite" style="margin-top:9px;font-size:13.5px;line-height:1.55;color:var(--muted)">If an account exists for this email, a private link is on its way.</div>
+<div style="margin-top:18px;padding-top:14px;border-top:1px solid var(--rule);font-size:11px;font-weight:600;letter-spacing:.08em;text-transform:uppercase;color:var(--dim2)">Prototype — simulate the link</div>
+<div style="margin-top:10px;display:flex;gap:8px">
+<div onClick="{{ onDotOpenLink }}" role="button" tabIndex="0" style="flex:1;height:38px;display:flex;align-items:center;justify-content:center;border-radius:9px;background:var(--btn);color:var(--btnFg);font-size:13px;font-weight:600;cursor:pointer" style-hover="opacity:.88">Open private link</div>
+<div onClick="{{ onDotExpire }}" role="button" tabIndex="0" style="flex:1;height:38px;display:flex;align-items:center;justify-content:center;border-radius:9px;border:1px solid var(--rule3);background:var(--surface);font-size:13px;font-weight:500;color:var(--ink);cursor:pointer" style-hover="border-color:var(--hov)">Open expired link</div>
+</div>
+</div>
+</sc-if>
+
+<sc-if value="{{ isDotOpened }}" hint-placeholder-val="{{ false }}">
+<div>
+<div style="font-size:19px;font-weight:600;line-height:1.2;letter-spacing:-.012em">Private link opened</div>
+<div aria-live="polite" style="margin-top:9px;font-size:13.5px;line-height:1.55;color:var(--muted)">{{ dotLocateLabel }}</div>
+<div style="margin-top:16px;height:3px;border-radius:2px;background:var(--pill);overflow:hidden"><div style="width:60%;height:100%;border-radius:2px;background:var(--brand);opacity:.8"></div></div>
+</div>
+</sc-if>
+
+<sc-if value="{{ isDotFound }}" hint-placeholder-val="{{ false }}">
+<div>
+<div style="display:flex;align-items:flex-start;justify-content:space-between;gap:12px">
+<div style="font-size:19px;font-weight:600;line-height:1.2;letter-spacing:-.012em">This one is yours</div>
+<div onClick="{{ onDotClose }}" role="button" aria-label="Close" style="flex:none;width:26px;height:26px;display:flex;align-items:center;justify-content:center;border-radius:7px;color:var(--dim);font-size:17px;cursor:pointer" style-hover="background:var(--pill)">×</div>
+</div>
+<div aria-live="polite" style="margin-top:9px;font-size:13.5px;line-height:1.55;color:var(--muted)">Your dot is marked in the network behind this panel. It stays yours.</div>
+<div style="margin-top:12px;font-size:11.5px;color:var(--dim2)">{{ dotAcctLabel }}</div>
+<div onClick="{{ onDotClose }}" role="button" tabIndex="0" style="margin-top:16px;height:38px;display:flex;align-items:center;justify-content:center;border-radius:9px;border:1px solid var(--rule3);background:var(--surface);font-size:13px;font-weight:500;color:var(--ink);cursor:pointer" style-hover="border-color:var(--hov)">Done</div>
+</div>
+</sc-if>
+
+<sc-if value="{{ isDotExpired }}" hint-placeholder-val="{{ false }}">
+<div>
+<div style="display:flex;align-items:flex-start;justify-content:space-between;gap:12px">
+<div style="font-size:19px;font-weight:600;line-height:1.2;letter-spacing:-.012em">This link no longer works</div>
+<div onClick="{{ onDotClose }}" role="button" aria-label="Close" style="flex:none;width:26px;height:26px;display:flex;align-items:center;justify-content:center;border-radius:7px;color:var(--dim);font-size:17px;cursor:pointer" style-hover="background:var(--pill)">×</div>
+</div>
+<div role="alert" style="margin-top:9px;font-size:13.5px;line-height:1.55;color:var(--muted)">Private links expire after a short while, and each one can be used once. Request a new link to try again.</div>
+<div onClick="{{ onDotRetry }}" role="button" tabIndex="0" style="margin-top:16px;height:38px;display:flex;align-items:center;justify-content:center;border-radius:9px;background:var(--btn);color:var(--btnFg);font-size:13px;font-weight:600;cursor:pointer" style-hover="opacity:.88">Request a new link</div>
+</div>
+</sc-if>
+
+</div>
+</div>
+</sc-if>
+
+<sc-if value="{{ authOpen }}" hint-placeholder-val="{{ false }}">
+<div onClick="{{ onAuthCancel }}" style="position:absolute;inset:0;z-index:80;display:flex;align-items:center;justify-content:center;background:rgba(20,30,45,.34)">
+<div onClick="{{ stop }}" class="omx-th" style="width:400px;box-sizing:border-box;padding:24px;border-radius:14px;background:var(--surface);box-shadow:0 18px 48px rgba(20,30,45,.26)">
+<div style="display:flex;align-items:center;justify-content:space-between;gap:12px">
+<div style="font-size:11px;font-weight:600;letter-spacing:.06em;text-transform:uppercase;color:var(--brand)">{{ authKicker }}</div>
+<div onClick="{{ onAuthCancel }}" title="Close" style="width:26px;height:26px;display:flex;align-items:center;justify-content:center;border-radius:7px;color:var(--dim);font-size:17px;line-height:1;cursor:pointer" style-hover="background:var(--pill)">×</div>
+</div>
+<div style="margin-top:8px;font-size:19px;font-weight:600;line-height:1.25">{{ authTitle }}</div>
+<div style="margin-top:6px;font-size:13.5px;line-height:1.5;color:var(--muted)">{{ authBody }}</div>
+<div style="margin-top:16px;display:flex;flex-direction:column;gap:8px">
+<div ref="{{ authBtnRef }}" tabIndex="0" onClick="{{ onAuthDone }}" onKeyDown="{{ onAuthKey }}" style="display:flex;align-items:center;justify-content:center;height:42px;border-radius:9px;background:var(--btn);color:var(--btnFg);font-size:13.5px;font-weight:600;cursor:pointer" style-hover="opacity:.88">Continue with KTH account</div>
+<div tabIndex="0" onClick="{{ onAuthDone }}" onKeyDown="{{ onAuthKey }}" style="display:flex;align-items:center;justify-content:center;height:42px;border-radius:9px;border:1px solid var(--rule3);background:var(--surface);font-size:13.5px;font-weight:500;color:var(--ink);cursor:pointer" style-hover="border-color:var(--hov)">Sign up with email</div>
+</div>
+<div onClick="{{ onAuthCancel }}" style="margin-top:14px;text-align:center;font-size:12.5px;font-weight:500;color:var(--brand);cursor:pointer" style-hover="text-decoration:underline">{{ authCancelLabel }}</div>
+</div>
+</div>
+</sc-if>
+
+</div>
+
+</div>
+
+</x-dc>
+<script type="text/x-dc" data-dc-script data-props="{&quot;$preview&quot;:{&quot;width&quot;:1440,&quot;height&quot;:900},&quot;accountCount&quot;:{&quot;editor&quot;:&quot;int&quot;,&quot;default&quot;:50,&quot;min&quot;:6,&quot;max&quot;:200,&quot;tsType&quot;:&quot;number&quot;},&quot;mobile&quot;:{&quot;editor&quot;:&quot;boolean&quot;,&quot;default&quot;:false,&quot;tsType&quot;:&quot;boolean&quot;}}">
+const REASONS = {
+  "log-in": {
+    kicker: "Welcome back", title: "Log in to Course Community",
+    body: "Browsing never needs an account — logging in adds saved courses, your reviews and your own sidebar.",
+    cancel: "Keep browsing as a guest"
+  },
+  "sign-up": {
+    kicker: "Join", title: "Create your account",
+    body: "Free for KTH students. You keep everything you were looking at.",
+    cancel: "Keep browsing as a guest"
+  },
+  "save-course": {
+    kicker: "One step left", title: "Sign in to save this course",
+    body: "Your search and the course you are looking at stay exactly as they are. We finish the save as soon as you are in.",
+    cancel: "Back to the course"
+  },
+  "post-review": {
+    kicker: "One step left", title: "Sign in to publish your review",
+    body: "Your draft is held as it is — text, ratings and the course all stay put. Nothing is published until you confirm.",
+    cancel: "Back to my draft"
+  }
+};
+
+class Component extends DCLogic {
+  state = {
+    phase: "landing",
+    q: "",
+    authed: false,
+    authOpen: false,
+    // The protected action waiting on authentication, resumed verbatim afterwards.
+    pending: null,
+    reason: null,
+    toast: null,
+    railSeen: false,
+    loading: false,
+    theme: (() => { try { return window.localStorage.getItem("cc:theme") === "dark" ? "dark" : "light"; } catch (e) { return "light"; } })(),
+    // Mock "Find your dot" flow: null | email | submitting | sent | opened | locating | found | expired
+    dot: null,
+    dotEmail: "",
+    dotErr: false,
+    dotAcct: null
+  };
+
+  dotTimers = [];
+
+  dotAfter(ms, fn) {
+    this.dotTimers.push(setTimeout(fn, ms));
+  }
+
+  clearDotTimers() {
+    this.dotTimers.forEach(clearTimeout);
+    this.dotTimers = [];
+  }
+
+  openDot() {
+    this.clearDotTimers();
+    this.setState({ dot: "email", dotErr: false });
+  }
+
+  closeDot() {
+    this.clearDotTimers();
+    this.clearYou();
+    this.setState({ dot: null, dotErr: false, dotAcct: null });
+  }
+
+  submitDot() {
+    const email = (this.state.dotEmail || "").trim();
+    if (!/^[^@\s]+@[^@\s.]+\.[^@\s]{2,}$/.test(email)) {
+      this.setState({ dot: "email", dotErr: true });
+      return;
+    }
+    this.setState({ dot: "submitting", dotErr: false });
+    // Always the same neutral outcome: the UI never reveals whether an account exists.
+    this.dotAfter(1100, () => this.setState({ dot: "sent" }));
+  }
+
+  /** Mock: the recipient opens the private link from their inbox. */
+  openLink() {
+    this.clearDotTimers();
+    this.setState({ dot: "opened" });
+    this.dotAfter(700, () => {
+      this.setState({ dot: "locating" });
+      this.dotAfter(1200, () => {
+        const acct = this.mockAcctFor(this.state.dotEmail) || "kth-1000";
+        this.revealYou(acct);
+        this.setState({ dot: "found", dotAcct: acct });
+        // The network returns to normal on its own after the reveal.
+        this.dotAfter(6000, () => { if (this.state.dot === "found") this.closeDot(); });
+      });
+    });
+  }
+
+  expireLink() {
+    this.clearDotTimers();
+    this.clearYou();
+    this.setState({ dot: "expired" });
+  }
+
+  inputRef = React.createRef();
+  authBtnRef = React.createRef();
+  appRef = React.createRef();
+  lastFocus = null;
+  replayTarget = null;
+  passThrough = false;
+
+  /* The protected controls live inside the embedded app, which must not be edited,
+     so the shell intercepts them in the capture phase and owns the whole auth step. */
+  onAppClick = (e) => {
+    if (this.passThrough) return;
+    const el = e.target.closest ? e.target.closest("div") : null;
+    if (!el) return;
+    const label = (el.textContent || "").trim();
+    const isSave = /^(Save course|Save|Saved)$/.test(label);
+    const isPost = /^(Post review|Publish review|Published)$/.test(label);
+    if (!isSave && !isPost) return;
+    e.preventDefault();
+    e.stopPropagation();
+    if (!this.state.authed) {
+      this.replayTarget = isSave ? el : null;
+      this.openAuth(isSave ? "save-course" : "post-review");
+      return;
+    }
+    if (isSave) {
+      // Signed in: hand the click back to the app untouched.
+      this.replay(el);
+    } else {
+      this.setState({ toast: "Review published on the course" });
+      setTimeout(() => this.setState({ toast: null }), 3200);
+    }
+  };
+
+  replay(el) {
+    if (!el) return;
+    this.passThrough = true;
+    el.click();
+    this.passThrough = false;
+  }
+
+  reduced() {
+    return typeof window.matchMedia === "function"
+      && window.matchMedia("(prefers-reduced-motion: reduce)").matches;
+  }
+
+  componentDidMount() {
+    document.addEventListener("click", this.onAppClickGuard, true);
+
+    // A shared link lands straight in the Explore state with the query applied.
+    const q = new URLSearchParams(window.location.search).get("q");
+    if (q) this.setState({ q: q, phase: "explore" });
+    document.documentElement.setAttribute("data-cc-theme", this.state.theme);
+    window.__ccLandingMounted = (window.__ccLandingMounted || 0) + 1;
+    // Nested inside another component's own mount (e.g. embedded via
+    // dc-import), the canvas ref can still be null on the first tick —
+    // retry a few times rather than silently leaving the graph blank.
+    this.vizTries = 0;
+    const tryStart = () => {
+      // The ref hole can come back unbound this deep inside a nested import —
+      // fall back to a plain DOM lookup scoped to this instance's own root.
+      if (!this.vizRef.current) {
+        const root = this.appRef && this.appRef.current;
+        const found = root ? root.querySelector("canvas") : document.querySelector("canvas");
+        if (found) this.vizRef.current = found;
+      }
+      if (this.vizRef.current) { this.startViz(); return; }
+      if (this.vizTries++ < 30) requestAnimationFrame(tryStart);
+    };
+    tryStart();
+  }
+
+  // The runtime calls this with prevProps only, so prior state is tracked here.
+  seen = { theme: "light", phase: "landing" };
+
+  componentDidUpdate() {
+    const prev = this.seen;
+    const s = this.state;
+    if (prev.theme !== s.theme) {
+      document.documentElement.setAttribute("data-cc-theme", s.theme);
+      if (this.viz) this.viz.goal = this.palFor(s.theme);
+    }
+    if (prev.phase !== s.phase && this.viz) {
+      this.viz.paused = s.phase !== "landing";
+      if (this.viz.paused) this.closeCard();
+      else this.viz.last = performance.now();
+    }
+    this.seen = { theme: s.theme, phase: s.phase };
+  }
+
+  componentWillUnmount() {
+    document.removeEventListener("click", this.onAppClickGuard, true);
+    document.removeEventListener("visibilitychange", this.onVis);
+    document.removeEventListener("keydown", this.onVizKey);
+    document.removeEventListener("pointerdown", this.onDocDown, true);
+    const land = this.landingRef.current;
+    if (land) {
+      land.removeEventListener("pointermove", this.onVizMove);
+      land.removeEventListener("pointerleave", this.onVizOut);
+    }
+    this.clearDotTimers();
+    if (this.ro) this.ro.disconnect();
+    window.removeEventListener("resize", this.onWinResize);
+    if (this.mq && this.mq.removeEventListener) this.mq.removeEventListener("change", this.onMq);
+    if (this.viz) cancelAnimationFrame(this.viz.raf);
+    clearTimeout(this.closeTimer);
+    this.viz = null;
+  }
+
+  onAppClickGuard = (e) => {
+    const app = this.appRef.current;
+    if (app && app.contains(e.target)) this.onAppClick(e);
+  };
+
+  /** The app's own field is hidden, so the shell's bar drives its query directly. */
+  syncApp(q) {
+    const app = this.appRef.current;
+    const input = app && app.querySelector('input[placeholder="Search a course, code or subject"]');
+    if (!input) return;
+    const setter = Object.getOwnPropertyDescriptor(window.HTMLInputElement.prototype, "value").set;
+    setter.call(input, q);
+    input.dispatchEvent(new Event("input", { bubbles: true }));
+  }
+
+  EXPLORE_PAGE = "Course Community - Explore.dc.html";
+  HANDOFF_KEY = "cc:searchHandoff";
+  barRef = React.createRef();
+
+  /** Warm the next page while the user is still typing. */
+  prefetchExplore() {
+    if (this.prefetched) return;
+    this.prefetched = true;
+    const l = document.createElement("link");
+    l.rel = "prefetch";
+    l.href = this.EXPLORE_PAGE;
+    document.head.appendChild(l);
+  }
+
+  /** Hand the search bar's on-screen box to Explore, which picks the animation
+      up from exactly there — the bar reads as one element across the two pages. */
+  toExplore(q) {
+    const query = (q === undefined ? this.state.q : q).trim();
+    if (!query) return;
+    const soft = this.reduced();
+    const bar = this.barRef.current;
+    try {
+      if (bar && !soft) {
+        const r = bar.getBoundingClientRect();
+        window.sessionStorage.setItem(this.HANDOFF_KEY, JSON.stringify({
+          x: r.left, y: r.top, w: r.width, h: r.height, t: Date.now()
+        }));
+      } else {
+        window.sessionStorage.removeItem(this.HANDOFF_KEY);
+      }
+    } catch (e) { /* storage unavailable */ }
+
+    const url = this.EXPLORE_PAGE + "?q=" + encodeURIComponent(query);
+    if (soft) { window.location.href = url; return; }
+
+    // Competing motion is the biggest tell: the hero network stops the moment
+    // the search starts, so the only thing moving is the layout.
+    if (this.viz) { this.viz.paused = true; this.closeCard(); }
+
+    // Surroundings leave fast; the bar itself stays put until the page swaps under it.
+    this.setState({ q: query, leaving: true }, () => {
+      setTimeout(() => { window.location.href = url; }, 130);
+    });
+  }
+
+  toExploreLegacy(q) {
+    const query = (q === undefined ? this.state.q : q).trim();
+    if (!query) return;
+    try {
+      const url = new URL(window.location.href);
+      url.searchParams.set("q", query);
+      window.history.pushState({ q: query }, "", url);
+    } catch (e) { /* file:// has no history to push */ }
+    // Results start loading as the curtain rolls; skeletons cover whichever lands last.
+    if (this.viz) { this.viz.paused = true; this.closeCard(); }
+    this.setState({ q: query, phase: "explore", loading: true }, () => {
+      requestAnimationFrame(() => this.closeSeededPanes());
+    });
+    clearTimeout(this.loadTimer);
+    this.loadTimer = setTimeout(() => this.setState({ loading: false }), 760);
+  }
+
+  /** The app ships with sample panes open; a fresh search should arrive with none. */
+  closeSeededPanes() {
+    const app = this.appRef.current;
+    if (!app) return;
+    this.passThrough = true;
+    const caret = app.querySelector('[title="All open panes"]');
+    if (caret) {
+      caret.click();
+      for (let i = 0; i < 12; i++) {
+        const x = app.querySelector('[title="Close pane"]');
+        if (!x) break;
+        x.click();
+      }
+      const stillOpen = app.querySelector('[title="Close pane"]');
+      if (stillOpen === null && caret.isConnected) caret.click();
+    }
+    this.passThrough = false;
+  }
+
+  toLanding() {
+    try {
+      const url = new URL(window.location.href);
+      url.searchParams.delete("q");
+      window.history.pushState({}, "", url);
+    } catch (e) { /* ignore */ }
+    if (this.viz) { this.viz.paused = false; this.viz.last = performance.now(); }
+    this.setState({ phase: "landing" });
+  }
+
+  openAuth(reason, pending) {
+    this.lastFocus = document.activeElement;
+    // A protected action is its own pending job; plain log in / sign up resume nothing.
+    const job = pending || (reason === "save-course" || reason === "post-review" ? reason : null);
+    this.setState({ authOpen: true, reason: reason, pending: job }, () => {
+      requestAnimationFrame(() => {
+        const el = this.authBtnRef.current;
+        if (el && el.focus) el.focus();
+      });
+    });
+  }
+
+  closeAuth(authed) {
+    const pending = this.state.pending;
+    const next = { authOpen: false, reason: null, pending: null };
+    if (authed) {
+      next.authed = true;
+      next.railSeen = true;
+      // Only the save resumes on its own; a review is never published as a side effect.
+      if (pending === "save-course") next.toast = "Course saved to your list";
+      else if (pending === "post-review") next.toast = "Draft restored — confirm to publish";
+    }
+    this.setState(next, () => {
+      // The save resumes itself; the review waits for an explicit confirmation.
+      if (authed && pending === "save-course") this.replay(this.replayTarget);
+      this.replayTarget = null;
+      if (next.toast) setTimeout(() => this.setState({ toast: null }), 3200);
+      const el = this.lastFocus;
+      if (el && el.focus) el.focus();
+    });
+  }
+
+  /* ---------- hero: recommendations travelling between students ----------
+     One canvas, one rAF loop, no React work per frame. Dots are students;
+     the only sign that two of them are connected is a flash passing between. */
+
+  vizRef = React.createRef();
+  landingRef = React.createRef();
+  viz = null;
+  held = null;
+  closeTimer = null;
+
+  INSIGHTS = [
+    { code: "DD2380", text: "Don’t forget to start the labs early." },
+    { code: "DD2424", text: "The hardest course I took — but so worth it." },
+    { code: "SF1918", text: "The lectures help, but old exams are essential." },
+    { code: "DH2642", text: "Pick your group in week one and the rest follows." },
+    { code: "DD1337", text: "Week three is the wall. After that it clicks." },
+    { code: "EQ2300", text: "Do the hand-ins with someone. Alone it is brutal." },
+    { code: "DD2421", text: "Lab 2 is the whole course. Budget a weekend." },
+    { code: "SF1626", text: "Go to the exercise sessions — that is where it lands." }
+  ];
+
+  PAL = {
+    light: { dot: [23, 81, 166], dotA: 0.82, core: [10, 42, 96], mid: [28, 88, 172], halo: [30, 92, 178], haloA: 0.14, line: [150, 186, 232], lineA: 0.26 },
+    dark:  { dot: [240, 234, 222], dotA: 0.80, core: [255, 255, 255], mid: [168, 214, 255], halo: [180, 220, 255], haloA: 0.20, line: [176, 208, 244], lineA: 0.16 }
+  };
+
+  palFor(theme) {
+    const p = this.PAL[theme === "dark" ? "dark" : "light"];
+    return {
+      dot: p.dot.slice(), dotA: p.dotA, core: p.core.slice(), mid: p.mid.slice(),
+      halo: p.halo.slice(), haloA: p.haloA, line: p.line.slice(), lineA: p.lineA
+    };
+  }
+
+  rgba(c, a) {
+    return "rgba(" + Math.round(c[0]) + "," + Math.round(c[1]) + "," + Math.round(c[2]) + "," + Math.max(0, a).toFixed(3) + ")";
+  }
+
+  /** Measured from the live hero elements, so the keep-out zone is exactly the
+      copy, the search field and the chips — nothing guessed. */
+  exRects(w, h) {
+    const e = this.viz;
+    if (e && e.cv) {
+      const root = e.cv.closest("[data-cc-theme]");
+      const cr = e.cv.getBoundingClientRect();
+      if (root && cr.width && cr.height) {
+        const sx = w / cr.width, sy = h / cr.height;
+        // One padded rect per content block, not one box around them all: a
+        // two-column hero must leave the gap between its columns usable.
+        const pad = this.SAFETY;
+        const out = [];
+        const push = (r) => {
+          if (!r.width || !r.height) return;
+          out.push({
+            x: (r.left - cr.left) * sx - pad,
+            y: (r.top - cr.top) * sy - pad,
+            w: r.width * sx + pad * 2,
+            h: r.height * sy + pad * 2
+          });
+        };
+        root.querySelectorAll("[data-om-clear]").forEach((el) => {
+          // Text blocks reserve their actual lines, not the width of their box —
+          // a centred headline in a 720px column must not claim the empty sides.
+          if (!el.children.length && el.textContent.trim()) {
+            const rng = document.createRange();
+            rng.selectNodeContents(el);
+            const lines = rng.getClientRects();
+            if (lines.length) { for (let i = 0; i < lines.length; i++) push(lines[i]); return; }
+          }
+          push(el.getBoundingClientRect());
+        });
+        if (out.length) return out;
+      }
+    }
+    return this.fallbackRects(w, h);
+  }
+
+  fallbackRects(w, h) {
+    const copy = Math.min(780, w * 0.74);
+    return [
+      { x: w / 2 - copy / 2, y: 10, w: copy, h: h * 0.50 },
+      { x: w / 2 - copy * 0.45, y: h * 0.50, w: copy * 0.9, h: h * 0.30 }
+    ];
+  }
+
+  inEx(x, y, rects, pad) {
+    for (let i = 0; i < rects.length; i++) {
+      const r = rects[i];
+      if (x > r.x - pad && x < r.x + r.w + pad && y > r.y - pad && y < r.y + r.h + pad) return true;
+    }
+    return false;
+  }
+
+  /** Halton — a low-discrepancy sequence: evenly spread without rows or clumps. */
+  halton(i, base) {
+    let f = 1, r = 0, n = i + 1;
+    while (n > 0) { f /= base; r += f * (n % base); n = Math.floor(n / base); }
+    return r;
+  }
+
+  /** Deterministic per-node jitter, so a relayout reproduces the same field. */
+  hash(i, salt) {
+    let x = Math.sin((i + 1) * 12.9898 + salt * 78.233) * 43758.5453;
+    return x - Math.floor(x);
+  }
+
+  /** A node from its Halton index. Visible nodes are community accounts; the
+      off-screen shadow nodes are anchors only and never carry an account. */
+  makeNode(i, x, y, ghost, acct) {
+    const dir = this.hash(i, 1) * 6.2832, sp = 1.8 + this.hash(i, 2) * 0.4;
+    return {
+      hi: i, x: x, y: y, hx: x, hy: y, r: 4, a: 1, ghost: !!ghost,
+      acct: ghost ? null : acct || null,
+      quota: 3 + (this.hash(i, 3) < 0.55 ? 1 : 0) + (this.hash(i, 4) < 0.28 ? 1 : 0),
+      vx: Math.cos(dir) * sp, vy: Math.sin(dir) * sp
+    };
+  }
+
+  /** One new account joins: the next Halton point inside the allowed area. The
+      existing field is untouched — nothing is re-placed and no edge is redrawn. */
+  addAccount() {
+    const e = this.viz;
+    if (!e) return null;
+    const ins = e.inset || 20, gap = (e.gapRef || 60) * 0.82;
+    const seed = this.roster.reduce((m, a) => Math.max(m, a.seed), -1) + 1;
+    let num = 1000;
+    this.roster.forEach((a) => {
+      const v = parseInt(String(a.acct).slice(4), 10);
+      if (v >= num) num = v + 1;
+    });
+    for (let i = e.pNext || 0; i < (e.pNext || 0) + 6000; i++) {
+      const x = ins + this.halton(i, 2) * (e.w - ins * 2);
+      const y = ins + this.halton(i, 3) * (e.h - ins * 2);
+      if (this.clearAt(x, y, 5) < 1) continue;
+      if (e.nodes.some((n) => Math.hypot(n.x - x, n.y - y) < gap)) continue;
+      const acct = "kth-" + num;
+      const n = this.makeNode(seed, x, y, false, acct);
+      e.pNext = i + 1;
+      this.roster.push({ acct: acct, seed: seed });
+      e.nodes.push(n);
+      e.byNode.set(n, []);
+      this.linkNode(n);
+      return n;
+    }
+    return null;
+  }
+
+  /** An account leaves: its dot and its links go, the rest of the field stays. */
+  removeAccount(acct) {
+    const e = this.viz;
+    if (!e) return false;
+    const n = e.nodes.find((v) => v.acct === acct);
+    if (!n) return false;
+    if (this.roster) this.roster = this.roster.filter((a) => a.acct !== acct);
+    e.signals = e.signals.filter((s) => s.na !== n && s.nb !== n);
+    (e.byNode.get(n) || []).forEach((ed) => {
+      const other = ed.a === n ? ed.b : ed.a;
+      e.byNode.set(other, (e.byNode.get(other) || []).filter((x) => x !== ed));
+    });
+    e.edges = e.edges.filter((ed) => ed.a !== n && ed.b !== n);
+    e.byNode.delete(n);
+    e.nodes = e.nodes.filter((v) => v !== n);
+    return true;
+  }
+
+  /** Wire one node to its 3–5 closest neighbours that still have room. */
+  linkNode(n) {
+    const e = this.viz;
+    const cand = e.nodes
+      .filter((o) => o !== n && !(o.ghost && n.ghost))
+      .map((o) => ({ o: o, len: Math.hypot(o.x - n.x, o.y - n.y) }))
+      .sort((a, b) => a.len - b.len);
+    for (let k = 0; k < cand.length && (e.byNode.get(n) || []).length < n.quota; k++) {
+      const o = cand[k].o;
+      if ((e.byNode.get(o) || []).length >= o.quota) continue;
+      if (!this.lineClear(n, o)) continue;
+      const ed = { a: n, b: o, len: cand[k].len };
+      e.edges.push(ed);
+      e.byNode.get(n).push(ed);
+      e.byNode.get(o).push(ed);
+    }
+  }
+
+  /* ---------- "Find your dot": mock reveal of one account's node ---------- */
+
+  /** Deterministic mock: an address always maps to the same account node. */
+  mockAcctFor(email) {
+    const e = this.viz;
+    const real = (e && e.nodes.filter((n) => !n.ghost)) || [];
+    if (!real.length) return null;
+    const key = String(email || "").trim().toLowerCase();
+    let h = 0;
+    for (let i = 0; i < key.length; i++) h = (h * 31 + key.charCodeAt(i)) % 100000;
+    return real[h % real.length].acct;
+  }
+
+  revealYou(acct) {
+    const e = this.viz;
+    if (!e) return;
+    // Always a real, visible account dot — never a shadow anchor, never hidden.
+    let n = e.nodes.find((v) => v.acct === acct && !v.ghost && this.clearAt(v.x, v.y, v.r) >= 1);
+    if (!n) n = e.nodes.find((v) => !v.ghost && this.clearAt(v.x, v.y, v.r) >= 1);
+    if (!n) n = this.addAccount();
+    if (!n) return;
+    e.you = n;
+    e.focus = { n: n, t: 0, phase: "in" };
+    // The graph never moves: the dot grows and pulses in place while the rest dims.
+    e.cam = { x: 0, y: 0, s: 1 };
+    e.camTo = { x: 0, y: 0, s: 1 };
+  }
+
+  clearYou() {
+    const e = this.viz;
+    if (!e) return;
+    if (e.focus) e.focus.phase = "out";
+    e.camTo = { x: 0, y: 0, s: 1 };
+  }
+
+  /** The graph lives on a virtual canvas larger than the hero on every side, so
+      the screen is a crop of a bigger network: edges and signals cross the edges. */
+  layoutViz() {
+    const e = this.viz;
+    if (!e) return;
+    e.rects = this.exRects(e.w, e.h);
+    const bx = e.bx = Math.max(140, Math.round(e.w * 0.26));
+    const by = e.by = Math.max(130, Math.round(e.h * 0.45));
+    const vw = e.w + bx * 2, vh = e.h + by * 2;
+    const inset = e.inset = 20;
+    const onArea = Math.max(1, (e.w - inset * 2) * (e.h - inset * 2));
+    const target = this.ACCOUNTS;
+    const gap = Math.sqrt(onArea / target) * 0.62;
+    const nodes = [];
+    // The roster holds MEMBERSHIP — which accounts exist, in a stable order.
+    // Positions are re-derived per layout, so every dot lands in the allowed area
+    // of the current viewport and hero variant.
+    if (!this.roster) {
+      this.roster = [];
+      for (let i = 0; i < this.ACCOUNTS; i++) this.roster.push({ acct: "kth-" + (1000 + i), seed: i });
+    }
+    let p = 0;
+    for (let r = 0; r < this.roster.length; r++) {
+      const acc = this.roster[r];
+      let placed = null;
+      for (; p < 30000 && !placed; p++) {
+        const x = inset + this.halton(p, 2) * (e.w - inset * 2);
+        const y = inset + this.halton(p, 3) * (e.h - inset * 2);
+        if (this.clearAt(x, y, 5) < 1) continue;
+        if (this.hash(p, 7) > this.densityAt(x, y)) continue; // thin out near the copy
+        let ok = true;
+        for (let j = 0; j < nodes.length; j++) {
+          if (Math.hypot(nodes[j].x - x, nodes[j].y - y) < gap) { ok = false; break; }
+        }
+        if (!ok) continue;
+        placed = this.makeNode(acc.seed, x, y, false, acc.acct);
+      }
+      if (!placed) break; // this viewport has no room left; membership is unchanged
+      nodes.push(placed);
+    }
+    e.pNext = p;
+    e.gapRef = gap;
+    e.clearCursor = 0;
+    // …and the network continues past the frame through anchors that are never drawn,
+    // so links and signals travel off screen and back.
+    const ghosts = Math.min(140, Math.round(target * 0.55));
+    for (let i = 0, added = 0; added < ghosts && i < ghosts * 30; i++) {
+      const x = -bx + this.halton(i + 977, 2) * vw;
+      const y = -by + this.halton(i + 977, 3) * vh;
+      if (x > inset && x < e.w - inset && y > inset && y < e.h - inset) continue;
+      let ok = true;
+      for (let j = 0; j < nodes.length; j++) {
+        if (Math.hypot(nodes[j].x - x, nodes[j].y - y) < gap * 0.8) { ok = false; break; }
+      }
+      if (!ok) continue;
+      nodes.push(this.makeNode(i + 977, x, y, true));
+      added++;
+    }
+    e.nodes = nodes;
+    e.minGap = gap * 0.7;
+    e.max = e.w < 620 ? 3 : e.w < 1000 ? 5 : 8;
+    e.edges = this.buildEdges(nodes, e);
+    e.byNode = new Map();
+    nodes.forEach((n) => e.byNode.set(n, []));
+    e.edges.forEach((ed) => { e.byNode.get(ed.a).push(ed); e.byNode.get(ed.b).push(ed); });
+
+    // With motion off, two students hold a soft steady glow instead of travelling.
+    const still = nodes.filter((n) => !n.ghost && this.clearAt(n.x, n.y) > 0.9).sort((p, q) => q.y - p.y);
+    e.glows = [];
+    for (let i = 0; i < still.length && e.glows.length < 2; i++) {
+      const n = still[i];
+      if (e.glows.every((g) => Math.hypot(g.x - n.x, g.y - n.y) > 200)) e.glows.push(n);
+    }
+  }
+
+  /** Sampled clearance along a link — 1 well clear of the copy, 0 crossing it. */
+  lineClearance(a, b) {
+    let m = 1;
+    for (let i = 0; i <= 10; i++) {
+      const t = i / 10;
+      m = Math.min(m, this.clearAt(a.x + (b.x - a.x) * t, a.y + (b.y - a.y) * t));
+      if (m <= 0) break;
+    }
+    return m;
+  }
+
+  lineClear(a, b) {
+    return this.lineClearance(a, b) >= 1;
+  }
+
+  /** Mostly short links to nearby students, plus a few long cross-network ones. */
+  buildEdges(nodes, e) {
+    const span = Math.max(e.w, e.h);
+    const near = span * 0.34;
+    const seen = {};
+    const edges = [];
+    const deg = new Array(nodes.length).fill(0);
+    const quota = nodes.map((n) => n.quota);
+    const add = (i, j, len) => {
+      const a = Math.min(i, j), b = Math.max(i, j), key = a + ":" + b;
+      if (a === b || seen[key]) return false;
+      if (deg[a] >= quota[a] || deg[b] >= quota[b]) return false;
+      if (nodes[a].ghost && nodes[b].ghost) return false; // two anchors off screen: pointless
+      if (!this.lineClear(nodes[a], nodes[b])) return false; // no link crosses the content
+      seen[key] = 1;
+      deg[a]++; deg[b]++;
+      edges.push({ a: nodes[a], b: nodes[b], len: len });
+      return true;
+    };
+    for (let i = 0; i < nodes.length; i++) {
+      const cand = [];
+      for (let j = 0; j < nodes.length; j++) {
+        if (i === j) continue;
+        const len = Math.hypot(nodes[j].x - nodes[i].x, nodes[j].y - nodes[i].y);
+        cand.push({ j: j, len: len });
+      }
+      cand.sort((a, b) => a.len - b.len);
+      // Closest first, skipping any link the copy blocks or a full neighbour.
+      for (let k = 0; k < cand.length && deg[i] < quota[i]; k++) {
+        if (cand[k].len > near) break;
+        add(i, cand[k].j, cand[k].len);
+      }
+    }
+    return edges;
+  }
+
+  /** The ellipse over the hero copy where the network is erased entirely. */
+  maskGeom() {
+    const e = this.viz;
+    const w = e.w, h = e.h;
+    return { cx: w * 0.5, cy: h * 0.45, rx: w * 0.40, ry: h * 0.60 };
+  }
+
+  /** 1 well clear of the hero copy and search bar, easing to 0 inside them. */
+  FEATHER = 10;
+  SAFETY = 25;
+  get ACCOUNTS() { return this.props.accountCount || 50; }
+
+  clearAt(x, y, radius) {
+    const e = this.viz;
+    const rects = e.rects || (e.rects = this.exRects(e.w, e.h));
+    const grow = radius || 0;
+    let m = 1;
+    for (let i = 0; i < rects.length; i++) {
+      const r = rects[i];
+      const dx = Math.max(r.x - x, 0, x - (r.x + r.w)) - grow;
+      const dy = Math.max(r.y - y, 0, y - (r.y + r.h)) - grow;
+      const d = Math.hypot(Math.max(0, dx), Math.max(0, dy));
+      if (d >= this.FEATHER) continue;
+      const t = d / this.FEATHER;
+      m = Math.min(m, t * t * (3 - 2 * t));
+    }
+    return m;
+  }
+
+  maskAt(x, y) {
+    return 1 - this.clearAt(x, y);
+  }
+
+  /** Distance from the content keep-out, in px. */
+  distToContent(x, y) {
+    const e = this.viz;
+    const rects = e.rects || (e.rects = this.exRects(e.w, e.h));
+    let m = Infinity;
+    for (let i = 0; i < rects.length; i++) {
+      const r = rects[i];
+      const dx = Math.max(r.x - x, 0, x - (r.x + r.w));
+      const dy = Math.max(r.y - y, 0, y - (r.y + r.h));
+      m = Math.min(m, Math.hypot(dx, dy));
+    }
+    return m;
+  }
+
+  /** Thinner near the copy, full density further out — the field stays legible. */
+  densityAt(x, y) {
+    const t = Math.min(1, this.distToContent(x, y) / 300);
+    return 0.16 + 0.84 * t * t;
+  }
+
+  resizeViz() {
+    const e = this.viz;
+    if (!e) return;
+    const box = e.cv.parentNode.getBoundingClientRect();
+    const w = Math.max(320, Math.round(box.width));
+    const h = Math.max(220, Math.round(box.height));
+    const dpr = Math.min(2, window.devicePixelRatio || 1);
+    // Same live measurement drives the narrow-viewport layout switch below —
+    // self-detected off the real rendered box, not a prop threaded in from
+    // whatever embeds this page, so mobile and desktop share one code path.
+    const narrow = w < 500;
+    if (narrow !== this.state.narrow) this.setState({ narrow: narrow });
+    if (w === e.w && h === e.h && dpr === e.dpr) return;
+    e.w = w; e.h = h; e.dpr = dpr;
+    e.cam = { x: 0, y: 0, s: 1 }; e.camTo = { x: 0, y: 0, s: 1 };
+    e.cv.width = Math.round(w * dpr);
+    e.cv.height = Math.round(h * dpr);
+    e.ctx.setTransform(dpr, 0, 0, dpr, 0, 0);
+    this.layoutViz();
+    // A reveal in progress survives the relayout — the dot is the same account.
+    if (this.state.dotAcct && ["opened", "locating", "found"].indexOf(this.state.dot) >= 0) {
+      this.revealYou(this.state.dotAcct);
+    } else {
+      e.you = null; e.focus = null; e.dim = 0;
+    }
+  }
+
+  startViz() {
+    const cv = this.vizRef.current;
+    if (!cv || this.viz) return;
+    const theme = this.state.theme;
+    this.viz = {
+      cv: cv, ctx: cv.getContext("2d"), w: 0, h: 0, dpr: 1,
+      nodes: [], signals: [], seq: 0, ins: 0,
+      last: performance.now(), spawnAt: performance.now() + 500,
+      max: 3, raf: 0, paused: false, reduced: this.reduced(),
+      pal: this.palFor(theme), goal: this.palFor(theme),
+      cam: { x: 0, y: 0, s: 1 }, camTo: { x: 0, y: 0, s: 1 },
+      dim: 0, focus: null, you: null
+    };
+    this.resizeViz();
+    if (typeof ResizeObserver === "function") {
+      this.ro = new ResizeObserver(() => this.resizeViz());
+      this.ro.observe(cv.parentNode);
+    } else {
+      window.addEventListener("resize", this.onWinResize);
+    }
+    document.addEventListener("visibilitychange", this.onVis);
+    document.addEventListener("keydown", this.onVizKey);
+    document.addEventListener("pointerdown", this.onDocDown, true);
+    const land = this.landingRef.current;
+    if (land) {
+      land.addEventListener("pointermove", this.onVizMove);
+      land.addEventListener("pointerleave", this.onVizOut);
+    }
+    if (window.matchMedia) {
+      this.mq = window.matchMedia("(prefers-reduced-motion: reduce)");
+      this.onMq = () => { if (this.viz) { this.viz.reduced = this.reduced(); this.layoutViz(); } };
+      if (this.mq.addEventListener) this.mq.addEventListener("change", this.onMq);
+    }
+    this.viz.raf = requestAnimationFrame(this.tick);
+  }
+
+  /** Colour only — the flight keeps its positions and any open card stays put. */
+  setTheme(next) {
+    document.documentElement.setAttribute("data-cc-theme", next);
+    try { window.localStorage.setItem("cc:theme", next); } catch (e) { /* storage off */ }
+    if (this.viz) this.viz.goal = this.palFor(next);
+    this.setState({ theme: next });
+  }
+
+  onWinResize = () => this.resizeViz();
+  onVis = () => {
+    const e = this.viz;
+    if (!e) return;
+    if (document.hidden) { cancelAnimationFrame(e.raf); e.raf = 0; }
+    else if (!e.raf) { e.last = performance.now(); e.raf = requestAnimationFrame(this.tick); }
+  };
+
+  at(s, p) {
+    const q = 1 - p;
+    return {
+      x: q * q * s.ax + 2 * q * p * s.cx + p * p * s.bx,
+      y: q * q * s.ay + 2 * q * p * s.cy + p * p * s.by
+    };
+  }
+
+  routeClear(s, rects) {
+    for (let i = 0; i <= 14; i++) {
+      const pt = this.at(s, i / 14);
+      if (this.inEx(pt.x, pt.y, rects, 6)) return false;
+    }
+    return true;
+  }
+
+  makeSignal(ed, from, note) {
+    const e = this.viz;
+    const a = from || (Math.random() < 0.5 ? ed.a : ed.b);
+    const b = a === ed.a ? ed.b : ed.a;
+    const len = Math.max(1, Math.hypot(b.x - a.x, b.y - a.y));
+    const speed = 26 + Math.random() * 22; // px/s — constant pace regardless of edge length
+    return {
+      id: ++e.seq, edge: ed, na: a, nb: b, ax: a.x, ay: a.y, bx: b.x, by: b.y,
+      cx: (a.x + b.x) / 2, cy: (a.y + b.y) / 2,
+      len: len, p: 0, dur: Math.max(2.6, len / speed),
+      prom: 0.72 + Math.random() * 0.28, hold: false, hx: a.x, hy: a.y,
+      relay: Math.random() < 0.42 ? 1 + (Math.random() < 0.35 ? 1 : 0) : 0,
+      note: note || this.INSIGHTS[(e.ins++) % this.INSIGHTS.length]
+    };
+  }
+
+  spawnSignal() {
+    const e = this.viz;
+    if (!e || !e.edges || !e.edges.length) return;
+    for (let t = 0; t < 14; t++) {
+      const ed = e.edges[(Math.random() * e.edges.length) | 0];
+      if (e.signals.some((s) => s.edge === ed)) continue;
+      e.signals.push(this.makeSignal(ed));
+      return;
+    }
+  }
+
+  /** The insight continues from the student who just received it. */
+  relaySignal(prev) {
+    const e = this.viz;
+    const outs = (e.byNode && e.byNode.get(prev.nb)) || [];
+    const open = outs.filter((ed) => ed !== prev.edge && !e.signals.some((s) => s.edge === ed));
+    if (!open.length) return;
+    const ed = open[(Math.random() * open.length) | 0];
+    const s = this.makeSignal(ed, prev.nb, prev.note);
+    s.relay = prev.relay - 1;
+    e.signals.push(s);
+  }
+
+  /** A student passing their recommendation to everyone they are connected to. */
+  burst(node) {
+    const e = this.viz;
+    if (!e || !e.byNode) return;
+    const outs = e.byNode.get(node) || [];
+    const note = this.INSIGHTS[(e.ins++) % this.INSIGHTS.length];
+    let delay = 0;
+    for (let i = 0; i < outs.length; i++) {
+      const ed = outs[i];
+      if (e.signals.some((s) => s.edge === ed)) continue;
+      const s = this.makeSignal(ed, node, note);
+      s.p = -delay;
+      s.relay = 0;
+      delay += 0.06;
+      e.signals.push(s);
+    }
+  }
+
+  /** Faint on departure, defined mid-flight, gone on arrival. */
+  env(p) {
+    const ss = (a, b, x) => { const t = Math.max(0, Math.min(1, (x - a) / (b - a))); return t * t * (3 - 2 * t); };
+    const rise = Math.pow(ss(0.03, 0.42, p), 1.5);
+    const fall = 1 - ss(0.86, 1, p);
+    return Math.min(rise, fall);
+  }
+
+  tick = (ts) => {
+    const e = this.viz;
+    if (!e) return;
+    const dt = Math.max(0, Math.min(0.05, (ts - e.last) / 1000 || 0.016));
+    e.last = ts;
+
+    // Theme changes ease the palette across; the flight itself never restarts.
+    const k = Math.min(1, dt / 0.34);
+    ["dot", "core", "mid", "halo"].forEach((key) => {
+      for (let i = 0; i < 3; i++) e.pal[key][i] += (e.goal[key][i] - e.pal[key][i]) * k;
+    });
+    e.pal.dotA += (e.goal.dotA - e.pal.dotA) * k;
+
+    // Reveal: the graph eases toward the dot, the rest of the field dims back.
+    const cam = e.cam, to = e.camTo || cam;
+    const ck = e.reduced ? 1 : Math.min(1, dt / 0.5);
+    cam.x += (to.x - cam.x) * ck;
+    cam.y += (to.y - cam.y) * ck;
+    cam.s += (to.s - cam.s) * ck;
+    const f = e.focus;
+    if (f) {
+      f.t += dt;
+      const want = f.phase === "in" ? 1 : 0;
+      e.dim += (want - e.dim) * (e.reduced ? 1 : Math.min(1, dt / 0.42));
+      if (f.phase === "out" && e.dim < 0.02) { e.focus = null; e.you = null; e.dim = 0; }
+    }
+
+    const ctx = e.ctx;
+    ctx.setTransform(e.dpr, 0, 0, e.dpr, 0, 0);
+    ctx.clearRect(0, 0, e.w, e.h);
+    ctx.setTransform(e.dpr * cam.s, 0, 0, e.dpr * cam.s, -cam.x * e.dpr * cam.s, -cam.y * e.dpr * cam.s);
+    const fade = 1 - 0.74 * e.dim;
+
+    // The community drifts slowly; the fine lines are the routes signals travel.
+    if (!e.reduced && !e.paused) {
+      for (let i = 0; i < e.nodes.length; i++) {
+        const n = e.nodes[i];
+        if (n.fixed) continue;
+        n.x += n.vx * dt;
+        n.y += n.vy * dt;
+        // Each student wanders inside a 10px box around where it started.
+        const R = 5;
+        if (n.x < n.hx - R) { n.x = n.hx - R; n.vx = Math.abs(n.vx); }
+        if (n.x > n.hx + R) { n.x = n.hx + R; n.vx = -Math.abs(n.vx); }
+        if (n.y < n.hy - R) { n.y = n.hy - R; n.vy = Math.abs(n.vy); }
+        if (n.y > n.hy + R) { n.y = n.hy + R; n.vy = -Math.abs(n.vy); }
+        const bx = e.bx || 0, by = e.by || 0, ins = e.inset || 20;
+        // Drawn students stay on screen; anchors stay off it.
+        const lo = n.ghost ? -bx : ins, hi = n.ghost ? e.w + bx : e.w - ins;
+        const tp = n.ghost ? -by : ins, bt = n.ghost ? e.h + by : e.h - ins;
+        if (n.x < lo) { n.x = lo; n.vx = Math.abs(n.vx); }
+        if (n.x > hi) { n.x = hi; n.vx = -Math.abs(n.vx); }
+        if (n.y < tp) { n.y = tp; n.vy = Math.abs(n.vy); }
+        if (n.y > bt) { n.y = bt; n.vy = -Math.abs(n.vy); }
+        if (n.ghost && n.x > ins && n.x < e.w - ins && n.y > ins && n.y < e.h - ins) {
+          n.x -= n.vx * dt * 2; n.y -= n.vy * dt * 2;
+          n.vx = -n.vx; n.vy = -n.vy;
+        }
+        // Drift never carries a student into the copy: it turns away at the margin.
+        if (this.clearAt(n.x, n.y, n.r + 1) < 1) {
+          n.x -= n.vx * dt * 2; n.y -= n.vy * dt * 2;
+          n.vx = -n.vx; n.vy = -n.vy;
+        }
+      }
+    }
+
+    // Links keep off the content; if drift swings one towards it, it fades out.
+    // Drift must not undo the even Halton spread: close pairs ease back apart.
+    // Drift is box-bounded, so a large field does not need the O(n²) pass.
+    if (!e.reduced && !e.paused && e.nodes.length <= 200) {
+      const min = e.minGap || 0, ns = e.nodes;
+      for (let i = 0; i < ns.length; i++) {
+        for (let j = i + 1; j < ns.length; j++) {
+          const a = ns[i], b = ns[j];
+          const dx = b.x - a.x, dy = b.y - a.y;
+          const d2 = dx * dx + dy * dy;
+          if (d2 >= min * min || d2 < 0.01) continue;
+          const d = Math.sqrt(d2), push = (min - d) * 0.5 * Math.min(1, dt * 3) / d;
+          a.x -= dx * push; a.y -= dy * push;
+          b.x += dx * push; b.y += dy * push;
+        }
+      }
+    }
+
+    const edges = e.edges || [];
+    ctx.lineWidth = 1;
+    // Clearance is near-constant (drift is clamped to ±5px), so it is cached on
+    // the edge and refreshed on a rolling slice — never for every edge per frame.
+    const buckets = [null, null, null, null];
+    const slice = Math.max(1, Math.ceil(edges.length / 30));
+    const from = e.clearCursor || 0;
+    for (let s = 0; s < slice; s++) {
+      const ed = edges[(from + s) % edges.length];
+      if (ed) ed.clear = this.lineClearance(ed.a, ed.b);
+    }
+    e.clearCursor = edges.length ? (from + slice) % edges.length : 0;
+    for (let i = 0; i < edges.length; i++) {
+      const ed = edges[i];
+      const c = ed.clear === undefined ? (ed.clear = this.lineClearance(ed.a, ed.b)) : ed.clear;
+      if (c <= 0.02) continue;
+      const bi = Math.min(3, Math.floor(c * 4 - 0.0001));
+      (buckets[bi] || (buckets[bi] = [])).push(ed);
+    }
+    for (let bi = 0; bi < 4; bi++) {
+      const list = buckets[bi];
+      if (!list) continue;
+      ctx.strokeStyle = this.rgba(e.pal.line, e.pal.lineA * ((bi + 1) / 4) * fade);
+      ctx.beginPath();
+      for (let i = 0; i < list.length; i++) {
+        ctx.moveTo(list[i].a.x, list[i].a.y);
+        ctx.lineTo(list[i].b.x, list[i].b.y);
+      }
+      ctx.stroke();
+    }
+
+    for (let i = 0; i < e.nodes.length; i++) {
+      const n = e.nodes[i];
+      if (n.ghost) continue; // an anchor, not a student
+      const mine = n === e.you;
+      const em = mine ? 1 : fade;
+      ctx.fillStyle = this.rgba(e.pal.dot, e.pal.dotA * n.a * this.clearAt(n.x, n.y) * em);
+      ctx.beginPath();
+      ctx.arc(n.x, n.y, mine ? n.r + 3.5 * e.dim : n.r, 0, 6.2832);
+      ctx.fill();
+    }
+    if (e.you && e.dim > 0.02) this.drawYou(ctx, e, e.you);
+
+    if (e.reduced) {
+      const ms = e.glows || [];
+      for (let i = 0; i < ms.length; i++) this.drawGlow(ctx, e, ms[i].x, ms[i].y, 0.62);
+    } else if (!e.paused) {
+      if (ts > e.spawnAt && e.signals.length < e.max) {
+        this.spawnSignal();
+        e.spawnAt = ts + 260 + Math.random() * 900;
+      }
+      for (let i = e.signals.length - 1; i >= 0; i--) {
+        const s = e.signals[i];
+        if (!s.hold) s.p += dt / s.dur;
+        if (s.p >= 1) {
+          if (this.held === s) { this.held = null; this.closeCard(); }
+          e.signals.splice(i, 1);
+          // Some recommendations carry on past the student who received them.
+          if (s.relay > 0 && e.signals.length < e.max + 3) this.relaySignal(s);
+          continue;
+        }
+        // Endpoints follow their students, so the flash still lands on the node.
+        s.ax = s.na.x; s.ay = s.na.y; s.bx = s.nb.x; s.by = s.nb.y;
+        s.cx = (s.ax + s.bx) / 2; s.cy = (s.ay + s.by) / 2;
+        s.len = Math.max(1, Math.hypot(s.bx - s.ax, s.by - s.ay));
+        const pt = this.at(s, s.p);
+        s.hx = pt.x; s.hy = pt.y;
+        this.drawSignal(ctx, e, s);
+      }
+    }
+    e.raf = requestAnimationFrame(this.tick);
+  };
+
+  /** The user's own dot: a restrained pulse and a small label, no fanfare. */
+  drawYou(ctx, e, n) {
+    const t = e.focus ? e.focus.t : 0;
+    const a = e.dim;
+    const rr = n.r + 3.5 * a;
+    if (!e.reduced) {
+      const ph = Math.max(0, (Math.max(0, t) % 1.9) / 1.9);
+      const ease = Math.max(0, ph * (2 - ph));
+      ctx.strokeStyle = this.rgba(e.pal.dot, 0.34 * (1 - ease) * a);
+      ctx.lineWidth = 1.3;
+      ctx.beginPath();
+      ctx.arc(n.x, n.y, Math.max(0.5, rr + 2 + ease * 17), 0, 6.2832);
+      ctx.stroke();
+    }
+    ctx.strokeStyle = this.rgba(e.pal.dot, 0.45 * a);
+    ctx.lineWidth = 1;
+    ctx.beginPath();
+    ctx.arc(n.x, n.y, Math.max(0.5, rr + 5), 0, 6.2832);
+    ctx.stroke();
+
+    const label = "You";
+    ctx.font = "600 11px Geist, system-ui, sans-serif";
+    const w = ctx.measureText(label).width;
+    const lx = Math.min(Math.max(n.x - w / 2 - 7, 6), e.w - w - 20);
+    const ly = n.y + rr + 9;
+    ctx.fillStyle = this.rgba(e.pal.dot, 0.94 * a);
+    ctx.beginPath();
+    if (ctx.roundRect) { ctx.roundRect(lx, ly, w + 14, 19, 9.5); } else { ctx.rect(lx, ly, w + 14, 19); }
+    ctx.fill();
+    ctx.fillStyle = this.rgba(this.state.theme === "dark" ? [23, 81, 166] : [250, 248, 241], 0.98 * a);
+    ctx.textBaseline = "middle";
+    ctx.fillText(label, lx + 7, ly + 10);
+  }
+
+  drawGlow(ctx, e, x, y, k) {
+    const hr = 6 + 8 * k;
+    const g = ctx.createRadialGradient(x, y, 0, x, y, hr);
+    g.addColorStop(0, this.rgba(e.pal.halo, e.pal.haloA * 1.4 * k));
+    g.addColorStop(1, this.rgba(e.pal.halo, 0));
+    ctx.fillStyle = g;
+    ctx.beginPath(); ctx.arc(x, y, hr, 0, 6.2832); ctx.fill();
+    ctx.fillStyle = this.rgba(e.pal.core, 0.85 * k);
+    ctx.beginPath(); ctx.arc(x, y, 2, 0, 6.2832); ctx.fill();
+  }
+
+  drawSignal(ctx, e, s) {
+    const k = Math.min(1, this.env(s.p) * s.prom * (s.hold ? 1.18 : 1) * (1 - 0.74 * e.dim));
+    if (k <= 0.002) return;
+    // A drawn stroke rather than a glow: the trail is a tapering line on the edge.
+    const trail = 16 + 74 * k;
+    const back = Math.min(s.p, trail / s.len);
+    const tail = this.at(s, s.p - back);
+
+    const hr = 5 + 9 * k;
+    const halo = ctx.createRadialGradient(s.hx, s.hy, 0, s.hx, s.hy, hr);
+    halo.addColorStop(0, this.rgba(e.pal.halo, e.pal.haloA * k));
+    halo.addColorStop(1, this.rgba(e.pal.halo, 0));
+    ctx.fillStyle = halo;
+    ctx.beginPath(); ctx.arc(s.hx, s.hy, hr, 0, 6.2832); ctx.fill();
+
+    const g = ctx.createLinearGradient(tail.x, tail.y, s.hx, s.hy);
+    g.addColorStop(0, this.rgba(e.pal.mid, 0));
+    g.addColorStop(0.55, this.rgba(e.pal.mid, k * 0.5));
+    g.addColorStop(0.9, this.rgba(e.pal.mid, k * 0.9));
+    g.addColorStop(1, this.rgba(e.pal.core, Math.min(1, k * 1.1)));
+    ctx.strokeStyle = g;
+    ctx.lineWidth = 1.1 + 1.9 * k;
+    ctx.lineCap = "round";
+    ctx.beginPath();
+    ctx.moveTo(tail.x, tail.y);
+    ctx.lineTo(s.hx, s.hy);
+    ctx.stroke();
+
+
+  }
+
+  /* --- interaction: a student fans their recommendation out to their neighbours --- */
+
+  closeCard() {}
+
+  scheduleClose() {}
+
+  /** Pointer position only drives the cursor affordance for a clickable student. */
+  onVizMove = (ev) => {
+    const e = this.viz;
+    if (!e || e.reduced || e.paused) return;
+    const hit = this.hitAt(ev.clientX, ev.clientY);
+    const want = hit ? "pointer" : "";
+    if (e.cursor !== want) {
+      e.cursor = want;
+      const land = this.landingRef.current;
+      if (land) land.style.cursor = want;
+    }
+  };
+
+  onVizOut = () => {
+    const land = this.landingRef.current;
+    if (land) land.style.cursor = "";
+    if (this.viz) this.viz.cursor = "";
+  };
+
+  /** The student under the pointer, if any. */
+  hitAt(cx, cy) {
+    const e = this.viz;
+    if (!e) return null;
+    const r = e.cv.getBoundingClientRect();
+    const sx = r.width / e.w, sy = r.height / e.h;
+    const px = (cx - r.left) / (sx || 1), py = (cy - r.top) / (sy || 1);
+    if (px < 0 || py < 0 || px > e.w || py > e.h) return null;
+    const cam = e.cam || { x: 0, y: 0, s: 1 };
+    const x = cam.x + px / cam.s, y = cam.y + py / cam.s;
+    let bn = null, bnd = 20 * 20;
+    for (let i = 0; i < e.nodes.length; i++) {
+      const n = e.nodes[i];
+      if (n.ghost || this.maskAt(n.x, n.y) > 0.35) continue;
+      const d = (n.x - x) * (n.x - x) + (n.y - y) * (n.y - y);
+      if (d < bnd) { bnd = d; bn = { kind: "node", n: n }; }
+    }
+    return bn;
+  }
+
+  onDocDown = (ev) => {
+    const t = ev.target;
+    const e = this.viz;
+    if (!e || e.paused || e.reduced) return;
+    if (t && t.closest && t.closest('input,button,a,[role="button"],[data-om-pane]')) return;
+    const hit = this.hitAt(ev.clientX, ev.clientY);
+    if (hit && hit.kind === "node") this.burst(hit.n);
+  };
+
+  onVizKey = () => {};
+
+  renderVals() {
+    const s = this.state;
+    const mobile = Boolean(this.props.mobile) || Boolean(s.narrow);
+    const explore = s.phase === "explore";
+    const soft = this.reduced();
+    const move = soft ? "opacity .18s linear" : "top .52s cubic-bezier(.22,.61,.19,1), width .52s cubic-bezier(.22,.61,.19,1), height .46s ease, padding .46s ease, font-size .46s ease, border-radius .46s ease, box-shadow .46s ease, opacity .3s ease";
+    const night = s.theme === "dark";
+    const dark = false;
+    const centre = 400;
+    const r = REASONS[s.reason] || REASONS["log-in"];
+
+    return {
+      appRef: this.appRef,
+
+      isMobile: mobile,
+      isNotMobile: !mobile,
+      titleSize: mobile ? "30px" : "44px",
+      sectionsDisplay: mobile ? "flex" : "grid",
+      barPosition: mobile ? "static" : "absolute",
+      barWidth: mobile ? "100%" : "560px",
+      showBottomAuth: mobile && !s.authed,
+      headBg: mobile ? "#1751a6" : (night ? "rgba(19,70,145,.94)" : dark ? "#1751a6" : "rgba(250,248,241,.94)"),
+      headFg: mobile ? "#fff" : (night ? "#f4eee2" : dark ? "#fff" : "#16202b"),
+      headMuted: mobile ? "rgba(255,255,255,.85)" : (night ? "rgba(244,238,226,.86)" : dark ? "rgba(255,255,255,.85)" : "#4a5560"),
+      headRule: mobile ? "#1751a6" : (night ? "rgba(244,238,226,.14)" : dark ? "#1751a6" : "#eae6da"),
+      headDivider: night ? "rgba(244,238,226,.26)" : dark ? "rgba(255,255,255,.3)" : "#e5e0d2",
+      markBg: night ? "rgba(244,238,226,.16)" : dark ? "rgba(255,255,255,.16)" : "#1751a6",
+      loginBorder: "1px solid transparent",
+      loginBg: "transparent",
+      loginFg: night ? "#f4eee2" : dark ? "#fff" : "#1751a6",
+      signupBg: night ? "#f4eee2" : dark ? "#fff" : "#1751a6",
+      signupFg: night ? "#1751a6" : dark ? "#12417f" : "#fff",
+
+      dotOpen: !!s.dot,
+      // While the network is being revealed the panel steps aside and the scrim lifts.
+      dotAlign: s.dot === "opened" || s.dot === "locating" || s.dot === "found" ? "flex-end" : "center",
+      dotPadBottom: s.dot === "opened" || s.dot === "locating" || s.dot === "found" ? "36px" : "0px",
+      dotScrim: s.dot === "opened" || s.dot === "locating" || s.dot === "found" ? "rgba(14,26,44,.08)" : "rgba(14,26,44,.34)",
+      dotEmail: s.dotEmail,
+      dotStep: s.dot,
+      isDotForm: s.dot === "email",
+      isDotBusy: s.dot === "submitting",
+      isDotSent: s.dot === "sent",
+      isDotOpened: s.dot === "opened" || s.dot === "locating",
+      isDotFound: s.dot === "found",
+      isDotExpired: s.dot === "expired",
+      dotErr: s.dotErr,
+      dotErrBorder: s.dotErr ? "1px solid #c2410c" : "1px solid var(--rule3)",
+      dotBusyLabel: s.dot === "submitting" ? "Sending…" : "Send private link",
+      dotLocateLabel: s.dot === "locating" ? "Locating your dot in the network…" : "Opening your private link…",
+      dotAcctLabel: s.dotAcct ? "Account " + s.dotAcct : "",
+      onFindDot: () => this.openDot(),
+      onDotEmail: (ev) => this.setState({ dotEmail: ev.target.value, dotErr: false }),
+      onDotKey: (ev) => { if (ev.key === "Enter") this.submitDot(); if (ev.key === "Escape") this.closeDot(); },
+      onDotSubmit: () => this.submitDot(),
+      onDotOpenLink: () => this.openLink(),
+      onDotExpire: () => this.expireLink(),
+      onDotRetry: () => this.setState({ dot: "email", dotErr: false }),
+      onDotClose: () => this.closeDot(),
+
+      theme: s.theme,
+      night: night,
+      notNight: !night,
+      themeTitle: night ? "Switch to light mode" : "Switch to dark mode",
+      onTheme: () => this.setTheme(night ? "light" : "dark"),
+      onThemeKey: (e) => {
+        if (e.key === "Enter" || e.key === " ") { e.preventDefault(); this.setTheme(night ? "light" : "dark"); }
+      },
+
+      vizRef: this.vizRef,
+      landingRef: this.landingRef,
+
+
+      // The landing layer clears the way; Explore is already mounted underneath.
+      curtain: explore && !soft ? "100%" : "0%",
+      // On the way to Explore the surroundings fade and the bar is left standing.
+      landingOpacity: s.leaving || (explore && soft) ? 0 : 1,
+      landingShift: explore && !soft ? "-40px" : "0px",
+      landingTween: (s.leaving ? "opacity .12s cubic-bezier(.4,0,1,1)" : soft ? "opacity .18s linear" : "clip-path .56s cubic-bezier(.4,.02,.2,1), transform .56s cubic-bezier(.4,.02,.2,1)") + ", background-color .34s ease, color .34s ease",
+      landingPointer: explore ? "none" : "auto",
+      // Explore reads ?q= once, on its own mount — so it must not exist before the push.
+      mountExplore: explore,
+      exploreOpacity: explore ? 1 : 0,
+      explorePointer: explore ? "auto" : "none",
+      fadeTween: soft ? "opacity .18s linear" : "opacity .2s ease",
+
+      // One search element, two positions.
+      q: s.q,
+      inputRef: this.inputRef,
+      barRef: this.barRef,
+      barTop: (explore ? 20 : centre) + "px",
+      barW: explore ? "560px" : "600px",
+      barH: explore ? "42px" : "56px",
+      barPad: explore ? "14px" : "18px",
+      barRadius: explore ? "10px" : "12px",
+      barFont: explore ? "14px" : "16px",
+      barShadow: explore ? "none" : "0 2px 10px rgba(20,30,45,.06)",
+      barTween: move,
+      barOpacity: 1,
+      barPointer: "auto",
+      showSearchBtn: !explore,
+      loading: s.loading,
+      onQ: (e) => {
+        this.setState({ q: e.target.value });
+        if (explore) this.syncApp(e.target.value);
+      },
+      onFocusSearch: () => this.prefetchExplore(),
+      onKey: (e) => { if (e.key === "Enter") this.toExplore(); },
+      onGo: () => this.toExplore(),
+      // Every suggestion is a term the dataset actually returns.
+      onTry1: () => this.toExplore("deep learning"),
+      onTry2: () => this.toExplore("machine learning"),
+      onTry3: () => this.toExplore("DD2380"),
+      onTry4: () => this.toExplore("agents"),
+      onHome: () => this.toLanding(),
+
+      // Guests get a discovery rail, not an account sidebar; it slides away on login.
+      railShift: (mobile || s.authed || !explore) ? "-236px" : "0px",
+      railTween: soft ? "none" : "transform .42s cubic-bezier(.22,.61,.19,1)",
+      railPointer: s.authed || !explore ? "none" : "auto",
+
+      authOpen: s.authOpen,
+      authKicker: r.kicker, authTitle: r.title, authBody: r.body, authCancelLabel: r.cancel,
+      authSwitchLabel: s.reason === "log-in" ? "New here? Sign up instead" : "Already have an account? Log in",
+      onSwitchReason: () => this.setState({ reason: s.reason === "log-in" ? "sign-up" : "log-in" }),
+      authBtnRef: this.authBtnRef,
+      authed: !!s.authed,
+      // Explore's own auth gate is a session for the whole shell, not just that view.
+      onExploreAuthed: () => { if (!this.state.authed) this.setState({ authed: true, railSeen: true }); },
+      isGuest: !s.authed,
+      isMember: !!s.authed,
+      chipBg: night ? "rgba(244,238,226,.14)" : "#f0ece0",
+      onLogOut: () => this.setState({ authed: false, railSeen: false, toast: "Signed out — browsing as a guest" }, () => {
+        setTimeout(() => this.setState({ toast: null }), 3200);
+      }),
+      onLogIn: () => this.openAuth("log-in"),
+      onSignUp: () => this.openAuth("sign-up"),
+      onAuthDone: () => this.closeAuth(true),
+      onAuthCancel: () => this.closeAuth(false),
+      onAuthKey: (e) => {
+        if (e.key === "Enter" || e.key === " ") { e.preventDefault(); this.closeAuth(true); }
+        if (e.key === "Escape") this.closeAuth(false);
+      },
+      stop: (e) => e.stopPropagation(),
+      toast: s.toast
+    };
+  }
+}
+
+</script>
+</body>
+</html>

--- a/docs/design/Course Community - My Page.dc.html
+++ b/docs/design/Course Community - My Page.dc.html
@@ -1,0 +1,877 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<script src="./support.js"></script>
+</head>
+<body>
+<x-dc>
+<helmet data-dc-atomics><link rel="preconnect" href="https://fonts.googleapis.com"><link rel="preconnect" href="https://fonts.gstatic.com" crossorigin><link href="https://fonts.googleapis.com/css2?family=Geist:wght@400;500;600;700&family=Geist+Mono:wght@400;500&display=swap" rel="stylesheet"><link rel="stylesheet" href="cc-theme.css"><style>body{background:var(--pg);color:var(--ink)}html,body{margin:0;height:100%;background:var(--pg);font-family:Geist,system-ui,sans-serif;color:var(--ink)}a{color:#1751a6}a:hover{color:#10386f}*{box-sizing:border-box}input,button,textarea{font-family:Geist,system-ui,sans-serif}@keyframes rise{from{opacity:0;transform:translateY(6px)}to{opacity:1;transform:none}}@keyframes pulse{0%,100%{opacity:.45}50%{opacity:1}}</style></helmet>
+
+<div style="position:relative;display:flex;height:900px;background:var(--pg);color:var(--ink);font-size:14px">
+<div data-cc-topbar="1" data-cc-fade="1" style="position:absolute;top:0;left:0;right:0;height:66px;z-index:1;box-sizing:border-box;display:flex;align-items:center;justify-content:flex-end;gap:8px;padding:0 28px;border-bottom:1px solid var(--rule);background:var(--pg)">
+<div onClick="{{ onTheme }}" role="button" tabIndex="0" title="{{ themeTitle }}" aria-label="{{ themeTitle }}" style="width:34px;height:34px;display:flex;align-items:center;justify-content:center;border-radius:8px;color:var(--chipInk);cursor:pointer" style-hover="background:rgba(125,145,175,.14)">
+<sc-if value="{{ notNight }}" hint-placeholder-val="{{ true }}"><svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><path d="M20.5 14.5A8.5 8.5 0 1 1 9.5 3.5a7 7 0 0 0 11 11z"></path></svg></sc-if>
+<sc-if value="{{ night }}" hint-placeholder-val="{{ false }}"><svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round"><circle cx="12" cy="12" r="4.2"></circle><path d="M12 3v2M12 19v2M3 12h2M19 12h2M5.6 5.6l1.4 1.4M17 17l1.4 1.4M18.4 5.6 17 7M7 17l-1.4 1.4"></path></svg></sc-if>
+</div>
+</div>
+
+
+<div data-cc-sidebar="1" data-cc-fade="1" style="position:relative;z-index:2;box-sizing:border-box;width:236px;flex:none;display:flex;flex-direction:column;gap:6px;padding:14px 10px;background:#1751a6;color:#fff">
+<a href="Course Community - Landing.dc.html" style="display:flex;align-items:center;gap:10px;padding:6px 8px 14px;color:#fff;text-decoration:none">
+<img src="assets/ais-symbol-white.png" alt="KTH AI Society" style="height:34px;width:34px;object-fit:contain">
+<div style="width:1px;height:28px;background:rgba(255,255,255,.35)"></div>
+<div style="font-size:15px;font-weight:600;line-height:1.15">Course<br>Community</div>
+</a>
+<div style="display:flex;flex-direction:column;gap:2px;margin-top:14px">
+<a href="Course Community - Explore.dc.html" style="display:flex;align-items:center;gap:10px;padding:9px 10px;border-radius:8px;background:transparent;font-weight:400;color:#fff;text-decoration:none" style-hover="background:rgba(255,255,255,.1)"><svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="#fff" stroke-width="2.4" stroke-linecap="round"><circle cx="11" cy="11" r="7"></circle><line x1="16.5" y1="16.5" x2="21" y2="21"></line></svg><span style="flex:1">Explore</span></a>
+<a href="Course Community - Saved.dc.html" style="display:flex;align-items:center;gap:10px;padding:9px 10px;border-radius:8px;background:transparent;font-weight:400;color:#fff;text-decoration:none" style-hover="background:rgba(255,255,255,.1)"><svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="#fff" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="m19 21-7-4-7 4V5a2 2 0 0 1 2-2h10a2 2 0 0 1 2 2z"></path></svg><span style="flex:1">Saved courses</span><sc-if value="{{ hasSavedCount }}" hint-placeholder-val="{{ true }}"><span style="padding:1px 7px;border-radius:9px;background:rgba(255,255,255,.22);font-size:11.5px;font-weight:600">{{ savedCountLabel }}</span></sc-if></a>
+<a href="Course Community - My Page.dc.html" style="display:flex;align-items:center;gap:10px;padding:9px 10px;border-radius:8px;background:rgba(255,255,255,.16);font-weight:600;color:#fff;text-decoration:none" style-hover="background:rgba(255,255,255,.1)"><svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="#fff" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="8" r="4"></circle><path d="M5.5 21a6.5 6.5 0 0 1 13 0"></path></svg><span style="flex:1">My Page</span></a>
+<a href="Course Community - Taken Courses.dc.html" style="display:flex;align-items:center;gap:10px;padding:9px 10px;border-radius:8px;background:transparent;font-weight:400;color:#fff;text-decoration:none" style-hover="background:rgba(255,255,255,.1)"><svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="#fff" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="10"></circle><path d="m9 12 2 2 4-4"></path></svg><span style="flex:1">Taken courses</span></a>
+</div>
+<div style="margin-top:auto;display:flex;flex-direction:column;gap:2px">
+<a href="Course Community - About.dc.html" style="display:flex;align-items:center;gap:10px;padding:9px 10px;border-radius:8px;color:rgba(255,255,255,.82);text-decoration:none" style-hover="background:rgba(255,255,255,.1)"><svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="#fff" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M12 7v14"></path><path d="M3 18a1 1 0 0 1-1-1V4a1 1 0 0 1 1-1h5a4 4 0 0 1 4 4 4 4 0 0 1 4-4h5a1 1 0 0 1 1 1v13a1 1 0 0 1-1 1h-6a3 3 0 0 0-3 3 3 3 0 0 0-3-3z"></path></svg>About &amp; contact</a>
+<sc-if value="{{ isMember }}" hint-placeholder-val="{{ false }}">
+<div style="display:flex;align-items:center;gap:10px;padding:10px;margin-top:8px;border-radius:8px;background:rgba(255,255,255,.1)">
+<div style="width:34px;height:34px;flex:none;border-radius:50%;background:#7ea6d8;color:#0d2f5e;display:flex;align-items:center;justify-content:center;font-weight:700;font-size:13px">EL</div>
+<div style="flex:1;min-width:0;font-size:13px;font-weight:500">Elsa Lindqvist</div>
+<div onClick="{{ onSignOut }}" role="button" tabIndex="0" aria-label="Sign out" title="Sign out" style="flex:none;width:28px;height:28px;display:flex;align-items:center;justify-content:center;border-radius:7px;color:rgba(255,255,255,.75);cursor:pointer" style-hover="background:rgba(255,255,255,.16);color:#fff"><svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.9" stroke-linecap="round" stroke-linejoin="round"><path d="M9 21H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h4"></path><path d="M16 17l5-5-5-5"></path><path d="M21 12H9"></path></svg></div>
+</div>
+</sc-if>
+<sc-if value="{{ isGuest }}" hint-placeholder-val="{{ true }}">
+<div style="margin-top:8px;padding-top:12px;border-top:1px solid rgba(255,255,255,.2)">
+<div style="font-size:11.5px;line-height:1.45;color:rgba(255,255,255,.78)">Browsing as a guest. Saving courses and posting reviews need an account.</div>
+<div onClick="{{ onSignUp }}" role="button" tabIndex="0" style="margin-top:10px;display:flex;align-items:center;justify-content:center;height:34px;border-radius:8px;background:#fff;color:#12417f;font-size:13px;font-weight:600;cursor:pointer">Sign up</div>
+<div onClick="{{ onLogIn }}" role="button" tabIndex="0" style="margin-top:6px;display:flex;align-items:center;justify-content:center;height:34px;border-radius:8px;border:1px solid rgba(255,255,255,.4);font-size:13px;font-weight:500;color:#fff;cursor:pointer">Log in</div>
+</div>
+</sc-if>
+</div>
+</div>
+
+<div style="position:relative;flex:1;min-width:0;min-height:0;margin-top:{{ paneTop }};display:flex;flex-direction:column;overflow-y:auto;overflow-x:hidden">
+<div style="width:100%;max-width:{{ pageMaxWidth }};box-sizing:border-box;margin:0 auto;padding:0 {{ pageSidePadding }};display:flex;flex-direction:column">
+<dc-import name="Course Community - Page Header" title="My Page" subtitle="Private to you." hint-size="100%,90px"></dc-import>
+
+<div style="padding:0 20px">
+<sc-if value="{{ signedIn }}" hint-placeholder-val="{{ false }}">
+<div style="padding:18px 0 0">
+<div style="display:flex;align-items:flex-end;justify-content:space-between;gap:24px">
+<div style="min-width:0">
+<div style="font-size:19px;font-weight:600;line-height:1.25">Elsa Lindqvist</div>
+<div style="margin-top:8px;font-size:13.5px;color:var(--muted)">{{ profileLine }}</div>
+</div>
+</div>
+<div style="margin-top:20px;display:flex;gap:4px;border-bottom:1px solid var(--rule)">
+<sc-for list="{{ tabs }}" as="t" hint-placeholder-count="4">
+<div onClick="{{ t.onClick }}" style="display:flex;align-items:center;gap:8px;padding:0 13px;height:40px;border-bottom:2px solid {{ t.line }};color:{{ t.fg }};font-size:13.5px;font-weight:{{ t.weight }};cursor:pointer" style-hover="color:var(--ink)">{{ t.label }}<span style="padding:1px 7px;border-radius:999px;background:{{ t.pillBg }};color:{{ t.pillFg }};font-size:11.5px;font-weight:600;font-variant-numeric:tabular-nums">{{ t.count }}</span></div>
+</sc-for>
+</div>
+</div>
+</sc-if>
+
+<sc-if value="{{ signedOut }}" hint-placeholder-val="{{ true }}">
+<div style="flex:1;display:flex;flex-direction:column">
+<div style="padding:18px 0 0">
+<div style="max-width:520px;padding:16px 17px;border:1px solid var(--rule2);border-radius:11px;background:var(--surface)">
+<div style="display:flex;align-items:center;gap:8px">
+<svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="#6b6355" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><rect x="4" y="10.5" width="16" height="10.5" rx="2.5"></rect><path d="M8 10.5V7.5a4 4 0 0 1 8 0v3"></path></svg>
+<div style="font-size:13.5px;font-weight:600">Sign in to see your page</div>
+</div>
+<div style="margin-top:6px;font-size:12.5px;line-height:1.5;color:var(--muted)">Your course list, reviews and average stay private to you and sync across devices.</div>
+<div style="margin-top:11px;display:flex;gap:7px">
+<div onClick="{{ onSignIn }}" role="button" tabIndex="0" style="display:flex;align-items:center;justify-content:center;height:32px;padding:0 14px;border-radius:8px;background:var(--btn);color:var(--btnFg);font-size:12.5px;font-weight:600;cursor:pointer;white-space:nowrap" style-hover="background:var(--btn)">Sign up</div>
+<div onClick="{{ onSignIn }}" role="button" tabIndex="0" style="display:flex;align-items:center;justify-content:center;height:32px;padding:0 14px;border-radius:8px;border:1px solid var(--rule3);background:var(--surface);font-size:12.5px;font-weight:500;color:var(--brand);cursor:pointer;white-space:nowrap" style-hover="border-color:var(--hov)">Log in</div>
+</div>
+</div>
+</div>
+</div>
+</sc-if>
+
+<sc-if value="{{ isLoading }}" hint-placeholder-val="{{ false }}">
+<div style="flex:1;padding:22px 0 0;display:flex;flex-direction:column;gap:16px">
+<div style="display:flex;flex-direction:column;gap:16px">
+<div style="display:grid;grid-template-columns:repeat(4,1fr);gap:12px">
+<sc-for list="{{ skeletonRows }}" as="k" hint-placeholder-count="4">
+<div style="border:1px solid var(--rule);border-radius:12px;background:var(--surface);padding:16px 17px">
+<div style="height:11px;width:70%;border-radius:4px;background:var(--pill);animation:pulse 1.2s ease-in-out infinite"></div>
+<div style="margin-top:12px;height:22px;width:46%;border-radius:5px;background:#eae6da;animation:pulse 1.2s ease-in-out infinite"></div>
+</div>
+</sc-for>
+</div>
+<div style="border:1px solid var(--rule);border-radius:12px;background:var(--surface);overflow:hidden">
+<sc-for list="{{ skeletonRows }}" as="k" hint-placeholder-count="5">
+<div style="display:flex;align-items:center;gap:14px;padding:15px 16px;border-bottom:1px solid #f4f2ea">
+<div style="width:70px;height:11px;flex:none;border-radius:4px;background:var(--pill);animation:pulse 1.2s ease-in-out infinite"></div>
+<div style="height:11px;width:{{ k.w }};border-radius:4px;background:var(--pill);animation:pulse 1.2s ease-in-out infinite"></div>
+</div>
+</sc-for>
+</div>
+</div>
+<div style="border:1px solid var(--rule);border-radius:12px;background:var(--surface);padding:16px 17px 15px">
+<div style="height:11px;width:52%;border-radius:4px;background:var(--pill);animation:pulse 1.2s ease-in-out infinite"></div>
+<div style="margin-top:14px;height:11px;width:88%;border-radius:4px;background:var(--pill);animation:pulse 1.2s ease-in-out infinite"></div>
+<div style="margin-top:9px;height:11px;width:76%;border-radius:4px;background:var(--pill);animation:pulse 1.2s ease-in-out infinite"></div>
+</div>
+</div>
+</sc-if>
+
+<sc-if value="{{ isError }}" hint-placeholder-val="{{ false }}">
+<div style="flex:1;padding:22px 0 0;display:flex;justify-content:center;align-items:flex-start">
+<div style="width:100%;max-width:560px;border:1px solid #f0d7cf;border-radius:14px;background:var(--surface);padding:26px 24px 22px;animation:rise .2s ease-out">
+<div style="display:flex;align-items:center;gap:10px">
+<span style="width:26px;height:26px;border-radius:50%;background:#fbeceb;display:flex;align-items:center;justify-content:center"><svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="#a3452a" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round"><path d="M12 8v5"></path><path d="M12 16.5h.01"></path></svg></span>
+<div style="font-size:11px;font-weight:600;letter-spacing:.09em;text-transform:uppercase;color:#a3452a">Could not load</div>
+</div>
+<div style="margin-top:12px;font-size:20px;font-weight:600;line-height:1.25">{{ errorTitle }}</div>
+<div style="margin-top:8px;font-size:13.5px;line-height:1.55;color:var(--muted);text-wrap:pretty">{{ errorBody }}</div>
+<div style="margin-top:18px;display:flex;align-items:center;gap:10px">
+<div onClick="{{ onRetry }}" style="display:flex;align-items:center;gap:8px;height:40px;padding:0 17px;border-radius:9px;background:var(--btn);color:var(--btnFg);font-size:13.5px;font-weight:600;cursor:pointer" style-hover="background:var(--btn)"><svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="#fff" stroke-width="1.9" stroke-linecap="round" stroke-linejoin="round"><path d="M20 12a8 8 0 1 1-2.6-5.9"></path><path d="M20 4v4h-4"></path></svg>Try again</div>
+<a href="Course Community - Explore.dc.html" style="display:flex;align-items:center;height:40px;padding:0 15px;border-radius:9px;border:1px solid var(--rule3);background:var(--surface);font-size:13px;font-weight:500;color:var(--chipInk);text-decoration:none" style-hover="border-color:var(--hov)">Browse courses instead</a>
+</div>
+</div>
+</div>
+</sc-if>
+
+<sc-if value="{{ isOverview }}" hint-placeholder-val="{{ true }}">
+<div style="flex:1;padding:22px 0 0;display:flex;flex-direction:column;gap:16px">
+<div style="display:flex;flex-direction:column;gap:16px">
+<div style="display:grid;grid-template-columns:repeat(4,1fr);gap:12px">
+<div style="border:1px solid var(--rule);border-radius:12px;background:var(--surface);padding:16px 17px">
+<div style="font-size:11.5px;font-weight:500;color:var(--dim)">Completed courses</div>
+<div style="margin-top:7px;font-size:28px;font-weight:600;letter-spacing:-.02em;font-variant-numeric:tabular-nums">{{ courseCount }}</div>
+<div style="margin-top:5px;font-size:12px;color:var(--dim2)">{{ courseNote }}</div>
+</div>
+<div style="border:1px solid var(--rule);border-radius:12px;background:var(--surface);padding:16px 17px">
+<div style="font-size:11.5px;font-weight:500;color:var(--dim)">Credits earned</div>
+<div style="margin-top:7px;font-size:28px;font-weight:600;letter-spacing:-.02em;font-variant-numeric:tabular-nums">{{ credits }} <span style="font-size:15px;font-weight:500;color:var(--dim)">hp</span></div>
+<div style="margin-top:5px;font-size:12px;color:var(--dim2)">{{ creditRange }}</div>
+</div>
+<div style="border:1px solid var(--rule);border-radius:12px;background:var(--surface);padding:16px 17px">
+<div style="font-size:11.5px;font-weight:500;color:var(--dim)">Written reviews</div>
+<div style="margin-top:7px;font-size:28px;font-weight:600;letter-spacing:-.02em;font-variant-numeric:tabular-nums">{{ mineCount }}</div>
+<div style="margin-top:5px;font-size:12px;color:var(--dim2)">{{ likesNote }}</div>
+</div>
+<div style="border:1px solid {{ avgCardBorder }};border-radius:12px;background:{{ avgCardBg }};padding:16px 17px">
+<div style="font-size:11.5px;font-weight:500;color:var(--dim)">Average grade</div>
+<div style="margin-top:7px;font-size:28px;font-weight:600;letter-spacing:-.02em;color:{{ avgCardInk }};font-variant-numeric:tabular-nums">{{ avgCardValue }}</div>
+<div style="margin-top:5px;font-size:12px;color:var(--dim2)">{{ avgCardNote }}</div>
+</div>
+</div>
+
+<dc-import name="Course Community - Unreviewed Card" courses="{{ unreviewedCourses }}" total="{{ takenTotal }}" on-start="{{ onStartReviewer }}" hint-size="100%,320px"></dc-import>
+</div>
+
+</div>
+</sc-if>
+
+<sc-if value="{{ isMine }}" hint-placeholder-val="{{ false }}">
+<div style="flex:1;padding:22px 0 0;display:grid;grid-template-columns:1fr 1px 1fr;gap:24px">
+
+<div>
+<div style="font-size:12px;font-weight:600;letter-spacing:.05em;text-transform:uppercase;color:var(--dim);margin-bottom:10px">Your reviews</div>
+<sc-if value="{{ hasMine }}" hint-placeholder-val="{{ true }}">
+<div style="display:flex;flex-direction:column;gap:14px">
+<sc-for list="{{ mine }}" as="r" hint-placeholder-count="4">
+<dc-import name="Course Community - Review Card" review="{{ r }}" hint-size="100%,150px"></dc-import>
+</sc-for>
+</div>
+</sc-if>
+<sc-if value="{{ noMine }}" hint-placeholder-val="{{ false }}">
+<div style="border:1px dashed var(--rule3);border-radius:12px;background:var(--surface);padding:44px 20px;text-align:center">
+<div style="font-size:16px;font-weight:600">Nothing written yet</div>
+<div style="margin-top:7px;max-width:420px;margin-left:auto;margin-right:auto;font-size:13px;line-height:1.5;color:var(--muted)">Reviews you publish land here, with how many students found them helpful.</div>
+<div onClick="{{ onGoTranscript }}" style="margin-top:16px;display:inline-flex;align-items:center;height:40px;padding:0 17px;border-radius:9px;background:var(--btn);color:var(--btnFg);font-size:13.5px;font-weight:600;cursor:pointer">Open the quick reviewer</div>
+</div>
+</sc-if>
+</div>
+
+<div style="background:var(--rule)"></div>
+
+<div>
+<div style="font-size:12px;font-weight:600;letter-spacing:.05em;text-transform:uppercase;color:var(--dim);margin-bottom:10px">Liked reviews</div>
+<sc-if value="{{ hasLiked }}" hint-placeholder-val="{{ true }}">
+<div style="display:flex;flex-direction:column;gap:14px">
+<sc-for list="{{ liked }}" as="r" hint-placeholder-count="4">
+<dc-import name="Course Community - Review Card" review="{{ r }}" hint-size="100%,150px"></dc-import>
+</sc-for>
+</div>
+</sc-if>
+<sc-if value="{{ noLiked }}" hint-placeholder-val="{{ false }}">
+<div style="border:1px dashed var(--rule3);border-radius:12px;background:var(--surface);padding:44px 20px;text-align:center">
+<div style="font-size:16px;font-weight:600">No liked reviews</div>
+<div style="margin-top:7px;max-width:420px;margin-left:auto;margin-right:auto;font-size:13px;line-height:1.5;color:var(--muted)">Marking a review helpful on a course page keeps it here, so you can find it again.</div>
+</div>
+</sc-if>
+</div>
+
+</div>
+</sc-if>
+
+<sc-if value="{{ isDetail }}" hint-placeholder-val="{{ false }}">
+<div style="flex:1;padding:20px 0 0;display:flex;justify-content:center">
+<div style="width:100%;max-width:760px;animation:rise .2s ease-out">
+<div onClick="{{ onCloseDetail }}" style="display:inline-flex;align-items:center;gap:8px;font-size:13px;font-weight:500;color:var(--brand);cursor:pointer" style-hover="text-decoration:underline"><svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="#1751a6" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M19 12H6"></path><path d="m11.5 5.5-6.5 6.5 6.5 6.5"></path></svg>{{ backLabel }}</div>
+
+<div style="margin-top:14px;border:1px solid #e4dfd0;border-radius:14px;background:var(--surface);overflow:hidden">
+<div style="padding:20px 22px 18px;background:#fdf7ea;border-bottom:1px solid #f0e6d2">
+<div style="display:flex;align-items:flex-start;justify-content:space-between;gap:16px">
+<div style="min-width:0">
+<div style="font:500 12.5px Geist Mono,ui-monospace,monospace;color:var(--brand)">{{ detail.code }}</div>
+<div style="margin-top:7px;font-size:21px;font-weight:600;line-height:1.25">{{ detail.name }}</div>
+<div style="margin-top:6px;font-size:12.5px;color:var(--dim)">{{ detail.meta }}</div>
+</div>
+<div style="flex:none;display:flex;align-items:center;gap:8px">
+<div style="display:flex;align-items:center;gap:7px;padding:5px 11px;border-radius:999px;background:var(--surface);border:1px solid #f0e6d2;font-size:12px;font-weight:600;color:#6b4c0d"><svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="#6b4c0d" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round" style="flex:none"><path d="M7 21h10a2 2 0 0 0 2-1.6l1.2-6A1.6 1.6 0 0 0 18.6 11H14V6a2.5 2.5 0 0 0-4.8-1L7 11"></path><rect x="3" y="11" width="4" height="10" rx="1"></rect></svg>{{ detail.likes }} helpful</div>
+</div>
+</div>
+</div>
+
+<div style="padding:18px 22px 20px;display:flex;flex-direction:column;gap:14px">
+
+<div style="border:1px solid var(--rule);border-radius:12px;background:var(--pg);padding:15px 16px 14px">
+<div style="font-size:10.5px;font-weight:600;letter-spacing:.09em;text-transform:uppercase;color:var(--dim)">Format</div>
+<div style="margin-top:6px;display:flex;align-items:baseline;justify-content:space-between;gap:10px">
+<div style="font-size:14.5px;font-weight:600">How it was examined</div>
+<div style="flex:none;padding:2px 9px;border-radius:999px;background:var(--pill);color:var(--brand);font-size:12px;font-weight:600;font-variant-numeric:tabular-nums">{{ detail.examSplit }}</div>
+</div>
+<sc-if value="{{ detailHasExam }}" hint-placeholder-val="{{ true }}">
+<div style="margin-top:11px;display:flex;height:38px;border-radius:8px;overflow:hidden;background:#eae6da">
+<sc-for list="{{ detailExam }}" as="s" hint-placeholder-count="3">
+<div style="width:{{ s.width }};background:{{ s.color }};display:flex;align-items:center;justify-content:center;color:{{ s.ink }};font-size:12px;font-weight:600;overflow:hidden;white-space:nowrap">{{ s.label }}</div>
+</sc-for>
+</div>
+</sc-if>
+<sc-if value="{{ detailNoExam }}" hint-placeholder-val="{{ false }}">
+<div style="margin-top:11px;display:flex;align-items:center;gap:9px;height:38px;padding:0 13px;border-radius:8px;border:1px dashed #cfc9b8;background:var(--surface);font-size:12.5px;color:var(--dim)">{{ detailUnknownNote }}</div>
+</sc-if>
+<div style="height:1px;margin:14px 0;background:#eae6da"></div>
+<div style="display:flex;align-items:baseline;justify-content:space-between;gap:10px">
+<div style="font-size:14.5px;font-weight:600">The approach</div>
+<div style="flex:none;padding:2px 9px;border-radius:999px;background:var(--pill);color:var(--brand);font-size:12px;font-weight:600;font-variant-numeric:tabular-nums">{{ detail.theoryLabel }}</div>
+</div>
+<sc-if value="{{ detailHasTheory }}" hint-placeholder-val="{{ true }}">
+<div style="margin-top:11px;display:flex;height:38px;border-radius:8px;overflow:hidden;background:#eae6da">
+<div style="width:{{ detail.theoryW1 }};background:var(--btn);display:flex;align-items:center;padding-left:11px;color:var(--btnFg);font-size:12px;font-weight:600;overflow:hidden;white-space:nowrap">Theoretical</div>
+<div style="width:{{ detail.theoryW2 }};background:#cfe0f2;display:flex;align-items:center;justify-content:flex-end;padding-right:11px;color:var(--brand);font-size:12px;font-weight:600;overflow:hidden;white-space:nowrap">Applied</div>
+</div>
+</sc-if>
+<sc-if value="{{ detailNoTheory }}" hint-placeholder-val="{{ false }}">
+<div style="margin-top:11px;display:flex;align-items:center;gap:9px;height:38px;padding:0 13px;border-radius:8px;border:1px dashed #cfc9b8;background:var(--surface);font-size:12.5px;color:var(--dim)">{{ detailUnknownNote }}</div>
+</sc-if>
+</div>
+
+<div style="border:1px solid var(--rule);border-radius:12px;background:var(--pg);padding:15px 16px 14px">
+<div style="font-size:10.5px;font-weight:600;letter-spacing:.09em;text-transform:uppercase;color:var(--dim);margin-bottom:12px">Course profile</div>
+<sc-for list="{{ detailMeters }}" as="m" hint-placeholder-count="2">
+<div style="margin-bottom:14px">
+<div style="display:flex;align-items:baseline;justify-content:space-between;gap:10px;margin-bottom:9px"><div style="font-size:14.5px;font-weight:600">{{ m.label }}</div><div style="flex:none;padding:2px 9px;border-radius:999px;background:var(--pill);color:var(--brand);font-size:12px;font-weight:600;font-variant-numeric:tabular-nums">{{ m.value }}</div></div>
+<div style="height:8px;width:100%;border-radius:4px;background:#eae6da;overflow:hidden"><div style="height:100%;width:{{ m.width }};background:var(--btn)"></div></div>
+<div style="display:flex;justify-content:space-between;font-size:11.5px;color:var(--muted);margin-top:5px"><span>{{ m.lo }}</span><span>{{ m.hi }}</span></div>
+</div>
+</sc-for>
+</div>
+
+<div style="border:1px solid var(--rule);border-radius:12px;background:var(--pg);padding:15px 16px 14px">
+<div style="display:flex;align-items:center;gap:10px">
+<span style="width:9px;height:9px;flex:none;border-radius:50%;background:{{ detail.happyDot }}"></span>
+<div style="font-size:14.5px;font-weight:600;color:{{ detail.happyFg }}">{{ detail.happyHeadline }}</div>
+</div>
+<div style="margin-top:12px;font-size:14px;line-height:1.6;color:var(--ink2);text-wrap:pretty">{{ detail.text }}</div>
+</div>
+
+</div>
+
+<div style="display:flex;align-items:center;justify-content:space-between;gap:12px;padding:14px 22px;border-top:1px solid var(--rule);background:var(--surface)">
+<div style="font-size:12px;color:var(--dim2)">{{ detail.footNote }}</div>
+<div style="display:flex;gap:9px">
+<sc-if value="{{ detailIsMine }}" hint-placeholder-val="{{ true }}">
+<div style="display:flex;gap:9px">
+<div onClick="{{ onAskDeleteReview }}" style="display:flex;align-items:center;height:38px;padding:0 14px;border-radius:9px;border:1px solid var(--rule3);background:var(--surface);font-size:13px;font-weight:500;color:var(--chipInk);cursor:pointer" style-hover="border-color:#c96a4a;color:#c96a4a">Delete review</div>
+<div style="display:flex;align-items:center;gap:8px;height:38px;padding:0 16px;border-radius:9px;background:var(--btn);color:var(--btnFg);font-size:13px;font-weight:600;cursor:pointer" style-hover="background:var(--btn)"><svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="#fff" stroke-width="1.9" stroke-linecap="round" stroke-linejoin="round"><path d="M12 20h9"></path><path d="M16.5 3.5a2.1 2.1 0 0 1 3 3L7 19l-4 1 1-4z"></path></svg>Edit review</div>
+</div>
+</sc-if>
+<sc-if value="{{ detailIsLiked }}" hint-placeholder-val="{{ false }}">
+<div style="display:flex;gap:9px">
+<div onClick="{{ onUnlikeDetail }}" style="display:flex;align-items:center;height:38px;padding:0 14px;border-radius:9px;border:1px solid var(--rule3);background:var(--surface);font-size:13px;font-weight:500;color:var(--chipInk);cursor:pointer" style-hover="border-color:var(--hov)">Remove from liked</div>
+<div style="display:flex;align-items:center;height:38px;padding:0 16px;border-radius:9px;background:var(--btn);color:var(--btnFg);font-size:13px;font-weight:600;cursor:pointer" style-hover="background:var(--btn)">Open course page</div>
+</div>
+</sc-if>
+</div>
+</div>
+</div>
+</div>
+</div>
+</sc-if>
+
+<sc-if value="{{ isSettings }}" hint-placeholder-val="{{ false }}">
+<div style="flex:1;padding:22px 0 0;display:flex;flex-direction:column;gap:14px">
+<div style="border:1px solid var(--rule);border-radius:12px;background:var(--surface);padding:16px 17px 15px">
+<div style="font-size:10.5px;font-weight:600;letter-spacing:.09em;text-transform:uppercase;color:var(--dim)">What others see</div>
+<div style="margin-top:10px;display:flex;flex-direction:column;gap:10px">
+<div style="display:flex;gap:9px"><svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="#1751a6" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" style="flex:none;margin-top:2px"><path d="M20 6 9 17l-5-5"></path></svg><div style="font-size:12.5px;line-height:1.5;color:var(--ink2)">Your reviews, under {{ shownAs }}.</div></div>
+<div style="display:flex;gap:9px"><svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="#6b6355" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" style="flex:none;margin-top:2px"><path d="M5 12h14"></path></svg><div style="font-size:12.5px;line-height:1.5;color:var(--ink2)">Never your grades, your average or your course list.</div></div>
+</div>
+</div>
+
+
+<div style="border:1px solid var(--rule);border-radius:12px;background:var(--surface);overflow:hidden">
+<div style="padding:16px 18px 14px;border-bottom:1px solid #f2efe6">
+<div style="font-size:15.5px;font-weight:600">GPA and grades</div>
+<div style="margin-top:5px;font-size:13px;line-height:1.5;color:var(--muted)">Grades are private to you in every case. These two switches decide whether they are stored at all, and whether an average is worked out from them.</div>
+</div>
+<div onClick="{{ onToggleStore }}" style="display:flex;align-items:flex-start;gap:13px;padding:16px 18px;border-bottom:1px solid #f4f2ea;cursor:pointer" style-hover="background:var(--pg)">
+<div style="flex:none;width:42px;height:24px;border-radius:99px;background:{{ storeTrack }};padding:3px;display:flex;justify-content:{{ storeJustify }};transition:background .16s ease-out"><div style="width:18px;height:18px;border-radius:50%;background:var(--surface);box-shadow:0 1px 2px rgba(20,30,45,.28)"></div></div>
+<div style="flex:1;min-width:0">
+<div style="font-size:14px;font-weight:600">Store grades from my transcript</div>
+<div style="margin-top:4px;font-size:12.5px;line-height:1.5;color:var(--muted)">{{ storeHint }}</div>
+</div>
+</div>
+<div onClick="{{ onToggleAvg }}" style="display:flex;align-items:flex-start;gap:13px;padding:16px 18px;cursor:{{ avgCursor }};opacity:{{ avgOpacity }}" style-hover="background:var(--pg)">
+<div style="flex:none;width:42px;height:24px;border-radius:99px;background:{{ avgTrack }};padding:3px;display:flex;justify-content:{{ avgJustify }};transition:background .16s ease-out"><div style="width:18px;height:18px;border-radius:50%;background:var(--surface);box-shadow:0 1px 2px rgba(20,30,45,.28)"></div></div>
+<div style="flex:1;min-width:0">
+<div style="font-size:14px;font-weight:600">Calculate my average</div>
+<div style="margin-top:4px;font-size:12.5px;line-height:1.5;color:var(--muted)">{{ avgHint }}</div>
+</div>
+<sc-if value="{{ showAvg }}" hint-placeholder-val="{{ true }}">
+<div style="flex:none;font-size:19px;font-weight:600;color:var(--brand);font-variant-numeric:tabular-nums">{{ avgLabel }}</div>
+</sc-if>
+</div>
+</div>
+
+
+<div style="border:1px solid var(--rule);border-radius:12px;background:var(--surface);padding:16px 18px;display:flex;align-items:center;justify-content:space-between;gap:16px">
+<div style="min-width:0">
+<div style="font-size:14px;font-weight:600">Delete my account</div>
+<div style="margin-top:4px;font-size:12.5px;line-height:1.5;color:var(--muted)">Removes your course list, grades and drafts. Published reviews stay up, unsigned.</div>
+</div>
+<div style="flex:none;display:flex;align-items:center;height:38px;padding:0 14px;border-radius:9px;border:1px solid #e0cdc4;background:var(--surface);font-size:13px;font-weight:500;color:#c96a4a;cursor:pointer" style-hover="background:#fdf3ef">Delete account</div>
+</div>
+
+<div style="margin-top:8px;padding-top:16px;border-top:1px solid var(--rule)">
+<div style="display:flex;align-items:baseline;gap:8px;font-size:11px;font-weight:600;letter-spacing:.09em;text-transform:uppercase;color:var(--dim2)">Who runs this service</div>
+<div style="margin-top:8px;font-size:12.5px;line-height:1.6;color:var(--dim2);max-width:640px;text-wrap:pretty">Course Community is built and run by KTH AI Society, a student organisation. It is not an official KTH service. Credits, grades and averages are your own entries from a transcript you uploaded — for the official record, use Ladok. Reviews are the opinions of individual students, and courses change between rounds.</div>
+<div style="margin-top:10px;display:flex;flex-wrap:wrap;gap:16px;font-size:12.5px;font-weight:500">
+<a href="#terms">Terms of use</a>
+<a href="#privacy">What we store about you</a>
+<a href="#contact">Contact KTH AI Society</a>
+</div>
+</div>
+</div>
+</sc-if>
+
+<sc-if value="{{ isDot }}" hint-placeholder-val="{{ false }}">
+<div style="flex:1;padding:22px 0 0;display:flex;flex-direction:column;gap:14px">
+
+<div style="border:1px solid var(--rule);border-radius:12px;background:var(--surface);padding:16px 17px 15px">
+<div style="font-size:15.5px;font-weight:600">Your node on the landing page</div>
+<div style="margin-top:5px;font-size:13px;line-height:1.5;color:var(--muted)">Review courses to unlock how your dot looks in the network. Go quiet for a while and it settles back to default.</div>
+</div>
+
+<div style="border:1px solid var(--rule);border-radius:12px;background:var(--surface);overflow:hidden">
+<sc-for list="{{ dotTiers }}" as="tier" hint-placeholder-count="3">
+<div style="padding:16px 18px;border-bottom:{{ tier.divider }}">
+<div style="display:flex;align-items:flex-start;justify-content:space-between;gap:12px">
+<div style="display:flex;align-items:flex-start;gap:10px">
+<sc-if value="{{ tier.locked }}" hint-placeholder-val="{{ true }}">
+<svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="var(--dim2)" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round" style="flex:none;margin-top:2px"><rect x="4" y="10.5" width="16" height="10.5" rx="2.5"></rect><path d="M8 10.5V7.5a4 4 0 0 1 8 0v3"></path></svg>
+</sc-if>
+<div>
+<div style="font-size:14.5px;font-weight:600;color:{{ tier.titleColor }}">{{ tier.title }}</div>
+<div style="margin-top:4px;font-size:12.5px;line-height:1.5;color:var(--muted)">{{ tier.hint }}</div>
+</div>
+</div>
+<span style="flex:none;padding:3px 9px;border-radius:999px;background:{{ tier.badgeBg }};color:{{ tier.badgeFg }};font-size:11px;font-weight:600;white-space:nowrap">{{ tier.badgeLabel }}</span>
+</div>
+<sc-if value="{{ tier.unlocked }}" hint-placeholder-val="{{ false }}">
+<div style="margin-top:12px;margin-left:25px;display:flex;flex-wrap:wrap;gap:8px">
+<sc-for list="{{ tier.options }}" as="o" hint-placeholder-count="3">
+<div onClick="{{ o.onClick }}" role="button" tabIndex="0" style="display:flex;align-items:center;gap:8px;height:36px;padding:0 13px;border-radius:9px;border:1px solid {{ o.border }};background:{{ o.bg }};color:{{ o.fg }};font-size:13px;font-weight:{{ o.weight }};cursor:pointer;text-transform:capitalize" style-hover="border-color:var(--brand)">{{ o.swatch }}{{ o.label }}</div>
+</sc-for>
+</div>
+</sc-if>
+<sc-if value="{{ tier.lockedNote }}" hint-placeholder-val="{{ false }}">
+<div style="margin-top:6px;margin-left:25px;font-size:12.5px;color:var(--dim)">{{ tier.lockedNote }}</div>
+</sc-if>
+</div>
+</sc-for>
+</div>
+
+</div>
+</sc-if>
+
+<div style="padding:22px 0 26px;display:flex;align-items:center;gap:8px;font-size:11.5px;color:var(--dim2)">
+<svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="#8a857a" stroke-width="1.9" stroke-linecap="round" stroke-linejoin="round" style="flex:none"><circle cx="12" cy="12" r="10"></circle><path d="M12 16v-5"></path><path d="M12 8h.01"></path></svg>
+Course Community is run by KTH AI Society, a student organisation. Credits, grades and any average shown here are your own entries — not an official KTH record.
+</div>
+
+</div>
+
+</div>
+
+</div>
+
+<sc-if value="{{ hasToast }}" hint-placeholder-val="{{ false }}">
+<div style="position:fixed;left:50%;bottom:26px;transform:translateX(-50%);z-index:80;display:flex;align-items:center;gap:14px;padding:11px 14px;border-radius:10px;background:#16202b;color:#fff;box-shadow:0 10px 30px rgba(20,30,45,.28);animation:rise .18s ease-out">
+<div style="font-size:13px">{{ toastText }}</div>
+<sc-if value="{{ canUndo }}" hint-placeholder-val="{{ false }}">
+<div onClick="{{ onUndo }}" style="font-size:13px;font-weight:600;color:#9dbfe4;cursor:pointer" style-hover="text-decoration:underline">Undo</div>
+</sc-if>
+<sc-if value="{{ noUndo }}" hint-placeholder-val="{{ true }}">
+<div onClick="{{ onDismissToast }}" style="font-size:13px;font-weight:600;color:#9dbfe4;cursor:pointer" style-hover="text-decoration:underline">Dismiss</div>
+</sc-if>
+</div>
+</sc-if>
+
+<sc-if value="{{ confirmOpen }}" hint-placeholder-val="{{ false }}">
+<div onClick="{{ onCancelConfirm }}" style="position:fixed;inset:0;z-index:70;display:flex;align-items:center;justify-content:center;padding:28px;background:rgba(20,30,45,.34)">
+<div onClick="{{ stopClick }}" style="width:440px;border-radius:14px;background:var(--surface);box-shadow:0 18px 48px rgba(20,30,45,.24);padding:22px;animation:rise .18s ease-out">
+<div style="font-size:11px;font-weight:600;letter-spacing:.06em;text-transform:uppercase;color:var(--brand)">{{ confirmEyebrow }}</div>
+<div style="margin-top:8px;font-size:19px;font-weight:600;line-height:1.3">{{ confirmTitle }}</div>
+<div style="margin-top:9px;font-size:13.5px;line-height:1.55;color:var(--muted)">{{ confirmBody }}</div>
+<div style="margin-top:18px;display:flex;justify-content:flex-end;gap:9px">
+<div onClick="{{ onCancelConfirm }}" style="display:flex;align-items:center;height:38px;padding:0 14px;border-radius:9px;border:1px solid var(--rule3);background:var(--surface);font-size:13px;font-weight:500;color:var(--chipInk);cursor:pointer" style-hover="border-color:var(--hov)">{{ confirmCancelLabel }}</div>
+<div onClick="{{ onConfirmDelete }}" style="display:flex;align-items:center;height:38px;padding:0 16px;border-radius:9px;background:#c96a4a;color:#fff;font-size:13px;font-weight:600;cursor:pointer" style-hover="background:#b25b3d">{{ confirmActionLabel }}</div>
+</div>
+</div>
+</div>
+</sc-if>
+
+</div>
+
+</x-dc>
+<script type="text/x-dc" data-dc-script data-props="{&quot;$preview&quot;:{&quot;width&quot;:1440,&quot;height&quot;:900},&quot;session&quot;:{&quot;editor&quot;:&quot;enum&quot;,&quot;default&quot;:&quot;member&quot;,&quot;options&quot;:[&quot;guest&quot;,&quot;member&quot;],&quot;tsType&quot;:&quot;\&quot;guest\&quot; | \&quot;member\&quot;&quot;,&quot;section&quot;:&quot;Session&quot;},&quot;scenario&quot;:{&quot;editor&quot;:&quot;enum&quot;,&quot;default&quot;:&quot;populated&quot;,&quot;options&quot;:[&quot;populated&quot;,&quot;empty&quot;,&quot;loading&quot;,&quot;error&quot;,&quot;edge-case&quot;],&quot;tsType&quot;:&quot;string&quot;,&quot;section&quot;:&quot;Prototype state&quot;},&quot;view&quot;:{&quot;editor&quot;:&quot;enum&quot;,&quot;default&quot;:&quot;overview&quot;,&quot;options&quot;:[&quot;overview&quot;,&quot;reviews&quot;,&quot;liked&quot;,&quot;settings&quot;,&quot;review-detail&quot;],&quot;tsType&quot;:&quot;string&quot;,&quot;section&quot;:&quot;Prototype state&quot;},&quot;reviewState&quot;:{&quot;editor&quot;:&quot;enum&quot;,&quot;default&quot;:&quot;idle&quot;,&quot;options&quot;:[&quot;idle&quot;,&quot;editing&quot;,&quot;saving&quot;,&quot;saved&quot;,&quot;failed&quot;],&quot;tsType&quot;:&quot;string&quot;,&quot;section&quot;:&quot;Prototype state&quot;},&quot;dotTier&quot;:{&quot;editor&quot;:&quot;enum&quot;,&quot;default&quot;:&quot;account&quot;,&quot;options&quot;:[&quot;account&quot;,&quot;0&quot;,&quot;1&quot;,&quot;2&quot;,&quot;3&quot;],&quot;tsType&quot;:&quot;string&quot;,&quot;section&quot;:&quot;Prototype state&quot;},&quot;locale&quot;:{&quot;editor&quot;:&quot;enum&quot;,&quot;default&quot;:&quot;en&quot;,&quot;options&quot;:[&quot;en&quot;,&quot;sv&quot;],&quot;tsType&quot;:&quot;\&quot;en\&quot; | \&quot;sv\&quot;&quot;,&quot;section&quot;:&quot;Prototype state&quot;}}">
+/* This page keeps no course or review facts of its own. Everything is derived
+   from the shared store through selectors. */
+let STORE = null;
+const ME = "u1";
+const VIEWS = ["overview", "reviews", "dot", "settings"];
+
+const rv = (r, locale) => STORE.reviewView(r, { locale, userId: ME });
+const myReviews = (locale) => STORE.reviewsByUser(ME).map((r) => rv(r, locale));
+const otherReviews = (locale) => STORE.reviews.filter((r) => r.userId !== ME).map((r) => rv(r, locale));
+
+class Component extends DCLogic {
+  /* Theme choice is shared across the pages through one storage key. */
+  ccDark() {
+    if (this.state.ccNight !== undefined) return this.state.ccNight === true;
+    try { return window.localStorage.getItem("cc:theme") === "dark"; } catch (e) { return false; }
+  }
+
+  ccSetDark(next) {
+    document.documentElement.setAttribute("data-cc-theme", next ? "dark" : "light");
+    try { window.localStorage.setItem("cc:theme", next ? "dark" : "light"); } catch (e) { /* storage off */ }
+    this.setState({ ccNight: next });
+  }
+
+  ccApplyTheme() {
+    document.documentElement.setAttribute("data-cc-theme", this.ccDark() ? "dark" : "light");
+  }
+
+  /** Published by Explore and Saved, which own the list; this page only shows it. */
+  savedCount() {
+    try {
+      const n = parseInt(window.localStorage.getItem("cc:savedBadge"), 10);
+      return isNaN(n) ? 0 : n;
+    } catch (e) { return 0; }
+  }
+
+  state = {
+    signedIn: false,
+    view: "overview",
+    open: null,
+    avg: true,
+    confirm: null,
+    liked: [],
+    toast: null,
+    // Scenario-driven data conditions. Never mixed into the session.
+    empty: false,
+    loading: false,
+    error: false,
+    reviewPhase: "idle"
+  };
+
+  /* Shared axes: session (guest | member) and scenario (populated | empty |
+     loading | error | edge-case). Which tab is open is navigation, so it is a
+     page substate (`view`), not part of the site-wide scenario. */
+  harnessKey() {
+    return [this.props.session, this.props.scenario, this.props.view, this.props.reviewState, this.props.dotTier].join("|");
+  }
+
+  pose() {
+    const h = STORE.resolveHarness(this.props);
+    const want = this.props.view;
+    const base = {
+      signedIn: h.isMember,
+      view: VIEWS.indexOf(want) >= 0 ? want : "overview",
+      open: null, confirm: null, toast: null,
+      liked: STORE.likedReviewIds(ME),
+      empty: false, loading: false, error: false,
+      reviewPhase: this.props.reviewState || "idle"
+    };
+    if (h.isGuest) return { ...base, signedIn: false };
+    if (h.isLoading) return { ...base, loading: true };
+    if (h.isError) return { ...base, error: true };
+    if (h.isEmpty) return { ...base, empty: true, liked: [] };
+    if (h.isEdgeCase) {
+      // A review where the student did not remember the examination split:
+      // examinationDistribution and approachTheoryPercent are both null.
+      const sparse = STORE.reviewsByUser(ME).find((r) => r.examinationDistribution == null);
+      return { ...base, view: "reviews", open: sparse ? { from: "mine", id: sparse.id } : null };
+    }
+    if (want === "review-detail") {
+      const first = STORE.reviewsByUser(ME)[0];
+      return { ...base, view: "reviews", open: first ? { from: "mine", id: first.id } : null };
+    }
+    return base;
+  }
+
+  componentDidMount() {
+    this.ccApplyTheme();
+    import("./cc-store.js").then((mod) => {
+      STORE = mod;
+      this.seenHarness = this.harnessKey();
+      this.setState(this.pose());
+    });
+  }
+
+  componentDidUpdate() {
+    if (!STORE) return;
+    if (this.harnessKey() !== this.seenHarness) {
+      this.seenHarness = this.harnessKey();
+      this.setState(this.pose());
+    }
+  }
+
+  meta(r) {
+    return r.startTerm + " · published " + r.createdAtLabel;
+  }
+
+  detailFor(open) {
+    const raw = STORE.reviews.find((x) => x.id === open.id);
+    return raw ? rv(raw, this.props.locale === "sv" ? "sv" : "en") : null;
+  }
+
+  listRow(r, from) {
+    const happy = r.happyTook;
+    return {
+      id: r.id, code: r.courseCode, name: r.name, term: r.startTerm,
+      date: r.createdAtLabel, likes: r.helpfulCount, author: r.author,
+      message: r.message, workloadScore: r.workloadScore, happyTook: happy,
+      excerpt: r.message.length > 108 ? r.message.slice(0, 105).replace(/[,;\s]+$/, "") + "…" : r.message,
+      happyLabel: happy === true ? "Happy I took it" : happy === false ? "Not really" : "Not answered",
+      happyFg: happy === true ? "#1c6b60" : happy === false ? "#8a6a1e" : "#8a857a",
+      happyDot: happy === true ? "#2f9e8e" : happy === false ? "#dfa53c" : "#cfc9b8",
+      onOpen: () => this.setState({ open: { from, id: r.id } }),
+      onUnlike: from === "liked" ? (e) => { e.stopPropagation(); this.unlike(r.id); } : null
+    };
+  }
+
+  unlike(id) {
+    const before = this.state.liked;
+    const r = this.detailFor({ id });
+    const next = before.filter((i) => i !== id);
+    STORE.setLikedReviewIds(ME, next);
+    this.setState({
+      liked: next,
+      open: null,
+      toast: { text: "Removed " + (r ? r.courseCode : "review") + " from liked reviews", undo: before }
+    });
+  }
+
+  renderVals() {
+    const importedAt = STORE
+      ? (STORE.takenCourses("u1").map((r) => r.transcriptImportedAt).filter(Boolean).sort().slice(-1)[0] || null)
+      : null;
+    const lastRead = importedAt && STORE ? STORE.formatDate(importedAt) : null;
+    const s = this.state;
+    const locale = this.props.locale === "sv" ? "sv" : "en";
+    if (!STORE) return { isGuest: false, isMember: false, paneTop: "66px", isLoading: true };
+
+    const mineAll = s.empty ? [] : myReviews(locale);
+    const othersAll = s.empty ? [] : otherReviews(locale);
+    const mine = mineAll.map((r) => this.listRow(r, "mine"));
+    const liked = othersAll.filter((r) => s.liked.indexOf(r.id) >= 0).map((r) => this.listRow(r, "liked"));
+    const totalLikes = mineAll.reduce((acc, r) => acc + r.helpfulCount, 0);
+
+    const taken = s.empty ? [] : STORE.takenCourses(ME);
+    // No separate "are grades stored" flag — it's just whether any row has one.
+    const hasStoredGrades = taken.some((t) => t.grade != null);
+    const credits = taken.reduce((acc, t) => acc + (t.earnedCredits || 0), 0);
+    const years = taken.map((t) => t.attendanceYear).filter(Boolean).sort();
+    const gpa = STORE.gpaFor(ME);
+    const average = gpa.average;
+
+    const reviewedCodes = mineAll.map((r) => r.courseCode);
+    const unreviewed = taken
+      .filter((t) => t.courseCode && reviewedCodes.indexOf(t.courseCode) < 0)
+      .map((t) => {
+        const v = STORE.takenView(t, { locale });
+        return { code: t.courseCode, name: v.name };
+      });
+
+    const open = s.open;
+    const d = open ? this.detailFor(open) : null;
+    const busy = s.loading || s.error;
+    const avgAllowed = hasStoredGrades && s.avg && average != null;
+    const segments = d ? STORE.examinationSegments(d.examination, locale) : [];
+
+    const tabDefs = [
+      ["Overview", "", "overview"],
+      ["Reviews", String(mine.length + liked.length), "reviews"],
+      ["My dot", "", "dot"],
+      ["Settings", "", "settings"]
+    ];
+
+    return {
+      night: this.ccDark(),
+      notNight: !this.ccDark(),
+      themeTitle: this.ccDark() ? "Switch to light mode" : "Switch to dark mode",
+      onTheme: () => this.ccSetDark(!this.ccDark()),
+      paneTop: "66px",
+      handleLine: "reviews signed " + (STORE.userName(ME) || "your account name"),
+      // `users` carries a required name and no programme, year or anonymity flag.
+      profileLine: "At KTH since " + (years.length ? STORE.termLabel(years[0]) : "—")
+        + " · reviews signed " + (STORE.userName(ME) || "your account name"),
+      shownAs: STORE.userName(ME) || "your account name",
+
+      tabs: tabDefs.map(([label, count, key]) => {
+        const active = s.view === key;
+        const on = active && !open;
+        return {
+          label, count,
+          line: active ? "#1751a6" : "transparent",
+          fg: active ? "var(--ink)" : "var(--dim)",
+          weight: active ? "600" : "500",
+          pillBg: count === "" ? "transparent" : on ? "var(--pill)" : "var(--pill)",
+          pillFg: count === "" ? "transparent" : active ? "#12417f" : "#6b6355",
+          onClick: () => this.setState({ view: key, open: null })
+        };
+      }),
+
+      signedIn: s.signedIn,
+      signedOut: !s.signedIn,
+      isMember: s.signedIn,
+      isGuest: !s.signedIn,
+      pageMaxWidth: STORE.PAGE_MAX_WIDTH,
+      pageSidePadding: STORE.PAGE_SIDE_PADDING,
+      onLogIn: () => this.setState({ signedIn: true }),
+      onSignUp: () => this.setState({ signedIn: true }),
+      hasSavedCount: this.savedCount() > 0,
+      savedCountLabel: String(this.savedCount()),
+      onSignIn: () => this.setState({ signedIn: true }),
+      onSignOut: () => this.setState({ signedIn: false, open: null, toast: null }),
+
+      isLoading: s.signedIn && s.loading,
+      isError: s.signedIn && s.error,
+      isOverview: s.signedIn && !busy && s.view === "overview" && !open,
+      isMine: s.signedIn && !busy && s.view === "reviews" && !open,
+      isLiked: s.signedIn && !busy && s.view === "reviews" && !open,
+      isSettings: s.signedIn && !busy && s.view === "settings" && !open,
+      isDot: s.signedIn && !busy && s.view === "dot" && !open,
+      dotTiers: (() => {
+        const forced = this.props.dotTier != null && this.props.dotTier !== "account" ? parseInt(this.props.dotTier, 10) : null;
+        const realAx = STORE.tierAxes(ME);
+        const ax = forced == null ? realAx : { unlocked: [1,2,3].filter((n) => n <= forced).map((n) => STORE.TIER_AXES[n]), dormant: [] };
+        const picks = STORE.personalizationPicks(ME);
+        const pick = (axis, v) => { STORE.setPersonalization(ME, { [axis]: v }); this.forceUpdate(); };
+        const OPTS = { color: STORE.DOT_COLORS, style: STORE.DOT_STYLES, signalStyle: STORE.DOT_SIGNALS };
+        const mk = (n, title, hint, lockedNote, axis) => {
+          const unlocked = ax.unlocked.indexOf(axis) >= 0;
+          const dormant = ax.dormant.indexOf(axis) >= 0;
+          const options = OPTS[axis];
+          const current = picks[axis] || options[0];
+          const brighten = (hex) => {
+            const n2 = parseInt(hex.slice(1), 16);
+            const r = (n2 >> 16) & 255, g = (n2 >> 8) & 255, b = n2 & 255;
+            const mix = (c) => Math.round(c + (255 - c) * 0.82);
+            return "rgb(" + mix(r) + "," + mix(g) + "," + mix(b) + ")";
+          };
+          return {
+            title: unlocked ? title : "Unknown", hint, unlocked, locked: !unlocked,
+            titleColor: unlocked ? "var(--ink)" : "var(--dim)",
+            lockedNote: "",
+            badgeLabel: unlocked ? "Unlocked" : dormant ? "Dormant" : "Locked",
+            badgeBg: unlocked ? "var(--pill)" : "var(--pg)",
+            badgeFg: unlocked ? "var(--brand)" : "var(--dim)",
+            options: unlocked ? options.map((opt) => {
+              const on = opt === current;
+              const isDefaultBlue = axis === "color" && opt === options[0];
+              const brightBg = axis === "color" && !isDefaultBlue ? brighten(opt) : "var(--pill)";
+              return {
+                label: opt, weight: on ? "600" : "500",
+                border: on ? "var(--brand)" : "var(--rule3)",
+                bg: on ? brightBg : "var(--surface)",
+                fg: on ? "var(--brand)" : "var(--ink)",
+                swatch: n === 1 ? React.createElement("span", { style: { width: 13, height: 13, borderRadius: "50%", background: opt, flex: "none" } }) : null,
+                onClick: () => pick(axis, opt)
+              };
+            }) : []
+          };
+        };
+        const list = [
+          mk(1, "Dot color", "Unlocks once you have written 5 reviews.", "Write 5 reviews to unlock a color for your dot.", "color"),
+          mk(2, "Dot style", "Unlocks once your uploaded transcript is fully reviewed.", "Upload your transcript and review everything in it to unlock a style.", "style"),
+          mk(3, "Signal on click", "Unlocks once you have referred friends to Course Community.", "Refer friends to unlock a signal that goes out from your node.", "signalStyle")
+        ];
+        return list.map((t, i) => ({ ...t, divider: i < list.length - 1 ? "1px solid #f2efe6" : "none" }));
+      })(),
+      isDetail: s.signedIn && !busy && Boolean(open) && Boolean(d),
+      onRetry: () => this.setState(this.pose()),
+      errorTitle: "Your page did not load",
+      errorBody: "The request for your courses and reviews timed out. Nothing is lost — this is a read, so nothing of yours was changed.",
+      skeletonRows: [1, 2, 3, 4, 5].map((n) => ({ w: (92 - n * 7) + "%" })),
+
+      courseCount: taken.length,
+      // The date the transcript was last read, from user_taken_courses.transcript_imported_at.
+      courseNote: taken.length ? "read from your transcript " + (lastRead || "") : "no transcript imported yet",
+      credits: credits.toFixed(1),
+      creditRange: years.length
+        ? STORE.termLabel(years[0]) + " – " + STORE.termLabel(years[years.length - 1])
+        : "—",
+      mineCount: mine.length,
+      likesNote: totalLikes + " students found them helpful",
+      hasMine: mine.length > 0,
+      noMine: mine.length === 0,
+      hasLiked: liked.length > 0,
+      noLiked: liked.length === 0,
+      mine,
+      liked,
+
+
+      showAvg: avgAllowed,
+      avgLabel: average == null ? "—" : average.toFixed(1),
+      avgCardValue: avgAllowed ? average.toFixed(1) : "—",
+      avgCardInk: avgAllowed ? "#12417f" : "#b0a99a",
+      avgCardBg: avgAllowed ? "var(--pill)" : "var(--surface)",
+      avgCardBorder: avgAllowed ? "#dde7f4" : "var(--rule)",
+      avgCardNote: !hasStoredGrades
+        ? "no grades stored"
+        : avgAllowed ? "credit-weighted, A–F only · yours alone" : "not calculated",
+
+      onToggleAvg: () => { if (hasStoredGrades) this.setState({ avg: !s.avg }); },
+      avgTrack: hasStoredGrades && s.avg ? "#1751a6" : "#cfc9b8",
+      avgJustify: hasStoredGrades && s.avg ? "flex-end" : "flex-start",
+      avgCursor: hasStoredGrades ? "pointer" : "not-allowed",
+      avgOpacity: hasStoredGrades ? "1" : "0.55",
+      avgHint: hasStoredGrades
+        ? "A credit-weighted average over your A–F courses, shown on My Page. Pass/fail courses are left out."
+        : "Unavailable while no grades are stored.",
+
+      onToggleStore: () => {
+        if (hasStoredGrades) this.setState({ confirm: "grades" });
+        else this.setState({ toast: { text: "Grade storage switched on — upload your transcript to fill the grades in", undo: null } });
+      },
+      storeTrack: hasStoredGrades ? "#1751a6" : "#cfc9b8",
+      storeJustify: hasStoredGrades ? "flex-end" : "flex-start",
+      storeHint: hasStoredGrades
+        ? "Grades read from your transcript are kept with your course list. Only you ever see them."
+        : "Grade columns are skipped when a transcript is read, and nothing is kept. Credits, names and terms are unaffected.",
+
+      confirmOpen: Boolean(s.confirm),
+      confirmEyebrow: s.confirm === "review" ? "Reviews" : "Grades",
+      confirmTitle: s.confirm === "review" ? "Delete this review?" : "Delete the grades already stored?",
+      confirmBody: s.confirm === "review"
+        ? "This removes your review — scores, workload split and write-up — from the course. It stops counting toward that course's review total right away."
+        : "Turning this off removes every grade read from your transcript, and your average with it. Course names, credits and terms stay. To get grades back you upload the transcript again with grade reading switched on.",
+      confirmCancelLabel: s.confirm === "review" ? "Keep review" : "Keep my grades",
+      confirmActionLabel: s.confirm === "review" ? "Delete review" : "Delete grades",
+      onCancelConfirm: () => this.setState({ confirm: null }),
+      onConfirmDelete: () => {
+        if (s.confirm === "review") {
+          const id = open && open.id;
+          const i = STORE.reviews.findIndex((r) => r.id === id);
+          if (i >= 0) STORE.reviews.splice(i, 1);
+          this.setState({ confirm: null, open: null, toast: { text: "Review deleted", undo: null } });
+          return;
+        }
+        // Clearing storage means clearing the real column on every taken row —
+        // not a local flag — so it actually leaves once the user confirms.
+        taken.forEach((row) => { if (row.grade != null) STORE.setTakenOverride(ME, row.courseCode, { grade: null }); });
+        this.setState({
+          confirm: null, avg: false,
+          toast: { text: "Grades deleted from your account", undo: null }
+        });
+      },
+      stopClick: (e) => e.stopPropagation(),
+
+
+      unreviewedLine: unreviewed.length
+        ? unreviewed.length + (unreviewed.length === 1 ? " completed course has" : " completed courses have")
+          + " no review yet. Each one is a card in the quick reviewer."
+        : "Every completed course in your list has a review.",
+      unreviewedCourses: unreviewed.map((u) => {
+        const card = STORE.catalogCardView(u.code, { locale: locale });
+        return {
+          code: u.code,
+          name: card ? card.title : u.name,
+          meta: card ? card.meta : u.code,
+          onClick: () => { window.location.href = "Course Community - Taken Courses.dc.html?review=1"; }
+        };
+      }),
+      takenTotal: taken.length,
+
+      backLabel: open && open.from === "mine" ? "Back to my reviews" : "Back to liked reviews",
+      onCloseDetail: () => this.setState({ open: null }),
+      detailIsMine: Boolean(open) && open.from === "mine",
+      detailIsLiked: Boolean(open) && open.from === "liked",
+      detail: d ? {
+        code: d.courseCode, name: d.name, likes: d.helpfulCount,
+        meta: open.from === "mine"
+          ? this.meta(d)
+          : d.startTerm + " · " + d.author + " · " + d.createdAtLabel,
+        examSplit: segments.length ? segments.map((x) => x.percent + "%").join(" / ") : "Not recorded",
+        theoryLabel: d.theoryPercent == null ? "Not recorded" : d.theoryPercent + " / " + (100 - d.theoryPercent),
+        theoryW1: d.theoryPercent == null ? "0%" : d.theoryPercent + "%",
+        theoryW2: d.theoryPercent == null ? "0%" : (100 - d.theoryPercent) + "%",
+        happyHeadline: d.happyTook === true
+          ? "Happy to have taken it"
+          : d.happyTook === false ? "Would not take it again" : "Did not answer whether it was worth it",
+        happyFg: d.happyTook === true ? "#1c6b60" : d.happyTook === false ? "#8a6a1e" : "#6b6355",
+        happyDot: d.happyTook === true ? "#2f9e8e" : d.happyTook === false ? "#dfa53c" : "#cfc9b8",
+        text: d.message,
+        footNote: open.from === "mine"
+          ? "Published " + d.createdAtLabel + " as " + (STORE.userName(ME) || "your account name")
+          : "Written by " + d.author
+      } : {},
+      detailHasExam: Boolean(d) && segments.length > 0,
+      detailNoExam: Boolean(d) && segments.length === 0,
+      detailHasTheory: Boolean(d) && d.theoryPercent != null,
+      detailNoTheory: Boolean(d) && d.theoryPercent == null,
+      // Not-remembered answers stay null; nothing is drawn as a zero.
+      detailUnknownNote: "The student chose “I don’t remember” — nothing is estimated in its place.",
+      detailExam: segments.map((x) => ({
+        label: x.percent >= 18 ? x.label + " " + x.percent + "%" : x.percent + "%",
+        width: x.percent + "%", color: x.color, ink: x.ink
+      })),
+      detailMeters: d ? [
+        { label: "How demanding it was", value: d.workloadScore + " / 10",
+          width: d.workloadScore * 10 + "%", lo: "Not at all", hi: "Very" },
+        { label: "How much was learned", value: d.learningScore + " / 10",
+          width: d.learningScore * 10 + "%", lo: "Nothing new", hi: "Transformative" }
+      ] : [],
+      onAskDeleteReview: () => this.setState({ confirm: "review" }),
+      onUnlikeDetail: () => { if (d) this.unlike(d.id); },
+
+      onGoSettings: () => this.setState({ view: "settings", open: null }),
+      onGoTranscript: () => { window.location.href = "Course Community - Taken Courses.dc.html"; },
+      // The reviewer is offered here, so it opens from here.
+      onStartReviewer: () => { window.location.href = "Course Community - Taken Courses.dc.html?review=1"; },
+
+      hasToast: Boolean(s.toast),
+      toastText: s.toast ? s.toast.text : "",
+      canUndo: Boolean(s.toast && s.toast.undo),
+      noUndo: Boolean(s.toast) && !(s.toast && s.toast.undo),
+      onDismissToast: () => this.setState({ toast: null }),
+      onUndo: () => {
+        const restored = s.toast && s.toast.undo ? s.toast.undo : s.liked;
+        STORE.setLikedReviewIds(ME, restored);
+        this.setState({ liked: restored, toast: null });
+      }
+    };
+  }
+}
+
+</script>
+</body>
+</html>

--- a/docs/design/Course Community - Page Header.dc.html
+++ b/docs/design/Course Community - Page Header.dc.html
@@ -1,0 +1,33 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<script src="./support.js"></script>
+</head>
+<body>
+<x-dc>
+<div style="padding:26px 28px 0">
+<h1 style="margin:0;font-size:26px;font-weight:600;letter-spacing:-.02em">{{ title }}</h1>
+<sc-if value="{{ hasSubtitle }}" hint-placeholder-val="{{ true }}">
+<div style="margin-top:6px;font-size:13.5px;line-height:1.5;color:var(--muted)">{{ subtitle }}</div>
+</sc-if>
+</div>
+
+</x-dc>
+<script type="text/x-dc" data-dc-script data-props="{&quot;$preview&quot;:{&quot;width&quot;:700,&quot;height&quot;:90},&quot;title&quot;:{&quot;editor&quot;:&quot;text&quot;,&quot;default&quot;:&quot;Page title&quot;,&quot;tsType&quot;:&quot;string&quot;},&quot;subtitle&quot;:{&quot;editor&quot;:&quot;text&quot;,&quot;default&quot;:&quot;Supporting description line.&quot;,&quot;tsType&quot;:&quot;string&quot;}}">
+/* The one page-title block every page uses — same padding, size, and spacing
+   everywhere, so no page hand-writes its own header markup. */
+class Component extends DCLogic {
+  renderVals() {
+    return {
+      title: this.props.title || "",
+      subtitle: this.props.subtitle || "",
+      hasSubtitle: Boolean(this.props.subtitle)
+    };
+  }
+}
+
+</script>
+</body>
+</html>

--- a/docs/design/Course Community - Review Card.dc.html
+++ b/docs/design/Course Community - Review Card.dc.html
@@ -1,0 +1,79 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<script src="./support.js"></script>
+</head>
+<body>
+<x-dc>
+<div onClick="{{ r.onOpen }}" style="border:1px solid var(--rule);border-left:3px solid {{ r.accent }};border-radius:12px;background:var(--surface);padding:16px 16px 12px;cursor:pointer" style-hover="border-color:var(--hov)">
+<div style="display:flex;align-items:center;gap:5px;font-size:11px;font-weight:600;color:{{ r.happyFg }}"><svg width="11" height="11" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.6" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="9.5"></circle><sc-if value="{{ r.isHappy }}" hint-placeholder-val="{{ false }}"><path d="m8.5 12.2 2.4 2.4 4.6-5"></path></sc-if><sc-if value="{{ r.isUnhappy }}" hint-placeholder-val="{{ false }}"><path d="M8.5 8.5l7 7M15.5 8.5l-7 7"></path></sc-if><sc-if value="{{ r.isUnset }}" hint-placeholder-val="{{ true }}"><path d="M8 12h8"></path></sc-if></svg>{{ r.happyLabel }}</div>
+<div style="margin-top:9px;font-size:13.5px;line-height:1.5;color:var(--ink)">{{ r.excerpt }}</div>
+<div style="margin-top:11px;display:flex;align-items:center;justify-content:space-between;gap:10px;font-size:11.5px;color:var(--dim2)">
+<span>{{ r.code }} · {{ r.term }}</span>
+<div onClick="{{ stopClick }}" style="display:flex;align-items:center;border:1px solid var(--rule);border-radius:8px;overflow:hidden">
+<div onClick="{{ r.onUpvote }}" title="Helpful" style="display:flex;align-items:center;justify-content:center;width:24px;height:22px;cursor:pointer;color:{{ r.upColor }};transform:{{ r.upScale }};transition:transform .1s ease-out"><svg width="12" height="12" viewBox="0 0 24 24" fill="{{ r.upFill }}" stroke="currentColor" stroke-width="2.3" stroke-linecap="round" stroke-linejoin="round"><path d="M12 19V6"></path><path d="m6 11 6-6 6 6"></path></svg></div>
+<span style="min-width:20px;text-align:center;font-size:11px;font-weight:700;color:var(--ink2)">{{ r.netScore }}</span>
+<div onClick="{{ r.onDownvote }}" title="Not helpful" style="display:flex;align-items:center;justify-content:center;width:24px;height:22px;cursor:pointer;color:{{ r.downColor }};transform:{{ r.downScale }};transition:transform .1s ease-out"><svg width="12" height="12" viewBox="0 0 24 24" fill="{{ r.downFill }}" stroke="currentColor" stroke-width="2.3" stroke-linecap="round" stroke-linejoin="round"><path d="M12 5v13"></path><path d="m18 13-6 6-6-6"></path></svg></div>
+</div>
+</div>
+</div>
+
+</x-dc>
+<script type="text/x-dc" data-dc-script data-props="{&quot;$preview&quot;:{&quot;width&quot;:420,&quot;height&quot;:130},&quot;review&quot;:{&quot;editor&quot;:null,&quot;tsType&quot;:&quot;{ code, name, term, author, date, likes?, upvotes?, downvotes?, message, happyTook, workloadScore, onOpen, onUnlike? }&quot;}}">
+/* One review: a colored left edge for happy/not-happy (green/red, the same
+   solid-accent language as the course-page tabs), the message leading,
+   a compact code+term meta line, and an upvote/downvote pair on the right
+   with a net score. A review passed with onUnlike (the Liked column) starts
+   with its upvote already filled in; clicking it off calls onUnlike.
+   Reviews are anonymous, so no name is shown. */
+class Component extends DCLogic {
+  state = { upOverride: null, downOverride: null };
+
+  renderVals() {
+    const r = this.props.review || {};
+    const happy = r.happyTook;
+    const excerpt = r.message && r.message.length > 160
+      ? r.message.slice(0, 157).replace(/[,;\s]+$/, "") + "…"
+      : (r.message || "");
+    const base = r.upvotes != null ? r.upvotes - (r.downvotes || 0) : (r.likes || 0);
+    const initialUp = Boolean(r.onUnlike);
+    const up = this.state.upOverride != null ? this.state.upOverride : initialUp;
+    const down = this.state.downOverride != null ? this.state.downOverride : false;
+    const net = base + ((up ? 1 : 0) - (initialUp ? 1 : 0)) - (down ? 1 : 0);
+    return {
+      r: {
+        code: r.code, term: r.term, excerpt,
+        isHappy: happy === true, isUnhappy: happy === false, isUnset: happy == null,
+        happyLabel: happy === true ? "Happy they took it" : happy === false ? "Not really" : "Not answered",
+        happyFg: happy === true ? "#1c6b60" : happy === false ? "#a3452a" : "var(--dim)",
+        accent: happy === true ? "#2f9e8e" : happy === false ? "#dfa53c" : "var(--rule3)",
+        netScore: net,
+        upColor: up ? "var(--brand)" : "var(--dim)",
+        upFill: up ? "currentColor" : "none",
+        upScale: up ? "scale(1.2)" : "scale(1)",
+        downColor: down ? "#a3452a" : "var(--dim)",
+        downFill: down ? "currentColor" : "none",
+        downScale: down ? "scale(1.2)" : "scale(1)",
+        onUpvote: (e) => {
+          e.stopPropagation();
+          const next = !up;
+          this.setState({ upOverride: next, downOverride: next ? false : this.state.downOverride });
+          if (!next && r.onUnlike) r.onUnlike(e);
+        },
+        onDownvote: (e) => {
+          e.stopPropagation();
+          const next = !down;
+          this.setState({ downOverride: next, upOverride: next ? false : this.state.upOverride });
+        },
+        onOpen: r.onOpen || (() => {})
+      },
+      stopClick: (e) => e.stopPropagation()
+    };
+  }
+}
+
+</script>
+</body>
+</html>

--- a/docs/design/Course Community - Saved.dc.html
+++ b/docs/design/Course Community - Saved.dc.html
@@ -1,0 +1,1226 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<script src="./support.js"></script>
+</head>
+<body>
+<x-dc>
+<helmet data-dc-atomics><link rel="preconnect" href="https://fonts.googleapis.com"><link rel="preconnect" href="https://fonts.gstatic.com" crossorigin><link href="https://fonts.googleapis.com/css2?family=Geist:wght@400;500;600;700&family=Geist+Mono:wght@400;500&display=swap" rel="stylesheet"><link rel="stylesheet" href="cc-theme.css"><style>body{background:var(--pg);color:var(--ink)}body{margin:0;background:var(--pg);color:var(--ink);font-family:Geist,system-ui,sans-serif}a{color:#1751a6}a:hover{color:#10386f}.dv-turn{padding:40px 44px 32px;border-bottom:1px solid rgba(0,0,0,.08);scroll-margin-top:16px}.dv-thd{display:flex;align-items:baseline;gap:10px;margin:0 0 20px}.dv-tid{font:600 10px ui-monospace,Menlo,monospace;padding:3px 7px;background:#16202b;color:#fff;border-radius:4px;text-decoration:none}.dv-tname{font:600 13px/1.2 Geist,system-ui,sans-serif;color:var(--ink)}.dv-opts{display:flex;flex-wrap:wrap;gap:28px;align-items:flex-start}.dv-opt{flex:none;display:flex;flex-direction:column;gap:9px;scroll-margin-top:16px}.dv-oid{font:600 10.5px ui-monospace,Menlo,monospace;padding:3px 7px;background:rgba(0,0,0,.08);color:var(--ink);border-radius:5px;text-decoration:none}.dv-olabel{display:flex;align-items:baseline;gap:8px;font:400 11px/1.3 Geist,system-ui,sans-serif;color:rgba(0,0,0,.55)}.dv-card{max-width:100%;background:var(--surface);border:1px solid rgba(0,0,0,.08);border-radius:8px;box-shadow:0 1px 3px rgba(0,0,0,.06);overflow:hidden}.dv-opt:target .dv-oid{background:var(--btn);color:#fff}.dv-next{margin:22px 0 0;font:12px/1.5 Geist,system-ui,sans-serif;color:rgba(0,0,0,.5)}@keyframes om-spin{to{transform:rotate(360deg)}}</style></helmet>
+
+<div style="position:relative;display:flex;height:900px;background:var(--pg);color:var(--ink);font-size:14px">
+<div data-cc-topbar="1" data-cc-fade="1" style="position:absolute;top:0;left:0;right:0;height:66px;z-index:1;box-sizing:border-box;display:flex;align-items:center;justify-content:flex-end;gap:8px;padding:0 28px;border-bottom:1px solid var(--rule);background:var(--pg)">
+<div onClick="{{ onTheme }}" role="button" tabIndex="0" title="{{ themeTitle }}" aria-label="{{ themeTitle }}" style="width:34px;height:34px;display:flex;align-items:center;justify-content:center;border-radius:8px;color:var(--chipInk);cursor:pointer" style-hover="background:rgba(125,145,175,.14)">
+<sc-if value="{{ notNight }}" hint-placeholder-val="{{ true }}"><svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><path d="M20.5 14.5A8.5 8.5 0 1 1 9.5 3.5a7 7 0 0 0 11 11z"></path></svg></sc-if>
+<sc-if value="{{ night }}" hint-placeholder-val="{{ false }}"><svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round"><circle cx="12" cy="12" r="4.2"></circle><path d="M12 3v2M12 19v2M3 12h2M19 12h2M5.6 5.6l1.4 1.4M17 17l1.4 1.4M18.4 5.6 17 7M7 17l-1.4 1.4"></path></svg></sc-if>
+</div>
+</div>
+
+
+<div data-cc-sidebar="1" data-cc-fade="1" style="position:relative;z-index:2;box-sizing:border-box;width:236px;flex:none;display:flex;flex-direction:column;gap:6px;padding:14px 10px;background:#1751a6;color:#fff">
+<a href="Course Community - Landing.dc.html" style="display:flex;align-items:center;gap:10px;padding:6px 8px 14px;color:#fff;text-decoration:none">
+<img src="assets/ais-symbol-white.png" alt="KTH AI Society" style="height:34px;width:34px;object-fit:contain">
+<div style="width:1px;height:28px;background:rgba(255,255,255,.35)"></div>
+<div style="font-size:15px;font-weight:600;line-height:1.15">Course<br>Community</div>
+</a>
+<div style="display:flex;flex-direction:column;gap:2px;margin-top:14px">
+<a href="Course Community - Explore.dc.html" style="display:flex;align-items:center;gap:10px;padding:9px 10px;border-radius:8px;background:transparent;font-weight:400;color:#fff;text-decoration:none" style-hover="background:rgba(255,255,255,.1)"><svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="#fff" stroke-width="2.4" stroke-linecap="round"><circle cx="11" cy="11" r="7"></circle><line x1="16.5" y1="16.5" x2="21" y2="21"></line></svg><span style="flex:1">Explore</span></a>
+<a href="Course Community - Saved.dc.html" style="display:flex;align-items:center;gap:10px;padding:9px 10px;border-radius:8px;background:rgba(255,255,255,.16);font-weight:600;color:#fff;text-decoration:none" style-hover="background:rgba(255,255,255,.1)"><svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="#fff" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="m19 21-7-4-7 4V5a2 2 0 0 1 2-2h10a2 2 0 0 1 2 2z"></path></svg><span style="flex:1">Saved courses</span><sc-if value="{{ hasSavedCount }}" hint-placeholder-val="{{ true }}"><span style="padding:1px 7px;border-radius:9px;background:rgba(255,255,255,.22);font-size:11.5px;font-weight:600">{{ savedCountLabel }}</span></sc-if></a>
+<a href="Course Community - My Page.dc.html" style="display:flex;align-items:center;gap:10px;padding:9px 10px;border-radius:8px;background:transparent;font-weight:400;color:#fff;text-decoration:none" style-hover="background:rgba(255,255,255,.1)"><svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="#fff" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="8" r="4"></circle><path d="M5.5 21a6.5 6.5 0 0 1 13 0"></path></svg><span style="flex:1">My Page</span></a>
+<a href="Course Community - Taken Courses.dc.html" style="display:flex;align-items:center;gap:10px;padding:9px 10px;border-radius:8px;background:transparent;font-weight:400;color:#fff;text-decoration:none" style-hover="background:rgba(255,255,255,.1)"><svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="#fff" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="10"></circle><path d="m9 12 2 2 4-4"></path></svg><span style="flex:1">Taken courses</span></a>
+</div>
+<div style="margin-top:auto;display:flex;flex-direction:column;gap:2px">
+<a href="Course Community - About.dc.html" style="display:flex;align-items:center;gap:10px;padding:9px 10px;border-radius:8px;color:rgba(255,255,255,.82);text-decoration:none" style-hover="background:rgba(255,255,255,.1)"><svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="#fff" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M12 7v14"></path><path d="M3 18a1 1 0 0 1-1-1V4a1 1 0 0 1 1-1h5a4 4 0 0 1 4 4 4 4 0 0 1 4-4h5a1 1 0 0 1 1 1v13a1 1 0 0 1-1 1h-6a3 3 0 0 0-3 3 3 3 0 0 0-3-3z"></path></svg>About &amp; contact</a>
+<sc-if value="{{ isMember }}" hint-placeholder-val="{{ false }}">
+<div style="display:flex;align-items:center;gap:10px;padding:10px;margin-top:8px;border-radius:8px;background:rgba(255,255,255,.1)">
+<div style="width:34px;height:34px;flex:none;border-radius:50%;background:#7ea6d8;color:#0d2f5e;display:flex;align-items:center;justify-content:center;font-weight:700;font-size:13px">EL</div>
+<div style="flex:1;min-width:0;font-size:13px;font-weight:500">Elsa Lindqvist</div>
+<div onClick="{{ onSignOut }}" role="button" tabIndex="0" aria-label="Sign out" title="Sign out" style="flex:none;width:28px;height:28px;display:flex;align-items:center;justify-content:center;border-radius:7px;color:rgba(255,255,255,.75);cursor:pointer" style-hover="background:rgba(255,255,255,.16);color:#fff"><svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.9" stroke-linecap="round" stroke-linejoin="round"><path d="M9 21H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h4"></path><path d="M16 17l5-5-5-5"></path><path d="M21 12H9"></path></svg></div>
+</div>
+</sc-if>
+<sc-if value="{{ isGuest }}" hint-placeholder-val="{{ true }}">
+<div style="margin-top:8px;padding-top:12px;border-top:1px solid rgba(255,255,255,.2)">
+<div style="font-size:11.5px;line-height:1.45;color:rgba(255,255,255,.78)">Browsing as a guest. Saving courses and posting reviews need an account.</div>
+<div onClick="{{ onSignUp }}" role="button" tabIndex="0" style="margin-top:10px;display:flex;align-items:center;justify-content:center;height:34px;border-radius:8px;background:#fff;color:#12417f;font-size:13px;font-weight:600;cursor:pointer">Sign up</div>
+<div onClick="{{ onLogIn }}" role="button" tabIndex="0" style="margin-top:6px;display:flex;align-items:center;justify-content:center;height:34px;border-radius:8px;border:1px solid rgba(255,255,255,.4);font-size:13px;font-weight:500;color:#fff;cursor:pointer">Log in</div>
+</div>
+</sc-if>
+</div>
+</div>
+
+<div style="position:relative;flex:1;min-width:0;min-height:0;margin-top:{{ paneTop }};display:flex;flex-direction:column;overflow-y:auto;overflow-x:hidden">
+
+<sc-if value="{{ authOpen }}" hint-placeholder-val="{{ false }}">
+<div style="position:absolute;inset:0;z-index:60;display:flex;align-items:center;justify-content:center;padding:24px;background:rgba(20,30,45,.34)">
+<div style="width:392px;box-sizing:border-box;padding:24px;border-radius:14px;background:var(--surface);box-shadow:0 18px 48px rgba(20,30,45,.24)">
+<div style="display:flex;align-items:center;justify-content:space-between;gap:12px">
+<div style="font-size:11px;font-weight:600;letter-spacing:.06em;text-transform:uppercase;color:var(--brand)">One step left</div>
+<div onClick="{{ onAuthCancel }}" title="Back to my draft" style="width:26px;height:26px;display:flex;align-items:center;justify-content:center;border-radius:7px;color:var(--dim);font-size:17px;line-height:1;cursor:pointer" style-hover="background:var(--pill)">×</div>
+</div>
+<div style="margin-top:8px;font-size:19px;font-weight:600;line-height:1.25">Sign in to publish your review</div>
+<div style="margin-top:6px;font-size:13.5px;line-height:1.5;color:var(--muted)">Your draft is saved as it is — text, scores and the course all stay put. Nothing is published until you confirm.</div>
+<div style="margin-top:16px;display:flex;flex-direction:column;gap:8px">
+<div onClick="{{ onAuthDone }}" style="display:flex;align-items:center;justify-content:center;gap:9px;height:42px;border-radius:9px;background:var(--btn);color:var(--btnFg);font-size:13.5px;font-weight:600;cursor:pointer" style-hover="background:var(--btn)">Continue with KTH account</div>
+<div onClick="{{ onAuthDone }}" style="display:flex;align-items:center;justify-content:center;height:42px;border-radius:9px;border:1px solid var(--rule3);background:var(--surface);font-size:13.5px;font-weight:500;color:var(--ink);cursor:pointer" style-hover="border-color:var(--hov)">Sign up with email</div>
+</div>
+<div onClick="{{ onAuthCancel }}" style="margin-top:14px;text-align:center;font-size:12.5px;font-weight:500;color:var(--brand);cursor:pointer" style-hover="text-decoration:underline">Back to my draft</div>
+</div>
+</div>
+</sc-if>
+
+
+
+<sc-if value="{{ isSavedView }}" hint-placeholder-val="{{ true }}">
+<div data-cc-fade="1" style="flex:1;min-height:0;overflow:auto;background:var(--pg);color:var(--ink)">
+<div style="width:100%;max-width:{{ pageMaxWidth }};box-sizing:border-box;margin:0 auto;padding:0 {{ pageSidePadding }};display:flex;flex-direction:column">
+
+<dc-import name="Course Community - Page Header" title="Saved courses" subtitle="Keep track of courses you are interested in and organize them into groups for comparison." hint-size="100%,90px"></dc-import>
+
+<div style="padding:18px 28px 10px;margin-right:{{ savedTopMargin }}">
+
+<dc-import name="Course Community - Collections" store-module="{{ workspaceStore }}" courses="{{ collectionsCourses }}" saved-codes="{{ savedCodesForCollections }}" is-guest="{{ isGuest }}" compact="{{ true }}" on-change="{{ onCollectionsChanged }}" on-detail-change="{{ onCollectionsDetailChange }}" hint-size="100%,320px"></dc-import>
+</div>
+
+<div aria-live="polite" style="position:sticky;top:0;z-index:5;display:flex;flex-direction:column;gap:8px">
+<sc-if value="{{ hasNote }}" hint-placeholder-val="{{ false }}">
+<div style="display:flex;align-items:center;gap:8px;padding:9px 13px;border-radius:9px;border:1px solid var(--rule2);background:var(--pill);font-size:12.5px;color:var(--brand)">
+<svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="#1751a6" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round"><path d="M20 6 9 17l-5-5"></path></svg>{{ note }}
+</div>
+</sc-if>
+</div>
+
+<div ref="{{ rowRef }}" style="display:flex;gap:18px;flex:1;min-height:0;min-width:0;padding:18px 28px 20px">
+<div data-cc-results="1" style="flex:1;min-width:340px;min-height:0;overflow-y:auto;padding-right:2px">
+<div style="display:flex;flex-direction:column;gap:12px">
+
+<div style="display:flex;flex-direction:column;gap:26px">
+
+<sc-if value="{{ importRunning }}" hint-placeholder-val="{{ false }}">
+<div aria-live="polite" style="display:flex;align-items:center;gap:10px;padding:12px 14px;border-radius:10px;border:1px solid var(--rule2);background:var(--pill);font-size:12.5px;color:var(--brand)">
+<span style="flex:none;width:14px;height:14px;border-radius:50%;border:2px solid var(--hov);border-top-color:var(--brand);animation:om-spin .9s linear infinite"></span>
+Adding the courses saved in this browser to your account…
+</div>
+</sc-if>
+<sc-if value="{{ importDone }}" hint-placeholder-val="{{ false }}">
+<div aria-live="polite" style="display:flex;align-items:center;gap:10px;padding:12px 14px;border-radius:10px;border:1px solid var(--rule2);background:var(--pill);font-size:12.5px;color:var(--brand)">
+<svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="#1751a6" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round"><path d="M20 6 9 17l-5-5"></path></svg>
+<span style="flex:1">{{ importMsg }}</span>
+<span onClick="{{ onDismissImport }}" role="button" tabIndex="0" aria-label="Dismiss" style="cursor:pointer;color:var(--muted)">×</span>
+</div>
+</sc-if>
+<sc-if value="{{ importDupes }}" hint-placeholder-val="{{ false }}">
+<div aria-live="polite" style="display:flex;align-items:center;gap:10px;padding:12px 14px;border-radius:10px;border:1px solid var(--rule2);background:var(--pg);font-size:12.5px;color:var(--muted)">
+<svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="#6b6355" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M20 6 9 17l-5-5"></path></svg>
+<span style="flex:1">Your saved courses are already up to date</span>
+<span onClick="{{ onDismissImport }}" role="button" tabIndex="0" aria-label="Dismiss" style="cursor:pointer">×</span>
+</div>
+</sc-if>
+<sc-if value="{{ pendingImport }}" hint-placeholder-val="{{ false }}">
+<div style="display:flex;align-items:center;gap:12px;padding:12px 14px;border-radius:10px;border:1px solid var(--rule2);background:var(--surface);font-size:12.5px;color:var(--chipInk)">
+<span style="flex:1">{{ pendingImportMsg }}</span>
+<div onClick="{{ onRunImport }}" role="button" tabIndex="0" style="height:30px;display:flex;align-items:center;padding:0 12px;border-radius:8px;background:var(--btn);color:var(--btnFg);font-size:12.5px;font-weight:600;cursor:pointer" style-hover="background:var(--btn)">Add to my account</div>
+</div>
+</sc-if>
+
+
+
+<sc-if value="{{ showSavedSection }}" hint-placeholder-val="{{ true }}">
+<div>
+<h2 style="margin:0;font-size:16px;font-weight:600">Saved courses</h2>
+<div style="margin-top:4px;font-size:12.5px;color:var(--muted)">Courses you have saved but not yet added to a comparison.</div>
+
+<sc-if value="{{ hasUnorganized }}" hint-placeholder-val="{{ true }}">
+<div style="margin-top:14px;display:flex;flex-direction:column;gap:14px">
+<sc-for list="{{ unorganized }}" as="c" hint-placeholder-count="4">
+<dc-import name="Course Community - Course Card" c="{{ c }}" geo="{{ geo }}" action="add" picker-above="{{ true }}" new-label="Create new comparison" is-guest="{{ isGuest }}" is-member="{{ isMember }}" on-sign-up="{{ onSignUp }}" on-log-in="{{ onLogIn }}" hint-size="100%,236px"></dc-import>
+</sc-for>
+</div>
+</sc-if>
+</div>
+
+<sc-if value="{{ allOrganized }}" hint-placeholder-val="{{ false }}">
+<div style="margin-top:14px;padding:20px 22px;border:1px solid var(--rule);border-radius:11px;background:var(--surface);text-align:center">
+<div style="font-size:13.5px;font-weight:600">Every saved course is in a comparison</div>
+<div style="margin-top:5px;font-size:12.5px;color:var(--muted)">{{ allOrganizedLabel }}</div>
+</div>
+</sc-if>
+
+<sc-if value="{{ noSaved }}" hint-placeholder-val="{{ false }}">
+<div style="margin-top:14px;padding:24px;border:1px solid var(--rule);border-radius:11px;background:var(--surface);text-align:center">
+<div style="font-size:14.5px;font-weight:600">No saved courses yet</div>
+<div style="margin-top:5px;font-size:12.5px;color:var(--muted)">Explore courses and save the ones you want to revisit.</div>
+<div onClick="{{ onOpenExplore }}" role="button" tabIndex="0" style="margin:13px auto 0;width:max-content;height:34px;display:flex;align-items:center;padding:0 14px;border-radius:9px;background:var(--btn);color:var(--btnFg);font-size:13px;font-weight:600;cursor:pointer" style-hover="background:var(--btn)">Explore courses</div>
+</div>
+</sc-if>
+</sc-if>
+
+</div>
+</div>
+</div>
+<sc-if value="{{ hasTabs }}" hint-placeholder-val="{{ true }}">
+<div style="display:flex;flex:{{ paneGrow }};min-width:0;min-height:0;margin-left:-14px">
+<div onPointerDown="{{ onPaneDrag }}" onDoubleClick="{{ onPaneReset }}" title="Drag to resize · double-click to reset" style="flex:none;width:11px;margin-right:3px;display:flex;align-items:center;justify-content:center;cursor:{{ dragCursor }}">
+<div style="width:2px;height:34px;border-radius:2px;background:#ddd8c9"></div>
+</div>
+<dc-import name="Course Community - Workspace Pane" pane-width="{{ paneWidth }}" pane-grow="{{ paneGrow }}" courses="{{ workspaceCourses }}" store-module="{{ workspaceStore }}" locale="{{ workspaceLocale }}" is-guest="{{ isGuest }}" open-signal="{{ openSignal }}" on-tabs-change="{{ onTabsChange }}" on-authed="{{ onWorkspaceAuthed }}" hint-size="504px,100%"></dc-import>
+</div>
+</sc-if>
+</div>
+</div>
+</div>
+</sc-if>
+
+
+
+</div>
+
+</div>
+
+</x-dc>
+<script type="text/x-dc" data-dc-script data-props="{&quot;$preview&quot;:{&quot;width&quot;:1440,&quot;height&quot;:900},&quot;session&quot;:{&quot;editor&quot;:&quot;enum&quot;,&quot;default&quot;:&quot;member&quot;,&quot;options&quot;:[&quot;guest&quot;,&quot;member&quot;],&quot;tsType&quot;:&quot;\&quot;guest\&quot; | \&quot;member\&quot;&quot;,&quot;section&quot;:&quot;Session&quot;},&quot;scenario&quot;:{&quot;editor&quot;:&quot;enum&quot;,&quot;default&quot;:&quot;populated&quot;,&quot;options&quot;:[&quot;populated&quot;,&quot;empty&quot;,&quot;loading&quot;,&quot;error&quot;,&quot;edge-case&quot;],&quot;tsType&quot;:&quot;string&quot;,&quot;section&quot;:&quot;Prototype state&quot;},&quot;locale&quot;:{&quot;editor&quot;:&quot;enum&quot;,&quot;default&quot;:&quot;en&quot;,&quot;options&quot;:[&quot;en&quot;,&quot;sv&quot;],&quot;tsType&quot;:&quot;\&quot;en\&quot; | \&quot;sv\&quot;&quot;,&quot;section&quot;:&quot;Prototype state&quot;}}">
+/* No course data lives on this page. Cards are built by the shared selector
+   `catalogCardView`, the same one Explore uses. */
+let STORE = null;
+let COURSES = [];
+
+/* ---------------------------------------------------------------------------
+   MOCK FIXTURES — Saved courses prototype only. No backend, no real auth, no
+   real AI. Everything below is frontend sample data for review purposes.
+--------------------------------------------------------------------------- */
+const libOf = (code) => COURSES.find((c) => c.code === code) || null;
+const richOf = libOf;
+
+let MOCK_ACCOUNT_SAVES = [];
+let MOCK_LOCAL_SAVES = [];
+
+/* The five canonical data conditions. Session is a separate axis. */
+const FIXTURES = [
+  { key: "populated", label: "Populated" },
+  { key: "empty", label: "Empty" },
+  { key: "loading", label: "Loading" },
+  { key: "error", label: "Error" },
+  { key: "edge-case", label: "Edge case" }
+];
+
+/* The examination categories are the schema's five keys, so a review draft
+   writes an examinationDistribution the store can hold as-is. */
+const METHODS = [
+  { key: "exam", label: "On-campus exam", short: "Exam", color: "var(--brand)", ink: "var(--btnFg)" },
+  { key: "assignments", label: "Assignments", short: "Assign.", color: "#dfa53c", ink: "#3a2a06" },
+  { key: "labs", label: "Labs", short: "Labs", color: "#2f9e8e", ink: "#06251f" },
+  { key: "projects", label: "Project", short: "Project", color: "#6a4ea8", ink: "var(--btnFg)" },
+  { key: "other", label: "Other", short: "Other", color: "#57646f", ink: "var(--btnFg)" }
+];
+
+const COMPARE_CAP = 4;
+const SAVED_KEY = "kth-cc:saved-courses";
+
+const countOf = (v) => parseInt(String(v).replace(/\D/g, ""), 10) || 0;
+const fmtCount = (n) => String(n).replace(/\B(?=(\d{3})+(?!\d))/g, "\u2009");
+
+const EMPTY_DRAFT = {
+  overall: null, picked: [], pcts: [], theory: null,
+  workload: null, learning: null, recommend: null, reviewText: ""
+};
+
+/** Even split across n segments in 5% steps; the remainder lands on the last. */
+function evenSplit(n) {
+  if (n === 0) return [];
+  const base = Math.max(5, Math.round(100 / n / 5) * 5);
+  const out = new Array(n).fill(base);
+  out[n - 1] = 100 - base * (n - 1);
+  return out;
+}
+
+/** Card-level summary of an examination split: "Only X" / "Mainly X" / "Mixed".
+    Takes the store's segments, which carry their own labels — never an array
+    position matched against a local name list. */
+function examLabel(segments) {
+  if (!segments || segments.length === 0) return null;
+  const total = segments.reduce((a, x) => a + (x.percent || 0), 0);
+  if (total === 0) return null;
+  let top = 0;
+  for (let i = 1; i < segments.length; i++) if (segments[i].percent > segments[top].percent) top = i;
+  const share = (segments[top].percent / total) * 100;
+  if (share === 100) return "Only " + segments[top].label;
+  if (share > 50) return "Mainly " + segments[top].label;
+  return "Mixed Evaluation Methods";
+}
+
+function mixLabel(theoretical) {
+  if (theoretical == null) return null;
+  if (theoretical >= 60) return "mostly theoretical";
+  if (theoretical <= 40) return "mostly applied";
+  return "balanced";
+}
+
+class Component extends DCLogic {
+  /* Theme choice is shared across the pages through one storage key. */
+  ccDark() {
+    if (this.state.ccNight !== undefined) return this.state.ccNight === true;
+    try { return window.localStorage.getItem("cc:theme") === "dark"; } catch (e) { return false; }
+  }
+
+  ccSetDark(next) {
+    document.documentElement.setAttribute("data-cc-theme", next ? "dark" : "light");
+    try { window.localStorage.setItem("cc:theme", next ? "dark" : "light"); } catch (e) { /* storage off */ }
+    this.setState({ ccNight: next });
+  }
+
+  ccApplyTheme() {
+    document.documentElement.setAttribute("data-cc-theme", this.ccDark() ? "dark" : "light");
+  }
+
+  state = {
+    tab: 0,
+    collectionsOpenDetail: null,
+    // One draft per course code — nothing exists until that student answers something.
+    drafts: {},
+    flags: { DD2421: { compare: true }, DD2380: { saved: true } },
+    tabs: [],
+    workspaceTabCount: 0,
+    openSignal: null,
+    overflowOpen: false,
+    contentOpen: false,
+    reviewsOpen: false,
+    guest: true,
+    authOpen: false,
+    justAuthed: false,
+    posted: false,
+    compareHelpOpen: false,
+    dragging: false,
+    paneW: 504,
+    rowW: 0
+  };
+
+  /* One global "open surface" at a time; every trigger and panel is tagged
+     data-pop, so dismissal is a single containment test. */
+  closeAll = (extra) => {
+    this.setState({ takenMenu: null, overflowOpen: false, ...(extra || {}) });
+  };
+
+  onDocDown = (e) => {
+    if (e.target.closest && e.target.closest("[data-pop]")) return;
+    if (this.state.takenMenu || this.state.overflowOpen) this.closeAll();
+  };
+
+  onDocKey = (e) => {
+    if (e.key !== "Escape") return;
+    if (this.state.takenMenu || this.state.overflowOpen) this.closeAll();
+  };
+
+  onDocScroll = (e) => {
+    if (e.target.closest && e.target.closest("[data-pop-panel]")) return;
+    if (this.state.takenMenu || this.state.overflowOpen) this.closeAll();
+  };
+
+  measure = () => {
+    const row = this.rowRef.current;
+    if (row && row.clientWidth !== this.state.rowW) this.setState({ rowW: row.clientWidth });
+  };
+
+  componentDidMount() {
+    this.ccApplyTheme();
+    this.ccHydrate();
+    // Guest saves have nowhere else to live, so they are kept under our own key.
+    try {
+      const raw = window.localStorage.getItem(SAVED_KEY);
+      const codes = raw ? JSON.parse(raw) : [];
+      if (Array.isArray(codes) && codes.length) {
+        const flags = { ...this.state.flags };
+        codes.forEach((code) => { flags[code] = { ...(flags[code] || {}), saved: true }; });
+        this.setState({ flags });
+      }
+    } catch (e) { /* storage unavailable */ }
+    document.addEventListener("pointerdown", this.onDocDown, true);
+    document.addEventListener("keydown", this.onDocKey, true);
+    window.addEventListener("resize", this.measure);
+    this.measure();
+    document.addEventListener("scroll", this.onDocScroll, true);
+    import("./cc-store.js").then((mod) => {
+      STORE = mod;
+      this.seenHarness = this.harnessKey();
+      this.applyFixture(this.props.scenario);
+    });
+  }
+
+  componentDidUpdate() {
+    if (!STORE) return;
+    if (this.harnessKey() !== this.seenHarness) {
+      this.seenHarness = this.harnessKey();
+      this.applyFixture(this.props.scenario);
+    }
+  }
+
+  componentWillUnmount() {
+    document.removeEventListener("pointerdown", this.onDocDown, true);
+    document.removeEventListener("keydown", this.onDocKey, true);
+    window.removeEventListener("resize", this.measure);
+    document.removeEventListener("scroll", this.onDocScroll, true);
+  }
+
+  rowRef = React.createRef();
+  paneScrollRef = React.createRef();
+  reviewsRef = React.createRef();
+
+  /** Opens the review list and brings it into view inside the pane's own scroller. */
+  revealReviews() {
+    this.setState({ reviewsOpen: true }, () => {
+      requestAnimationFrame(() => {
+        const box = this.paneScrollRef.current;
+        const head = this.reviewsRef.current;
+        if (!box || !head) return;
+        const top = head.getBoundingClientRect().top - box.getBoundingClientRect().top + box.scrollTop;
+        box.scrollTo({ top: Math.max(0, top - 12), behavior: "smooth" });
+      });
+    });
+  }
+
+
+  // The widths the layout is pinned to: the cropped card's floor and the pane's.
+  // Comfortable down to 440; when the row is tight, the pane may narrow further
+  // (to 356) rather than refuse to shrink at all — the results card keeps its
+  // own 396px floor either way.
+  maxPane() {
+    const row = this.rowRef.current;
+    const w = row ? row.clientWidth : window.innerWidth;
+    return Math.max(356, w - 396 - 40 - 18);
+  }
+
+  minPane() {
+    return this.maxPane() >= 440 ? 440 : 356;
+  }
+
+  examTrackRef = React.createRef();
+
+  drag(onMove) {
+    const move = (ev) => onMove(ev);
+    const up = () => {
+      window.removeEventListener("pointermove", move);
+      window.removeEventListener("pointerup", up);
+      document.body.style.cursor = "";
+      document.body.style.userSelect = "";
+    };
+    window.addEventListener("pointermove", move);
+    window.addEventListener("pointerup", up);
+    document.body.style.cursor = "ew-resize";
+    document.body.style.userSelect = "none";
+  }
+
+  draftFor(code) {
+    return this.state.drafts[code] || EMPTY_DRAFT;
+  }
+
+  patchDraft(code, patch) {
+    const drafts = { ...this.state.drafts };
+    drafts[code] = { ...this.draftFor(code), ...patch };
+    this.setState({ drafts });
+  }
+
+  /* The controls take a value plus a setter, so the draft panel and the
+     standalone demos can share them without sharing state. */
+  dividerDown(i, rect, pcts, setPcts) {
+    const before = pcts.slice(0, i).reduce((a, p) => a + p, 0);
+    const pair = pcts[i] + pcts[i + 1];
+    this.drag((ev) => {
+      let x = ((ev.clientX - rect.left) / rect.width) * 100 - before;
+      x = Math.round(x / 5) * 5;
+      x = Math.max(5, Math.min(pair - 5, x));
+      const next = pcts.slice();
+      next[i] = x;
+      next[i + 1] = pair - x;
+      setPcts(next);
+    });
+  }
+
+  bump(i, delta, pcts, setPcts) {
+    const next = pcts.slice();
+    const j = (i + 1) % next.length;
+    if (i === j) return;
+    if (next[i] + delta < 5 || next[j] - delta < 5) return;
+    next[i] += delta;
+    next[j] -= delta;
+    setPcts(next);
+  }
+
+  toggleMethod(method, picked, setBoth) {
+    const next = picked.slice();
+    const at = next.indexOf(method);
+    if (at >= 0) next.splice(at, 1); else next.push(method);
+    // Re-splitting evenly keeps the bar honest when the segment count changes.
+    setBoth(next, evenSplit(next.length));
+  }
+
+  startPct(e, scale, apply) {
+    const rect = e.currentTarget.getBoundingClientRect();
+    const run = (ev) => {
+      const raw = ((ev.clientX - rect.left) / rect.width) * 100;
+      apply(scale === 100
+        ? Math.round(Math.max(5, Math.min(95, raw)))
+        : Math.round(Math.max(1, Math.min(10, raw / 10))));
+    };
+    run(e);
+    this.drag(run);
+  }
+
+  /* ---------- Saved courses (mock prototype) ---------- */
+
+  savedState = {
+    view: "saved",
+    localSaves: MOCK_LOCAL_SAVES.slice(),
+    acctSaves: MOCK_ACCOUNT_SAVES.slice(),
+    importState: null, importCount: 0,
+    note: null, fixture: "guest-saves", pickerFor: null
+  };
+
+  sv(patch, then) {
+    this.savedState = { ...this.savedState, ...patch };
+    this.ccPersist();
+    this.forceUpdate();
+    if (then) then();
+  }
+  CC_KEYS = { member: "cc:member", saves: "cc:saves", badge: "cc:savedBadge" };
+
+  ccRead(key, fallback) {
+    try {
+      const raw = window.localStorage.getItem(key);
+      return raw === null ? fallback : JSON.parse(raw);
+    } catch (e) { return fallback; }
+  }
+
+  ccWrite(key, value) {
+    try { window.localStorage.setItem(key, JSON.stringify(value)); } catch (e) { /* storage unavailable */ }
+  }
+
+  /** Pull session + library from storage on mount; each page starts where the last left off. */
+  ccHydrate() {
+    const member = this.ccRead(this.CC_KEYS.member, null);
+    const saves = this.ccRead(this.CC_KEYS.saves, null);
+    if (saves) this.savedState.acctSaves = saves;
+    if (member !== null && member !== !this.state.guest) this.setState({ guest: !member });
+    else this.forceUpdate();
+  }
+
+  ccPersist() {
+    this.ccWrite(this.CC_KEYS.member, !this.state.guest);
+    this.ccWrite(this.CC_KEYS.saves, this.savedState.acctSaves);
+    // The count the sidebar shows, for the session in force right now.
+    this.ccWrite(this.CC_KEYS.badge, this.savedCodes().length);
+  }
+
+
+  savedMember() {
+    // Seeded from the shared session, then owned by whatever the user does here.
+    return !this.state.guest;
+  }
+
+  /** Everything saved, account list or browser list depending on the session. */
+  savedCodes() {
+    const v = this.savedState;
+    return this.savedMember() ? v.acctSaves : v.localSaves;
+  }
+
+  /** Collections are groupings — a course in one is still in the library. */
+  unorganizedCodes() {
+    const v = this.savedState;
+    const codes = this.savedCodes();
+    if (!this.savedMember()) return codes.slice();
+    const grouped = {};
+    ((STORE && STORE.collections) || []).forEach((c) => c.codes.forEach((k) => { grouped[k] = 1; }));
+    return codes.filter((k) => !grouped[k]);
+  }
+
+  harnessKey() {
+    return [this.props.session, this.props.scenario, this.props.locale].join("|");
+  }
+
+  locale() {
+    return this.props.locale === "sv" ? "sv" : "en";
+  }
+
+  /* Session (guest | member) and scenario (populated | empty | loading | error |
+     edge-case) are the shared axes. A scenario poses the screen; it never
+     writes to the store. */
+  applyFixture(key) {
+    if (!STORE) return;
+    const h = STORE.resolveHarness({
+      session: this.props.session,
+      scenario: STORE.SCENARIOS.indexOf(key) >= 0 ? key : this.props.scenario
+    });
+    COURSES = STORE.catalogCards({ locale: this.locale() });
+    MOCK_ACCOUNT_SAVES = STORE.savedCourses.account.slice();
+    MOCK_LOCAL_SAVES = STORE.savedCourses.local.slice();
+
+    const base = {
+      fixture: h.scenario, importState: null, importCount: 0, note: null, pickerFor: null,
+      localSaves: [], acctSaves: [], loading: false, error: false
+    };
+    if (h.isLoading) {
+      base.loading = true;
+      base.acctSaves = h.isGuest ? [] : MOCK_ACCOUNT_SAVES.slice();
+    } else if (h.isError) {
+      base.error = true;
+    } else if (h.isEdgeCase) {
+      base.localSaves = ["DD2421", "DD2380"];
+      base.acctSaves = MOCK_ACCOUNT_SAVES.slice();
+    } else {
+      base.localSaves = h.isGuest ? MOCK_LOCAL_SAVES.slice() : [];
+      base.acctSaves = MOCK_ACCOUNT_SAVES.slice();
+    }
+    this.savedState = { ...this.savedState, ...base };
+    if (h.isGuest !== this.state.guest) {
+      this.setState({ guest: h.isGuest }, () => this.afterPose(h));
+    } else {
+      this.forceUpdate();
+      this.afterPose(h);
+    }
+  }
+
+  /** A member arriving with local saves gets the merge run for them. */
+  afterPose(h) {
+    if (h.isMember && h.isPopulated && this.savedState.localSaves.length) this.runImport(true);
+  }
+
+  /** Simulated merge: dedupe by course code, never by title; collections untouched. */
+  runImport(silentIfEmpty) {
+    const v = this.savedState;
+    const local = v.localSaves.slice();
+    if (!local.length) { if (!silentIfEmpty) this.sv({ importState: null }); return; }
+    this.sv({ importState: "running" });
+    clearTimeout(this.importTimer);
+    this.importTimer = setTimeout(() => {
+      const acct = this.savedState.acctSaves.slice();
+      const fresh = local.filter((code) => acct.indexOf(code) < 0);
+      const merged = acct.concat(fresh);
+      this.sv({
+        acctSaves: merged,
+        localSaves: [],           // the browser hand-off is cleared only now
+        importState: fresh.length ? "done" : "dupes",
+        importCount: fresh.length
+      });
+      try { window.localStorage.removeItem(SAVED_KEY); } catch (e) { /* storage unavailable */ }
+    }, 1400);
+  }
+
+  toggleSaved(code) {
+    const v = this.savedState;
+    const key = this.savedMember() ? "acctSaves" : "localSaves";
+    const list = v[key];
+    const next = list.indexOf(code) >= 0 ? list.filter((k) => k !== code) : list.concat([code]);
+    this.sv({ [key]: next, note: list.indexOf(code) >= 0 ? "Removed from saved courses" : "Saved" });
+    if (!this.savedMember()) {
+      try { window.localStorage.setItem(SAVED_KEY, JSON.stringify(next)); } catch (e) { /* storage unavailable */ }
+    }
+    this.clearNote();
+  }
+
+  clearNote() {
+    clearTimeout(this.noteTimer);
+    this.noteTimer = setTimeout(() => this.sv({ note: null }), 3000);
+  }
+
+  savedVals(guest) {
+    const v = this.savedState;
+    const member = !guest;
+    const saved = this.savedCodes();
+    const unorganized = this.unorganizedCodes();
+    const collectionsNow = (STORE && STORE.collections) || [];
+
+    // Same clip geometry as Explore's fully collapsed card.
+    const perLine = 52;
+    const clipTo = (str, lines) => {
+      const max = perLine * lines;
+      if (!str || str.length <= max) return str || "";
+      const cut = str.slice(0, Math.max(0, max - 1));
+      const space = cut.lastIndexOf(" ");
+      return (space > max * 0.6 ? cut.slice(0, space) : cut).replace(/[,;·\s]+$/, "") + "…";
+    };
+    const card = (code, extra) => {
+      const c = libOf(code) || { code: code, title: code, hp: "", school: "", period: "" };
+      const r = richOf(code);
+      const flags = this.state.flags[code] || {};
+      return {
+        code: c.code, title: c.title, meta: c.hp + " · " + c.code + " · " + c.school,
+        period: c.period, workload: c.workload || "—", assessment: c.assessment || "—",
+        keywords: r ? r.keywords : "",
+        keywordsClipped: clipTo(r ? r.keywords : "", 2),
+        prereqCourses: (r && r.prereqCourses ? r.prereqCourses : []).map((p) => {
+          const taken = this.isTaken(p.code);
+          return {
+            code: p.code, name: p.name, taken: taken,
+            bg: taken ? "rgba(23,81,166,.08)" : "transparent",
+            weight: "500",
+            radius: taken ? "999px" : "6px",
+            padding: taken ? "0 8px 0 5px" : "0 8px 0 5px",
+            gap: "5px"
+          };
+        }),
+        hasPrereq: Boolean(r && r.prereqCourses && r.prereqCourses.length),
+        noPrereq: !(r && r.prereqCourses && r.prereqCourses.length),
+        prereq: r ? r.prereq : "",
+        prereqClipped: clipTo(r ? r.prereq : "", 2),
+        // Identical expressions to Explore's card model.
+        hasStats: Boolean(r && examLabel(r.exSegments)),
+        noStats: !(r && examLabel(r.exSegments)),
+        examLabel: r ? examLabel(r.exSegments) : "",
+        happyPct: r ? r.happy + "%" : "—",
+        statReviews: r ? r.stats[2] : "0",
+        statTaken: r ? fmtCount(countOf(r.stats[1])) : "0",
+        workload: r ? (r.wl / 10).toFixed(1) : "—",
+        learning: r ? (r.le / 10).toFixed(1) : "—",
+        wlW: (r ? r.wl : 0) + "%",
+        leW: (r ? r.le : 0) + "%",
+        takenTitle: this.isTaken(code) ? "You have taken this course" : "Mark as taken",
+        takenBg: this.isTaken(code) ? "rgba(23,81,166,.08)" : "transparent",
+        takenCountFg: this.isTaken(code) ? "var(--brand)" : "var(--muted)",
+        takenHoverBg: this.isTaken(code) ? "rgba(23,81,166,.14)" : "var(--pill)",
+        takenFill: "none",
+        takenStroke: this.isTaken(code) ? "currentColor" : "currentColor",
+        onTaken: (e) => this.toggleFlag(e, code, "taken"),
+        onReview: (e) => { e.stopPropagation(); this.openTab(code, "r"); },
+        onOpen: () => this.openTab(code, "c"),
+        onRemove: (e) => { if (e && e.stopPropagation) e.stopPropagation(); this.toggleSaved(c.code); },
+        borderColor: "var(--rule)",
+        summaryClipped: r ? clipTo(r.summary || r.content || "", 3) : "",
+        hasReviewStats: Boolean(r && r.happy != null),
+        noReviewStats: !(r && r.happy != null),
+        onPicker: (e) => { if (e && e.stopPropagation) e.stopPropagation(); this.sv({ pickerFor: v.pickerFor === c.code ? null : c.code }); },
+        pickerOpen: v.pickerFor === c.code,
+        // The shared picker reads its list off the store, as Explore's does.
+        comparisons: collectionsNow.map((col) => ({
+          name: col.name,
+          fill: col.codes.indexOf(code) >= 0 ? "currentColor" : "none",
+          stroke: col.codes.indexOf(code) >= 0 ? "currentColor" : "currentColor",
+          tick: col.codes.indexOf(code) >= 0 ? "m7 12 2.5 2.5L14 9" : "",
+          onClick: (e) => {
+            if (e && e.stopPropagation) e.stopPropagation();
+            const inIt = col.codes.indexOf(code) >= 0;
+            if (STORE) { if (inIt) STORE.removeCourseFromCollection(col.id, code); else STORE.addCourseToCollection(col.id, code); }
+            this.sv({
+              pickerFor: null,
+              note: inIt ? code + " removed from “" + col.name + "”" : code + " added to “" + col.name + "”"
+            }, () => this.clearNote());
+          }
+        })),
+        hasComparisons: collectionsNow.length > 0,
+        creating: false,
+        notCreating: true,
+        onNewComparison: (e) => { if (e && e.stopPropagation) e.stopPropagation(); this.sv({ pickerFor: null }); },
+        removeLabel: "Remove " + c.code + " from saved courses",
+        addLabel: "Add " + c.code + " to a comparison",
+        openLabel: "Open " + c.code,
+        ...(extra || {})
+      };
+    };
+
+    return {
+      stop: (ev) => ev.stopPropagation(),
+      pageMaxWidth: STORE.PAGE_MAX_WIDTH,
+      pageSidePadding: STORE.PAGE_SIDE_PADDING,
+      geo: {
+        tween: "padding .18s ease-out, width .18s ease-out, gap .18s ease-out, max-height .18s ease-out, max-width .18s ease-out, opacity .14s ease-out, font-size .18s ease-out",
+        titleSize: "17px", cardGap: "10px", cardPad: "18px", factsGap: "14px",
+        reviewPad: "0 13px", saveW: "126px", savePad: "12px",
+        railW: "224px", railPad: "18px 16px",
+        summaryMax: "57px", summaryOpacity: 1, labelMax: "120px", labelOpacity: 1,
+        showLabel: true, reviewFlex: "0 1 132px", saveFlex: "0 1 158px", cardHeight: "236px"
+      },
+      isSavedView: v.view === "saved",
+      savedCount: saved.length,
+      savedCountLabel: String(saved.length),
+      hasSavedCount: saved.length > 0,
+      savedNavBg: v.view === "saved" ? "rgba(255,255,255,.16)" : "transparent",
+      savedNavWeight: v.view === "saved" ? "600" : "400",
+      exploreNavBg: v.view === "explore" ? "rgba(255,255,255,.16)" : "transparent",
+      exploreNavWeight: v.view === "explore" ? "600" : "400",
+      onOpenSaved: () => { window.location.href = "Course Community - Saved.dc.html"; },
+      onOpenExplore: () => { window.location.href = "Course Community - Explore.dc.html"; },
+      onSignOut: () => {
+        this.ccWrite(this.CC_KEYS.member, false);
+        this.setState({ guest: true });
+      },
+
+      fixtures: FIXTURES.map((f) => ({
+        key: f.key, label: f.label,
+        bg: v.fixture === f.key ? "var(--ink)" : "var(--surface)",
+        fg: v.fixture === f.key ? "var(--btnFg)" : "var(--chipInk)",
+        onPick: () => this.applyFixture(f.key)
+      })),
+
+      importRunning: v.importState === "running",
+      importDone: v.importState === "done",
+      importDupes: v.importState === "dupes",
+      importMsg: v.importCount + (v.importCount === 1 ? " saved course added to your account" : " saved courses added to your account"),
+      pendingImport: member && v.localSaves.length > 0 && v.importState !== "running",
+      pendingImportMsg: v.localSaves.length + " course" + (v.localSaves.length === 1 ? "" : "s") + " saved in this browser are ready to add to your account.",
+      onRunImport: () => this.runImport(false),
+      onDismissImport: () => this.sv({ importState: null }),
+
+      unorganized: unorganized.map((code) => card(code)),
+      hasUnorganized: unorganized.length > 0,
+      noSaved: saved.length === 0,
+      // Saved courses exist, but every one of them is already filed.
+      allOrganized: saved.length > 0 && unorganized.length === 0,
+      allOrganizedLabel: "All " + saved.length + " saved course" + (saved.length === 1 ? " is" : "s are")
+        + " grouped above. Save more from Explore to see them here.",
+
+      collectionsCourses: COURSES,
+      savedCodesForCollections: saved,
+      onCollectionsChanged: () => this.forceUpdate(),
+      onCollectionsDetailChange: (id) => this.setState({ collectionsOpenDetail: id }),
+      showSavedSection: !this.state.collectionsOpenDetail,
+
+      note: v.note,
+      hasNote: !!v.note
+    };
+  }
+
+  renderVals() {
+    const s = this.state;
+    // Seeded from the shared session, then owned by whatever the user does here.
+    const guest = s.guest;
+    const active = s.tabs[s.tab] || s.tabs[0] || { kind: "none", code: "" };
+    const course = COURSES.find((c) => c.code === active.code) || COURSES[0];
+
+    // Every open pane lives in one dropdown; the trigger is just a count.
+    const indexed = s.tabs.map((t, i) => ({ ...t, i }));
+
+    const d = this.draftFor(active.code);
+    const setDraft = (patch) => this.patchDraft(active.code, patch);
+
+    const buildMix = (keys, pcts, ref, setPcts, setBoth) => {
+      const items = keys.map((k) => METHODS.find((m) => m.key === k)).filter(Boolean);
+      let acc = 0;
+      const cuts = [];
+      for (let i = 0; i < items.length - 1; i++) { acc += pcts[i] || 0; cuts.push(acc); }
+      return {
+        items,
+        segs: items.map((m, i) => {
+          const p = pcts[i] || 0;
+          return {
+            label: m.label, short: m.short, color: m.color, ink: m.ink,
+            width: p + "%", pctLabel: p + "%",
+            // Name in the slice when it fits, then the abbreviation, then nothing.
+            slotLabel: p >= 24 ? m.label : p >= 13 ? m.short : ""
+          };
+        }),
+        dividers: cuts.map((left, i) => ({
+          left: left + "%",
+          onDown: (e) => {
+            e.preventDefault();
+            const el = ref.current;
+            if (el) this.dividerDown(i, el.getBoundingClientRect(), pcts, setPcts);
+          }
+        })),
+        rows: items.map((m, i) => ({
+          label: m.label, color: m.color, pctLabel: (pcts[i] || 0) + "%",
+          onMinus: () => this.bump(i, -5, pcts, setPcts),
+          onPlus: () => this.bump(i, 5, pcts, setPcts)
+        })),
+        chips: METHODS.map((m) => {
+          const on = keys.indexOf(m.key) >= 0;
+          return {
+            label: m.label,
+            dot: on ? m.color : "#ded8c8",
+            bg: on ? "var(--pill)" : "var(--surface)",
+            fg: on ? "var(--ink)" : "var(--muted)",
+            border: on ? "var(--brand)" : "var(--rule3)",
+            onClick: () => this.toggleMethod(m.key, keys, setBoth)
+          };
+        })
+      };
+    };
+
+    const draftMix = buildMix(d.picked, d.pcts, this.examTrackRef,
+      (pcts) => setDraft({ pcts }),
+      (picked, pcts) => setDraft({ picked, pcts }));
+
+    const chosen = draftMix.items;
+    // The results column decides which card it can hold; the pane just yields.
+    const rowW = s.rowW || window.innerWidth;
+    const paneW = Math.min(s.paneW, Math.max(356, rowW - 396 - 40 - 18));
+    // 0 = the cropped card's floor, 1 = full width; everything in between lerps.
+    const resultsW = (s.workspaceTabCount || 0) === 0 ? Infinity : rowW - 40 - 18 - paneW;
+    const t = Math.max(0, Math.min(1, (resultsW - 470) / 170));
+    const px = (a, b, k) => Math.round((a + (b - a) * (k === undefined ? t : k)) * 10) / 10 + "px";
+    const ramp = (from) => Math.max(0, Math.min(1, (t - from) / (1 - from)));
+    // The buttons only give way in the last stretch, where the column really is tight.
+    const late = Math.max(0, Math.min(1, t / 0.22));
+    // Cut away earlier and in three steps, so the summary shrinks gradually
+    // instead of jumping straight from full to gone.
+    const summaryLines = t >= 0.62 ? 2 : t >= 0.38 ? 1 : 0;
+    // -webkit-line-clamp does not survive the style pipeline, so the strings are cut here.
+    const colW = resultsW === Infinity ? Infinity : resultsW - (134 + 90 * t) - 2 * (14 + 4 * t);
+    const perLine = colW === Infinity ? Infinity : Math.floor(colW / 6.45);
+    const clip = (str, lines) => {
+      const max = perLine * lines;
+      if (!str || max === Infinity || str.length <= max) return lines === 0 ? "" : str;
+      const cut = str.slice(0, Math.max(0, max - 1));
+      const space = cut.lastIndexOf(" ");
+      return (space > max * 0.6 ? cut.slice(0, space) : cut).replace(/[,;·\s]+$/, "") + "…";
+    };
+    const factsW = colW === Infinity ? Infinity : (colW >= 320 ? colW / 2 - 7 : colW);
+    const factsPerLine = factsW === Infinity ? Infinity : Math.floor(factsW / 6.45);
+    const clipFacts = (str) => {
+      const max = factsPerLine * 2;
+      if (!str || max === Infinity || str.length <= max) return str;
+      const cut = str.slice(0, Math.max(0, max - 1));
+      const space = cut.lastIndexOf(" ");
+      return (space > max * 0.6 ? cut.slice(0, space) : cut).replace(/[,;·\s]+$/, "") + "…";
+    };
+    // One pill per answer group, and a fresh draft starts at zero.
+    const doneCount = [
+      d.picked.length > 0,
+      d.theory != null,
+      d.workload != null && d.learning != null,
+      d.recommend != null && Boolean(d.reviewText.trim())
+    ].filter(Boolean).length;
+    const untouched = doneCount === 0 && d.recommend == null && !d.reviewText.trim();
+
+
+    return {
+      // Tabs tighten in three steps instead of scrolling or growing a "+N".
+      tabGap: indexed.length > 8 ? "2px" : "4px",
+      caretBg: s.overflowOpen ? "#eae6da" : "var(--pill)",
+      tabItems: indexed.map((t) => {
+        const on = t.i === s.tab;
+        const tight = indexed.length > 8;
+        const medium = !tight && indexed.length > 4;
+        const width = tight ? (on ? 44 : 30) : medium ? (on ? 90 : 68) : (on ? 104 : 88);
+        return {
+          title: t.label,
+          label: tight ? "" : medium ? t.code.slice(2) : t.code,
+          labelFlex: tight ? "0 0 0" : "1",
+          justify: tight ? "center" : "flex-start",
+          width: width + "px",
+          padding: tight ? "0" : on ? "0 8px 0 9px" : "0 9px",
+          dot: tight ? "8px" : "7px",
+          accent: t.kind === "r" ? "#dfa53c" : "#1751a6",
+          bg: on ? "var(--surface)" : "var(--pill)",
+          fg: on ? "var(--ink)" : "var(--dim)",
+          weight: on ? "600" : "500",
+          z: on ? "1" : "0",
+          dip: on ? "-1px" : "0",
+          isActive: on,
+          onClick: () => this.setState({ tab: t.i, overflowOpen: false }),
+          onClose: (e) => this.closeTab(e, t.i)
+        };
+      }),
+      reviewsOpen: s.reviewsOpen,
+      reviewsCaret: s.reviewsOpen ? "▴" : "▾",
+      reviewsTabBorder: s.reviewsOpen ? "var(--brand)" : "transparent",
+      reviewsTabFg: s.reviewsOpen ? "#1751a6" : "#5c6570",
+      onToggleReviews: () => this.setState({ reviewsOpen: !s.reviewsOpen }),
+      paneScrollRef: this.paneScrollRef,
+      reviewsRef: this.reviewsRef,
+      onExpandReviews: () => this.revealReviews(),
+      compareHelpOpen: s.compareHelpOpen,
+      compareHelpBg: s.compareHelpOpen ? "#eae6da" : "transparent",
+      onToggleCompareHelp: (e) => {
+        e.stopPropagation();
+        this.setState({ compareHelpOpen: !s.compareHelpOpen });
+      },
+      authOpen: s.authOpen,
+      justAuthed: s.justAuthed && !s.posted,
+      posted: s.posted,
+      postLabel: s.posted ? "Published" : s.justAuthed ? "Publish review" : "Post review",
+      onPostReview: () => {
+        // Happy/workload/learning are required to publish; only the write-up is optional.
+        if (d.recommend == null || d.workload == null || d.learning == null) return;
+        // A guest writes the whole review; only publishing needs an account.
+        if (guest) { this.setState({ authOpen: true }); return; }
+        if (!STORE.userTakenCourses.some((r) => r.userId === "u1" && r.courseCode === active.code)) {
+          const now = new Date().toISOString();
+          STORE.userTakenCourses.push({
+            userId: "u1", courseCode: active.code, attendancePeriods: [], attendanceYear: null,
+            grade: null, earnedCredits: null, transcriptImportedAt: null,
+            createdAt: now, updatedAt: now
+          });
+        }
+        STORE.reviews.push({
+          id: "r" + Date.now(), userId: "u1", courseCode: active.code,
+          examinationDistribution: STORE.examinationDistributionFrom(draftMix.items, d.pcts),
+          approachTheoryPercent: d.theory == null ? 50 : d.theory,
+          workloadScore: d.workload, learningScore: d.learning,
+          happyTook: d.recommend,
+          message: d.reviewText || "",
+          createdAt: new Date().toISOString(), updatedAt: new Date().toISOString()
+        });
+        this.setState({ posted: true, justAuthed: false });
+      },
+      // When a host owns the session, tell it — otherwise the two disagree.
+      onAuthDone: () => {
+        this.setState({ guest: false, authOpen: false, justAuthed: true });
+        if (this.props.onAuthed) this.props.onAuthed();
+      },
+      onAuthCancel: () => this.setState({ authOpen: false }),
+      isGuest: guest,
+      isMember: !guest,
+      night: this.ccDark(),
+      notNight: !this.ccDark(),
+      themeTitle: this.ccDark() ? "Switch to light mode" : "Switch to dark mode",
+      onTheme: () => this.ccSetDark(!this.ccDark()),
+      paneTop: "66px",
+      ...this.savedVals(guest),
+      onSignUp: (e) => { e.stopPropagation(); this.closeAll({ authOpen: true }); },
+      onLogIn: (e) => { e.stopPropagation(); this.closeAll({ authOpen: true }); },
+      hasTabs: Boolean(s.openSignal) || (s.workspaceTabCount || 0) > 0,
+      savedTopMargin: (Boolean(s.openSignal) || (s.workspaceTabCount || 0) > 0) ? "236px" : "0",
+      resultsMax: Boolean(s.openSignal) || (s.workspaceTabCount || 0) > 0 ? "none" : "880px",
+      workspaceCourses: COURSES,
+      workspaceStore: STORE,
+      workspaceLocale: this.locale(),
+      openSignal: s.openSignal,
+      onTabsChange: (count) => {
+        if (count === 0) { this.setState({ workspaceTabCount: 0, openSignal: null }); return; }
+        if (count !== s.workspaceTabCount) this.setState({ workspaceTabCount: count });
+      },
+      onWorkspaceAuthed: () => {},
+      rowRef: this.rowRef,
+      paneW: paneW + "px",
+      onPaneDrag: (e) => {
+        e.preventDefault();
+        const startX = e.clientX;
+        const startW = paneW;
+        const max = this.maxPane();
+        const min = this.minPane();
+        // Transitions off mid-drag, so the card tracks the handle exactly.
+        this.setState({ dragging: true });
+        window.addEventListener("pointerup", () => this.setState({ dragging: false }), { once: true });
+        this.drag((ev) => {
+          const next = Math.round(Math.max(min, Math.min(max, startW - (ev.clientX - startX))));
+          if (next !== this.state.paneW) this.setState({ paneW: next });
+        });
+      },
+      onPaneReset: () => this.setState({ paneW: 504 }),
+
+      // Every width in the card is interpolated from t, so no state is binary.
+      tween: s.dragging
+        ? "none"
+        : "padding .18s ease-out, width .18s ease-out, gap .18s ease-out, max-height .18s ease-out, max-width .18s ease-out, opacity .14s ease-out, font-size .18s ease-out",
+      titleSize: px(15.5, 17),
+      cardGap: px(8, 10),
+      cardPad: px(14, 18),
+      factsGap: px(10, 14),
+      reviewPad: "0 " + px(10, 13, late),
+      saveW: px(96, 126, late),
+      savePad: px(10, 12, late),
+      railW: px(134, 224),
+      railPad: px(14, 18) + " " + px(12, 16),
+      // Whole 19px line boxes only, so a partial line can never be sliced.
+      summaryLines: String(Math.max(1, summaryLines)),
+      summaryMax: summaryLines * 19 + "px",
+      summaryOpacity: summaryLines === 0 ? 0 : 1,
+      labelMax: px(0, 120, late),
+      labelOpacity: late,
+      showLabel: t > 0.02,
+      reviewFlex: t > 0.02 ? "0 1 132px" : "0 0 34px",
+      saveFlex: t > 0.02 ? "0 1 158px" : "0 0 68px",
+      cardHeight: "236px",
+      openCountLabel: (s.workspaceTabCount || 0) + " open",
+      noTabs: (s.workspaceTabCount || 0) === 0,
+      overflowOpen: s.overflowOpen,
+      onToggleOverflow: (e) => {
+        e.stopPropagation();
+        this.closeAll({ overflowOpen: !s.overflowOpen });
+      },
+      switcherItems: indexed.map((t) => ({
+        label: t.label,
+        accent: t.kind === "r" ? "#dfa53c" : "#1751a6",
+        bg: t.i === s.tab ? "var(--pill)" : "transparent",
+        fg: t.i === s.tab ? "var(--brand)" : "var(--ink2)",
+        weight: t.i === s.tab ? "600" : "400",
+        onClick: () => this.setState({ tab: t.i, overflowOpen: false }),
+        onClose: (e) => this.closeTab(e, t.i)
+      })),
+      isDetails: active.kind === "c",
+      isReview: active.kind === "r",
+      // The pane reads one course, so every figure in it follows the open tab.
+      detail: (() => {
+        const known = COURSES.find((x) => x.code === active.code);
+        // Codes outside the sample set stand in as unreviewed courses.
+        const c = known || {
+          code: active.code, title: active.code, meta: "7.5 hp · " + active.code + " · SCI",
+          summary: "No description on file yet. Open the course on KTH.se for the official syllabus.",
+          keywords: "", exSegments: [], th: null, wl: 0, le: 0, happy: 0, stats: ["0", "0", "0"]
+        };
+        const segs = c.exSegments || [];
+        const rounds = (STORE.getCourse(active.code) || { rounds: [] }).rounds || [];
+        return {
+          title: c.title, meta: c.meta, content: c.summary,
+          offerings: rounds.map((r, i) => ({
+            key: r.roundCode || String(i),
+            periods: r.formattedPeriodsAndCredits || r.periodLabel || "—",
+            language: r.language || "—",
+            tutoring: r.tutoringForm || "—"
+          })),
+          hasOfferings: rounds.length > 0,
+          noOfferings: rounds.length === 0,
+          reviews: c.stats[2], hp: c.meta.split(" · ")[0],
+          reviewed: Boolean(known), unreviewed: !known,
+          happy: c.happy != null ? c.happy + "%" : "—",
+          summaryLine: known
+            ? "Reviewers single out " + c.keywords.split(", ")[0] + " as the part of the course that sticks, and flag "
+              + (c.wl >= 80 ? "the workload as the thing to plan around." : "the pace as brisk but manageable.")
+            : "",
+
+          examSegments: segs.map((x) => ({ w: x.percent + "%", color: x.color })),
+          hasExam: segs.length > 0,
+          noExam: segs.length === 0,
+          exSplit: segs.length ? segs.map((x) => x.percent).join(" / ") : "—",
+          exNames: segs.length ? segs.map((x) => x.label).join(" · ") : "No examination breakdown yet",
+          thW: (c.th || 0) + "%", apW: (c.th == null ? 0 : 100 - c.th) + "%",
+          thSplit: c.th == null ? "—" : c.th + " / " + (100 - c.th),
+          wl: c.wl != null ? (c.wl / 10).toFixed(1) : "—", wlW: (c.wl || 0) + "%",
+          le: c.le != null ? (c.le / 10).toFixed(1) : "—", leW: (c.le || 0) + "%",
+          hasReviewStats: c.happy != null, noReviewStats: c.happy == null
+        };
+      })(),
+      onOpenReviewTab: () => this.openTab(active.code, "r"),
+      dragCursor: "col-resize",
+      happyNotSet: d.recommend == null,
+      paneGrow: "0 0 auto",
+      paneWidth: paneW + "px",
+      postBg: (d.recommend != null && d.workload != null && d.learning != null) ? "var(--btn)" : "var(--pill)",
+      postCursor: (d.recommend != null && d.workload != null && d.learning != null) ? "pointer" : "not-allowed",
+      postHint: (d.recommend != null && d.workload != null && d.learning != null) ? "" : "Answer happy, workload and learning to publish — the write-up is the only optional part",
+
+      examTrackRef: this.examTrackRef,
+      examSegs: draftMix.segs,
+      examSplitLabel: chosen.length ? chosen.map((m, i) => d.pcts[i] || 0).join(" / ") : "Not set",
+      examEmpty: chosen.length === 0,
+      savedLabel: untouched ? "Not saved yet" : "Saved just now",
+      examDividers: draftMix.dividers,
+      methodChips: draftMix.chips,
+
+      theoryW1: (d.theory == null ? 50 : d.theory) + "%",
+      theoryW2: (d.theory == null ? 50 : 100 - d.theory) + "%",
+      theoryFill1: d.theory == null ? "#ded8c8" : "currentColor",
+      theoryFill2: d.theory == null ? "#ded8c8" : "currentColor",
+      theoryInk1: d.theory == null ? "#6b6355" : "#fff",
+      theoryInk2: d.theory == null ? "#6b6355" : "#0f2c50",
+      theorySet: d.theory != null,
+      theoryUnset: d.theory == null,
+      theoryLabel: d.theory == null ? "Not set" : d.theory + " / " + (100 - d.theory),
+      onTheoryDown: (e) => this.startPct(e, 100, (v) => setDraft({ theory: v })),
+
+      workloadW: (d.workload == null ? 0 : d.workload * 10) + "%",
+      workloadSet: d.workload != null,
+      workloadLabel: d.workload == null ? "Not set" : d.workload + " / 10",
+      onWorkloadDown: (e) => this.startPct(e, 10, (v) => setDraft({ workload: v })),
+      learningW: (d.learning == null ? 0 : d.learning * 10) + "%",
+      learningSet: d.learning != null,
+      learningLabel: d.learning == null ? "Not set" : d.learning + " / 10",
+      onLearningDown: (e) => this.startPct(e, 10, (v) => setDraft({ learning: v })),
+
+      overallOpts: ["Bad", "Poor", "Okay", "Good", "Great"].map((label, i) => {
+        const v = i + 1;
+        const on = d.overall === v;
+        return {
+          value: v, label,
+          bg: on ? "var(--btn)" : "var(--surface)",
+          fg: on ? "var(--btnFg)" : "var(--muted)",
+          border: on ? "var(--brand)" : "#dde7f4",
+          onClick: () => setDraft({ overall: v })
+        };
+      }),
+
+      reviewText: d.reviewText,
+      onReviewChange: (e) => setDraft({ reviewText: e.target.value }),
+      promptChips: [
+        ["What surprised you?", "One thing that surprised me was "],
+        ["Who is it for?", "This course is a great fit if you "],
+        ["Time it really took?", "Budget more time than you think for "]
+      ].map(([label, starter]) => ({
+        label,
+        onClick: () => setDraft({
+          reviewText: d.reviewText ? d.reviewText.replace(/\s*$/, "") + "\n" + starter : starter
+        })
+      })),
+      progressLabel: doneCount + " of 4 sections done",
+      progressSegs: [0, 1, 2, 3].map((i) => ({ bg: i < doneCount ? "var(--btn)" : "var(--pill)" })),
+
+      stopClick: (e) => e.stopPropagation(),
+
+      contentClamp: s.contentOpen ? "unset" : "3",
+      contentToggleLabel: s.contentOpen ? "Show less" : "Read more",
+      onToggleContent: () => this.setState({ contentOpen: !s.contentOpen }),
+
+      happyOpts: [[true, "Yes, I am"], [false, "No, I am not"]].map(([v, label]) => {
+        const on = d.recommend === v;
+        return {
+          label,
+          bg: on ? "var(--pill)" : "var(--surface)",
+          fg: on ? "var(--brand)" : "var(--chipInk)",
+          border: on ? "var(--brand)" : "var(--rule3)",
+          weight: on ? "600" : "500",
+          dot: on ? "#1751a6" : "transparent",
+          dotBorder: on ? "var(--brand)" : "#c8c2b2",
+          onClick: () => setDraft({ recommend: v })
+        };
+      }),
+      recommendBg: d.recommend ? "var(--btn)" : "#cfc9b8",
+      recommendJustify: d.recommend ? "flex-end" : "flex-start",
+      recommendLabel: d.recommend == null
+        ? "I would recommend this course — not answered yet"
+        : d.recommend ? "Yes, I would recommend this course" : "No, I would not recommend this course",
+      onToggleRecommend: () => setDraft({ recommend: !d.recommend })
+    };
+  }
+
+  toggleFlag(e, code, key) {
+    e.stopPropagation();
+    if (key === "taken") { this.toggleTaken(code); return; }
+    const flags = { ...this.state.flags };
+    const cur = { ...(flags[code] || {}) };
+    cur[key] = !cur[key];
+    flags[code] = cur;
+    this.setState({ flags });
+    if (key === "saved") this.persistSaved(flags);
+  }
+
+  /** "Taken" lives in user_taken_courses, not the local flags cache, so
+      every card that lists this course (including as a prerequisite)
+      agrees the moment it changes. */
+  toggleTaken(code) {
+    const rows = STORE.userTakenCourses;
+    const at = rows.findIndex((r) => r.userId === "u1" && r.courseCode === code);
+    if (at >= 0) rows.splice(at, 1);
+    else {
+      const now = new Date().toISOString();
+      rows.push({ userId: "u1", courseCode: code, attendancePeriods: [], attendanceYear: null,
+        grade: null, earnedCredits: null, transcriptImportedAt: null, createdAt: now, updatedAt: now });
+    }
+    this.forceUpdate();
+  }
+
+  isTaken(code) {
+    return STORE.userTakenCourses.some((r) => r.userId === "u1" && r.courseCode === code);
+  }
+
+  /** Writes only our own key, so nothing else in storage is touched. */
+  persistSaved(flags) {
+    try {
+      const codes = Object.keys(flags).filter((code) => flags[code] && flags[code].saved);
+      window.localStorage.setItem(SAVED_KEY, JSON.stringify(codes));
+    } catch (e) { /* storage unavailable */ }
+  }
+
+  closeTab(e, i) {
+    e.stopPropagation();
+    const tabs = this.state.tabs.slice();
+    tabs.splice(i, 1);
+    let tab = this.state.tab;
+    if (i < tab) tab -= 1;
+    if (tab >= tabs.length) tab = tabs.length - 1;
+    this.setState({ tabs, tab: Math.max(0, tab) });
+  }
+
+  openTab(code, kind) {
+    this.setState({ openSignal: { code, kind, nonce: Date.now() } });
+  }
+}
+</script>
+</body>
+</html>

--- a/docs/design/Course Community - Taken Courses.dc.html
+++ b/docs/design/Course Community - Taken Courses.dc.html
@@ -1,0 +1,1549 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<script src="./support.js"></script>
+</head>
+<body>
+<x-dc>
+<helmet data-dc-atomics><link rel="preconnect" href="https://fonts.googleapis.com"><link rel="preconnect" href="https://fonts.gstatic.com" crossorigin><link href="https://fonts.googleapis.com/css2?family=Geist:wght@400;500;600;700&family=Geist+Mono:wght@400;500&display=swap" rel="stylesheet"><link rel="stylesheet" href="cc-theme.css"><style>body{background:var(--pg);color:var(--ink)}html,body{margin:0;height:100%;background:var(--pg);font-family:Geist,system-ui,sans-serif;color:var(--ink)}a{color:#1751a6}a:hover{color:#10386f}*{box-sizing:border-box}input,button,textarea{font-family:Geist,system-ui,sans-serif}@keyframes pulse{0%,100%{opacity:.35}50%{opacity:1}}@keyframes sweep{0%{transform:translateX(-100%)}100%{transform:translateX(320%)}}@keyframes rise{from{opacity:0;transform:translateY(6px)}to{opacity:1;transform:none}}</style></helmet>
+
+<div style="position:relative;display:flex;height:900px;background:var(--pg);color:var(--ink);font-size:14px">
+<div data-cc-topbar="1" data-cc-fade="1" style="position:absolute;top:0;left:0;right:0;height:66px;z-index:1;box-sizing:border-box;display:flex;align-items:center;justify-content:flex-end;gap:8px;padding:0 28px;border-bottom:1px solid var(--rule);background:var(--pg)">
+<div onClick="{{ onTheme }}" role="button" tabIndex="0" title="{{ themeTitle }}" aria-label="{{ themeTitle }}" style="width:34px;height:34px;display:flex;align-items:center;justify-content:center;border-radius:8px;color:var(--chipInk);cursor:pointer" style-hover="background:rgba(125,145,175,.14)">
+<sc-if value="{{ notNight }}" hint-placeholder-val="{{ true }}"><svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><path d="M20.5 14.5A8.5 8.5 0 1 1 9.5 3.5a7 7 0 0 0 11 11z"></path></svg></sc-if>
+<sc-if value="{{ night }}" hint-placeholder-val="{{ false }}"><svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round"><circle cx="12" cy="12" r="4.2"></circle><path d="M12 3v2M12 19v2M3 12h2M19 12h2M5.6 5.6l1.4 1.4M17 17l1.4 1.4M18.4 5.6 17 7M7 17l-1.4 1.4"></path></svg></sc-if>
+</div>
+</div>
+
+<div data-cc-sidebar="1" data-cc-fade="1" style="position:relative;z-index:2;box-sizing:border-box;width:236px;flex:none;display:flex;flex-direction:column;gap:6px;padding:14px 10px;background:#1751a6;color:#fff">
+<a href="Course Community - Landing.dc.html" style="display:flex;align-items:center;gap:10px;padding:6px 8px 14px;color:#fff;text-decoration:none">
+<img src="assets/ais-symbol-white.png" alt="KTH AI Society" style="height:34px;width:34px;object-fit:contain">
+<div style="width:1px;height:28px;background:rgba(255,255,255,.35)"></div>
+<div style="font-size:15px;font-weight:600;line-height:1.15">Course<br>Community</div>
+</a>
+<div style="display:flex;flex-direction:column;gap:2px;margin-top:14px">
+<a href="Course Community - Explore.dc.html" style="display:flex;align-items:center;gap:10px;padding:9px 10px;border-radius:8px;background:transparent;font-weight:400;color:#fff;text-decoration:none" style-hover="background:rgba(255,255,255,.1)"><svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="#fff" stroke-width="2.4" stroke-linecap="round"><circle cx="11" cy="11" r="7"></circle><line x1="16.5" y1="16.5" x2="21" y2="21"></line></svg><span style="flex:1">Explore</span></a>
+<a href="Course Community - Saved.dc.html" style="display:flex;align-items:center;gap:10px;padding:9px 10px;border-radius:8px;background:transparent;font-weight:400;color:#fff;text-decoration:none" style-hover="background:rgba(255,255,255,.1)"><svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="#fff" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="m19 21-7-4-7 4V5a2 2 0 0 1 2-2h10a2 2 0 0 1 2 2z"></path></svg><span style="flex:1">Saved courses</span><sc-if value="{{ hasSavedCount }}" hint-placeholder-val="{{ true }}"><span style="padding:1px 7px;border-radius:9px;background:rgba(255,255,255,.22);font-size:11.5px;font-weight:600">{{ savedCountLabel }}</span></sc-if></a>
+<a href="Course Community - My Page.dc.html" style="display:flex;align-items:center;gap:10px;padding:9px 10px;border-radius:8px;background:transparent;font-weight:400;color:#fff;text-decoration:none" style-hover="background:rgba(255,255,255,.1)"><svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="#fff" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="8" r="4"></circle><path d="M5.5 21a6.5 6.5 0 0 1 13 0"></path></svg><span style="flex:1">My Page</span></a>
+<a href="Course Community - Taken Courses.dc.html" style="display:flex;align-items:center;gap:10px;padding:9px 10px;border-radius:8px;background:rgba(255,255,255,.16);font-weight:600;color:#fff;text-decoration:none" style-hover="background:rgba(255,255,255,.1)"><svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="#fff" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="10"></circle><path d="m9 12 2 2 4-4"></path></svg><span style="flex:1">Taken courses</span></a>
+</div>
+<div style="margin-top:auto;display:flex;flex-direction:column;gap:2px">
+<a href="Course Community - About.dc.html" style="display:flex;align-items:center;gap:10px;padding:9px 10px;border-radius:8px;color:rgba(255,255,255,.82);text-decoration:none" style-hover="background:rgba(255,255,255,.1)"><svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="#fff" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M12 7v14"></path><path d="M3 18a1 1 0 0 1-1-1V4a1 1 0 0 1 1-1h5a4 4 0 0 1 4 4 4 4 0 0 1 4-4h5a1 1 0 0 1 1 1v13a1 1 0 0 1-1 1h-6a3 3 0 0 0-3 3 3 3 0 0 0-3-3z"></path></svg>About &amp; contact</a>
+<sc-if value="{{ isMember }}" hint-placeholder-val="{{ false }}">
+<div style="display:flex;align-items:center;gap:10px;padding:10px;margin-top:8px;border-radius:8px;background:rgba(255,255,255,.1)">
+<div style="width:34px;height:34px;flex:none;border-radius:50%;background:#7ea6d8;color:#0d2f5e;display:flex;align-items:center;justify-content:center;font-weight:700;font-size:13px">EL</div>
+<div style="flex:1;min-width:0;font-size:13px;font-weight:500">Elsa Lindqvist</div>
+<div onClick="{{ onSignOut }}" role="button" tabIndex="0" aria-label="Sign out" title="Sign out" style="flex:none;width:28px;height:28px;display:flex;align-items:center;justify-content:center;border-radius:7px;color:rgba(255,255,255,.75);cursor:pointer" style-hover="background:rgba(255,255,255,.16);color:#fff"><svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.9" stroke-linecap="round" stroke-linejoin="round"><path d="M9 21H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h4"></path><path d="M16 17l5-5-5-5"></path><path d="M21 12H9"></path></svg></div>
+</div>
+</sc-if>
+<sc-if value="{{ isGuest }}" hint-placeholder-val="{{ true }}">
+<div style="margin-top:8px;padding-top:12px;border-top:1px solid rgba(255,255,255,.2)">
+<div style="font-size:11.5px;line-height:1.45;color:rgba(255,255,255,.78)">Browsing as a guest. Saving courses and posting reviews need an account.</div>
+<div onClick="{{ onSignUp }}" role="button" tabIndex="0" style="margin-top:10px;display:flex;align-items:center;justify-content:center;height:34px;border-radius:8px;background:#fff;color:#12417f;font-size:13px;font-weight:600;cursor:pointer">Sign up</div>
+<div onClick="{{ onLogIn }}" role="button" tabIndex="0" style="margin-top:6px;display:flex;align-items:center;justify-content:center;height:34px;border-radius:8px;border:1px solid rgba(255,255,255,.4);font-size:13px;font-weight:500;color:#fff;cursor:pointer">Log in</div>
+</div>
+</sc-if>
+</div>
+</div>
+
+<div style="position:relative;flex:1;min-width:0;min-height:0;margin-top:{{ paneTop }};display:flex;flex-direction:column;overflow-y:auto;overflow-x:hidden">
+<div style="width:100%;max-width:{{ pageMaxWidth }};box-sizing:border-box;margin:0 auto;padding:0 {{ pageSidePadding }};flex:1;min-width:0;display:flex;flex-direction:column">
+<dc-import name="Course Community - Page Header" title="Taken courses" subtitle="Your completed courses." hint-size="100%,90px"></dc-import>
+
+<div style="padding:0 20px">
+<sc-if value="{{ isAuth }}" hint-placeholder-val="{{ false }}">
+<div style="flex:1;display:flex;align-items:flex-start;justify-content:center;padding:30px 0 40px">
+<div style="width:100%;max-width:520px">
+<div style="font-size:11px;font-weight:600;letter-spacing:.09em;text-transform:uppercase;color:var(--brand)">One step left</div>
+<div style="margin-top:10px;font-size:24px;font-weight:600;line-height:1.2;letter-spacing:-.015em">Sign in to keep this list</div>
+<div style="margin-top:8px;font-size:14px;line-height:1.55;color:var(--muted)">{{ authReturnLine }}</div>
+<div style="margin-top:20px;display:flex;flex-direction:column;gap:9px">
+<div onClick="{{ onSignIn }}" style="display:flex;align-items:center;justify-content:center;height:42px;border-radius:9px;background:var(--btn);color:var(--btnFg);font-size:13.5px;font-weight:600;cursor:pointer">Continue with KTH account</div>
+<div onClick="{{ onSignIn }}" style="display:flex;align-items:center;justify-content:center;height:42px;border-radius:9px;border:1px solid var(--rule3);background:var(--surface);font-size:13.5px;font-weight:500;color:var(--ink);cursor:pointer" style-hover="border-color:var(--hov)">Sign up with email</div>
+</div>
+<div onClick="{{ onBackToWork }}" style="margin-top:14px;font-size:12.5px;font-weight:500;color:var(--brand);cursor:pointer" style-hover="text-decoration:underline">Back to the list</div>
+</div>
+</div>
+</sc-if>
+
+<sc-if value="{{ isEmpty }}" hint-placeholder-val="{{ false }}">
+<div style="flex:1;display:flex;flex-direction:column;align-items:center;padding:14px 20px 40px">
+<div style="width:100%;max-width:480px;text-align:center">
+
+<div style="display:flex;align-items:flex-start;gap:9px;padding:11px 13px;border-radius:10px;background:var(--pill);text-align:left">
+<svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" style="flex:none;margin-top:1px;color:var(--dim)"><circle cx="12" cy="12" r="9.5"></circle><path d="M12 8v5"></path><path d="M12 16h.01"></path></svg>
+<div style="font-size:12.5px;line-height:1.5;color:var(--ink2)">Remember to pick <span style="font-weight:600">Resultatintyg</span> in Ladok, and make sure course codes are included.</div>
+</div>
+
+<div onClick="{{ onToggleGrades }}" style="margin-top:14px;display:flex;align-items:center;justify-content:space-between;gap:16px;padding:14px 2px;border-bottom:1px solid var(--rule);cursor:pointer;text-align:left">
+<div style="min-width:0">
+<div style="font-size:13.5px;font-weight:600">Read grades from transcript</div>
+<div style="margin-top:3px;font-size:12.5px;line-height:1.5;color:var(--muted)">{{ gradesHint }}</div>
+</div>
+<div style="flex:none;width:42px;height:24px;border-radius:99px;background:{{ gradesTrack }};padding:3px;display:flex;justify-content:{{ gradesJustify }};transition:background .16s ease-out"><div style="width:18px;height:18px;border-radius:50%;background:var(--surface);box-shadow:0 1px 2px rgba(20,30,45,.28)"></div></div>
+</div>
+
+<div onClick="{{ onUpload }}" onPointerEnter="{{ onDropEnter }}" onPointerLeave="{{ onDropLeave }}" style="margin-top:20px;padding:40px 28px;border-radius:14px;border:2px dashed {{ dropBorder }};background:{{ dropBg }};display:flex;flex-direction:column;align-items:center;cursor:pointer;transition:background .16s ease-out,border-color .16s ease-out">
+<div style="width:48px;height:48px;border-radius:13px;background:var(--pill);display:flex;align-items:center;justify-content:center"><svg width="21" height="21" viewBox="0 0 24 24" fill="none" stroke="#1751a6" stroke-width="1.9" stroke-linecap="round" stroke-linejoin="round"><path d="M12 16V4"></path><path d="m7.5 8.5 4.5-4.5 4.5 4.5"></path><path d="M4 15v3a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2v-3"></path></svg></div>
+<div style="margin-top:14px;font-size:16px;font-weight:600">{{ dropTitle }}</div>
+<div style="margin-top:5px;font-size:12.5px;color:var(--muted)">PDF from Ladok · up to 10 MB</div>
+<div style="margin-top:16px;display:flex;align-items:center;gap:8px;height:38px;padding:0 15px;border-radius:9px;background:var(--btn);color:var(--btnFg);font-size:13px;font-weight:600" style-hover="background:var(--btn)"><svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="#fff" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M14 3H7a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h10a2 2 0 0 0 2-2V8z"></path><path d="M14 3v5h5"></path></svg>Choose a PDF</div>
+</div>
+
+<div onClick="{{ onManualStart }}" style="margin-top:16px;font-size:12.5px;font-weight:500;color:var(--brand);cursor:pointer" style-hover="text-decoration:underline">Add courses manually instead</div>
+</div>
+</div>
+</sc-if>
+
+<sc-if value="{{ isParsing }}" hint-placeholder-val="{{ false }}">
+<div style="flex:1;display:flex;align-items:flex-start;justify-content:center;padding:30px 0 40px">
+<div style="width:100%;max-width:520px">
+<div style="font-size:22px;font-weight:600;line-height:1.2;letter-spacing:-.015em">{{ parseHeading }}</div>
+<div style="margin-top:8px;font-size:13.5px;color:var(--muted)">{{ parseFile }} · nothing is saved until you confirm</div>
+<div style="margin-top:20px;height:6px;border-radius:99px;background:var(--pill);overflow:hidden;position:relative">
+<div style="position:absolute;top:0;bottom:0;left:0;width:34%;border-radius:99px;background:var(--btn);animation:sweep 1.1s ease-in-out infinite"></div>
+</div>
+<div onClick="{{ onCancelParse }}" style="margin-top:16px;font-size:12.5px;color:var(--muted);cursor:pointer" style-hover="text-decoration:underline">Cancel</div>
+</div>
+</div>
+</sc-if>
+
+<sc-if value="{{ isFailed }}" hint-placeholder-val="{{ false }}">
+<div style="flex:1;display:flex;align-items:flex-start;justify-content:center;padding:18px 0 40px">
+<div style="width:100%;max-width:620px;animation:rise .2s ease-out">
+<div style="display:flex;align-items:center;gap:10px">
+<span style="width:26px;height:26px;border-radius:50%;background:#fbeceb;display:flex;align-items:center;justify-content:center"><svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="#a3452a" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round"><path d="M12 8v5"></path><path d="M12 16.5h.01"></path></svg></span>
+<div style="font-size:11px;font-weight:600;letter-spacing:.09em;text-transform:uppercase;color:#a3452a">Reading failed</div>
+</div>
+<div style="margin-top:12px;font-size:22px;font-weight:600;line-height:1.2;letter-spacing:-.015em">{{ errorTitle }}</div>
+<div style="margin-top:8px;font-size:14px;line-height:1.55;color:var(--muted);text-wrap:pretty">{{ errorBody }}</div>
+<div style="margin-top:18px;display:flex;align-items:center;gap:12px;padding:14px 16px;border-radius:12px;border:1px solid #f0d7cf;background:#fdf3ef">
+<div style="width:38px;height:38px;flex:none;border-radius:9px;background:#fbeceb;display:flex;align-items:center;justify-content:center"><svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="#a3452a" stroke-width="1.9" stroke-linecap="round" stroke-linejoin="round"><path d="M14 3H7a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h10a2 2 0 0 0 2-2V8z"></path><path d="M14 3v5h5"></path></svg></div>
+<div style="flex:1;min-width:0;font-size:13px;color:#7a3b26">{{ errorFile }}</div>
+<div style="flex:none;font-size:12.5px;font-weight:500;color:#a3452a">Nothing was saved</div>
+</div>
+<div style="margin-top:16px;border:1px solid var(--rule);border-radius:12px;background:var(--surface);padding:15px 16px">
+<div style="font-size:13px;line-height:1.55;color:var(--muted)">Download the certificate straight from Ladok rather than scanning it — if no text selects in the PDF, it is a scan.</div>
+</div>
+<div style="margin-top:18px;display:flex;align-items:center;gap:11px">
+<div onClick="{{ onUpload }}" style="display:flex;align-items:center;gap:9px;height:44px;padding:0 20px;border-radius:9px;background:var(--btn);color:var(--btnFg);font-size:14px;font-weight:600;cursor:pointer" style-hover="background:var(--btn)">Try another file</div>
+<div onClick="{{ onManualStart }}" style="display:flex;align-items:center;height:44px;padding:0 16px;border-radius:9px;border:1px solid var(--rule3);background:var(--surface);font-size:13.5px;font-weight:500;color:var(--chipInk);cursor:pointer" style-hover="border-color:var(--hov)">Add courses manually</div>
+</div>
+</div>
+</div>
+</sc-if>
+
+<sc-if value="{{ isPreview }}" hint-placeholder-val="{{ false }}">
+<div style="flex:1;display:flex;align-items:flex-start;justify-content:center;padding:30px 0 40px">
+<div style="width:100%;max-width:560px">
+<div style="font-size:11px;font-weight:600;letter-spacing:.09em;text-transform:uppercase;color:var(--brand)">Transcript read</div>
+<div style="margin-top:9px;font-size:24px;font-weight:600;line-height:1.2;letter-spacing:-.015em">{{ previewHeadline }}</div>
+<div style="margin-top:8px;font-size:14px;line-height:1.55;color:var(--muted)">Nothing is saved to your list until you confirm.</div>
+
+<sc-if value="{{ hasSkipped }}" hint-placeholder-val="{{ false }}">
+<div style="margin-top:16px;display:flex;align-items:flex-start;gap:11px;padding:13px 15px;border-radius:11px;border:1px solid var(--rule2);background:var(--pill)">
+<svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" style="flex:none;margin-top:1px;color:var(--dim)"><circle cx="12" cy="12" r="9.5"></circle><path d="M12 8v5"></path><path d="M12 16h.01"></path></svg>
+<div style="flex:1;min-width:0">
+<div style="font-size:13.5px;font-weight:600">{{ skippedTitle }}</div>
+<div style="margin-top:4px;font-size:12.5px;line-height:1.5;color:var(--muted)">These rows don't match a KTH catalog course, so they were left out.</div>
+<div style="margin-top:8px;display:flex;flex-direction:column;gap:4px">
+<sc-for list="{{ skippedItems }}" as="x" hint-placeholder-count="3">
+<div style="display:flex;align-items:baseline;gap:8px;font-size:12.5px;color:var(--ink2)"><span style="flex:none;width:5px;height:5px;margin-top:5px;border-radius:50%;background:var(--rule3)"></span><span style="min-width:0;overflow:hidden;text-overflow:ellipsis;white-space:nowrap">{{ x.label }}</span></div>
+</sc-for>
+</div>
+</div>
+</div>
+</sc-if>
+
+<div style="margin-top:20px;display:flex;align-items:center;gap:11px">
+<div onClick="{{ onConfirm }}" role="button" tabIndex="0" style="display:flex;align-items:center;height:44px;padding:0 20px;border-radius:9px;background:var(--btn);color:var(--btnFg);font-size:14px;font-weight:600;cursor:pointer" style-hover="opacity:.88">{{ confirmCta }}</div>
+</div>
+</div>
+</div>
+</sc-if>
+
+<sc-if value="{{ isList }}" hint-placeholder-val="{{ false }}">
+<div style="flex:1;display:flex;flex-direction:column;min-width:0">
+
+<div style="padding:20px 0 18px;border-bottom:1px solid var(--rule)">
+<div style="display:flex;flex-wrap:wrap;align-items:center;justify-content:space-between;gap:16px 24px">
+<div style="min-width:340px;flex:1">
+<div style="margin-top:9px;font-size:13.5px;color:var(--muted)"><span style="font-weight:600;color:var(--ink);font-variant-numeric:tabular-nums">{{ count }}</span> courses</div>
+</div>
+<div style="flex:1 1 auto;min-width:0;max-width:100%;display:flex;flex-direction:column;align-items:flex-end;gap:6px">
+<div onClick="{{ onUpdateStart }}" style="display:flex;align-items:center;gap:8px;height:38px;padding:0 14px;border-radius:9px;border:1px solid var(--rule3);background:var(--surface);font-size:13px;font-weight:500;color:var(--chipInk);cursor:pointer" style-hover="border-color:var(--hov)"><svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="#4a5560" stroke-width="1.9" stroke-linecap="round" stroke-linejoin="round"><path d="M20 12a8 8 0 1 1-2.6-5.9"></path><path d="M20 4v4h-4"></path></svg>Update transcript</div>
+<div style="font-size:12px;color:var(--dim2);white-space:nowrap">{{ sourceLabel }}</div>
+</div>
+</div>
+
+<sc-if value="{{ hasBanner }}" hint-placeholder-val="{{ false }}">
+<div style="margin-top:16px;display:flex;align-items:flex-start;gap:11px;padding:13px 15px;border-radius:11px;border:1px solid #cfe4de;background:#e9f3ef;animation:rise .22s ease-out">
+<svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="#1c6b60" stroke-width="2.1" stroke-linecap="round" stroke-linejoin="round" style="flex:none;margin-top:1px"><circle cx="12" cy="12" r="9.5"></circle><path d="m8.5 12.2 2.4 2.4 4.6-5"></path></svg>
+<div style="flex:1;min-width:0">
+<div style="font-size:13.5px;font-weight:600;color:#1c6b60">{{ bannerTitle }}</div>
+<div style="margin-top:4px;font-size:12.5px;line-height:1.5;color:#2b6a60">{{ bannerBody }}</div>
+</div>
+<div onClick="{{ onDismissBanner }}" style="flex:none;width:24px;height:24px;display:flex;align-items:center;justify-content:center;border-radius:6px;color:#1c6b60;font-size:16px;line-height:1;cursor:pointer" style-hover="background:rgba(28,107,96,.1)">×</div>
+</div>
+</sc-if>
+
+<div style="flex:1;padding:18px 0 0;display:flex;flex-direction:column;gap:18px">
+
+<sc-if value="{{ hasPending }}" hint-placeholder-val="{{ true }}">
+<dc-import name="Course Community - Unreviewed Card" courses="{{ unreviewedCourses }}" line="{{ pendingLine }}" on-start="{{ onStartReviewer }}" hint-size="100%,220px"></dc-import>
+</sc-if>
+<div style="border:1px solid var(--rule);border-radius:12px;background:var(--surface);overflow-x:auto;overflow-y:hidden">
+<div style="display:grid;grid-template-columns:minmax(64px,96px) minmax(140px,1fr) minmax(50px,70px) minmax(64px,90px) minmax(50px,70px) minmax(76px,108px) minmax(110px,170px);gap:clamp(8px,1.4vw,18px);width:100%;min-width:640px;box-sizing:border-box;align-items:center;padding:14px 16px;border-bottom:1px solid #f2efe6;background:var(--pg);font-size:11px;font-weight:600;letter-spacing:.06em;text-transform:uppercase;color:var(--dim)">
+<div>Code</div><div>Course</div><div>Credits</div><div>Grade</div><div>Year</div><div>Reviewed</div><div style="text-align:right">Actions</div>
+</div>
+<div onClick="{{ onAddStart }}" role="button" tabIndex="0" style="display:flex;align-items:center;gap:9px;width:100%;min-width:600px;box-sizing:border-box;padding:11px 15px;margin:1px;border:1px dashed #9dbfe4;border-radius:9px;background:rgba(23,81,166,.06);color:var(--brand);cursor:pointer" style-hover="border-color:var(--brand);background:rgba(23,81,166,.11)"><svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M5 12h14"></path><path d="M12 5v14"></path></svg><span style="font-size:13.5px;font-weight:500">Add a course by hand</span></div>
+<sc-for list="{{ okRows }}" as="r" hint-placeholder-count="9">
+<div style="display:grid;grid-template-columns:minmax(64px,96px) minmax(140px,1fr) minmax(50px,70px) minmax(64px,90px) minmax(50px,70px) minmax(76px,108px) minmax(110px,170px);gap:clamp(8px,1.4vw,18px);width:100%;min-width:640px;box-sizing:border-box;align-items:center;padding:11px 16px;border-bottom:1px solid #f4f2ea;background:{{ r.rowBg }}" style-hover="background:var(--pg)">
+<div style="font:500 13px Geist Mono,ui-monospace,monospace;color:var(--brand)">{{ r.codeLabel }}</div>
+<div style="min-width:0;display:flex;align-items:center;gap:8px">
+<span style="font-size:13.5px;font-weight:500;overflow:hidden;text-overflow:ellipsis;white-space:nowrap">{{ r.name }}</span>
+<sc-if value="{{ r.isNew }}" hint-placeholder-val="{{ false }}">
+<span style="flex:none;padding:2px 7px;border-radius:5px;background:#e9f3ef;color:#1c6b60;font-size:11px;font-weight:600">New</span>
+</sc-if>
+<sc-if value="{{ r.edited }}" hint-placeholder-val="{{ false }}">
+<span style="flex:none;padding:2px 7px;border-radius:5px;background:var(--pill);color:var(--muted);font-size:11px;font-weight:500">Edited</span>
+</sc-if>
+</div>
+<sc-if value="{{ r.isEditing }}" hint-placeholder-val="{{ false }}">
+<input value="{{ r.draftHp }}" onChange="{{ r.onHpChange }}" onClick="{{ stopClick }}" inputMode="decimal" style="box-sizing:border-box;width:56px;height:28px;padding:0 6px;border-radius:6px;border:1px solid var(--brand);outline:none;font-family:inherit;font-size:13px;color:var(--ink)">
+</sc-if>
+<sc-if value="{{ r.notEditing }}" hint-placeholder-val="{{ true }}">
+<div style="font-size:13px;font-variant-numeric:tabular-nums;color:var(--ink2)">{{ r.hpLabel }}</div>
+</sc-if>
+<sc-if value="{{ r.isEditing }}" hint-placeholder-val="{{ false }}">
+<input value="{{ r.draftGrade }}" onChange="{{ r.onGradeChange }}" onClick="{{ stopClick }}" placeholder="—" maxLength="1" style="box-sizing:border-box;width:34px;height:28px;padding:0;text-align:center;border-radius:6px;border:1px solid var(--brand);outline:none;font-family:inherit;font-size:13px;font-weight:600;color:var(--ink);text-transform:uppercase">
+</sc-if>
+<sc-if value="{{ r.notEditing }}" hint-placeholder-val="{{ true }}">
+<div><span style="display:inline-flex;align-items:center;padding:3px 9px;border-radius:7px;background:{{ r.gradeBg }};color:{{ r.gradeFg }};font-size:13px;font-weight:600">{{ r.gradeLabel }}</span></div>
+</sc-if>
+<sc-if value="{{ r.isEditing }}" hint-placeholder-val="{{ false }}">
+<input value="{{ r.draftYear }}" onChange="{{ r.onYearChange }}" onClick="{{ stopClick }}" inputMode="numeric" maxLength="4" placeholder="2025" style="box-sizing:border-box;width:58px;height:28px;padding:0 6px;text-align:center;border-radius:6px;border:1px solid var(--brand);outline:none;font-family:inherit;font-size:13px;color:var(--ink)">
+</sc-if>
+<sc-if value="{{ r.notEditing }}" hint-placeholder-val="{{ true }}">
+<div style="font-size:13px;color:var(--ink2);font-variant-numeric:tabular-nums">{{ r.year }}</div>
+</sc-if>
+<div style="display:flex;align-items:center;min-width:0">
+<sc-if value="{{ r.reviewed }}" hint-placeholder-val="{{ false }}">
+<span style="display:inline-flex;align-items:center;gap:6px;font-size:12px;font-weight:600;color:#1c6b60"><svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="#1c6b60" stroke-width="2.1" stroke-linecap="round" stroke-linejoin="round" style="flex:none"><circle cx="12" cy="12" r="9.5"></circle><path d="m8.5 12.2 2.4 2.4 4.6-5"></path></svg>Done</span>
+</sc-if>
+<sc-if value="{{ r.canReview }}" hint-placeholder-val="{{ true }}">
+<span style="font-size:11.5px;color:var(--dim2)">Not yet</span>
+</sc-if>
+</div>
+<sc-if value="{{ r.isEditing }}" hint-placeholder-val="{{ false }}">
+<div style="display:flex;align-items:center;justify-content:flex-end;gap:8px">
+<div onClick="{{ r.onSaveEdit }}" title="Save" style="width:30px;height:30px;flex:none;display:flex;align-items:center;justify-content:center;border-radius:7px;background:var(--btn);color:var(--btnFg);cursor:pointer" style-hover="opacity:.88"><svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round"><path d="M20 6 9 17l-5-5"></path></svg></div>
+<div onClick="{{ r.onCancelEdit }}" title="Cancel" style="width:30px;height:30px;flex:none;display:flex;align-items:center;justify-content:center;border-radius:7px;border:1px solid var(--rule3);background:var(--surface);cursor:pointer" style-hover="border-color:var(--hov)"><svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="#6b6355" stroke-width="2" stroke-linecap="round"><path d="M6 6l12 12M18 6 6 18"></path></svg></div>
+</div>
+</sc-if>
+<sc-if value="{{ r.notEditing }}" hint-placeholder-val="{{ true }}">
+<div style="display:flex;align-items:center;justify-content:flex-end;gap:8px">
+<div onClick="{{ r.onEdit }}" title="Edit credits and grade" style="width:30px;height:30px;flex:none;display:flex;align-items:center;justify-content:center;border-radius:7px;border:1px solid var(--rule3);background:var(--surface);cursor:pointer" style-hover="border-color:var(--brand)"><svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="#1751a6" stroke-width="1.9" stroke-linecap="round" stroke-linejoin="round"><path d="M12 20h9"></path><path d="M16.5 3.5a2.1 2.1 0 0 1 3 3L7 19l-4 1 1-4z"></path></svg></div>
+<div onClick="{{ r.onRemove }}" title="Remove" style="width:30px;height:30px;flex:none;display:flex;align-items:center;justify-content:center;border-radius:7px;border:1px solid var(--rule3);background:var(--surface);cursor:pointer" style-hover="border-color:#c96a4a"><svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="#6b6355" stroke-width="1.9" stroke-linecap="round" stroke-linejoin="round"><path d="M4 7h16"></path><path d="M9 7V5h6v2"></path><path d="M6 7l1 13h10l1-13"></path></svg></div>
+</div>
+</sc-if>
+</div>
+</sc-for>
+<sc-if value="{{ listEmpty }}" hint-placeholder-val="{{ false }}">
+<div style="padding:40px 20px;display:flex;flex-direction:column;align-items:center;text-align:center">
+<div style="font-size:15px;font-weight:600">No courses in your list</div>
+<div style="margin-top:6px;max-width:400px;font-size:13px;line-height:1.5;color:var(--muted)">Upload a Ladok transcript and we will read the rows out of it, or add one by hand.</div>
+<div style="margin-top:16px;display:flex;gap:10px">
+<div onClick="{{ onAddStart }}" style="display:flex;align-items:center;gap:8px;height:38px;padding:0 15px;border-radius:9px;background:var(--btn);color:var(--btnFg);font-size:13px;font-weight:600;cursor:pointer">Add a course by hand</div>
+<div onClick="{{ onUpdateStart }}" style="display:flex;align-items:center;height:38px;padding:0 15px;border-radius:9px;border:1px solid var(--rule3);background:var(--surface);font-size:13px;font-weight:500;color:var(--chipInk);cursor:pointer">Upload a transcript</div>
+</div>
+</div>
+</sc-if>
+</div>
+
+</div>
+</div>
+
+<div style="padding:18px 0 26px;display:flex;align-items:center;gap:8px;font-size:11.5px;color:var(--dim2)">
+<svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="#8a857a" stroke-width="1.9" stroke-linecap="round" stroke-linejoin="round" style="flex:none"><circle cx="12" cy="12" r="10"></circle><path d="M12 16v-5"></path><path d="M12 8h.01"></path></svg>
+Course Community is run by KTH AI Society, a student organisation. Credits, grades and any average shown here are your own entries — not an official KTH record.
+</div>
+</div>
+</sc-if>
+
+<sc-if value="{{ isReviewer }}" hint-placeholder-val="{{ false }}">
+<div style="flex:1;display:flex;flex-direction:column;min-width:0">
+
+<div style="padding:18px 0 16px;border-bottom:1px solid var(--rule);display:flex;align-items:flex-start;justify-content:space-between;gap:24px">
+<div style="min-width:0">
+<div style="font-size:11px;font-weight:600;letter-spacing:.09em;text-transform:uppercase;color:#7a5309">Quick review</div>
+<div style="margin-top:7px;font-size:19px;font-weight:600;line-height:1.25">One card per course</div>
+<div style="margin-top:8px;max-width:560px;font-size:13.5px;line-height:1.5;color:var(--muted)">Four quick questions and a line of text per course. Skip the ones you have no opinion about — they stay in the list as unreviewed.</div>
+</div>
+<div onClick="{{ onCloseReviewer }}" style="flex:none;display:flex;align-items:center;gap:8px;height:38px;padding:0 14px;border-radius:9px;border:1px solid var(--rule3);background:var(--surface);font-size:13px;font-weight:500;color:var(--chipInk);cursor:pointer" style-hover="border-color:var(--hov)"><svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="#4a5560" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M19 12H6"></path><path d="m11.5 5.5-6.5 6.5 6.5 6.5"></path></svg>Back to courses</div>
+</div>
+
+<div style="padding:16px 0 0;display:flex;align-items:center;gap:14px">
+<div style="flex:none;font-size:12px;font-weight:500;color:var(--dim);font-variant-numeric:tabular-nums">{{ revProgressLabel }}</div>
+<div style="flex:1;display:flex;gap:5px">
+<sc-for list="{{ revSegs }}" as="p" hint-placeholder-count="8">
+<div style="flex:1;height:6px;border-radius:99px;background:{{ p.bg }}"></div>
+</sc-for>
+</div>
+</div>
+
+<sc-if value="{{ revActive }}" hint-placeholder-val="{{ true }}">
+<div style="flex:1;padding:22px 0 36px;display:flex;justify-content:center">
+<div style="position:relative;width:100%;max-width:640px">
+<sc-for list="{{ revPeeks }}" as="p" hint-placeholder-count="2">
+<div style="position:absolute;left:0;right:0;top:0;bottom:0;border-radius:16px;border:1px solid #e4dfd0;background:var(--surface);transform:translateY({{ p.y }}) scale({{ p.scale }});opacity:{{ p.opacity }}"></div>
+</sc-for>
+<div style="position:relative;z-index:3;border-radius:16px;border:1px solid #e4dfd0;background:var(--surface);box-shadow:0 14px 34px rgba(20,30,45,.09)">
+
+<div style="padding:20px 22px 17px;border-bottom:1px solid #f2efe6;display:flex;align-items:flex-start;gap:14px;background:#fdf7ea;border-radius:16px 16px 0 0">
+<div style="flex:1;min-width:0">
+<div style="font:500 12.5px Geist Mono,ui-monospace,monospace;color:var(--brand)">{{ revCode }}</div>
+<div style="margin-top:6px;font-size:20px;font-weight:600;line-height:1.25">{{ revName }}</div>
+<div style="margin-top:5px;font-size:12.5px;color:var(--dim)">{{ revMeta }}</div>
+</div>
+<div style="flex:none;padding:4px 11px;border-radius:999px;background:var(--surface);border:1px solid #f0e6d2;font-size:11.5px;font-weight:500;color:#8a6a1e;font-variant-numeric:tabular-nums">{{ revStackLabel }}</div>
+</div>
+
+<div style="padding:16px 22px 18px;display:flex;flex-direction:column;gap:14px">
+
+<div style="border:1px solid var(--rule);border-radius:12px;background:var(--pg);padding:15px 16px 14px">
+<div style="display:flex;align-items:baseline;justify-content:space-between;gap:10px">
+<div style="font-size:14.5px;font-weight:600">How was it examined?</div>
+<div style="flex:none;padding:2px 9px;border-radius:999px;background:var(--pill);color:var(--brand);font-size:12px;font-weight:600;font-variant-numeric:tabular-nums">{{ revExamSplitLabel }}</div>
+</div>
+<div style="display:flex;flex-wrap:wrap;gap:6px;margin-top:11px">
+<sc-for list="{{ revMethodChips }}" as="m" hint-placeholder-count="5">
+<div onClick="{{ m.onClick }}" style="display:flex;align-items:center;gap:6px;height:30px;padding:0 11px;border-radius:15px;border:1px solid {{ m.border }};background:{{ m.bg }};color:{{ m.fg }};font-size:12.5px;cursor:pointer" style-hover="border-color:var(--brand)">
+<span style="width:8px;height:8px;flex:none;border-radius:2px;background:{{ m.dot }}"></span>{{ m.label }}
+</div>
+</sc-for>
+</div>
+<div ref="{{ examTrackRef }}" style="position:relative;margin-top:11px;display:flex;height:38px;border-radius:8px;overflow:hidden;background:#eae6da;user-select:none">
+<sc-if value="{{ revExamEmpty }}" hint-placeholder-val="{{ false }}">
+<div style="flex:1;display:flex;align-items:center;justify-content:center;font-size:12px;color:var(--dim)">Click the formats this course used</div>
+</sc-if>
+<sc-for list="{{ revExamSegs }}" as="seg" hint-placeholder-count="3">
+<div style="width:{{ seg.width }};background:{{ seg.color }};display:flex;align-items:center;justify-content:center;color:{{ seg.ink }};font-size:12px;font-weight:600;overflow:hidden;white-space:nowrap">{{ seg.slotLabel }}</div>
+</sc-for>
+<sc-for list="{{ revExamDividers }}" as="d" hint-placeholder-count="2">
+<div onPointerDown="{{ d.onDown }}" style="position:absolute;top:0;bottom:0;left:{{ d.left }};width:18px;margin-left:-9px;cursor:ew-resize;display:flex;align-items:center;justify-content:center">
+<div style="width:4px;height:24px;border-radius:2px;background:var(--surface);box-shadow:0 0 0 1px rgba(20,30,45,.18)"></div>
+</div>
+</sc-for>
+</div>
+<div style="height:1px;margin:14px 0;background:#eae6da"></div>
+<div style="display:flex;align-items:baseline;justify-content:space-between;gap:10px">
+<div style="font-size:14.5px;font-weight:600">What was the approach?</div>
+<div style="flex:none;padding:2px 9px;border-radius:999px;background:var(--pill);color:var(--brand);font-size:12px;font-weight:600;font-variant-numeric:tabular-nums">{{ revTheoryLabel }}</div>
+</div>
+<div onPointerDown="{{ onRevTheoryDown }}" style="position:relative;margin-top:11px;display:flex;height:38px;border-radius:8px;overflow:hidden;background:#eae6da;cursor:ew-resize;user-select:none">
+<div style="display:flex;width:100%;height:100%">
+<div style="width:{{ revTheoryW1 }};background:{{ revTheoryFill1 }};display:flex;align-items:center;padding-left:11px;color:{{ revTheoryInk1 }};font-size:12px;font-weight:600;overflow:hidden;white-space:nowrap">Theoretical</div>
+<div style="width:{{ revTheoryW2 }};background:{{ revTheoryFill2 }};display:flex;align-items:center;justify-content:flex-end;padding-right:11px;color:{{ revTheoryInk2 }};font-size:12px;font-weight:600;overflow:hidden;white-space:nowrap">Applied</div>
+</div>
+<div style="position:absolute;top:0;bottom:0;left:{{ revTheoryW1 }};width:18px;margin-left:-9px;display:flex;align-items:center;justify-content:center"><div style="width:4px;height:24px;border-radius:2px;background:var(--surface);box-shadow:0 0 0 1px rgba(20,30,45,.18)"></div></div>
+</div>
+</div>
+
+<div style="border:1px solid var(--rule);border-radius:12px;background:var(--pg);padding:15px 16px 14px">
+<div style="display:flex;align-items:baseline;justify-content:space-between;gap:10px;margin-bottom:9px"><div style="font-size:14.5px;font-weight:600">How demanding was this course?</div><div style="flex:none;padding:2px 9px;border-radius:999px;background:var(--pill);color:var(--brand);font-size:12px;font-weight:600;font-variant-numeric:tabular-nums">{{ revWorkloadLabel }}</div></div>
+<div onPointerDown="{{ onRevWorkloadDown }}" style="position:relative;height:22px;display:flex;align-items:center;cursor:pointer;user-select:none">
+<div style="height:8px;width:100%;border-radius:4px;background:#eae6da;overflow:hidden"><div style="height:100%;width:{{ revWorkloadW }};background:var(--btn)"></div></div>
+<sc-if value="{{ revWorkloadSet }}" hint-placeholder-val="{{ false }}">
+<div style="position:absolute;left:{{ revWorkloadW }};width:20px;height:20px;margin-left:-10px;border-radius:50%;background:var(--surface);border:2px solid var(--brand);box-shadow:0 1px 3px rgba(0,0,0,.15)"></div>
+</sc-if>
+</div>
+<div style="display:flex;justify-content:space-between;font-size:11.5px;color:var(--muted);margin-top:4px"><span>Not at all</span><span>Very</span></div>
+<div style="height:1px;margin:14px 0;background:#eae6da"></div>
+<div style="display:flex;align-items:baseline;justify-content:space-between;gap:10px;margin-bottom:9px"><div style="font-size:14.5px;font-weight:600">How much did you learn?</div><div style="flex:none;padding:2px 9px;border-radius:999px;background:var(--pill);color:var(--brand);font-size:12px;font-weight:600;font-variant-numeric:tabular-nums">{{ revLearningLabel }}</div></div>
+<div onPointerDown="{{ onRevLearningDown }}" style="position:relative;height:22px;display:flex;align-items:center;cursor:pointer;user-select:none">
+<div style="height:8px;width:100%;border-radius:4px;background:#eae6da;overflow:hidden"><div style="height:100%;width:{{ revLearningW }};background:var(--btn)"></div></div>
+<sc-if value="{{ revLearningSet }}" hint-placeholder-val="{{ false }}">
+<div style="position:absolute;left:{{ revLearningW }};width:20px;height:20px;margin-left:-10px;border-radius:50%;background:var(--surface);border:2px solid var(--brand);box-shadow:0 1px 3px rgba(0,0,0,.15)"></div>
+</sc-if>
+</div>
+<div style="display:flex;justify-content:space-between;font-size:11.5px;color:var(--muted);margin-top:4px"><span>Nothing new</span><span>Transformative</span></div>
+</div>
+
+<div style="border:1px solid var(--rule);border-radius:12px;background:var(--pg);padding:15px 16px 14px">
+<div style="display:flex;align-items:baseline;justify-content:space-between;gap:10px"><span style="font-size:14.5px;font-weight:600">Are you happy you took this course?</span><sc-if value="{{ revHappyNotSet }}" hint-placeholder-val="{{ false }}"><span style="flex:none;padding:2px 9px;border-radius:999px;background:var(--pill);color:var(--brand);font-size:12px;font-weight:600">Not set</span></sc-if></div>
+<div style="margin-top:10px;display:flex;gap:8px">
+<sc-for list="{{ revHappyOpts }}" as="h" hint-placeholder-count="2">
+<div onClick="{{ h.onClick }}" style="flex:1;display:flex;align-items:center;justify-content:center;gap:7px;height:40px;border-radius:9px;border:1px solid {{ h.border }};background:{{ h.bg }};color:{{ h.fg }};font-size:13.5px;font-weight:{{ h.weight }};cursor:pointer" style-hover="border-color:var(--brand)">
+<span style="width:15px;height:15px;flex:none;border-radius:50%;border:1px solid {{ h.dotBorder }};background:{{ h.dot }}"></span>{{ h.label }}
+</div>
+</sc-for>
+</div>
+<div style="height:1px;margin:14px 0;background:#eae6da"></div>
+<div style="font-size:14.5px;font-weight:600">One line for the next student</div>
+<div style="margin-top:3px;font-size:12px;color:var(--muted)">Optional. You can write the full review later from the course page.</div>
+<div style="margin-top:10px;border:1px solid var(--rule3);border-radius:10px;overflow:hidden;background:var(--surface)">
+<textarea value="{{ revText }}" onChange="{{ onRevText }}" placeholder="What should they know before signing up?" style="display:block;width:100%;box-sizing:border-box;min-height:74px;padding:12px;border:none;outline:none;resize:vertical;background:var(--surface);font-family:Geist,system-ui,sans-serif;font-size:13.5px;line-height:1.55;color:var(--ink2)"></textarea>
+</div>
+</div>
+
+</div>
+
+<sc-if value="{{ revSaveError }}" hint-placeholder-val="{{ false }}">
+<div style="margin:0 22px 4px;display:flex;align-items:center;gap:10px;padding:11px 13px;border-radius:10px;border:1px solid #f0d7cf;background:#fdf3ef">
+<svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="#a3452a" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" style="flex:none"><path d="M12 8v5"></path><path d="M12 16.5h.01"></path><circle cx="12" cy="12" r="9.5"></circle></svg>
+<div style="flex:1;min-width:0;font-size:12.5px;line-height:1.45;color:#7a3b26">{{ revSaveErrorText }}</div>
+<div onClick="{{ onRetrySave }}" style="flex:none;font-size:12.5px;font-weight:600;color:#a3452a;cursor:pointer" style-hover="text-decoration:underline">Try again</div>
+</div>
+</sc-if>
+<div style="display:flex;align-items:center;justify-content:space-between;gap:12px;padding:14px 22px;border-top:1px solid var(--rule)">
+<div onClick="{{ onSkipCard }}" style="font-size:13px;font-weight:500;color:var(--muted);cursor:pointer" style-hover="text-decoration:underline">Skip for now</div>
+<div style="display:flex;align-items:center;gap:13px">
+<div style="font-size:11.5px;color:var(--dim2)">{{ revCardHint }}</div>
+<div onClick="{{ onSaveCard }}" style="display:flex;align-items:center;gap:9px;height:40px;padding:0 18px;border-radius:9px;background:{{ revSaveBg }};color:#fff;font-size:13.5px;font-weight:600;cursor:{{ revSaveCursor }}">{{ revSaveLabel }}<svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="#fff" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M5 12h13"></path><path d="m12.5 5.5 6.5 6.5-6.5 6.5"></path></svg></div>
+</div>
+</div>
+
+</div>
+</div>
+</div>
+</sc-if>
+
+<sc-if value="{{ revDone }}" hint-placeholder-val="{{ false }}">
+<div style="flex:1;padding:28px 0 40px;display:flex;justify-content:center;align-items:flex-start">
+<div style="width:100%;max-width:520px;border:1px solid var(--rule);border-radius:16px;background:var(--surface);padding:30px 26px 26px;text-align:center;animation:rise .2s ease-out">
+<span style="display:inline-flex;width:44px;height:44px;border-radius:50%;background:#e3f2ef;align-items:center;justify-content:center"><svg width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="#1c6b60" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round"><path d="M20 6 9 17l-5-5"></path></svg></span>
+<div style="margin-top:14px;font-size:21px;font-weight:600;letter-spacing:-.01em">{{ revDoneTitle }}</div>
+<div style="margin-top:8px;font-size:13.5px;line-height:1.55;color:var(--muted)">{{ revDoneBody }}</div>
+<div style="margin-top:20px;display:flex;justify-content:center;gap:10px">
+<div onClick="{{ onCloseReviewer }}" style="display:flex;align-items:center;height:40px;padding:0 18px;border-radius:9px;background:var(--btn);color:var(--btnFg);font-size:13.5px;font-weight:600;cursor:pointer" style-hover="background:var(--btn)">Back to my courses</div>
+<sc-if value="{{ revHasSkipped }}" hint-placeholder-val="{{ false }}">
+<div onClick="{{ onRoundTwo }}" style="display:flex;align-items:center;height:40px;padding:0 16px;border-radius:9px;border:1px solid var(--rule3);background:var(--surface);font-size:13.5px;font-weight:500;color:var(--chipInk);cursor:pointer" style-hover="border-color:var(--hov)">Go through the skipped ones</div>
+</sc-if>
+</div>
+</div>
+</div>
+</sc-if>
+
+</div>
+</sc-if>
+
+</div>
+
+</div>
+
+</div>
+
+<sc-if value="{{ hasToast }}" hint-placeholder-val="{{ false }}">
+<div style="position:fixed;left:50%;bottom:26px;transform:translateX(-50%);z-index:80;display:flex;align-items:center;gap:14px;padding:11px 14px;border-radius:10px;background:#16202b;color:#fff;box-shadow:0 10px 30px rgba(20,30,45,.28);animation:rise .18s ease-out">
+<div style="font-size:13px">{{ toastText }}</div>
+<sc-if value="{{ canUndo }}" hint-placeholder-val="{{ true }}">
+<div onClick="{{ onUndo }}" style="font-size:13px;font-weight:600;color:#9dbfe4;cursor:pointer" style-hover="text-decoration:underline">Undo</div>
+</sc-if>
+</div>
+</sc-if>
+
+<sc-if value="{{ modalOpen }}" hint-placeholder-val="{{ false }}">
+<div onClick="{{ onCloseModal }}" style="position:fixed;inset:0;z-index:70;display:flex;align-items:center;justify-content:center;padding:28px;background:rgba(20,30,45,.34)">
+<div onClick="{{ stopClick }}" style="width:{{ modalWidth }};max-height:88vh;overflow:auto;border-radius:14px;background:var(--surface);box-shadow:0 18px 48px rgba(20,30,45,.24);animation:rise .18s ease-out">
+
+<div style="display:flex;align-items:flex-start;justify-content:space-between;gap:14px;padding:20px 22px 0">
+<div>
+<div style="font-size:11px;font-weight:600;letter-spacing:.06em;text-transform:uppercase;color:var(--brand)">{{ modalKicker }}</div>
+<div style="margin-top:7px;font-size:19px;font-weight:600;line-height:1.25">{{ modalTitle }}</div>
+</div>
+<div onClick="{{ onCloseModal }}" style="flex:none;width:28px;height:28px;display:flex;align-items:center;justify-content:center;border-radius:7px;color:var(--dim);font-size:18px;line-height:1;cursor:pointer" style-hover="background:var(--pill)">×</div>
+</div>
+
+<sc-if value="{{ isUpdateModal }}" hint-placeholder-val="{{ false }}">
+<div style="padding:14px 22px 22px">
+<div style="font-size:13.5px;line-height:1.55;color:var(--muted)">Upload a newer Resultatintyg. Courses already in your list keep the edits you made — only new rows and missing fields are filled in.</div>
+<div onClick="{{ onToggleGrades }}" style="margin-top:14px;border:1px solid {{ gradesBorder }};border-radius:12px;background:{{ gradesBg }};padding:15px 16px 14px;cursor:pointer">
+<div style="display:flex;align-items:flex-start;gap:12px">
+<div style="flex:none;width:42px;height:24px;border-radius:99px;background:{{ gradesTrack }};padding:3px;display:flex;justify-content:{{ gradesJustify }};transition:background .16s ease-out"><div style="width:18px;height:18px;border-radius:50%;background:var(--surface);box-shadow:0 1px 2px rgba(20,30,45,.28)"></div></div>
+<div style="flex:1;min-width:0">
+<div style="font-size:13.5px;font-weight:600">Read grades from the file</div>
+<div style="margin-top:4px;font-size:12.5px;line-height:1.5;color:var(--muted)">{{ gradesHint }}</div>
+</div>
+</div>
+</div>
+<div onClick="{{ onUpload }}" style="margin-top:16px;padding:30px 22px;border-radius:12px;border:2px dashed var(--hov);background:var(--pill);display:flex;flex-direction:column;align-items:center;text-align:center;cursor:pointer" style-hover="background:var(--pill)">
+<div style="width:46px;height:46px;border-radius:13px;background:var(--pill);display:flex;align-items:center;justify-content:center"><svg width="21" height="21" viewBox="0 0 24 24" fill="none" stroke="#1751a6" stroke-width="1.9" stroke-linecap="round" stroke-linejoin="round"><path d="M12 16V4"></path><path d="m7.5 8.5 4.5-4.5 4.5 4.5"></path><path d="M4 15v3a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2v-3"></path></svg></div>
+<div style="margin-top:13px;font-size:15.5px;font-weight:600">Drop the new PDF here</div>
+<div style="margin-top:5px;font-size:12.5px;color:var(--muted)">PDF from Ladok · up to 10 MB</div>
+<div style="margin-top:14px;display:flex;align-items:center;gap:8px;height:38px;padding:0 15px;border-radius:9px;background:var(--btn);color:var(--btnFg);font-size:13px;font-weight:600">Choose a PDF</div>
+</div>
+<div style="margin-top:14px;display:flex;align-items:center;justify-content:space-between;gap:12px;font-size:12.5px;color:var(--dim)">
+<div>{{ lastReadLine }}</div>
+<div onClick="{{ onCloseModal }}" style="font-weight:500;color:var(--brand);cursor:pointer" style-hover="text-decoration:underline">Cancel</div>
+</div>
+</div>
+</sc-if>
+
+<sc-if value="{{ isFormModal }}" hint-placeholder-val="{{ false }}">
+<div style="padding:14px 22px 0">
+
+<sc-if value="{{ isAddModal }}" hint-placeholder-val="{{ false }}">
+<div>
+<div style="font-size:11.5px;font-weight:500;color:var(--dim)">Search the KTH catalog</div>
+<div style="margin-top:6px;display:flex;align-items:center;gap:9px;height:42px;padding:0 13px;border-radius:9px;border:1px solid var(--rule3);background:var(--surface)">
+<svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="#5c6570" stroke-width="2" stroke-linecap="round"><circle cx="11" cy="11" r="7"></circle><line x1="16.5" y1="16.5" x2="21" y2="21"></line></svg>
+<input value="{{ search }}" onChange="{{ onSearch }}" placeholder="Course code or name, e.g. DD2421" style="flex:1;min-width:0;border:none;outline:none;background:transparent;font-size:13.5px;color:var(--ink)">
+</div>
+<sc-if value="{{ showResults }}" hint-placeholder-val="{{ false }}">
+<div style="margin-top:8px;border:1px solid var(--rule);border-radius:10px;overflow:hidden">
+<sc-for list="{{ results }}" as="c" hint-placeholder-count="3">
+<div onClick="{{ c.onPick }}" style="display:flex;align-items:center;gap:11px;padding:10px 12px;border-bottom:1px solid #f4f2ea;cursor:pointer" style-hover="background:var(--pill)">
+<span style="flex:none;font:500 12.5px Geist Mono,ui-monospace,monospace;color:var(--brand);width:74px">{{ c.code }}</span>
+<span style="flex:1;min-width:0;font-size:13.5px;overflow:hidden;text-overflow:ellipsis;white-space:nowrap">{{ c.name }}</span>
+<span style="flex:none;font-size:12.5px;color:var(--dim)">{{ c.hp }} hp</span>
+</div>
+</sc-for>
+<sc-if value="{{ noResults }}" hint-placeholder-val="{{ false }}">
+<div style="padding:13px 14px;background:var(--pg)">
+<div style="font-size:13px;color:var(--muted)">Nothing in the catalog matches “{{ search }}”.</div>
+<div onClick="{{ onFreeForm }}" style="margin-top:9px;display:inline-flex;align-items:center;gap:7px;height:34px;padding:0 12px;border-radius:8px;border:1px dashed var(--hov);background:var(--surface);font-size:12.5px;font-weight:500;color:var(--brand);cursor:pointer" style-hover="background:var(--pill)">Add “{{ search }}” as a free-form course</div>
+</div>
+</sc-if>
+</div>
+</sc-if>
+</div>
+</sc-if>
+
+<sc-if value="{{ showFreeFormNote }}" hint-placeholder-val="{{ false }}">
+<div style="margin-top:14px;display:flex;gap:9px;padding:12px 13px;border-radius:10px;background:var(--pill);border:1px dashed #cfc9b8">
+<svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="#6b6355" stroke-width="1.9" stroke-linecap="round" stroke-linejoin="round" style="flex:none;margin-top:2px"><circle cx="12" cy="12" r="10"></circle><path d="M12 16v-5"></path><path d="M12 8h.01"></path></svg>
+<div style="font-size:12.5px;line-height:1.5;color:var(--muted)">A free-form course counts toward your credits and average, but it has no course page — so there is nothing to review it against, and it will not appear in the fast-track reviewer.</div>
+</div>
+</sc-if>
+
+<div style="margin-top:16px;display:grid;grid-template-columns:130px minmax(0,1fr);gap:12px">
+<div>
+<div style="font-size:11.5px;font-weight:500;color:var(--dim)">Course code</div>
+<input value="{{ formCode }}" onChange="{{ onFormCode }}" placeholder="—" style="margin-top:6px;width:100%;height:40px;padding:0 11px;border-radius:9px;border:1px solid var(--rule3);outline:none;font:500 13.5px Geist Mono,ui-monospace,monospace;color:var(--ink);background:{{ codeFieldBg }}">
+</div>
+<div>
+<div style="font-size:11.5px;font-weight:500;color:var(--dim)">Course name</div>
+<input value="{{ formName }}" onChange="{{ onFormName }}" placeholder="Course name" style="margin-top:6px;width:100%;height:40px;padding:0 11px;border-radius:9px;border:1px solid var(--rule3);outline:none;font-size:13.5px;color:var(--ink)">
+</div>
+</div>
+
+<div style="margin-top:12px;display:grid;grid-template-columns:1fr 1fr;gap:12px">
+<div>
+<div style="font-size:11.5px;font-weight:500;color:var(--dim)">Credits (hp)</div>
+<div style="margin-top:6px;display:flex;flex-wrap:wrap;gap:6px">
+<sc-for list="{{ hpOptions }}" as="h" hint-placeholder-count="4">
+<div onClick="{{ h.onClick }}" style="display:flex;align-items:center;height:34px;padding:0 12px;border-radius:8px;border:1px solid {{ h.border }};background:{{ h.bg }};color:{{ h.fg }};font-size:13px;font-weight:{{ h.weight }};font-variant-numeric:tabular-nums;cursor:pointer" style-hover="border-color:var(--brand)">{{ h.label }}</div>
+</sc-for>
+</div>
+</div>
+<div>
+<div style="font-size:11.5px;font-weight:500;color:var(--dim)">Year</div>
+<input value="{{ formYear }}" onChange="{{ onFormYear }}" inputMode="numeric" maxLength="4" placeholder="2025" style="margin-top:6px;width:100%;height:34px;padding:0 11px;border-radius:8px;border:1px solid var(--rule3);outline:none;font-size:13px;color:var(--ink);font-variant-numeric:tabular-nums">
+</div>
+</div>
+
+<sc-if value="{{ gradesOn }}" hint-placeholder-val="{{ true }}">
+<div style="margin-top:14px">
+<div style="font-size:11.5px;font-weight:500;color:var(--dim)">Grade</div>
+<div style="margin-top:6px;display:flex;flex-wrap:wrap;gap:6px">
+<sc-for list="{{ gradeOptions }}" as="g" hint-placeholder-count="8">
+<div onClick="{{ g.onClick }}" style="display:flex;align-items:center;justify-content:center;min-width:{{ g.minW }};height:34px;padding:0 11px;border-radius:8px;border:1px solid {{ g.border }};background:{{ g.bg }};color:{{ g.fg }};font-size:13px;font-weight:{{ g.weight }};cursor:pointer" style-hover="border-color:var(--brand)">{{ g.label }}</div>
+</sc-for>
+</div>
+</div>
+</sc-if>
+
+<sc-if value="{{ isEditModal }}" hint-placeholder-val="{{ false }}">
+<div style="margin-top:16px;padding:13px 14px;border-radius:11px;background:var(--pg);border:1px solid var(--rule)">
+<div style="display:flex;align-items:center;justify-content:space-between;gap:12px">
+<div style="font-size:10.5px;font-weight:600;letter-spacing:.09em;text-transform:uppercase;color:var(--dim)">{{ originalLabel }}</div>
+<sc-if value="{{ canRevert }}" hint-placeholder-val="{{ false }}">
+<div onClick="{{ onRevert }}" style="display:flex;align-items:center;gap:7px;font-size:12.5px;font-weight:500;color:var(--brand);cursor:pointer" style-hover="text-decoration:underline"><svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="#1751a6" stroke-width="1.9" stroke-linecap="round" stroke-linejoin="round"><path d="M4 12a8 8 0 1 0 2.6-5.9"></path><path d="M4 4v4h4"></path></svg>Revert to the parsed values</div>
+</sc-if>
+</div>
+<div style="margin-top:9px;display:flex;flex-wrap:wrap;gap:8px">
+<sc-for list="{{ originalFields }}" as="o" hint-placeholder-count="4">
+<div style="display:flex;align-items:baseline;gap:7px;padding:4px 9px;border-radius:7px;background:var(--surface);border:1px solid {{ o.border }}">
+<span style="font-size:11px;color:var(--dim)">{{ o.label }}</span>
+<span style="font-size:12.5px;font-weight:500;color:{{ o.fg }};text-decoration:{{ o.strike }}">{{ o.value }}</span>
+</div>
+</sc-for>
+</div>
+</div>
+</sc-if>
+</div>
+
+<div style="position:sticky;bottom:0;margin-top:18px;display:flex;align-items:center;justify-content:space-between;gap:12px;padding:14px 22px;border-top:1px solid var(--rule);background:var(--surface)">
+<div style="font-size:12px;color:var(--dim2)">{{ formHint }}</div>
+<div style="display:flex;gap:9px">
+<div onClick="{{ onCloseModal }}" style="display:flex;align-items:center;height:38px;padding:0 14px;border-radius:9px;border:1px solid var(--rule3);background:var(--surface);font-size:13px;font-weight:500;color:var(--chipInk);cursor:pointer" style-hover="border-color:var(--hov)">Cancel</div>
+<div onClick="{{ onSaveForm }}" style="display:flex;align-items:center;height:38px;padding:0 16px;border-radius:9px;background:{{ saveBg }};color:#fff;font-size:13px;font-weight:600;cursor:{{ saveCursor }}">{{ saveLabel }}</div>
+</div>
+</div>
+</sc-if>
+
+</div>
+</div>
+</sc-if>
+
+</div>
+
+</x-dc>
+<script type="text/x-dc" data-dc-script data-props="{&quot;$preview&quot;:{&quot;width&quot;:1440,&quot;height&quot;:900},&quot;session&quot;:{&quot;editor&quot;:&quot;enum&quot;,&quot;default&quot;:&quot;member&quot;,&quot;options&quot;:[&quot;guest&quot;,&quot;member&quot;],&quot;tsType&quot;:&quot;\&quot;guest\&quot; | \&quot;member\&quot;&quot;,&quot;section&quot;:&quot;Session&quot;},&quot;scenario&quot;:{&quot;editor&quot;:&quot;enum&quot;,&quot;default&quot;:&quot;populated&quot;,&quot;options&quot;:[&quot;populated&quot;,&quot;empty&quot;,&quot;loading&quot;,&quot;error&quot;,&quot;edge-case&quot;],&quot;tsType&quot;:&quot;string&quot;,&quot;section&quot;:&quot;Prototype state&quot;},&quot;transcriptState&quot;:{&quot;editor&quot;:&quot;enum&quot;,&quot;default&quot;:&quot;ready&quot;,&quot;options&quot;:[&quot;idle&quot;,&quot;parsing&quot;,&quot;conflicts&quot;,&quot;ready&quot;,&quot;failed&quot;],&quot;tsType&quot;:&quot;string&quot;,&quot;section&quot;:&quot;Prototype state&quot;},&quot;reviewState&quot;:{&quot;editor&quot;:&quot;enum&quot;,&quot;default&quot;:&quot;idle&quot;,&quot;options&quot;:[&quot;idle&quot;,&quot;editing&quot;,&quot;saving&quot;,&quot;saved&quot;,&quot;failed&quot;],&quot;tsType&quot;:&quot;string&quot;,&quot;section&quot;:&quot;Prototype state&quot;},&quot;locale&quot;:{&quot;editor&quot;:&quot;enum&quot;,&quot;default&quot;:&quot;en&quot;,&quot;options&quot;:[&quot;en&quot;,&quot;sv&quot;],&quot;tsType&quot;:&quot;\&quot;en\&quot; | \&quot;sv\&quot;&quot;,&quot;section&quot;:&quot;Prototype state&quot;}}">
+const POINTS = { A: 5, B: 4, C: 3, D: 2, E: 1 };
+const HP_CHOICES = ["6.0", "7.5", "9.0", "15.0"];
+const TERMS = ["HT24", "VT25", "HT25", "VT26", "HT26"];
+const PERIODS = ["P1", "P2", "P3", "P4"];
+const GRADES = ["A", "B", "C", "D", "E", "F", "P", "no grade"];
+
+/* No course facts live on this page. Names, credits and rounds come from the
+   shared store; transcript rows arrive in userTakenCourse shape. */
+let STORE = null;
+let CATALOG = [];
+
+const creditStr = (n) => Number(n).toFixed(1);
+
+function catalogFromStore(locale) {
+  return STORE.courses.map((c) => ({
+    code: c.code, name: STORE.courseName(c, locale), hp: creditStr(c.credits)
+  }));
+}
+
+/* A row the parser produced, joined with the catalog. `conflict` is a fact
+   about the file or the catalog — never a probability. */
+function rowsFromImport(which, locale) {
+  return STORE.transcriptImports[which].rows.map((r) => {
+    const v = STORE.takenView(r, { locale });
+    const match = !r.courseCode ? "freeform" : v.inCatalog ? "catalog" : "nomatch";
+    const issue = match === "nomatch"
+      ? "No course with this code in the catalog"
+      : match === "freeform"
+        ? "Free-form course — no KTH course page"
+        : v.grade == null ? "No grade in this row of the file" : null;
+    return { code: r.courseCode, name: v.name, hp: creditStr(v.credits),
+      grade: v.grade, term: STORE.termLabel(v.attendanceYear),
+      periods: v.attendancePeriods || [], year: STORE.yearOf(v.attendanceYear), match, issue,
+      // A course is reviewed when a review row exists for it, not when a flag is set here.
+      reviewed: v.reviewed };
+  });
+}
+
+let seq = 1;
+const METHODS = [
+  { key: "exam", label: "On-campus exam", short: "Exam", color: "var(--brand)", ink: "var(--btnFg)" },
+  { key: "assignments", label: "Assignments", short: "Assign.", color: "#dfa53c", ink: "#3a2a06" },
+  { key: "labs", label: "Labs", short: "Labs", color: "#2f9e8e", ink: "#06251f" },
+  { key: "projects", label: "Project", short: "Project", color: "#6a4ea8", ink: "var(--btnFg)" },
+  { key: "other", label: "Other", short: "Other", color: "#57646f", ink: "var(--btnFg)" }
+];
+/** Even split across n segments in 5% steps; the remainder lands on the last. */
+function evenSplit(n) {
+  if (n === 0) return [];
+  const base = Math.max(5, Math.round(100 / n / 5) * 5);
+  const out = new Array(n).fill(base);
+  out[n - 1] = 100 - base * (n - 1);
+  return out;
+}
+const withIds = (rows) => rows.map((r) => ({
+  id: seq++,
+  code: r.code, name: r.name, hp: r.hp, grade: r.grade, term: r.term,
+  periods: r.periods || [], year: r.year || null,
+  match: r.match, issue: r.issue || null, reviewed: Boolean(r.reviewed),
+  parsed: { code: r.code, name: r.name, hp: r.hp, grade: r.grade, term: r.term },
+  edited: false, isNew: false
+}));
+
+/* Grades the student chose not to hand over never enter a row at all. */
+const stripGrades = (rows) => rows.map((r) => ({
+  ...r, grade: null,
+  issue: r.issue === "No grade in this row of the file" ? null : r.issue,
+  parsed: r.parsed ? { ...r.parsed, grade: null } : r.parsed
+}));
+
+const termIndex = (t) => {
+  const i = TERMS.indexOf(t);
+  return i < 0 ? 99 : i;
+};
+
+class Component extends DCLogic {
+  examTrackRef = React.createRef();
+
+  /* Theme choice is shared across the pages through one storage key. */
+  ccDark() {
+    if (this.state.ccNight !== undefined) return this.state.ccNight === true;
+    try { return window.localStorage.getItem("cc:theme") === "dark"; } catch (e) { return false; }
+  }
+
+  ccSetDark(next) {
+    document.documentElement.setAttribute("data-cc-theme", next ? "dark" : "light");
+    try { window.localStorage.setItem("cc:theme", next ? "dark" : "light"); } catch (e) { /* storage off */ }
+    this.setState({ ccNight: next });
+  }
+
+  ccApplyTheme() {
+    document.documentElement.setAttribute("data-cc-theme", this.ccDark() ? "dark" : "light");
+  }
+
+  /** Published by Explore and Saved, which own the list; this page only shows it. */
+  savedCount() {
+    try {
+      const n = parseInt(window.localStorage.getItem("cc:savedBadge"), 10);
+      return isNaN(n) ? 0 : n;
+    } catch (e) { return 0; }
+  }
+
+  state = {
+    signedIn: false,
+    screen: "empty",
+    // Where sign-in should land once the student is back.
+    returnTo: "empty",
+    rows: [],
+    includeGrades: false,
+    revQueue: [],
+    revAt: 0,
+    revDrafts: {},
+    revSaved: 0,
+    revSkipped: 0,
+    parseStep: 0,
+    parseKind: "first",
+    banner: null,
+    toast: null,
+    modal: null,
+    form: null,
+    search: "",
+    drop: false,
+    reads: 0,
+    error: null,
+    reviewPhase: "idle",
+    confirming: false,
+    pending: null,
+    skipped: [],
+    skippedSeen: false,
+    inlineId: null,
+    inlineDraft: null,
+    termPanelOpen: false
+  };
+
+  timers = [];
+
+  /* Every state this page can be in, reachable without clicking through the flow.
+     Each one lands on the real screen with real rows — no separate mock path. */
+  /* The two shared axes are session (guest | member) and scenario (populated |
+     empty | loading | error | edge-case). How far this page has got with a
+     transcript or a review is its own substate, never the site-wide scenario. */
+  harnessKey() {
+    return [this.props.session, this.props.scenario, this.props.transcriptState,
+      this.props.reviewState].join("|");
+  }
+
+  pose() {
+    const h = STORE.resolveHarness(this.props);
+    const locale = this.props.locale === "sv" ? "sv" : "en";
+    // Rows with no catalog course are excluded here too, not only after an import.
+    const split = (list) => {
+      const all = withIds(list);
+      return {
+        kept: all.filter((r) => r.match !== "freeform" && r.match !== "nomatch"),
+        skipped: all.filter((r) => r.match === "freeform" || r.match === "nomatch")
+          .map((r) => ({ name: r.name || r.code || "Unnamed row", code: r.code || null }))
+      };
+    };
+    const seeded = split(rowsFromImport("first", locale));
+    const rows = () => seeded.kept;
+    const base = {
+      signedIn: h.isMember, screen: "list", rows: [], returnTo: "list", reads: 1,
+      includeGrades: false, banner: null, toast: null, modal: null, form: null,
+      search: "", drop: false, parseStep: 0, parseKind: "first", error: null,
+      revQueue: [], revAt: 0, revDrafts: {}, revSaved: 0, revSkipped: 0, reviewPhase: "idle",
+      confirming: false, pending: null,
+      skipped: seeded.skipped, skippedSeen: seeded.skipped.length === 0,
+      inlineId: null, inlineDraft: null, termPanelOpen: false
+    };
+    const failed = { ...base, screen: "failed", rows: [], reads: 0, returnTo: "empty" };
+
+    if (h.isGuest) return { ...base, signedIn: false, screen: "empty", rows: [], reads: 0, returnTo: "empty" };
+    if (h.isLoading) return { ...base, screen: "parsing", parseStep: 2, rows: [], reads: 0 };
+    if (h.isError) return failed;
+    if (h.isEmpty) return { ...base, screen: "empty", rows: [], reads: 0, returnTo: "empty" };
+    if (h.isEdgeCase) return { ...base, screen: "list", includeGrades: false,
+      rows: stripGrades(rows()) };
+
+    const t = this.props.transcriptState || "ready";
+    if (t === "idle") return { ...base, screen: "empty", rows: [], reads: 0, returnTo: "empty" };
+    if (t === "parsing") return { ...base, screen: "parsing", parseStep: 2, rows: [], reads: 0 };
+    if (t === "failed") return failed;
+    if (t === "conflicts") return { ...base, screen: "success", rows: rows() };
+
+    const r = this.props.reviewState || "idle";
+    if (r === "idle") return { ...base, screen: "list", rows: rows() };
+    const posed = rows();
+    const queue = posed.filter((x) => x.match !== "freeform").map((x) => x.id);
+    if (r === "saved") {
+      return { ...base, screen: "reviewer", reviewPhase: "saved",
+        rows: posed.map((x) => (x.match === "freeform" ? x : { ...x, reviewed: true })),
+        revQueue: queue, revAt: queue.length, revSaved: queue.length, revSkipped: 0 };
+    }
+    return { ...base, screen: "reviewer", reviewPhase: r, rows: posed,
+      revQueue: queue, revAt: 0,
+      revDrafts: r === "editing" || r === "saving" || r === "failed"
+        ? { [queue[0]]: { happy: true, workload: 4, learning: 5 } }
+        : {} };
+  }
+
+  applyScenario() {
+    if (!STORE) return;
+    this.clearTimers();
+    this.setState(this.pose());
+  }
+
+  componentDidMount() {
+    this.ccApplyTheme();
+    try {
+      this.wantReviewer = new URLSearchParams(window.location.search).get("review") === "1";
+    } catch (e) { this.wantReviewer = false; }
+    import("./cc-store.js").then((mod) => {
+      STORE = mod;
+      CATALOG = catalogFromStore(this.props.locale === "sv" ? "sv" : "en");
+      this.seenHarness = this.harnessKey();
+      this.setState(this.pose(), () => {
+        // Arriving from My Page's "review" CTAs: open the queue, not the list.
+        if (this.wantReviewer && this.state.rows.length) this.openReviewer(null);
+      });
+    });
+  }
+
+  componentDidUpdate() {
+    if (!STORE) return;
+    if (this.harnessKey() !== this.seenHarness) {
+      this.seenHarness = this.harnessKey();
+      this.applyScenario();
+    }
+  }
+
+  componentWillUnmount() {
+    this.timers.forEach(clearTimeout);
+  }
+
+  saveList() {
+    this.setState({ screen: "list", confirming: false, toast: { text: "Course list saved", undo: null } });
+  }
+
+  clearTimers() {
+    this.timers.forEach(clearTimeout);
+    this.timers = [];
+  }
+
+  startParse(kind) {
+    this.clearTimers();
+    this.setState({ screen: "parsing", parseKind: kind, parseStep: 0, modal: null, banner: null });
+    this.timers.push(window.setTimeout(() => this.finishParse(kind), 1300));
+  }
+
+  /** Rows the catalog cannot resolve have no storable home; they are reported. */
+  splitImport(rows) {
+    const kept = rows.filter((r) => r.match !== "freeform" && r.match !== "nomatch");
+    const skipped = rows.filter((r) => r.match === "freeform" || r.match === "nomatch")
+      .map((r) => ({ name: r.name || r.code || "Unnamed row", code: r.code || null }));
+    return { kept, skipped };
+  }
+
+  finishParse(kind) {
+    const keepGrades = this.state.includeGrades;
+    if (kind === "first") {
+      const all = withIds(rowsFromImport("first", this.props.locale === "sv" ? "sv" : "en"));
+      const split = this.splitImport(keepGrades ? all : stripGrades(all));
+      const missing = split.kept.filter((r) => r.issue).length;
+      this.setState({
+        rows: split.kept, skipped: split.skipped, skippedSeen: false,
+        previewSummary: split.kept.length + " courses read"
+          + (missing ? " · " + missing + (missing === 1 ? " is missing a field" : " are missing a field") : " · nothing missing"),
+        screen: "preview", confirming: true, reads: this.state.reads + 1
+      });
+      return;
+    }
+    // An update never overwrites an edit the student already made.
+    const rows = this.state.rows.slice();
+    let added = 0;
+    let filled = 0;
+    const skipped = [];
+    rowsFromImport("second", this.props.locale === "sv" ? "sv" : "en").forEach((incoming) => {
+      // Same rule as a first import: no catalog course, no row.
+      if (incoming.match === "freeform" || incoming.match === "nomatch") {
+        skipped.push({ name: incoming.name || incoming.code || "Unnamed row", code: incoming.code || null });
+        return;
+      }
+      const at = rows.findIndex((r) => r.code && r.code === incoming.code);
+      if (at < 0) {
+        const fresh = keepGrades ? withIds([incoming])[0] : stripGrades(withIds([incoming]))[0];
+        fresh.isNew = true;
+        rows.push(fresh);
+        added += 1;
+        return;
+      }
+      const row = rows[at];
+      if (keepGrades && row.grade == null && !row.edited) {
+        rows[at] = { ...row, grade: incoming.grade, issue: null, isNew: false,
+          parsed: { ...row.parsed, grade: incoming.grade } };
+        filled += 1;
+      }
+    });
+    const parts = [];
+    if (added) parts.push(added === 1 ? "1 new course" : added + " new courses");
+    if (filled) parts.push(filled === 1 ? "1 missing grade filled in" : filled + " missing grades filled in");
+    this.setState({
+      rows,
+      skipped: skipped,
+      skippedSeen: false,
+      previewSummary: parts.length ? "Transcript updated — " + parts.join(", ") : "Transcript re-read — nothing new in it",
+      screen: "preview",
+      confirming: true,
+      reads: this.state.reads + 1,
+      banner: {
+        title: parts.length ? "Transcript updated — " + parts.join(", ") : "Transcript re-read — nothing new in it",
+        body: "Courses already in your list kept their edits. New rows are marked below."
+      }
+    });
+  }
+
+  openForm(mode, id) {
+    if (mode === "add") {
+      this.setState({
+        modal: "add", search: "",
+        form: { code: "", name: "", hp: "7.5", grade: "no grade", year: "2025", match: "catalog", id: null }
+      });
+      return;
+    }
+    const row = this.state.rows.find((r) => r.id === id);
+    if (!row) return;
+    this.setState({
+      modal: "edit",
+      form: {
+        id: row.id, code: row.code || "", name: row.name, hp: row.hp,
+        grade: row.grade || "no grade", year: row.year != null ? String(row.year) : "", match: row.match
+      }
+    });
+  }
+
+  saveForm() {
+    const f = this.state.form;
+    if (!f || !f.name.trim()) return;
+    const grade = !this.state.includeGrades || f.grade === "no grade" ? null : f.grade;
+    const code = f.code.trim() ? f.code.trim().toUpperCase() : null;
+    const inCatalog = code ? CATALOG.some((c) => c.code === code) : false;
+    const match = code ? (inCatalog ? "catalog" : "nomatch") : "freeform";
+    const issue = match === "nomatch"
+      ? "No course with this code in the catalog"
+      : match === "freeform"
+        ? "Free-form course — no KTH course page"
+        : grade == null && this.state.includeGrades ? "No grade set yet" : null;
+
+    if (f.id == null) {
+      const row = {
+        id: seq++, code, name: f.name.trim(), hp: f.hp, grade, year: f.year ? parseInt(f.year, 10) : null, match, issue,
+        parsed: null, edited: false, isNew: true, reviewed: false
+      };
+      this.setState({ rows: this.state.rows.concat([row]), modal: null, form: null,
+        toast: { text: "Added " + (code || f.name.trim()), undo: this.state.rows } });
+      return;
+    }
+    const rows = this.state.rows.map((r) => {
+      if (r.id !== f.id) return r;
+      const changed = !r.parsed
+        || r.parsed.code !== code || r.parsed.name !== f.name.trim() || r.parsed.hp !== f.hp
+        || r.parsed.grade !== grade || r.parsed.year !== f.year;
+      return { ...r, code, name: f.name.trim(), hp: f.hp, grade, year: f.year ? parseInt(f.year, 10) : null, match, issue, edited: changed };
+    });
+    this.setState({ rows, modal: null, form: null });
+  }
+
+  revertForm() {
+    const f = this.state.form;
+    const row = this.state.rows.find((r) => r.id === f.id);
+    if (!row || !row.parsed) return;
+    const p = row.parsed;
+    this.setState({ form: { ...f, code: p.code || "", name: p.name, hp: p.hp,
+      grade: p.grade || "no grade", year: p.year } });
+  }
+
+  /* One queue of cards: whatever is reviewable and not yet reviewed. */
+  openReviewer(startId) {
+    const eligible = this.state.rows.filter((r) => r.match !== "freeform");
+    const pending = eligible.filter((r) => !r.reviewed).map((r) => r.id);
+    let queue = pending;
+    if (startId != null) queue = [startId].concat(pending.filter((i) => i !== startId));
+    if (!queue.length) return;
+    this.setState({ screen: "reviewer", revQueue: queue, revAt: 0, revSaved: 0, revSkipped: 0, modal: null });
+  }
+
+  patchCard(patch) {
+    const id = this.state.revQueue[this.state.revAt];
+    if (id == null) return;
+    const drafts = { ...this.state.revDrafts };
+    drafts[id] = { ...(drafts[id] || {}), ...patch };
+    this.setState({ revDrafts: drafts });
+  }
+
+  saveCard() {
+    const s = this.state;
+    const id = s.revQueue[s.revAt];
+    const d = s.revDrafts[id] || {};
+    const answered = d.happy != null && d.workload != null && d.learning != null;
+    if (!answered) return;
+    this.setState({
+      rows: s.rows.map((r) => (r.id === id ? { ...r, reviewed: true } : r)),
+      revAt: s.revAt + 1,
+      revSaved: s.revSaved + 1
+    });
+  }
+
+  skipCard() {
+    this.setState({ revAt: this.state.revAt + 1, revSkipped: this.state.revSkipped + 1 });
+  }
+
+  slide(e, max, set) {
+    const el = e.currentTarget;
+    const move = (ev) => {
+      const r = el.getBoundingClientRect();
+      const t = Math.min(1, Math.max(0, (ev.clientX - r.left) / r.width));
+      set(Math.round(t * max));
+    };
+    const up = () => {
+      window.removeEventListener("pointermove", move);
+      window.removeEventListener("pointerup", up);
+    };
+    window.addEventListener("pointermove", move);
+    window.addEventListener("pointerup", up);
+    move(e);
+  }
+
+  dividerDown(i, rect, pcts, setPcts) {
+    const before = pcts.slice(0, i).reduce((a, p) => a + p, 0);
+    const pair = pcts[i] + pcts[i + 1];
+    const move = (ev) => {
+      let x = ((ev.clientX - rect.left) / rect.width) * 100 - before;
+      x = Math.round(x / 5) * 5;
+      x = Math.max(5, Math.min(pair - 5, x));
+      const next = pcts.slice();
+      next[i] = x;
+      next[i + 1] = pair - x;
+      setPcts(next);
+    };
+    const up = () => {
+      window.removeEventListener("pointermove", move);
+      window.removeEventListener("pointerup", up);
+    };
+    window.addEventListener("pointermove", move);
+    window.addEventListener("pointerup", up);
+  }
+
+  bump(i, delta, pcts, setPcts) {
+    const next = pcts.slice();
+    const j = (i + 1) % next.length;
+    if (i === j) return;
+    if (next[i] + delta < 5 || next[j] - delta < 5) return;
+    next[i] += delta;
+    next[j] -= delta;
+    setPcts(next);
+  }
+
+  toggleMethod(method, picked, setBoth) {
+    const next = picked.slice();
+    const at = next.indexOf(method);
+    if (at >= 0) next.splice(at, 1); else next.push(method);
+    setBoth(next, evenSplit(next.length));
+  }
+
+  startPct(e, scale, apply) {
+    const rect = e.currentTarget.getBoundingClientRect();
+    const run = (ev) => {
+      const raw = ((ev.clientX - rect.left) / rect.width) * 100;
+      apply(scale === 100
+        ? Math.round(Math.max(5, Math.min(95, raw)))
+        : Math.round(Math.max(1, Math.min(10, raw / 10))));
+    };
+    run(e);
+    const up = () => {
+      window.removeEventListener("pointermove", run);
+      window.removeEventListener("pointerup", up);
+    };
+    window.addEventListener("pointermove", run);
+    window.addEventListener("pointerup", up);
+  }
+
+  removeRow(id) {
+    const before = this.state.rows;
+    const row = before.find((r) => r.id === id);
+    // The list row is a view of user_taken_courses — removing it here has to
+    // delete the real record too, or Explore still shows the course as taken.
+    if (row && row.code) {
+      const rows2 = STORE.userTakenCourses;
+      const at = rows2.findIndex((r) => r.userId === "u1" && r.courseCode === row.code);
+      if (at >= 0) rows2.splice(at, 1);
+    }
+    this.setState({
+      rows: before.filter((r) => r.id !== id),
+      toast: { text: "Removed " + (row.code || row.name), undo: before }
+    });
+  }
+
+  gradeStyle(g) {
+    if (g == null) return { gradeBg: "#fdf7ea", gradeFg: "#6b4c0d", gradeBorder: "#dfa53c", gradeBorderStyle: "dashed" };
+    if (g === "P" || g === "F") return { gradeBg: "var(--pill)", gradeFg: "#3d4650", gradeBorder: "transparent", gradeBorderStyle: "solid" };
+    return { gradeBg: "var(--pill)", gradeFg: "#12417f", gradeBorder: "transparent", gradeBorderStyle: "solid" };
+  }
+
+  matchStyle(kind) {
+    if (kind === "catalog") return { matchLabel: "In KTH catalog", matchBg: "var(--pill)", matchFg: "#12417f", matchBorder: "1px solid #dde7f4" };
+    if (kind === "nomatch") return { matchLabel: "No catalog match", matchBg: "#fdf7ea", matchFg: "#6b4c0d", matchBorder: "1px solid #f0e6d2" };
+    return { matchLabel: "Free-form course", matchBg: "var(--pill)", matchFg: "#5c6570", matchBorder: "1px dashed #cfc9b8" };
+  }
+
+  chip(on) {
+    return {
+      bg: on ? "var(--pill)" : "var(--surface)",
+      fg: on ? "var(--brand)" : "var(--muted)",
+      border: on ? "var(--brand)" : "var(--rule3)",
+      weight: on ? "600" : "500"
+    };
+  }
+
+  row(r) {
+    const off = !this.state.includeGrades;
+    const gs = r.grade != null ? this.gradeStyle(r.grade)
+      : off ? { gradeBg: "transparent", gradeFg: "#a09a8c", gradeBorder: "transparent", gradeBorderStyle: "solid" }
+      : this.gradeStyle(r.grade);
+    const editing = this.state.inlineId === r.id;
+    const draft = editing ? this.state.inlineDraft : null;
+    return {
+      ...gs,
+      ...this.matchStyle(r.match),
+      codeLabel: r.code || "—",
+      codeColor: r.match === "catalog" ? "var(--brand)" : "var(--dim)",
+      name: r.name,
+      hpLabel: r.hp + " hp",
+      gradeLabel: r.grade != null ? r.grade : off ? "not read" : "—",
+      reviewed: Boolean(r.reviewed),
+      canReview: r.match !== "freeform" && !r.reviewed,
+      onReview: () => this.openReviewer(r.id),
+      term: r.term,
+      issue: r.issue,
+      isNew: Boolean(r.isNew),
+      edited: Boolean(r.edited) && !r.isNew,
+      rowBg: r.isNew ? "#f7fbf9" : "transparent",
+      // Credits and grade are user_taken_courses fields — self-reported and
+      // editable in place, without the tab used to correct code/name/term.
+      isEditing: editing,
+      notEditing: !editing,
+      draftHp: draft ? draft.hp : r.hp,
+      onHpChange: (e) => this.setState({ inlineDraft: { ...this.state.inlineDraft, hp: e.target.value } }),
+      draftGrade: draft ? draft.grade : "",
+      onGradeChange: (e) => {
+        const v = e.target.value.toUpperCase().replace(/[^A-FP]/g, "").slice(0, 1);
+        this.setState({ inlineDraft: { ...this.state.inlineDraft, grade: v } });
+      },
+      year: r.year != null ? r.year : "—",
+      draftYear: draft ? draft.year : "",
+      onYearChange: (e) => {
+        const v = e.target.value.replace(/[^0-9]/g, "").slice(0, 4);
+        this.setState({ inlineDraft: { ...this.state.inlineDraft, year: v } });
+      },
+      onEdit: () => this.setState({
+        inlineId: r.id,
+        inlineDraft: { hp: r.hp, grade: r.grade || "", year: r.year != null ? String(r.year) : "" }
+      }),
+      onSaveEdit: () => this.saveInlineEdit(r.id),
+      onCancelEdit: () => this.setState({ inlineId: null, inlineDraft: null }),
+      onRemove: () => this.removeRow(r.id)
+    };
+  }
+
+  saveInlineEdit(id) {
+    const d = this.state.inlineDraft;
+    if (!d) return;
+    const hp = parseFloat(d.hp);
+    const hpOk = !isNaN(hp) && hp >= 0 ? hp.toFixed(1) : null;
+    const grade = d.grade ? d.grade : null;
+    const year = d.year && d.year.length === 4 ? parseInt(d.year, 10) : null;
+    const row = this.state.rows.find((r) => r.id === id);
+    this.setState({
+      inlineId: null, inlineDraft: null,
+      rows: this.state.rows.map((r) => r.id === id
+        ? { ...r, hp: hpOk != null ? hpOk : r.hp, grade, year: year != null ? year : r.year,
+            issue: grade == null && this.state.includeGrades ? "No grade set yet" : null, edited: true }
+        : r)
+    });
+    // Credits, grade and year are user_taken_courses fields — the edit is the
+    // course record, not a note kept only on this page.
+    if (row && row.code) {
+      STORE.setTakenOverride("u1", row.code, {
+        earnedCredits: hpOk != null ? parseFloat(hpOk) : parseFloat(row.hp),
+        grade, attendanceYear: year != null ? year : row.year
+      });
+    }
+  }
+
+  renderVals() {
+    const s = this.state;
+    const rows = s.rows;
+    const checks = rows.filter((r) => r.issue);
+    const ok = rows.filter((r) => !r.issue);
+    const credits = rows.reduce((a, r) => a + parseFloat(r.hp || 0), 0);
+    const terms = rows.map((r) => r.term).filter(Boolean).sort((a, b) => termIndex(a) - termIndex(b));
+    let points = 0;
+    let graded = 0;
+    rows.forEach((r) => {
+      const p = POINTS[r.grade];
+      if (p == null) return;
+      const hp = parseFloat(r.hp);
+      graded += hp;
+      points += p * hp;
+    });
+    const pending = rows.filter((r) => r.match !== "freeform" && !r.reviewed);
+    const cardId = s.revQueue[s.revAt];
+    const card = cardId == null ? null : rows.find((r) => r.id === cardId) || null;
+    const draft = (card && s.revDrafts[card.id]) || {};
+    const cardAnswered = Boolean(
+      draft.happy != null && draft.workload != null && draft.learning != null
+    );
+    const f = s.form;
+    const q = s.search.trim().toLowerCase();
+    const results = q
+      ? CATALOG.filter((c) => (c.code + " " + c.name).toLowerCase().includes(q)).slice(0, 5)
+      : [];
+
+    return {
+      signedIn: s.signedIn,
+      signedOut: !s.signedIn,
+      pageMaxWidth: STORE.PAGE_MAX_WIDTH,
+      pageSidePadding: STORE.PAGE_SIDE_PADDING,
+      isMember: s.signedIn,
+      night: this.ccDark(),
+      notNight: !this.ccDark(),
+      themeTitle: this.ccDark() ? "Switch to light mode" : "Switch to dark mode",
+      onTheme: () => this.ccSetDark(!this.ccDark()),
+      paneTop: "66px",
+      isGuest: !s.signedIn,
+      onLogIn: () => this.setState({ signedIn: true }),
+      onSignUp: () => this.setState({ signedIn: true }),
+      // The saved count is written by Explore and Saved; read it, never own it.
+      hasSavedCount: this.savedCount() > 0,
+      savedCountLabel: String(this.savedCount()),
+      isAuth: s.screen === "auth",
+      isEmpty: s.screen === "empty",
+      isParsing: s.screen === "parsing",
+      isSuccess: s.screen === "success",
+      isList: s.screen === "list",
+      isReviewer: s.screen === "reviewer",
+      isFailed: s.screen === "failed",
+      errorTitle: "We could not read that transcript",
+      errorBody: "The file opened, but no course rows came out of it. That is almost always a scanned PDF — a scan is a picture, so there is no text for the parser to read.",
+      errorFile: "resultatintyg-2026-08-24.pdf · 412 KB",
+      authReturnLine: s.rows.length
+        ? "Your course list is waiting — signing in brings you straight back to it."
+        : "Already have the PDF ready? Sign in and you land back here with the drop zone open.",
+      onSignIn: () => this.setState({ signedIn: true, screen: s.returnTo }, () => {
+        // The action that asked for the account finishes itself.
+        if (s.pending === "confirm") this.setState({ pending: null }, () => this.saveList());
+      }),
+      onBackToWork: () => this.setState({ screen: s.returnTo }),
+      onSignOut: () => this.setState({
+        signedIn: false, modal: null, toast: null,
+        returnTo: s.rows.length ? "list" : "empty"
+      }),
+
+      dropBorder: s.drop ? "var(--brand)" : "var(--hov)",
+      dropBg: s.drop ? "var(--pill)" : "var(--pill)",
+      dropTitle: s.drop ? "Drop to start reading" : "Drop your Ladok transcript here",
+      onDropEnter: () => this.setState({ drop: true }),
+      onDropLeave: () => this.setState({ drop: false }),
+      onUpload: () => this.startParse(s.rows.length ? "update" : "first"),
+      onManualStart: () => this.setState({ screen: "list", returnTo: "list" }, () => this.openForm("add")),
+
+      parseFile: s.parseKind === "first" ? "resultatintyg-2026-08-24.pdf" : "resultatintyg-2027-01-18.pdf",
+      parseFileMeta: s.parseKind === "first" ? "412 KB · 3 pages" : "438 KB · 3 pages",
+      parseHeading: s.parseKind === "first" ? "Reading your transcript" : "Reading the new transcript",
+      onCancelParse: () => { this.clearTimers(); this.setState({ screen: s.rows.length ? "list" : "empty" }); },
+
+      count: rows.length,
+      // Rows with no catalog match cannot be stored — user_taken_courses has an
+      // FK to courses.code — so they are reported once and excluded.
+      hasSkipped: s.skipped && s.skipped.length > 0 && !s.skippedSeen,
+      skippedTitle: s.skipped && s.skipped.length === 1
+        ? "1 row was not a KTH catalog course"
+        : (s.skipped ? s.skipped.length : 0) + " rows were not KTH catalog courses",
+      skippedItems: (s.skipped || []).map((x) => ({ label: x.code ? x.code + " — " + x.name : x.name })),
+      onDismissSkipped: () => this.setState({ skippedSeen: true }),
+      checkHeadline: checks.length === 1 ? "1 row needs your eyes" : checks.length + " rows need your eyes",
+      okRows: rows.map((r) => this.row(r)),
+      listEmpty: rows.length === 0,
+      onGoList: () => this.setState({ screen: "list", returnTo: "list" }),
+      sourceLabel: s.reads > 1
+        ? "Last updated 18 Jan 2027"
+        : s.reads === 1 ? "Last updated 24 Aug 2026" : "Added by hand",
+
+      gradesOn: s.includeGrades,
+      gradesOff: !s.includeGrades,
+      onToggleGrades: () => this.setState({ includeGrades: !s.includeGrades }),
+      gradesTrack: s.includeGrades ? "#1751a6" : "#cfc9b8",
+      gradesJustify: s.includeGrades ? "flex-end" : "flex-start",
+      gradesBg: s.includeGrades ? "var(--pill)" : "var(--surface)",
+      gradesBorder: s.includeGrades ? "#dde7f4" : "var(--rule)",
+      gradesHint: s.includeGrades
+        ? "The grade column is filled in from the file and your average is calculated. Only you can see either one."
+        : "Grade columns are left out of the parse, so no grade of yours is stored anywhere. Credits, names and terms are still read.",
+      readBullet: s.includeGrades
+        ? "It is read once to prefill your course list — code, name, credits, grade and term."
+        : "It is read once to prefill your course list — code, name, credits and term. Grade columns are skipped.",
+
+      isPreview: s.screen === "preview",
+      previewHeadline: s.previewSummary || (checks.length
+        ? rows.length + " courses read · " + checks.length + (checks.length === 1 ? " is missing a field" : " are missing a field")
+        : rows.length + " courses read · nothing missing"),
+      confirmCta: s.signedIn ? "Looks right" : "Sign in to keep this list",
+      onConfirm: () => {
+        if (!s.signedIn) { this.setState({ screen: "auth", returnTo: "list", pending: "confirm" }); return; }
+        this.saveList();
+      },
+      hasPending: pending.length > 0,
+      pendingLine: pending.length === 1
+        ? "You have 1 unreviewed course."
+        : "You have " + pending.length + " unreviewed courses.",
+      unreviewedCourses: pending.map((r) => ({ code: r.code, name: r.name, onClick: () => this.openReviewer(r.id) })),
+      onStartReviewer: () => this.openReviewer(null),
+      onCloseReviewer: () => this.setState({ screen: "list" }),
+      reviewCta: pending.length ? "Open the quick reviewer" : "All reviewed",
+      revActive: s.screen === "reviewer" && Boolean(card),
+      revDone: s.screen === "reviewer" && !card,
+      revProgressLabel: card
+        ? "Card " + (s.revAt + 1) + " of " + s.revQueue.length
+        : s.revQueue.length + (s.revQueue.length === 1 ? " card" : " cards") + " done",
+      revSegs: s.revQueue.map((id, i) => ({
+        bg: i < s.revAt ? "var(--btn)" : i === s.revAt ? "#7ea6d8" : "var(--pill)"
+      })),
+      revPeeks: [
+        { y: "14px", scale: "0.975", opacity: "1" },
+        { y: "26px", scale: "0.95", opacity: "0.65" }
+      ].slice(0, Math.max(0, s.revQueue.length - s.revAt - 1)),
+      revCode: card ? (card.code || "—") : "",
+      revName: card ? card.name : "",
+      revMeta: card ? card.hp + " hp · " + card.term : "",
+      revStackLabel: card
+        ? (s.revQueue.length - s.revAt - 1) + " more after this"
+        : "",
+      revHappyNotSet: draft.happy == null,
+      revHappyOpts: [["Yes, I am", true], ["No, not really", false]].map(([label, v]) => {
+        const on = draft.happy === v;
+        return {
+          label,
+          bg: on ? "var(--pill)" : "var(--surface)",
+          fg: on ? "var(--brand)" : "var(--muted)",
+          border: on ? "var(--brand)" : "var(--rule3)",
+          weight: on ? "600" : "500",
+          dot: on ? "#1751a6" : "transparent",
+          dotBorder: on ? "var(--brand)" : "#c8c2b2",
+          onClick: () => this.patchCard({ happy: v })
+        };
+      }),
+      examTrackRef: this.examTrackRef,
+      revPicked: draft.picked || [],
+      revPcts: draft.pcts || [],
+      revMethodChips: METHODS.map((m) => {
+        const picked = draft.picked || [];
+        const on = picked.indexOf(m.key) >= 0;
+        return {
+          label: m.label,
+          dot: on ? m.color : "#ded8c8",
+          bg: on ? "var(--pill)" : "var(--surface)",
+          fg: on ? "var(--ink)" : "var(--muted)",
+          border: on ? "var(--brand)" : "var(--rule3)",
+          onClick: () => this.toggleMethod(m.key, picked, (next, pcts) => this.patchCard({ picked: next, pcts }))
+        };
+      }),
+      revExamEmpty: !(draft.picked || []).length,
+      revExamSegs: (() => {
+        const picked = draft.picked || [];
+        const pcts = draft.pcts || [];
+        return picked.map((k, i) => {
+          const m = METHODS.find((x) => x.key === k);
+          const p = pcts[i] || 0;
+          return { label: m.label, short: m.short, color: m.color, ink: m.ink, width: p + "%", slotLabel: p >= 24 ? m.label : p >= 13 ? m.short : "" };
+        });
+      })(),
+      revExamDividers: (() => {
+        const picked = draft.picked || [];
+        const pcts = draft.pcts || [];
+        let acc = 0;
+        const cuts = [];
+        for (let i = 0; i < picked.length - 1; i++) { acc += pcts[i] || 0; cuts.push(acc); }
+        return cuts.map((left, i) => ({
+          left: left + "%",
+          onDown: (e) => {
+            e.preventDefault();
+            const el = this.examTrackRef.current;
+            if (el) this.dividerDown(i, el.getBoundingClientRect(), pcts, (next) => this.patchCard({ pcts: next }));
+          }
+        }));
+      })(),
+      revExamSplitLabel: (draft.picked || []).length ? (draft.picked || []).length + (draft.picked.length === 1 ? " format" : " formats") : "Not set",
+      revTheoryW1: (draft.theory == null ? 50 : draft.theory) + "%",
+      revTheoryW2: (draft.theory == null ? 50 : 100 - draft.theory) + "%",
+      revTheoryFill1: draft.theory == null ? "#ded8c8" : "#12417f",
+      revTheoryFill2: draft.theory == null ? "#ded8c8" : "#a9c8ec",
+      revTheoryInk1: draft.theory == null ? "#6b6355" : "#fff",
+      revTheoryInk2: draft.theory == null ? "#6b6355" : "#12417f",
+      revTheoryLabel: draft.theory == null ? "Not set" : draft.theory + " / " + (100 - draft.theory),
+      onRevTheoryDown: (e) => this.startPct(e, 100, (v) => this.patchCard({ theory: v })),
+      revWorkloadW: (draft.workload == null ? 0 : draft.workload * 10) + "%",
+      revWorkloadSet: draft.workload != null,
+      revWorkloadLabel: draft.workload == null ? "Not set" : draft.workload + " / 10",
+      onRevWorkloadDown: (e) => this.slide(e, 10, (v) => this.patchCard({ workload: v })),
+      revLearningW: (draft.learning == null ? 0 : draft.learning * 10) + "%",
+      revLearningSet: draft.learning != null,
+      revLearningLabel: draft.learning == null ? "Not set" : draft.learning + " / 10",
+      onRevLearningDown: (e) => this.slide(e, 10, (v) => this.patchCard({ learning: v })),
+      revText: draft.text || "",
+      onRevText: (e) => this.patchCard({ text: e.target.value }),
+      revAnswered: cardAnswered,
+      revSaveLabel: s.reviewPhase === "saving"
+        ? "Saving…"
+        : s.revAt === s.revQueue.length - 1 ? "Save and finish" : "Save and next",
+      revSaveBg: s.reviewPhase === "saving" ? "#7ea6d8" : cardAnswered ? "var(--btn)" : "#b9c9de",
+      revSaveCursor: s.reviewPhase === "saving" ? "progress" : cardAnswered ? "pointer" : "not-allowed",
+      revSaveError: s.reviewPhase === "failed",
+      revSaveErrorText: "That review did not reach the server. Nothing was lost — your answers are still on the card.",
+      onRetrySave: () => this.setState({ reviewPhase: "saving" }, () => {
+        this.timers.push(window.setTimeout(() => this.setState({ reviewPhase: "idle" }, () => this.saveCard()), 700));
+      }),
+      revCardHint: cardAnswered ? "Marks this course reviewed" : "Answer one thing to save",
+      onSaveCard: () => this.saveCard(),
+      onSkipCard: () => this.skipCard(),
+      revDoneTitle: s.revSaved
+        ? s.revSaved + (s.revSaved === 1 ? " course reviewed" : " courses reviewed")
+        : "Nothing reviewed this round",
+      revDoneBody: s.revSkipped
+        ? "The " + s.revSkipped + " you skipped are still marked unreviewed in your list — pick any of them up from there."
+        : "Every course in this round is marked reviewed in your list. You can reopen a card from the Reviewed column any time.",
+      revHasSkipped: s.revSkipped > 0,
+      onRoundTwo: () => this.openReviewer(null),
+
+      hasBanner: Boolean(s.banner),
+      bannerTitle: s.banner ? s.banner.title : "",
+      bannerBody: s.banner ? s.banner.body : "",
+      onDismissBanner: () => this.setState({ banner: null }),
+
+      hasToast: Boolean(s.toast),
+      toastText: s.toast ? s.toast.text : "",
+      canUndo: Boolean(s.toast && s.toast.undo),
+      onUndo: () => {
+        const removedRow = s.rows.length < s.toast.undo.length
+          ? s.toast.undo.find((r) => !s.rows.some((x) => x.id === r.id))
+          : null;
+        if (removedRow && removedRow.code && !STORE.userTakenCourses.some((r) => r.userId === "u1" && r.courseCode === removedRow.code)) {
+          const now = new Date().toISOString();
+          STORE.userTakenCourses.push({ userId: "u1", courseCode: removedRow.code, attendancePeriods: removedRow.periods || [],
+            attendanceYear: removedRow.year || null, grade: removedRow.grade || null, earnedCredits: parseFloat(removedRow.hp) || null,
+            transcriptImportedAt: null, createdAt: now, updatedAt: now });
+        }
+        this.setState({ rows: s.toast.undo, toast: null });
+      },
+
+      onUpdateStart: () => this.setState({ modal: "update" }),
+      onAddStart: () => this.openForm("add"),
+      modalOpen: Boolean(s.modal),
+      isUpdateModal: s.modal === "update",
+      isAddModal: s.modal === "add",
+      isEditModal: s.modal === "edit",
+      isFormModal: s.modal === "add" || s.modal === "edit",
+      modalWidth: s.modal === "update" ? "460px" : "560px",
+      modalKicker: s.modal === "update" ? "Update transcript" : s.modal === "edit" ? "Edit course" : "Add missing course",
+      modalTitle: s.modal === "update"
+        ? "Read a newer transcript"
+        : s.modal === "edit" ? "Correct what the parser read" : "Add a course by hand",
+      onCloseModal: () => this.setState({ modal: null, form: null }),
+      stopClick: (e) => e.stopPropagation(),
+
+      search: s.search,
+      onSearch: (e) => this.setState({ search: e.target.value }),
+      showResults: Boolean(q),
+      noResults: Boolean(q) && results.length === 0,
+      results: results.map((c) => ({
+        code: c.code, name: c.name, hp: c.hp,
+        onPick: () => this.setState({
+          search: "",
+          form: { ...f, code: c.code, name: c.name, hp: c.hp, match: "catalog" }
+        })
+      })),
+      onFreeForm: () => this.setState({
+        form: { ...f, code: "", name: s.search.trim(), match: "freeform" }, search: ""
+      }),
+      showFreeFormNote: Boolean(f) && !f.code.trim() && Boolean(f.name.trim()),
+
+      formCode: f ? f.code : "",
+      formName: f ? f.name : "",
+      codeFieldBg: f && !f.code.trim() ? "var(--inset)" : "var(--surface)",
+      onFormCode: (e) => this.setState({ form: { ...f, code: e.target.value } }),
+      onFormName: (e) => this.setState({ form: { ...f, name: e.target.value } }),
+      hpOptions: HP_CHOICES.map((h) => ({
+        label: h, ...this.chip(Boolean(f) && f.hp === h),
+        onClick: () => this.setState({ form: { ...f, hp: h } })
+      })),
+      formYear: f ? (f.year || "") : "",
+      onFormYear: (e) => this.setState({ form: { ...f, year: e.target.value.replace(/[^0-9]/g, "").slice(0, 4) } }),
+      gradeOptions: GRADES.map((g) => ({
+        label: g, minW: g === "no grade" ? "auto" : "38px",
+        ...this.chip(Boolean(f) && f.grade === g),
+        onClick: () => this.setState({ form: { ...f, grade: g } })
+      })),
+
+      originalLabel: f && f.id != null && (this.state.rows.find((r) => r.id === f.id) || {}).parsed
+        ? "Read from the transcript"
+        : "Added by hand — nothing was parsed",
+      originalFields: (() => {
+        if (!f || f.id == null) return [];
+        const row = this.state.rows.find((r) => r.id === f.id);
+        if (!row || !row.parsed) return [];
+        const p = row.parsed;
+        const cur = { code: f.code.trim() || null, name: f.name.trim(), hp: f.hp,
+          grade: f.grade === "no grade" ? null : f.grade, year: f.year };
+        return [
+          ["Code", p.code || "—", cur.code === p.code],
+          ["Name", p.name, cur.name === p.name],
+          ["Credits", p.hp + " hp", cur.hp === p.hp],
+          ["Grade", p.grade == null ? "not in file" : p.grade, cur.grade === p.grade],
+          ["Year", p.year, cur.year === p.year]
+        ].map(([label, value, same]) => ({
+          label, value,
+          fg: same ? "var(--ink2)" : "var(--dim2)",
+          strike: same ? "none" : "line-through",
+          border: same ? "var(--rule)" : "#f0e6d2"
+        }));
+      })(),
+      canRevert: (() => {
+        if (!f || f.id == null) return false;
+        const row = this.state.rows.find((r) => r.id === f.id);
+        if (!row || !row.parsed) return false;
+        const p = row.parsed;
+        return (p.code || "") !== f.code.trim() || p.name !== f.name.trim() || p.hp !== f.hp
+          || (p.grade || "no grade") !== f.grade || p.year !== f.year;
+      })(),
+      onRevert: () => this.revertForm(),
+
+      formHint: f && !f.code.trim()
+        ? "No code — this will be saved as a free-form course"
+        : f && f.code.trim() && !CATALOG.some((c) => c.code === f.code.trim().toUpperCase())
+          ? "This code is not in the catalog yet"
+          : "",
+      saveLabel: s.modal === "edit" ? "Save changes" : "Add course",
+      saveBg: f && f.name.trim() ? "var(--btn)" : "#b9c9de",
+      saveCursor: f && f.name.trim() ? "pointer" : "not-allowed",
+      onSaveForm: () => this.saveForm()
+    };
+  }
+}
+
+</script>
+</body>
+</html>

--- a/docs/design/Course Community - Unreviewed Card.dc.html
+++ b/docs/design/Course Community - Unreviewed Card.dc.html
@@ -1,0 +1,64 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<script src="./support.js"></script>
+</head>
+<body>
+<x-dc>
+<div style="box-sizing:border-box;width:100%;border:1px solid var(--rule2);border-radius:12px;background:var(--surface);box-shadow:0 1px 2px rgba(20,30,45,.05);padding:16px 18px 14px">
+<div style="display:flex;flex-wrap:wrap;align-items:center;justify-content:space-between;gap:12px 16px">
+<div style="min-width:180px">
+<div style="font-size:15.5px;font-weight:600">{{ headline }}</div>
+<div style="margin-top:3px;font-size:12.5px;color:var(--muted)">Your review is what the next student reads.</div>
+</div>
+<div onClick="{{ onStart }}" role="button" tabIndex="0" style="flex:none;display:flex;align-items:center;gap:8px;height:40px;padding:0 18px;border-radius:9px;background:var(--btn);color:var(--btnFg);font-size:13.5px;font-weight:600;cursor:pointer" style-hover="opacity:.88"><svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linejoin="round"><path d="M21 12a8 8 0 0 1-8 8H4l2-3.2A8 8 0 1 1 21 12z"></path></svg>{{ fastTrackLabel }}</div>
+</div>
+
+<div style="margin-top:12px;padding-top:12px;border-top:1px solid var(--rule);display:flex;flex-direction:column;gap:7px">
+<sc-for list="{{ items }}" as="c" hint-placeholder-count="4">
+<div onClick="{{ c.onClick }}" role="button" tabIndex="0" style="display:flex;align-items:baseline;gap:9px;cursor:{{ c.cursor }}">
+<span style="flex:none;width:4px;height:4px;margin-top:5px;border-radius:50%;background:var(--brand);opacity:.5"></span>
+<span style="flex:none;font:500 12px Geist Mono,ui-monospace,monospace;color:var(--brand)">{{ c.code }}</span>
+<span style="flex:1;min-width:0;font-size:13px;color:var(--ink2);overflow:hidden;text-overflow:ellipsis;white-space:nowrap">{{ c.name }}</span>
+</div>
+</sc-for>
+<sc-if value="{{ hasMore }}" hint-placeholder-val="{{ false }}">
+<div style="font-size:12px;color:var(--dim2)">{{ moreLabel }}</div>
+</sc-if>
+</div>
+</div>
+
+</x-dc>
+<script type="text/x-dc" data-dc-script data-props="{&quot;$preview&quot;:{&quot;width&quot;:640,&quot;height&quot;:260},&quot;courses&quot;:{&quot;editor&quot;:null,&quot;tsType&quot;:&quot;{ code: string; name: string; onClick?: () =&gt; void }[]&quot;},&quot;total&quot;:{&quot;editor&quot;:&quot;int&quot;,&quot;default&quot;:0,&quot;min&quot;:0,&quot;max&quot;:80,&quot;tsType&quot;:&quot;number&quot;},&quot;line&quot;:{&quot;editor&quot;:&quot;text&quot;,&quot;default&quot;:&quot;&quot;,&quot;tsType&quot;:&quot;string&quot;},&quot;max&quot;:{&quot;editor&quot;:&quot;int&quot;,&quot;default&quot;:6,&quot;min&quot;:2,&quot;max&quot;:12,&quot;tsType&quot;:&quot;number&quot;},&quot;onStart&quot;:{&quot;editor&quot;:null,&quot;tsType&quot;:&quot;() =&gt; void&quot;}}">
+/* The unreviewed list, shared by My Page's overview and Taken courses. A
+   minimal bullet per course — code and name only, no per-row action, since
+   the one entry point into reviewing is the fast-track button above. */
+class Component extends DCLogic {
+  renderVals() {
+    const p = this.props;
+    const all = p.courses || [];
+    const max = p.max || 6;
+    const shown = all.slice(0, max);
+    const rest = all.length - shown.length;
+    const n = all.length;
+    return {
+      headline: p.line || (n === 1 ? "1 course has no review yet" : n + " courses have no review yet"),
+      items: shown.map((c) => ({
+        code: c.code,
+        name: c.name || c.code,
+        onClick: c.onClick || null,
+        cursor: c.onClick ? "pointer" : "default"
+      })),
+      hasMore: rest > 0,
+      moreLabel: "+" + rest + " more",
+      fastTrackLabel: n === 1 ? "Fast track it" : "Fast track all " + n,
+      onStart: p.onStart || (() => {})
+    };
+  }
+}
+
+</script>
+</body>
+</html>

--- a/docs/design/Course Community - Workspace Pane.dc.html
+++ b/docs/design/Course Community - Workspace Pane.dc.html
@@ -1,0 +1,713 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<script src="./support.js"></script>
+</head>
+<body>
+<x-dc>
+<div style="position:relative;width:{{ paneWidth }};flex:{{ paneGrow }};min-width:0;display:flex;flex-direction:column;min-height:0">
+
+<sc-if value="{{ authOpen }}" hint-placeholder-val="{{ false }}">
+<div style="position:absolute;inset:0;z-index:60;display:flex;align-items:center;justify-content:center;padding:24px;background:rgba(20,30,45,.34)">
+<div style="width:392px;box-sizing:border-box;padding:24px;border-radius:14px;background:var(--surface);box-shadow:0 18px 48px rgba(20,30,45,.24)">
+<div style="display:flex;align-items:center;justify-content:space-between;gap:12px">
+<div style="font-size:11px;font-weight:600;letter-spacing:.06em;text-transform:uppercase;color:var(--brand)">One step left</div>
+<div onClick="{{ onAuthCancel }}" title="Back to my draft" style="width:26px;height:26px;display:flex;align-items:center;justify-content:center;border-radius:7px;color:var(--dim);font-size:17px;line-height:1;cursor:pointer" style-hover="background:var(--pill)">×</div>
+</div>
+<div style="margin-top:8px;font-size:19px;font-weight:600;line-height:1.25">Sign in to publish your review</div>
+<div style="margin-top:6px;font-size:13.5px;line-height:1.5;color:var(--muted)">Your draft is saved as it is — text, scores and the course all stay put. Nothing is published until you confirm.</div>
+<div style="margin-top:16px;display:flex;flex-direction:column;gap:8px">
+<div onClick="{{ onAuthDone }}" style="display:flex;align-items:center;justify-content:center;gap:9px;height:42px;border-radius:9px;background:var(--btn);color:var(--btnFg);font-size:13.5px;font-weight:600;cursor:pointer" style-hover="background:var(--btn)">Continue with KTH account</div>
+<div onClick="{{ onAuthDone }}" style="display:flex;align-items:center;justify-content:center;height:42px;border-radius:9px;border:1px solid var(--rule3);background:var(--surface);font-size:13.5px;font-weight:500;color:var(--ink);cursor:pointer" style-hover="border-color:var(--hov)">Sign up with email</div>
+</div>
+<div onClick="{{ onAuthCancel }}" style="margin-top:14px;text-align:center;font-size:12.5px;font-weight:500;color:var(--brand);cursor:pointer" style-hover="text-decoration:underline">Back to my draft</div>
+</div>
+</div>
+</sc-if>
+
+<sc-if value="{{ showTabStrip }}" hint-placeholder-val="{{ true }}">
+<div data-pop="tabs" style="position:relative;display:flex;align-items:flex-end;padding-left:2px">
+<div onClick="{{ onToggleOverflow }}" title="All open panes" style="display:flex;align-items:center;justify-content:center;flex:none;box-sizing:border-box;width:26px;height:30px;margin:0 6px 2px 0;border-radius:7px;border:1px solid var(--rule3);background:{{ caretBg }};color:var(--ink2);font-size:14px;line-height:1;cursor:pointer" style-hover="background:var(--pill)">▾</div>
+<div style="display:flex;align-items:flex-end;gap:{{ tabGap }};min-width:0">
+<sc-for list="{{ tabItems }}" as="t" hint-placeholder-count="3">
+<div onClick="{{ t.onClick }}" title="{{ t.title }}" style="display:flex;align-items:center;gap:7px;box-sizing:border-box;position:relative;z-index:{{ t.z }};width:{{ t.width }};height:34px;margin-bottom:{{ t.dip }};padding:{{ t.padding }};justify-content:{{ t.justify }};border-radius:9px 9px 0 0;border:1px solid var(--rule3);border-bottom:none;background:{{ t.bg }};color:{{ t.fg }};font-size:12.5px;font-weight:{{ t.weight }};box-shadow:inset 0 3px 0 0 {{ t.accent }};cursor:pointer">
+<span style="width:{{ t.dot }};height:{{ t.dot }};flex:none;border-radius:2px;background:{{ t.accent }}"></span>
+<span style="flex:{{ t.labelFlex }};overflow:hidden;text-overflow:ellipsis;white-space:nowrap">{{ t.label }}</span>
+<sc-if value="{{ t.isActive }}" hint-placeholder-val="{{ false }}">
+<span onClick="{{ t.onClose }}" title="Close pane" style="flex:none;color:var(--dim);font-size:15px;line-height:1;cursor:pointer">×</span>
+</sc-if>
+</div>
+</sc-for>
+</div>
+<sc-if value="{{ overflowOpen }}" hint-placeholder-val="{{ false }}">
+<div data-pop-panel="tabs" style="position:absolute;top:38px;left:0;z-index:30;box-sizing:border-box;width:262px;padding:5px;border-radius:10px;border:1px solid var(--rule2);background:var(--surface);box-shadow:0 8px 24px rgba(20,30,45,.14)">
+<div style="box-sizing:border-box;max-height:222px;overflow-y:auto;overflow-x:hidden">
+<sc-for list="{{ switcherItems }}" as="o" hint-placeholder-count="3">
+<div onClick="{{ o.onClick }}" style="display:flex;align-items:center;gap:9px;padding:7px 9px;border-radius:7px;background:{{ o.bg }};font-size:12.5px;font-weight:{{ o.weight }};color:{{ o.fg }};cursor:pointer" style-hover="background:var(--pill)">
+<span style="width:7px;height:7px;flex:none;border-radius:2px;background:{{ o.accent }}"></span>
+<span style="flex:1;overflow:hidden;text-overflow:ellipsis;white-space:nowrap">{{ o.label }}</span>
+<span onClick="{{ o.onClose }}" title="Close pane" style="width:22px;height:22px;flex:none;display:flex;align-items:center;justify-content:center;border-radius:5px;color:var(--dim);font-size:15px;line-height:1;cursor:pointer" style-hover="background:var(--pill)">×</span>
+</div>
+</sc-for>
+<sc-if value="{{ noTabs }}" hint-placeholder-val="{{ false }}">
+<div style="padding:14px 10px;text-align:center;font-size:12px;color:var(--dim)">No open panes</div>
+</sc-if>
+</div>
+</div>
+</sc-if>
+</div>
+</sc-if>
+
+<div ref="{{ paneScrollRef }}" style="flex:0 1 auto;max-height:100%;min-height:0;overflow:auto;border:{{ contentBorder }};border-radius:{{ contentRadius }};background:var(--surface);box-shadow:{{ contentShadow }}">
+
+<sc-if value="{{ isDetails }}" hint-placeholder-val="{{ true }}">
+<div>
+<div style="padding:18px 20px 15px;border-bottom:1px solid var(--rule);background:var(--info)">
+<div style="font-size:11px;font-weight:600;letter-spacing:.06em;text-transform:uppercase;color:var(--brand)">Course details</div>
+<div style="margin-top:6px;font-size:19px;font-weight:600;line-height:1.2">{{ detail.title }}</div>
+<div style="margin-top:3px;font-size:13px;color:var(--muted)">{{ detail.meta }}</div>
+<div style="margin-top:12px;display:flex;gap:8px">
+<div style="display:flex;align-items:center;gap:7px;box-sizing:border-box;height:34px;padding:0 12px;border-radius:8px;border:1px solid var(--rule3);background:var(--surface);font-size:13px;color:var(--chipInk);white-space:nowrap;cursor:pointer" style-hover="border-color:var(--hov)">Open on KTH.se ↗</div>
+</div>
+<div style="margin-top:14px;padding-top:12px;border-top:1px solid #dde7f4">
+<div style="font-size:10.5px;font-weight:600;letter-spacing:.09em;text-transform:uppercase;color:var(--dim)">Offerings</div>
+<div style="margin-top:7px;display:flex;flex-direction:column;gap:5px;font-size:13px;color:var(--muted)">
+<sc-for list="{{ detail.offerings }}" as="o" hint-placeholder-count="2">
+<div><span style="font-weight:600;color:var(--ink)">{{ o.periods }}</span> · {{ o.language }} · {{ o.tutoring }}</div>
+</sc-for>
+<sc-if value="{{ noOfferings }}" hint-placeholder-val="{{ false }}">
+<div style="color:var(--dim2)">No offering on file.</div>
+</sc-if>
+</div>
+</div>
+</div>
+
+<div style="padding:16px 20px 20px;display:flex;flex-direction:column;gap:14px;background:var(--surface)">
+
+<div style="border:1px solid var(--rule);border-radius:12px;background:var(--pg);padding:15px 16px 14px">
+<div style="font-size:10.5px;font-weight:600;letter-spacing:.09em;text-transform:uppercase;color:var(--dim)">Content</div>
+<div style="margin-top:9px;font-size:14px;line-height:1.6;color:var(--ink2);display:-webkit-box;-webkit-line-clamp:{{ contentClamp }};-webkit-box-orient:vertical;overflow:hidden">{{ detail.content }}</div>
+<div onClick="{{ onToggleContent }}" style="margin-top:7px;font-size:13px;font-weight:500;color:var(--brand);cursor:pointer" style-hover="text-decoration:underline">{{ contentToggleLabel }}</div>
+</div>
+
+<sc-if value="{{ detail.unreviewed }}" hint-placeholder-val="{{ false }}">
+<div style="border:1px solid var(--rule);border-radius:12px;background:var(--pg);padding:15px 16px 14px;font-size:13px;color:var(--dim)">No reviews yet — be the first to write one.</div>
+</sc-if>
+<sc-if value="{{ detail.reviewed }}" hint-placeholder-val="{{ true }}">
+<div style="border:1px solid var(--rule);border-radius:12px;background:var(--pg);padding:15px 16px 14px">
+<div style="display:grid;grid-template-columns:1fr 0.82fr;gap:30px;align-items:stretch">
+<div>
+<div style="font-size:10.5px;font-weight:600;letter-spacing:.09em;text-transform:uppercase;color:var(--dim)">Reviews summary</div>
+<div style="margin-top:5px;margin-bottom:14px;font-size:14.5px;font-weight:600">What students report</div>
+<div style="display:flex;align-items:baseline;justify-content:space-between;gap:8px;font-size:11.5px;color:var(--ink)"><span>Examination</span><span style="flex:none;padding:2px 8px;border-radius:999px;background:var(--pill);color:var(--dim);font-size:11px;font-weight:600;font-variant-numeric:tabular-nums;white-space:nowrap">{{ detail.exSplit }}</span></div>
+<div style="margin-top:7px;display:flex;height:14px;border-radius:4px;overflow:hidden;background:var(--pill)">
+<sc-for list="{{ detail.examSegments }}" as="x" hint-placeholder-count="3">
+<div style="width:{{ x.w }};background:{{ x.color }}"></div>
+</sc-for>
+</div>
+<div style="margin-top:6px;font-size:11px;color:var(--dim)">{{ detail.exNames }}</div>
+<div style="margin-top:18px;display:flex;align-items:baseline;justify-content:space-between;gap:8px;font-size:11.5px;color:var(--ink)"><span>Approach</span><span style="flex:none;padding:2px 8px;border-radius:999px;background:var(--pill);color:var(--dim);font-size:11px;font-weight:600;font-variant-numeric:tabular-nums;white-space:nowrap">{{ detail.thSplit }}</span></div>
+<div style="margin-top:7px;display:flex;height:6px;border-radius:3px;overflow:hidden"><div style="width:{{ detail.thW }};background:var(--btn)"></div><div style="width:{{ detail.apW }};background:#9dbfe4"></div></div>
+<div style="margin-top:6px;display:flex;justify-content:space-between;font-size:11px;color:var(--dim)"><span>Theoretical</span><span>Applied</span></div>
+<div style="height:1px;margin:18px 0;background:var(--pill)"></div>
+<div style="display:flex;align-items:baseline;justify-content:space-between;gap:8px;font-size:11.5px;color:var(--ink)"><span>Workload</span><span style="flex:none;padding:2px 8px;border-radius:999px;background:var(--pill);color:var(--dim);font-size:11px;font-weight:600;font-variant-numeric:tabular-nums;white-space:nowrap">{{ detail.wl }} / 10</span></div>
+<div style="margin-top:7px;height:6px;border-radius:3px;background:var(--pill);overflow:hidden"><div style="height:100%;width:{{ detail.wlW }};background:#dfa53c"></div></div>
+<div style="margin-top:18px;display:flex;align-items:baseline;justify-content:space-between;gap:8px;font-size:11.5px;color:var(--ink)"><span>Learning experience</span><span style="flex:none;padding:2px 8px;border-radius:999px;background:var(--pill);color:var(--dim);font-size:11px;font-weight:600;font-variant-numeric:tabular-nums;white-space:nowrap">{{ detail.le }} / 10</span></div>
+<div style="margin-top:7px;height:6px;border-radius:3px;background:var(--pill);overflow:hidden"><div style="height:100%;width:{{ detail.leW }};background:var(--btn)"></div></div>
+</div>
+<div style="display:flex;flex-direction:column;gap:10px;align-self:center;padding:16px 17px 15px;border-radius:11px;background:rgba(255,255,255,.55);border:1px solid var(--rule)">
+<div>
+<div style="display:flex;justify-content:center">
+<svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="#7a5309" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round"><path d="M12 3l1.7 4.8L18.5 9.5l-4.8 1.7L12 16l-1.7-4.8L5.5 9.5l4.8-1.7L12 3z"></path><path d="M18.6 15.4l.7 2 2 .7-2 .7-.7 2-.7-2-2-.7 2-.7.7-2z"></path></svg>
+</div>
+<div style="margin-top:8px;font-size:12px;line-height:1.5;color:var(--dim)">{{ detail.summaryLine }}</div>
+</div>
+<div onClick="{{ onExpandReviews }}" style="font-size:11.5px;font-weight:600;color:var(--dim);cursor:pointer" style-hover="text-decoration:underline">Read all {{ detail.reviews }} reviews →</div>
+</div>
+</div>
+</div>
+
+<div style="display:flex;align-items:center;justify-content:space-between;gap:12px;padding:11px 13px;border-radius:10px;background:var(--info);border:1px solid #dde7f4">
+<div style="font-size:12.5px;font-weight:500;line-height:1.45;color:var(--brand)">Taken this course? Your review helps the next student decide.</div>
+<div onClick="{{ onOpenReviewTab }}" style="flex:none;display:flex;align-items:center;gap:7px;white-space:nowrap;box-sizing:border-box;height:34px;padding:0 13px;border-radius:8px;background:var(--btn);color:var(--btnFg);font-size:13px;font-weight:500;cursor:pointer" style-hover="background:var(--btn)"><svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="#fff" stroke-width="2" stroke-linejoin="round"><path d="M21 12a8 8 0 0 1-8 8H4l2-3.2A8 8 0 1 1 21 12z"></path></svg>Write a review</div>
+</div>
+
+<div>
+<div style="display:flex;border-bottom:1px solid var(--rule)">
+</sc-if>
+<sc-if value="{{ detail.reviewed }}" hint-placeholder-val="{{ true }}">
+<div ref="{{ reviewsRef }}" onClick="{{ onToggleReviews }}" style="display:flex;align-items:center;gap:7px;margin-bottom:-1px;padding-bottom:9px;border-bottom:2px solid {{ reviewsTabBorder }};font-size:13px;font-weight:600;color:{{ reviewsTabFg }};cursor:pointer">Reviews · {{ detail.reviews }}<span style="font-size:9px">{{ reviewsCaret }}</span></div>
+</div>
+<sc-if value="{{ reviewsOpen }}" hint-placeholder-val="{{ false }}">
+<div style="margin-top:13px;display:flex;flex-direction:column;gap:12px">
+<sc-if value="{{ detail.hasReviewCards }}" hint-placeholder-val="{{ true }}">
+<sc-for list="{{ detail.reviewCards }}" as="rv" hint-placeholder-count="2">
+<dc-import name="Course Community - Review Card" review="{{ rv }}" hint-size="100%,150px"></dc-import>
+</sc-for>
+</sc-if>
+<sc-if value="{{ detail.noReviewCards }}" hint-placeholder-val="{{ false }}">
+<div style="font-size:13px;color:var(--dim)">No written review yet — the numbers above are the only signal so far.</div>
+</sc-if>
+</div>
+</sc-if>
+</div>
+
+</div>
+</div>
+</sc-if>
+</sc-if>
+
+<sc-if value="{{ isReview }}" hint-placeholder-val="{{ false }}">
+<div style="display:flex;flex-direction:column;min-height:100%">
+<div style="padding:18px 20px 14px;background:var(--warn)">
+<div style="display:flex;align-items:center;justify-content:space-between">
+<div style="font-size:11px;font-weight:600;letter-spacing:.06em;text-transform:uppercase;color:var(--warnInk)">Review draft</div>
+<div style="font-size:11.5px;color:var(--dim)">{{ savedLabel }}</div>
+</div>
+<div style="margin-top:6px;font-size:19px;font-weight:600;line-height:1.2">{{ detail.title }}</div>
+<div style="margin-top:3px;font-size:13px;color:var(--muted)">{{ detail.meta }}</div>
+</div>
+<div style="position:sticky;top:0;z-index:4;padding:11px 20px 12px;border-bottom:1px solid var(--warnBorder);background:var(--warn)">
+<div style="font-size:11.5px;color:var(--dim)">{{ progressLabel }}</div>
+<div style="margin-top:6px;display:flex;gap:6px">
+<sc-for list="{{ progressSegs }}" as="p" hint-placeholder-count="4">
+<div style="flex:1;height:6px;border-radius:99px;background:{{ p.bg }}"></div>
+</sc-for>
+</div>
+</div>
+
+<div style="padding:16px 20px 20px;display:flex;flex-direction:column;gap:14px;background:var(--surface)">
+
+<div style="border:1px solid var(--rule);border-radius:12px;background:var(--pg);padding:15px 16px 14px">
+<div style="font-size:10.5px;font-weight:600;letter-spacing:.09em;text-transform:uppercase;color:var(--dim)">Format</div>
+<div style="margin-top:5px;display:flex;align-items:baseline;justify-content:space-between;gap:10px">
+<div style="font-size:14.5px;font-weight:600">How was it examined?</div>
+<sc-if value="{{ examUnknownOff }}" hint-placeholder-val="{{ true }}">
+<div style="flex:none;padding:2px 9px;border-radius:999px;background:var(--pill);color:var(--brand);font-size:12px;font-weight:600;font-variant-numeric:tabular-nums">{{ examSplitLabel }}</div>
+</sc-if>
+</div>
+<div style="display:flex;flex-wrap:wrap;gap:6px;margin-top:11px">
+<sc-for list="{{ methodChips }}" as="m" hint-placeholder-count="7">
+<div onClick="{{ m.onClick }}" style="display:flex;align-items:center;gap:6px;height:30px;padding:0 11px;border-radius:15px;border:1px solid {{ m.border }};background:{{ m.bg }};color:{{ m.fg }};font-size:12.5px;cursor:pointer" style-hover="border-color:var(--brand)">
+<span style="width:8px;height:8px;flex:none;border-radius:2px;background:{{ m.dot }}"></span>{{ m.label }}
+</div>
+</sc-for>
+</div>
+<div ref="{{ examTrackRef }}" style="position:relative;margin-top:11px;display:flex;height:38px;border-radius:8px;overflow:hidden;background:var(--pill);user-select:none;opacity:{{ examTrackOpacity }};pointer-events:{{ examTrackPointer }}">
+<sc-if value="{{ examEmpty }}" hint-placeholder-val="{{ false }}">
+<div style="flex:1;display:flex;align-items:center;justify-content:center;font-size:12px;color:var(--dim)">Click the formats this course used</div>
+</sc-if>
+<sc-for list="{{ examSegs }}" as="s" hint-placeholder-count="3">
+<div style="width:{{ s.width }};background:{{ s.color }};display:flex;align-items:center;justify-content:center;color:{{ s.ink }};font-size:12px;font-weight:600;overflow:hidden;white-space:nowrap;transition:none">{{ s.slotLabel }}</div>
+</sc-for>
+<sc-for list="{{ examDividers }}" as="d" hint-placeholder-count="2">
+<div onPointerDown="{{ d.onDown }}" style="position:absolute;top:0;bottom:0;left:{{ d.left }};width:18px;margin-left:-9px;cursor:ew-resize;display:flex;align-items:center;justify-content:center">
+<div style="width:4px;height:24px;border-radius:2px;background:var(--surface);box-shadow:0 0 0 1px rgba(20,30,45,.18)"></div>
+</div>
+</sc-for>
+</div>
+<div onClick="{{ onToggleExamUnknown }}" role="checkbox" aria-checked="{{ examUnknown }}" tabIndex="0" style="margin-top:9px;display:flex;align-items:center;gap:8px;cursor:pointer">
+<span style="flex:none;width:16px;height:16px;border-radius:4px;border:1px solid {{ examCheckBorder }};background:{{ examCheckBg }};display:flex;align-items:center;justify-content:center"><sc-if value="{{ examUnknown }}" hint-placeholder-val="{{ false }}"><svg width="10" height="10" viewBox="0 0 24 24" fill="none" stroke="#fff" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"><path d="M20 6 9 17l-5-5"></path></svg></sc-if></span>
+<span style="font-size:12.5px;color:var(--ink2)">I don't remember</span>
+</div>
+<div style="height:1px;margin:14px 0;background:var(--pill)"></div>
+<div style="display:flex;align-items:baseline;justify-content:space-between;gap:10px">
+<div style="font-size:14.5px;font-weight:600">What was the approach?</div>
+<sc-if value="{{ theoryUnknownOff }}" hint-placeholder-val="{{ true }}">
+<div style="flex:none;padding:2px 9px;border-radius:999px;background:var(--pill);color:var(--brand);font-size:12px;font-weight:600;font-variant-numeric:tabular-nums">{{ theoryLabel }}</div>
+</sc-if>
+</div>
+<div onPointerDown="{{ onTheoryDown }}" style="position:relative;margin-top:11px;display:flex;height:38px;border-radius:8px;overflow:hidden;background:var(--pill);cursor:ew-resize;user-select:none;opacity:{{ theoryTrackOpacity }};pointer-events:{{ theoryTrackPointer }}">
+<div style="display:flex;width:100%;height:100%">
+<div style="width:{{ theoryW1 }};background:{{ theoryFill1 }};display:flex;align-items:center;padding-left:11px;color:{{ theoryInk1 }};font-size:12px;font-weight:600;overflow:hidden;white-space:nowrap">Theoretical</div>
+<div style="width:{{ theoryW2 }};background:{{ theoryFill2 }};display:flex;align-items:center;justify-content:flex-end;padding-right:11px;color:{{ theoryInk2 }};font-size:12px;font-weight:600;overflow:hidden;white-space:nowrap">Applied</div>
+</div>
+<div style="position:absolute;top:0;bottom:0;left:{{ theoryW1 }};width:18px;margin-left:-9px;display:flex;align-items:center;justify-content:center"><div style="width:4px;height:24px;border-radius:2px;background:var(--surface);box-shadow:0 0 0 1px rgba(20,30,45,.18)"></div></div>
+</div>
+<div onClick="{{ onToggleTheoryUnknown }}" role="checkbox" aria-checked="{{ theoryUnknown }}" tabIndex="0" style="margin-top:9px;display:flex;align-items:center;gap:8px;cursor:pointer">
+<span style="flex:none;width:16px;height:16px;border-radius:4px;border:1px solid {{ theoryCheckBorder }};background:{{ theoryCheckBg }};display:flex;align-items:center;justify-content:center"><sc-if value="{{ theoryUnknown }}" hint-placeholder-val="{{ false }}"><svg width="10" height="10" viewBox="0 0 24 24" fill="none" stroke="#fff" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"><path d="M20 6 9 17l-5-5"></path></svg></sc-if></span>
+<span style="font-size:12.5px;color:var(--ink2)">I don't remember</span>
+</div>
+</div>
+
+<div style="border:1px solid var(--rule);border-radius:12px;background:var(--pg);padding:15px 16px 14px">
+<div style="font-size:10.5px;font-weight:600;letter-spacing:.09em;text-transform:uppercase;color:var(--dim);margin-bottom:11px">Course profile</div>
+<div style="display:flex;align-items:baseline;justify-content:space-between;gap:10px;margin-bottom:9px"><div style="font-size:14.5px;font-weight:600">How demanding was this course?</div><div style="flex:none;padding:2px 9px;border-radius:999px;background:var(--pill);color:var(--brand);font-size:12px;font-weight:600;font-variant-numeric:tabular-nums">{{ workloadLabel }}</div></div>
+<div onPointerDown="{{ onWorkloadDown }}" style="position:relative;height:22px;display:flex;align-items:center;cursor:pointer;user-select:none">
+<div style="height:8px;width:100%;border-radius:4px;background:var(--pill);overflow:hidden"><div style="height:100%;width:{{ workloadW }};background:var(--warnBtn)"></div></div>
+<sc-if value="{{ workloadSet }}" hint-placeholder-val="{{ false }}">
+<div style="position:absolute;left:{{ workloadW }};width:20px;height:20px;margin-left:-10px;border-radius:50%;background:var(--surface);border:2px solid var(--brand);box-shadow:0 1px 3px rgba(0,0,0,.15)"></div>
+</sc-if>
+</div>
+<div style="display:flex;justify-content:space-between;font-size:11.5px;color:var(--muted);margin-top:4px"><span>Not at all</span><span>Very</span></div>
+<div style="height:1px;margin:14px 0;background:var(--pill)"></div>
+<div style="display:flex;align-items:baseline;justify-content:space-between;gap:10px;margin-bottom:9px"><div style="font-size:14.5px;font-weight:600">How much did you learn in this course?</div><div style="flex:none;padding:2px 9px;border-radius:999px;background:var(--pill);color:var(--brand);font-size:12px;font-weight:600;font-variant-numeric:tabular-nums">{{ learningLabel }}</div></div>
+<div onPointerDown="{{ onLearningDown }}" style="position:relative;height:22px;display:flex;align-items:center;cursor:pointer;user-select:none">
+<div style="height:8px;width:100%;border-radius:4px;background:var(--pill);overflow:hidden"><div style="height:100%;width:{{ learningW }};background:var(--warnBtn)"></div></div>
+<sc-if value="{{ learningSet }}" hint-placeholder-val="{{ false }}">
+<div style="position:absolute;left:{{ learningW }};width:20px;height:20px;margin-left:-10px;border-radius:50%;background:var(--surface);border:2px solid var(--brand);box-shadow:0 1px 3px rgba(0,0,0,.15)"></div>
+</sc-if>
+</div>
+<div style="display:flex;justify-content:space-between;font-size:11.5px;color:var(--muted);margin-top:4px"><span>Nothing new</span><span>Transformative</span></div>
+</div>
+
+<div style="border:1px solid var(--rule);border-radius:12px;background:var(--pg);padding:15px 16px 14px">
+<div style="font-size:10.5px;font-weight:600;letter-spacing:.09em;text-transform:uppercase;color:var(--dim)">Your take</div>
+<div style="margin-top:5px;display:flex;align-items:baseline;justify-content:space-between;gap:10px"><span style="font-size:14.5px;font-weight:600">Are you happy you took this course?</span><sc-if value="{{ happyNotSet }}" hint-placeholder-val="{{ false }}"><span style="flex:none;padding:2px 9px;border-radius:999px;background:var(--pill);color:var(--brand);font-size:12px;font-weight:600">Not set</span></sc-if></div>
+<div style="margin-top:10px;display:flex;gap:8px">
+<sc-for list="{{ happyOpts }}" as="h" hint-placeholder-count="2">
+<div onClick="{{ h.onClick }}" style="flex:1;display:flex;align-items:center;justify-content:center;gap:7px;height:40px;border-radius:9px;border:1px solid {{ h.border }};background:{{ h.bg }};color:{{ h.fg }};font-size:13.5px;font-weight:{{ h.weight }};cursor:pointer" style-hover="border-color:var(--brand)">
+<span style="width:15px;height:15px;flex:none;border-radius:50%;border:1px solid {{ h.dotBorder }};background:{{ h.dot }}"></span>{{ h.label }}
+</div>
+</sc-for>
+</div>
+<div style="height:1px;margin:14px 0;background:var(--pill)"></div>
+<div style="font-size:14.5px;font-weight:600">Write your review</div>
+<div style="margin-top:3px;font-size:12px;color:var(--muted)">Not sure where to start? Tap one:</div>
+<div style="display:flex;flex-wrap:wrap;gap:6px;margin-top:9px">
+<sc-for list="{{ promptChips }}" as="p" hint-placeholder-count="3">
+<div onClick="{{ p.onClick }}" style="display:flex;align-items:center;height:28px;padding:0 11px;border-radius:14px;border:1px dashed #9dbfe4;background:var(--pill);color:var(--brand);font-size:11.5px;font-weight:500;cursor:pointer" style-hover="background:var(--pill)">{{ p.label }}</div>
+</sc-for>
+</div>
+<div style="margin-top:10px;border:1px solid var(--rule3);border-radius:10px;overflow:hidden;background:var(--surface)">
+<div style="display:flex;gap:2px;padding:6px 8px;border-bottom:1px solid var(--rule);background:var(--pg);font-size:13px;color:var(--muted)">
+<span style="padding:3px 7px;border-radius:5px;font-weight:700">B</span><span style="padding:3px 7px;border-radius:5px;font-style:italic">I</span><span style="padding:3px 7px;border-radius:5px;text-decoration:underline">U</span><span style="padding:3px 7px;border-radius:5px">• List</span>
+</div>
+<textarea value="{{ reviewText }}" onChange="{{ onReviewChange }}" placeholder="What should the next student know before signing up?" style="display:block;width:100%;box-sizing:border-box;min-height:104px;padding:12px;border:none;outline:none;resize:vertical;background:var(--surface);font-family:Geist,system-ui,sans-serif;font-size:13.5px;line-height:1.55;color:var(--ink2)"></textarea>
+</div>
+<div style="margin-top:6px;font-size:11.5px;color:var(--muted)">Be constructive and respectful</div>
+</div>
+
+</div>
+
+<div style="position:sticky;bottom:0;margin-top:auto;border-top:1px solid var(--rule);background:var(--surface)">
+<sc-if value="{{ justAuthed }}" hint-placeholder-val="{{ false }}">
+<div style="display:flex;align-items:center;gap:9px;padding:10px 20px;border-bottom:1px solid var(--rule);background:var(--pill);font-size:12.5px;line-height:1.45;color:var(--brand)">
+<svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="#1751a6" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M20 6 9 17l-5-5"></path></svg>
+Signed in as Elsa Lindqvist. Your draft came back untouched — check it and publish when you are ready.
+</div>
+</sc-if>
+<sc-if value="{{ posted }}" hint-placeholder-val="{{ false }}">
+<div style="display:flex;align-items:center;gap:9px;padding:10px 20px;border-bottom:1px solid var(--rule);background:#e9f3ef;font-size:12.5px;color:#1c6b60">
+<svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="#1c6b60" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M20 6 9 17l-5-5"></path></svg>
+Published. Thanks — your review is live on the course.
+</div>
+</sc-if>
+<div style="display:flex;justify-content:flex-end;gap:9px;padding:12px 20px">
+<div style="display:flex;align-items:center;height:36px;padding:0 14px;border-radius:8px;border:1px solid var(--rule3);font-size:13px;color:var(--chipInk);cursor:pointer" style-hover="border-color:var(--hov)">Save draft</div>
+<div onClick="{{ onPostReview }}" style="display:flex;align-items:center;height:36px;padding:0 16px;border-radius:8px;background:{{ postBg }};color:{{ postFg }};font-size:13px;font-weight:600;cursor:{{ postCursor }}" title="{{ postHint }}">{{ postLabel }}</div>
+</div>
+</div>
+</div>
+</sc-if>
+
+</div>
+</div>
+
+</x-dc>
+<script type="text/x-dc" data-dc-script data-props="{&quot;$preview&quot;:{&quot;width&quot;:560,&quot;height&quot;:700},&quot;courses&quot;:{&quot;editor&quot;:null,&quot;tsType&quot;:&quot;any[]&quot;},&quot;storeModule&quot;:{&quot;editor&quot;:null,&quot;tsType&quot;:&quot;any&quot;},&quot;locale&quot;:{&quot;editor&quot;:&quot;enum&quot;,&quot;default&quot;:&quot;en&quot;,&quot;options&quot;:[&quot;en&quot;,&quot;sv&quot;],&quot;tsType&quot;:&quot;string&quot;},&quot;isGuest&quot;:{&quot;editor&quot;:&quot;boolean&quot;,&quot;default&quot;:false,&quot;tsType&quot;:&quot;boolean&quot;},&quot;paneWidth&quot;:{&quot;editor&quot;:null,&quot;tsType&quot;:&quot;string&quot;},&quot;paneGrow&quot;:{&quot;editor&quot;:null,&quot;tsType&quot;:&quot;string&quot;},&quot;openSignal&quot;:{&quot;editor&quot;:null,&quot;tsType&quot;:&quot;any&quot;},&quot;onTabsChange&quot;:{&quot;editor&quot;:null,&quot;tsType&quot;:&quot;(count:number)=&gt;void&quot;},&quot;onAuthed&quot;:{&quot;editor&quot;:null,&quot;tsType&quot;:&quot;()=&gt;void&quot;},&quot;hideTabs&quot;:{&quot;editor&quot;:&quot;boolean&quot;,&quot;default&quot;:false,&quot;tsType&quot;:&quot;boolean&quot;}}">
+const METHODS = [
+  { key: "exam", label: "On-campus exam", short: "Exam", color: "var(--brand)", ink: "var(--btnFg)" },
+  { key: "assignments", label: "Assignments", short: "Assign.", color: "#dfa53c", ink: "#3a2a06" },
+  { key: "labs", label: "Labs", short: "Labs", color: "#2f9e8e", ink: "#06251f" },
+  { key: "projects", label: "Project", short: "Project", color: "#6a4ea8", ink: "var(--btnFg)" },
+  { key: "other", label: "Other", short: "Other", color: "#57646f", ink: "var(--btnFg)" }
+];
+/** Even split across n segments in 5% steps; the remainder lands on the last. */
+function evenSplit(n) {
+  if (n === 0) return [];
+  const base = Math.max(5, Math.round(100 / n / 5) * 5);
+  const out = new Array(n).fill(base);
+  out[n - 1] = 100 - base * (n - 1);
+  return out;
+}
+const EMPTY_DRAFT = { picked: [], pcts: [], theory: null, examUnknown: false, theoryUnknown: false, workload: null, learning: null, recommend: null, reviewText: "" };
+
+/* Owns every open course-details/review-draft tab and its own drafts. The
+   host tells it which course to open (openSignal) and reads back how many
+   tabs are open (onTabsChange) for its own results-column sizing \u2014
+   otherwise this component is fully self-contained. */
+class Component extends DCLogic {
+  state = {
+    tabs: [], tab: 0, drafts: {},
+    overflowOpen: false, reviewsOpen: false, contentOpen: false,
+    authOpen: false, justAuthed: false, posted: false
+  };
+  examTrackRef = React.createRef();
+  paneScrollRef = React.createRef();
+  reviewsRef = React.createRef();
+  _lastCount = 0;
+
+  componentDidMount() {
+    document.addEventListener("pointerdown", this.onDocDown, true);
+    document.addEventListener("keydown", this.onDocKey, true);
+    document.addEventListener("scroll", this.onDocScroll, true);
+  }
+
+  componentWillUnmount() {
+    document.removeEventListener("pointerdown", this.onDocDown, true);
+    document.removeEventListener("keydown", this.onDocKey, true);
+    document.removeEventListener("scroll", this.onDocScroll, true);
+  }
+
+  /* This runtime never calls componentDidUpdate, so both cross-component
+     effects are driven from renderVals() itself \u2014 deferred a tick with a
+     microtask so the state write never lands mid-render. */
+  checkSignal() {
+    const sig = this.props.openSignal;
+    if (sig && sig.nonce !== this._appliedNonce) {
+      this._appliedNonce = sig.nonce;
+      Promise.resolve().then(() => this.openTab(sig.code, sig.kind));
+    }
+    const count = this.state.tabs.length;
+    if (count !== this._lastCount) {
+      this._lastCount = count;
+      if (this.props.onTabsChange) Promise.resolve().then(() => this.props.onTabsChange(count));
+    }
+  }
+
+  onDocDown = (e) => {
+    if (e.target.closest && e.target.closest("[data-pop]")) return;
+    if (this.state.overflowOpen) this.setState({ overflowOpen: false });
+  };
+  onDocKey = (e) => {
+    if (e.key !== "Escape") return;
+    if (this.state.overflowOpen) this.setState({ overflowOpen: false });
+  };
+  onDocScroll = (e) => {
+    if (e.target.closest && e.target.closest("[data-pop-panel]")) return;
+    if (this.state.overflowOpen) this.setState({ overflowOpen: false });
+  };
+
+  openTab(code, kind) {
+    const tabs = this.state.tabs.slice();
+    const idx = tabs.findIndex((t) => t.code === code && t.kind === kind);
+    if (idx >= 0) { this.setState({ tab: idx, overflowOpen: false }); return; }
+    tabs.push({ id: Date.now(), kind, code, label: code + (kind === "r" ? " · Review draft" : " · Details") });
+    this.setState({ tabs, tab: tabs.length - 1, overflowOpen: false });
+  }
+
+  closeTab(e, i) {
+    e.stopPropagation();
+    const tabs = this.state.tabs.slice();
+    tabs.splice(i, 1);
+    let tab = this.state.tab;
+    if (i < tab) tab -= 1;
+    if (tab >= tabs.length) tab = tabs.length - 1;
+    this.setState({ tabs, tab: Math.max(0, tab) });
+  }
+
+  draftFor(code) {
+    return this.state.drafts[code] || EMPTY_DRAFT;
+  }
+
+  patchDraft(code, patch) {
+    const drafts = { ...this.state.drafts };
+    drafts[code] = { ...this.draftFor(code), ...patch };
+    this.setState({ drafts });
+  }
+
+  drag(onMove) {
+    const move = (ev) => onMove(ev);
+    const up = () => {
+      window.removeEventListener("pointermove", move);
+      window.removeEventListener("pointerup", up);
+      document.body.style.cursor = "";
+      document.body.style.userSelect = "";
+    };
+    window.addEventListener("pointermove", move);
+    window.addEventListener("pointerup", up);
+    document.body.style.cursor = "ew-resize";
+    document.body.style.userSelect = "none";
+  }
+
+  dividerDown(i, rect, pcts, setPcts) {
+    const before = pcts.slice(0, i).reduce((a, p) => a + p, 0);
+    const pair = pcts[i] + pcts[i + 1];
+    this.drag((ev) => {
+      let x = ((ev.clientX - rect.left) / rect.width) * 100 - before;
+      x = Math.round(x / 5) * 5;
+      x = Math.max(5, Math.min(pair - 5, x));
+      const next = pcts.slice();
+      next[i] = x;
+      next[i + 1] = pair - x;
+      setPcts(next);
+    });
+  }
+
+  bump(i, delta, pcts, setPcts) {
+    const next = pcts.slice();
+    const j = (i + 1) % next.length;
+    if (i === j) return;
+    if (next[i] + delta < 5 || next[j] - delta < 5) return;
+    next[i] += delta;
+    next[j] -= delta;
+    setPcts(next);
+  }
+
+  toggleMethod(method, picked, setBoth) {
+    const next = picked.slice();
+    const at = next.indexOf(method);
+    if (at >= 0) next.splice(at, 1); else next.push(method);
+    setBoth(next, evenSplit(next.length));
+  }
+
+  startPct(e, scale, apply) {
+    const rect = e.currentTarget.getBoundingClientRect();
+    const run = (ev) => {
+      const raw = ((ev.clientX - rect.left) / rect.width) * 100;
+      apply(scale === 100
+        ? Math.round(Math.max(5, Math.min(95, raw)))
+        : Math.round(Math.max(1, Math.min(10, raw / 10))));
+    };
+    run(e);
+    this.drag(run);
+  }
+
+  revealReviews() {
+    this.setState({ reviewsOpen: true }, () => {
+      requestAnimationFrame(() => {
+        const box = this.paneScrollRef.current;
+        const head = this.reviewsRef.current;
+        if (!box || !head) return;
+        const top = head.getBoundingClientRect().top - box.getBoundingClientRect().top + box.scrollTop;
+        box.scrollTo({ top: Math.max(0, top - 12), behavior: "smooth" });
+      });
+    });
+  }
+
+  renderVals() {
+    this.checkSignal();
+    const s = this.state;
+    const STORE = this.props.storeModule;
+    const courses = this.props.courses || [];
+    const guest = Boolean(this.props.isGuest);
+    const active = s.tabs[s.tab] || s.tabs[0] || { kind: "none", code: "" };
+    const indexed = s.tabs.map((t, i) => ({ ...t, i }));
+    const d = this.draftFor(active.code);
+    const setDraft = (patch) => this.patchDraft(active.code, patch);
+
+    const buildMix = (keys, pcts, ref, setPcts, setBoth) => {
+      const items = keys.map((k) => METHODS.find((m) => m.key === k)).filter(Boolean);
+      let acc = 0;
+      const cuts = [];
+      for (let i = 0; i < items.length - 1; i++) { acc += pcts[i] || 0; cuts.push(acc); }
+      return {
+        items,
+        segs: items.map((m, i) => {
+          const p = pcts[i] || 0;
+          return { label: m.label, short: m.short, color: m.color, ink: m.ink, width: p + "%", slotLabel: p >= 24 ? m.label : p >= 13 ? m.short : "" };
+        }),
+        dividers: cuts.map((left, i) => ({
+          left: left + "%",
+          onDown: (e) => { e.preventDefault(); const el = ref.current; if (el) this.dividerDown(i, el.getBoundingClientRect(), pcts, setPcts); }
+        })),
+        chips: METHODS.map((m) => {
+          const on = keys.indexOf(m.key) >= 0;
+          return {
+            label: m.label, dot: on ? m.color : "#ded8c8",
+            bg: on ? "var(--pill)" : "var(--surface)", fg: on ? "var(--ink)" : "var(--muted)",
+            border: on ? "var(--brand)" : "var(--rule3)",
+            onClick: () => this.toggleMethod(m.key, keys, setBoth)
+          };
+        })
+      };
+    };
+
+    const draftMix = buildMix(d.picked, d.pcts, this.examTrackRef, (pcts) => setDraft({ pcts }), (picked, pcts) => setDraft({ picked, pcts }));
+    const chosen = draftMix.items;
+    const doneCount = [
+      (d.picked.length > 0 || d.examUnknown) && (d.theory != null || d.theoryUnknown),
+      d.workload != null && d.learning != null,
+      d.recommend != null && Boolean(d.reviewText.trim())
+    ].filter(Boolean).length;
+    const untouched = doneCount === 0 && d.recommend == null && !d.reviewText.trim();
+
+    const known = courses.find((x) => x.code === active.code);
+    const c = known || {
+      code: active.code, title: active.code, meta: "7.5 hp · " + active.code + " · SCI",
+      summary: "No description on file yet. Open the course on KTH.se for the official syllabus.",
+      keywords: "", exSegments: [], th: null, wl: 0, le: 0, happy: 0, stats: ["0", "0", "0"]
+    };
+    const segs = c.exSegments || [];
+    const rounds = (STORE && active.code ? (STORE.getCourse(active.code) || { rounds: [] }).rounds : []) || [];
+
+    return {
+      paneWidth: this.props.paneWidth, paneGrow: this.props.paneGrow,
+      showTabStrip: !this.props.hideTabs,
+      contentBorder: this.props.hideTabs ? "none" : "1px solid var(--rule3)",
+      contentRadius: this.props.hideTabs ? "0" : "0 12px 12px 12px",
+      contentShadow: this.props.hideTabs ? "none" : "0 1px 2px rgba(20,30,45,.05)",
+      tabGap: indexed.length > 8 ? "2px" : "4px",
+      caretBg: s.overflowOpen ? "var(--rule2)" : "var(--pill)",
+      tabItems: indexed.map((t) => {
+        const on = t.i === s.tab;
+        const tight = indexed.length > 8;
+        const medium = !tight && indexed.length > 4;
+        const width = tight ? (on ? 44 : 30) : medium ? (on ? 90 : 68) : (on ? 104 : 88);
+        return {
+          title: t.label, label: tight ? "" : medium ? t.code.slice(2) : t.code,
+          labelFlex: tight ? "0 0 0" : "1", justify: tight ? "center" : "flex-start",
+          width: width + "px", padding: tight ? "0" : on ? "0 8px 0 9px" : "0 9px",
+          dot: tight ? "8px" : "7px", accent: t.kind === "r" ? "#dfa53c" : "#1751a6",
+          bg: on ? "var(--surface)" : "var(--pill)", fg: on ? "var(--ink)" : "var(--dim)",
+          weight: on ? "600" : "500", z: on ? "1" : "0", dip: on ? "-1px" : "0", isActive: on,
+          onClick: () => this.setState({ tab: t.i, overflowOpen: false }),
+          onClose: (e) => this.closeTab(e, t.i)
+        };
+      }),
+      overflowOpen: s.overflowOpen,
+      onToggleOverflow: (e) => { e.stopPropagation(); this.setState({ overflowOpen: !s.overflowOpen }); },
+      noTabs: s.tabs.length === 0,
+      switcherItems: indexed.map((t) => ({
+        label: t.label, accent: t.kind === "r" ? "#dfa53c" : "#1751a6",
+        bg: t.i === s.tab ? "var(--pill)" : "transparent", fg: t.i === s.tab ? "var(--brand)" : "var(--ink2)",
+        weight: t.i === s.tab ? "600" : "400",
+        onClick: () => this.setState({ tab: t.i, overflowOpen: false }),
+        onClose: (e) => this.closeTab(e, t.i)
+      })),
+      paneScrollRef: this.paneScrollRef,
+      reviewsRef: this.reviewsRef,
+      reviewsOpen: s.reviewsOpen,
+      reviewsCaret: s.reviewsOpen ? "▴" : "▾",
+      reviewsTabBorder: s.reviewsOpen ? "var(--brand)" : "transparent",
+      reviewsTabFg: s.reviewsOpen ? "#1751a6" : "#5c6570",
+      onToggleReviews: () => this.setState({ reviewsOpen: !s.reviewsOpen }),
+      onExpandReviews: () => this.revealReviews(),
+      isDetails: active.kind === "c",
+      isReview: active.kind === "r",
+      noOfferings: rounds.length === 0,
+      contentClamp: s.contentOpen ? "unset" : "3",
+      contentToggleLabel: s.contentOpen ? "Show less" : "Read more",
+      onToggleContent: () => this.setState({ contentOpen: !s.contentOpen }),
+      onOpenReviewTab: () => this.openTab(active.code, "r"),
+      detail: {
+        title: c.title, meta: c.meta, content: c.summary,
+        offerings: rounds.map((r, i) => ({
+          key: r.roundCode || String(i),
+          periods: r.formattedPeriodsAndCredits || r.periodLabel || "—",
+          language: r.language || "—", tutoring: r.tutoringForm || "—"
+        })),
+        reviews: c.stats[2],
+        reviewed: Boolean(known), unreviewed: !known,
+        reviewCards: (STORE && active.code ? STORE.reviewsByCourse(active.code) : []).map((r) => STORE.reviewView(r, { locale: this.props.locale })).map((rv) => ({
+          code: rv.courseCode, name: rv.name, term: rv.startTermLabel,
+          author: rv.author, date: rv.createdAtLabel, likes: rv.helpfulCount,
+          message: rv.message, workloadScore: rv.workloadScore, happyTook: rv.happyTook
+        })),
+        hasReviewCards: STORE && active.code ? STORE.reviewsByCourse(active.code).length > 0 : false,
+        noReviewCards: STORE && active.code ? STORE.reviewsByCourse(active.code).length === 0 : true,
+        summaryLine: known
+          ? "Reviewers single out " + (c.keywords ? c.keywords.split(", ")[0] : "the material") + " as the part of the course that sticks, and flag "
+            + (c.wl >= 80 ? "the workload as the thing to plan around." : "the pace as brisk but manageable.")
+          : "",
+        examSegments: segs.map((x) => ({ w: x.percent + "%", color: x.color })),
+        exSplit: segs.length ? segs.map((x) => x.percent).join(" / ") : "—",
+        exNames: segs.length ? segs.map((x) => x.label).join(" · ") : "No examination breakdown yet",
+        thW: (c.th || 0) + "%", apW: (c.th == null ? 0 : 100 - c.th) + "%",
+        thSplit: c.th == null ? "—" : c.th + " / " + (100 - c.th),
+        wl: c.wl != null ? (c.wl / 10).toFixed(1) : "—", wlW: (c.wl || 0) + "%",
+        le: c.le != null ? (c.le / 10).toFixed(1) : "—", leW: (c.le || 0) + "%"
+      },
+      examTrackRef: this.examTrackRef,
+      examSegs: draftMix.segs,
+      examSplitLabel: chosen.length ? chosen.map((m, i) => d.pcts[i] || 0).join(" / ") : "Not set",
+      examUnknownOff: !d.examUnknown,
+      examEmpty: chosen.length === 0,
+      examUnknown: d.examUnknown,
+      examTrackOpacity: d.examUnknown ? "0.4" : "1",
+      examTrackPointer: d.examUnknown ? "none" : "auto",
+      onToggleExamUnknown: () => setDraft({ examUnknown: !d.examUnknown, picked: [], pcts: [] }),
+      examCheckBorder: d.examUnknown ? "var(--brand)" : "var(--rule3)",
+      examCheckBg: d.examUnknown ? "var(--brand)" : "transparent",
+      savedLabel: untouched ? "Not saved yet" : "Saved just now",
+      examDividers: draftMix.dividers,
+      methodChips: draftMix.chips,
+      theoryW1: (d.theory == null ? 50 : d.theory) + "%",
+      theoryW2: (d.theory == null ? 50 : 100 - d.theory) + "%",
+      theoryFill1: d.theory == null ? "#ded8c8" : "#12417f",
+      theoryFill2: d.theory == null ? "#ded8c8" : "#a9c8ec",
+      theoryInk1: d.theory == null ? "#6b6355" : "#fff",
+      theoryInk2: d.theory == null ? "#6b6355" : "#12417f",
+      theoryLabel: d.theory == null ? "Not set" : d.theory + " / " + (100 - d.theory),
+      theoryUnknownOff: !d.theoryUnknown,
+      onTheoryDown: (e) => { if (d.theoryUnknown) return; this.startPct(e, 100, (v) => setDraft({ theory: v })); },
+      theoryUnknown: d.theoryUnknown,
+      theoryTrackOpacity: d.theoryUnknown ? "0.4" : "1",
+      theoryTrackPointer: d.theoryUnknown ? "none" : "auto",
+      onToggleTheoryUnknown: () => setDraft({ theoryUnknown: !d.theoryUnknown, theory: null }),
+      theoryCheckBorder: d.theoryUnknown ? "var(--brand)" : "var(--rule3)",
+      theoryCheckBg: d.theoryUnknown ? "var(--brand)" : "transparent",
+      workloadW: (d.workload == null ? 0 : d.workload * 10) + "%",
+      workloadSet: d.workload != null,
+      workloadLabel: d.workload == null ? "Not set" : d.workload + " / 10",
+      onWorkloadDown: (e) => this.startPct(e, 10, (v) => setDraft({ workload: v })),
+      learningW: (d.learning == null ? 0 : d.learning * 10) + "%",
+      learningSet: d.learning != null,
+      learningLabel: d.learning == null ? "Not set" : d.learning + " / 10",
+      onLearningDown: (e) => this.startPct(e, 10, (v) => setDraft({ learning: v })),
+      reviewText: d.reviewText,
+      onReviewChange: (e) => setDraft({ reviewText: e.target.value }),
+      promptChips: [
+        ["What surprised you?", "One thing that surprised me was "],
+        ["Who is it for?", "This course is a great fit if you "],
+        ["Time it really took?", "Budget more time than you think for "]
+      ].map(([label, starter]) => ({
+        label,
+        onClick: () => setDraft({ reviewText: d.reviewText ? d.reviewText.replace(/\s*$/, "") + "\n" + starter : starter })
+      })),
+      progressLabel: doneCount + " of 3 sections done",
+      progressSegs: [0, 1, 2].map((i) => ({ bg: i < doneCount ? "var(--warnBtn)" : "var(--pill)" })),
+      happyNotSet: d.recommend == null,
+      happyOpts: [[true, "Yes, I am"], [false, "No, I am not"]].map(([v, label]) => {
+        const on = d.recommend === v;
+        return {
+          label, bg: on ? "var(--pill)" : "var(--surface)", fg: on ? "var(--brand)" : "var(--chipInk)",
+          border: on ? "var(--brand)" : "var(--rule3)", weight: on ? "600" : "500",
+          dot: on ? "#1751a6" : "transparent", dotBorder: on ? "var(--brand)" : "#c8c2b2",
+          onClick: () => setDraft({ recommend: v })
+        };
+      }),
+      authOpen: s.authOpen,
+      justAuthed: s.justAuthed && !s.posted,
+      posted: s.posted,
+      postLabel: s.posted ? "Published" : s.justAuthed ? "Publish review" : "Post review",
+      postBg: (d.recommend != null && d.workload != null && d.learning != null) ? "var(--warnBtn)" : "var(--pill)",
+      postFg: (d.recommend != null && d.workload != null && d.learning != null) ? "var(--warnBtnFg)" : "var(--dim)",
+      postCursor: (d.recommend != null && d.workload != null && d.learning != null) ? "pointer" : "not-allowed",
+      postHint: (d.recommend != null && d.workload != null && d.learning != null) ? "" : "Answer happy, workload and learning to publish — the write-up is the only optional part",
+      onPostReview: () => {
+        if (d.recommend == null || d.workload == null || d.learning == null) return;
+        if (guest) { this.setState({ authOpen: true }); return; }
+        if (STORE && !STORE.userTakenCourses.some((r) => r.userId === "u1" && r.courseCode === active.code)) {
+          const now = new Date().toISOString();
+          STORE.userTakenCourses.push({
+            userId: "u1", courseCode: active.code, attendancePeriods: [], attendanceYear: null,
+            grade: null, earnedCredits: null, transcriptImportedAt: null, createdAt: now, updatedAt: now
+          });
+        }
+        if (STORE) {
+          STORE.reviews.push({
+            id: "r" + Date.now(), userId: "u1", courseCode: active.code,
+            examinationDistribution: d.examUnknown ? null : STORE.examinationDistributionFrom(draftMix.items, d.pcts),
+            approachTheoryPercent: d.theoryUnknown ? null : (d.theory == null ? 50 : d.theory),
+            workloadScore: d.workload, learningScore: d.learning, happyTook: d.recommend,
+            message: d.reviewText || "", createdAt: new Date().toISOString(), updatedAt: new Date().toISOString()
+          });
+        }
+        this.setState({ posted: true, justAuthed: false });
+      },
+      onAuthDone: () => {
+        this.setState({ authOpen: false, justAuthed: true });
+        if (this.props.onAuthed) this.props.onAuthed();
+      },
+      onAuthCancel: () => this.setState({ authOpen: false })
+    };
+  }
+}
+
+</script>
+</body>
+</html>

--- a/docs/design/README.md
+++ b/docs/design/README.md
@@ -1,0 +1,124 @@
+# `docs/design/` — a read-only mirror of the Claude Design project
+
+This folder is a snapshot of the Claude Design project
+
+<https://claude.ai/design/p/d7c051c6-9911-493e-aedd-1c42261f30b1>
+
+copied into the repo so that the frontend track can read the artboards without
+design-tool access. It exists to be **read**, never edited.
+
+## The design project is the source of truth; this is downstream of it
+
+Every file here is a copy. Changing a file in this folder changes nothing about
+the design — it only makes the mirror lie. A design change is made in the Claude
+Design project and then re-mirrored (see [Re-syncing](#re-syncing)).
+
+The corollary is that the artboards, not this folder's age, decide what a page
+looks like. Within the wider precedence rule settled on
+[#68](https://github.com/kthaisociety/KTH-Course-Community/issues/68):
+
+- **The design is the visual source of truth** — layout, spacing, typography,
+  colour, copy, states, responsive behaviour. Match the artboard.
+- **The schema is the data source of truth** — what fields exist, what they are
+  called, what shape they have, what may be null. Where an artboard or
+  `cc-store.js` contradicts `apps/web/server/db/schema.ts`, the schema wins and
+  the design adapts with the smallest visual change that works.
+
+## What is here
+
+Filenames keep their spaces on purpose: they are the artboard names in the
+design project, and keeping them identical is what makes the mirror greppable
+against it. Do not rename or slugify them.
+
+### Deliverable artboards (13)
+
+Pages and components the frontend track implements, one child issue each.
+
+| File | What it is |
+| --- | --- |
+| `Course Community - Page Header.dc.html` | The app shell header |
+| `Course Community - Workspace Pane.dc.html` | The pane owning open course-details and review-draft tabs |
+| `Course Community - Course Card.dc.html` | The course card, shared by Explore and Saved |
+| `Course Community - Unreviewed Card.dc.html` | The taken-but-unreviewed list, shared by My Page and Taken courses |
+| `Course Community - Review Card.dc.html` | A single review |
+| `Course Community - Explore.dc.html` | The search-and-browse workspace |
+| `Course Community - Saved.dc.html` | Saved courses |
+| `Course Community - Taken Courses.dc.html` | Self-reported taken courses |
+| `Course Community - Collections.dc.html` | Collections |
+| `Course Community - My Page.dc.html` | The signed-in profile page |
+| `Course Community - Landing.dc.html` | The public landing page |
+| `Course Community - About.dc.html` | About |
+| `Course Community - Contact Form.dc.html` | Contact / feedback form |
+
+### `reference/` — not deliverables
+
+Artboards nobody implements as a page. They are exploration and shared
+reference: read them, but do not treat them as a screen to build.
+
+| File | What it is |
+| --- | --- |
+| `reference/Course Community - Design System.dc.html` | The palette and type scale, drawn out |
+| `reference/Course Community - Mobile Preview.dc.html` | Shared responsive reference for every page |
+| `reference/Course Community - Review Card Options.dc.html` | Rejected and alternate review-card treatments |
+| `reference/Course Community - Unreviewed Card Options.dc.html` | Alternate empty-state treatments |
+
+### Support files
+
+| File | What it is |
+| --- | --- |
+| `cc-theme.css` | The palette. Mirrored into `apps/web/app/globals.css` as `--cc-*` tokens — style against those, never against raw hex |
+| `support.js` | The design canvas runtime the artboards load. Generated; of no interest except that the artboards need it |
+| `cc-store.js` | The design's **mock** store. A sketch of intent, never a data contract — see below |
+
+## `cc-store.js` is a sketch, not a contract
+
+It is the fixture data the artboards render against, written before the schema
+settled, and it disagrees with `apps/web/server/db/schema.ts` in several places
+(review authorship, vote storage, collection shape, the examination keys). The
+schema wins in all of them. Each child PR that hits a contradiction states it,
+so the design gets corrected at source rather than each page diverging quietly.
+
+The one shape that *is* authoritative is the Course Card's `SAMPLE_COURSE` /
+`SAMPLE_GEO`, extracted to `apps/web/data/course-card-sample.ts`.
+
+## Formatters are kept off this folder — deliberately
+
+`docs/design` is excluded in `biome.json`, and `.gitattributes` marks
+`docs/design/**` as `-diff linguist-generated`.
+
+That is not tidiness. lefthook runs `biome check --write` on staged files and
+re-stages the result, and it had already silently rewritten `support.js` —
+stripping its generated-file header and its `"use strict"`, and rewrapping it
+from 1911 to 2105 lines. A reformatted mirror is no longer a mirror: it stops
+matching the design project byte-for-byte, which is the only property this
+folder has.
+
+For the same reason, `cc-theme.css` and `cc-store.js` were taken from the design
+**source** rather than from the exported folder, and committed after the
+exclusions were in place.
+
+The `-diff` marking also keeps ~700 KB of generated markup out of every diff and
+review; that is a welcome side effect, not the reason. This README is the one
+exception — it is ours rather than mirrored, so `.gitattributes` puts it back in
+the diff.
+
+**If you find yourself editing a file here, stop.** Either the change belongs in
+the design project, or it belongs in `apps/web/`.
+
+## Re-syncing
+
+Only someone with access to the design project can do this.
+
+1. Export the project, or copy each artboard's source out of it.
+2. Overwrite the files here, keeping the filenames and the `reference/` split
+   exactly as they are.
+3. Take `cc-theme.css`, `support.js` and `cc-store.js` from the design source
+   directly, not from an export that a formatter has been near.
+4. `git status` — an artboard nobody touched in the design project should show
+   no diff. If everything is modified, something reformatted the files.
+5. If `cc-theme.css` changed, mirror the change into the `--cc-*` blocks of
+   `apps/web/app/globals.css`. There are three parallel blocks there (the
+   Tailwind `--color-cc-*` bridge, light, dark) and they must stay in step.
+6. If the Course Card's `SAMPLE_COURSE` / `SAMPLE_GEO` changed, regenerate
+   `apps/web/data/course-card-sample.ts` from the artboard rather than
+   hand-editing it.

--- a/docs/design/README.md
+++ b/docs/design/README.md
@@ -93,9 +93,10 @@ from 1911 to 2105 lines. A reformatted mirror is no longer a mirror: it stops
 matching the design project byte-for-byte, which is the only property this
 folder has.
 
-For the same reason, `cc-theme.css` and `cc-store.js` were taken from the design
-**source** rather than from the exported folder, and committed after the
-exclusions were in place.
+For the same reason, the two `.js` files — `support.js` and `cc-store.js` — were
+taken from the design **source** rather than from the exported folder, and
+committed after the exclusions were in place. `support.js` is the one the
+rewrite was caught on.
 
 The `-diff` marking also keeps ~700 KB of generated markup out of every diff and
 review; that is a welcome side effect, not the reason. This README is the one

--- a/docs/design/cc-store.js
+++ b/docs/design/cc-store.js
@@ -1,0 +1,1172 @@
+/* ---------------------------------------------------------------------------
+   Course Community — shared mock store.
+
+   One normalized, schema-shaped store; every page derives its view models from
+   it through the selectors below. Pages must not keep their own copy of a
+   course name, credit figure or metric.
+
+   Rules this file enforces:
+   - `session` ("guest" | "member") is shared runtime state; it never lives in a
+     scenario name.
+   - `scenario` ("populated" | "empty" | "loading" | "error" | "edge-case") is a
+     presentation override for review. It never mutates stored mock data.
+   - Page-specific progress lives in its own substate (transcriptState,
+     reviewState), never in the site-wide scenario.
+   - Data holds no formatted strings: `credits` is numeric, `creditUnit` gives
+     the suffix, terms and periods come from the selected course round.
+   - Missing aggregates stay null. The frontend never invents zeros.
+--------------------------------------------------------------------------- */
+
+export const SESSIONS = ["guest", "member"];
+export const SCENARIOS = ["populated", "empty", "loading", "error", "edge-case"];
+export const TRANSCRIPT_STATES = ["idle", "parsing", "conflicts", "ready", "failed"];
+export const REVIEW_STATES = ["idle", "editing", "saving", "saved", "failed"];
+
+/* Examination categories are configuration, not data. Records carry the keys. */
+export const EXAMINATION_KEYS = ["exam", "assignments", "labs", "projects", "other"];
+export const EXAMINATION_LABELS = {
+  en: { exam: "On-campus exam", assignments: "Assignments", labs: "Labs", projects: "Project", other: "Other" },
+  sv: { exam: "Salstentamen", assignments: "Inlämningar", labs: "Laborationer", projects: "Projekt", other: "Övrigt" }
+};
+export const EXAMINATION_COLORS = {
+  exam: "#1751a6", assignments: "#dfa53c", labs: "#2f9e8e", projects: "#6a4ea8", other: "#57646f"
+};
+export const EXAMINATION_INK = {
+  exam: "#ffffff", assignments: "#3a2a06", labs: "#06251f", projects: "#ffffff", other: "#ffffff"
+};
+
+/* Which school a department belongs to. Configuration, not per-course data. */
+export const DEPARTMENT_SCHOOL = {
+  JJ: "EECS", DD: "EECS", EQ: "EECS", DH: "EECS",
+  SF: "SCI", SK: "SCI", SA: "SCI", ME: "ITM", AK: "ABE"
+};
+export const schoolOf = (course) => (course ? DEPARTMENT_SCHOOL[course.departmentCode] || "KTH" : null);
+
+const round = (code, startTerm, periodLabel, extra) => ({
+  roundCode: code, startTerm, periodLabel,
+  formattedPeriodsAndCredits: periodLabel,
+  studyPace: 50, language: "English", tutoringForm: "Normal daytime",
+  tutoringTimeOfDay: "Daytime", schemaUrl: "https://www.kth.se/schema",
+  isPu: false, isVu: false,
+  ...(extra || {})
+});
+
+export const courses = [
+  /* Transcript-backed catalog fixtures. Names, credits and grade scales come
+     from the supplied Swedish and English Ladok transcripts. Fields that the
+     transcripts do not establish stay nullable, and offerings are not
+     invented. */
+  { code: "SK1105", nameSwedish: "Experimentell fysik", nameEnglish: "Experimental Physics",
+    keywords: "experimental physics",
+    credits: 4, creditUnit: "hp", state: "ESTABLISHED",
+    departmentCode: "SK", department: "Physics", educationLevelCode: "BASIC", gradeScaleCode: "PF",
+    goals: null, content: null, eligibility: null,
+    rounds: [round("16762", 20261, "P4 (4,0 hp)", {
+      studyPace: 25,
+      schemaUrl: "https://www.kth.se/social/course/SK1105/subgroup/vt-2026-254/calendar/",
+      language: "Svenska", tutoringForm: "NML", tutoringTimeOfDay: "DAG",
+      isPu: true, isVu: false
+    })] },
+  { code: "SF1683", nameSwedish: "Differentialekvationer och transformmetoder",
+    nameEnglish: "Differential Equations and Transforms",
+    keywords: "differential equations, transforms",
+    credits: 9, creditUnit: "hp", state: "ESTABLISHED",
+    departmentCode: "SF", department: "Mathematics", educationLevelCode: "BASIC", gradeScaleCode: "AF",
+    goals: null, content: null, eligibility: null,
+    rounds: [round("16262", 20252, "P1 (5,0 hp), P2 (4,0 hp)", {
+      studyPace: 33,
+      schemaUrl: "https://www.kth.se/social/course/SF1683/subgroup/ht-2025-873/calendar/",
+      language: "Svenska", tutoringForm: "NML", tutoringTimeOfDay: "DAG",
+      isPu: true, isVu: false
+    })] },
+  { code: "SF1544", nameSwedish: "Numeriska metoder, grundkurs IV",
+    nameEnglish: "Numerical Methods, Basic Course IV",
+    keywords: "numerical methods",
+    credits: 6, creditUnit: "hp", state: "ESTABLISHED",
+    departmentCode: "SF", department: "Mathematics", educationLevelCode: "BASIC", gradeScaleCode: "AF",
+    goals: null, content: null, eligibility: null,
+    rounds: [round("17159", 20252, "P2 (1,0 hp)", {
+      studyPace: 17,
+      schemaUrl: "https://www.kth.se/social/course/SF1544/subgroup/ht-2025-ctfys2clgym/calendar/",
+      language: "Svenska", tutoringForm: "NML", tutoringTimeOfDay: "DAG",
+      isPu: true, isVu: false
+    })] },
+  { code: "DD1327", nameSwedish: "Grundläggande datalogi",
+    nameEnglish: "Fundamentals of Computer Science",
+    keywords: "computer science, algorithms, data structures",
+    credits: 6, creditUnit: "hp", state: "ESTABLISHED",
+    departmentCode: "DD", department: "Computer Science", educationLevelCode: "BASIC", gradeScaleCode: "AF",
+    goals: null, content: null, eligibility: null,
+    rounds: [round("16197", 20261, "P4 (6,0 hp)", {
+      studyPace: 33,
+      schemaUrl: "https://www.kth.se/social/course/DD1327/subgroup/vt-2026-grudat26/calendar/",
+      language: "Svenska", tutoringForm: "NML", tutoringTimeOfDay: "DAG",
+      isPu: true, isVu: false
+    })] },
+  { code: "SA2001", nameSwedish: "Hållbar utveckling och forskningsmetodik inom matematik",
+    nameEnglish: "Sustainable development and research methodology in mathematics",
+    keywords: "sustainable development, research methodology, mathematics",
+    credits: 3, creditUnit: "hp", state: "ESTABLISHED",
+    departmentCode: "SA", department: "Mathematics", educationLevelCode: "ADVANCED", gradeScaleCode: "PF",
+    goals: null, content: null, eligibility: null,
+    rounds: [round("17337", 20261, "P3 (3,0 hp)", {
+      studyPace: 25,
+      schemaUrl: "https://www.kth.se/social/course/SA2001/subgroup/vt-2026-131/calendar/",
+      language: "Engelska", tutoringForm: "NML", tutoringTimeOfDay: "DAG",
+      isPu: true, isVu: false
+    })] },
+  { code: "SF2524", nameSwedish: "Matrisberäkningar för storskaliga system",
+    nameEnglish: "Matrix Computations for Large-scale Systems",
+    keywords: "matrix computations, large-scale systems",
+    credits: 7.5, creditUnit: "hp", state: "ESTABLISHED",
+    departmentCode: "SF", department: "Mathematics", educationLevelCode: "ADVANCED", gradeScaleCode: "AF",
+    goals: null, content: null, eligibility: null,
+    rounds: [round("17235", 20252, "P2 (7,5 hp)", {
+      studyPace: 50,
+      schemaUrl: "https://www.kth.se/social/course/SF2524/subgroup/ht-2025-1036/calendar/",
+      language: "Engelska", tutoringForm: "NML", tutoringTimeOfDay: "DAG",
+      isPu: true, isVu: false
+    })] },
+  { code: "DD1337", nameSwedish: "Programmering", nameEnglish: "Programming",
+    keywords: "types, control flow, testing, version control",
+    credits: 7.5, creditUnit: "hp", state: "ESTABLISHED",
+    departmentCode: "JJ", department: "Computer Science", educationLevelCode: "BASIC", gradeScaleCode: "AF",
+    goals: "Write, read and debug small programs in a statically typed language.",
+    content: "Values and types, control flow, data structures, files, testing and version control.",
+    eligibility: "None",
+    rounds: [round("1", "HT2024", "P1–P2"), round("1", "HT2025", "P1–P2")] },
+  { code: "DD1338", nameSwedish: "Algoritmer och datastrukturer", nameEnglish: "Algorithms and Data Structures",
+    keywords: "lists, trees, hashing, graphs, complexity",
+    credits: 7.5, creditUnit: "hp", state: "ESTABLISHED",
+    departmentCode: "JJ", department: "Computer Science", educationLevelCode: "BASIC", gradeScaleCode: "AF",
+    goals: "Choose and analyse data structures and algorithms by asymptotic cost.",
+    content: "Lists, trees, hashing, graphs, sorting, complexity analysis.",
+    eligibility: "DD1337 or equivalent",
+    rounds: [round("1", "VT2025", "P3–P4")] },
+  { code: "DD2380", nameSwedish: "Artificiell intelligens", nameEnglish: "Artificial Intelligence",
+    keywords: "search, agents, planning, uncertainty",
+    credits: 6, creditUnit: "hp", state: "ESTABLISHED",
+    departmentCode: "JJ", department: "Computer Science", educationLevelCode: "ADVANCED", gradeScaleCode: "AF",
+    goals: "Model a problem as search, constraint satisfaction or probabilistic inference.",
+    content: "Search, adversarial games, constraint satisfaction, probabilistic reasoning, three labs.",
+    eligibility: "DD1337 and SF1626",
+    rounds: [round("1", "HT2025", "P2")] },
+  { code: "DD2421", nameSwedish: "Maskininlärning", nameEnglish: "Machine Learning",
+    keywords: "supervised learning, kernels, ensembles",
+    credits: 6, creditUnit: "hp", state: "ESTABLISHED",
+    departmentCode: "JJ", department: "Computer Science", educationLevelCode: "ADVANCED", gradeScaleCode: "AF",
+    goals: "Pick, train and evaluate a supervised model, and say why it generalises.",
+    content: "Decision trees, SVMs, boosting, Bayesian learning, weekly assignments in Python.",
+    eligibility: "SF1626 and SF1918",
+    rounds: [round("1", "HT2025", "P2")] },
+  { code: "DD2424", nameSwedish: "Djupinlärning i datavetenskap", nameEnglish: "Deep Learning in Data Science",
+    keywords: "backpropagation, convnets, regularisation",
+    credits: 7.5, creditUnit: "hp", state: "ESTABLISHED",
+    departmentCode: "JJ", department: "Computer Science", educationLevelCode: "ADVANCED", gradeScaleCode: "AF",
+    goals: "Implement and train deep networks from first principles.",
+    content: "Four numpy assignments before any framework, then an open project.",
+    eligibility: "DD2421 or equivalent",
+    rounds: [round("1", "HT2025", "P2"), round("1", "VT2026", "P3")] },
+  { code: "DD2437", nameSwedish: "Artificiella neuronnät och djupa arkitekturer",
+    nameEnglish: "Artificial Neural Networks and Deep Architectures",
+    keywords: "perceptrons, RBF networks, Hopfield nets",
+    credits: 7.5, creditUnit: "hp", state: "ESTABLISHED",
+    departmentCode: "JJ", department: "Computer Science", educationLevelCode: "ADVANCED", gradeScaleCode: "AF",
+    goals: "Relate network architecture to the learning problem it suits.",
+    content: "Perceptrons, RBF networks, Hopfield nets, deep architectures, lab series.",
+    eligibility: "SF1624 and programming experience",
+    rounds: [round("1", "HT2026", "P1–P2")] },
+  { code: "DD2412", nameSwedish: "Djupinlärning, avancerad kurs", nameEnglish: "Deep Learning, Advanced Course",
+    keywords: "paper seminars, reproduction, self-supervision",
+    credits: 7.5, creditUnit: "hp", state: "ESTABLISHED",
+    departmentCode: "JJ", department: "Computer Science", educationLevelCode: "ADVANCED", gradeScaleCode: "AF",
+    goals: "Read, reproduce and criticise a recent deep learning paper.",
+    content: "Paper seminars and a reproduction project.",
+    eligibility: "DD2424",
+    rounds: [round("1", "HT2026", "P2")] },
+  { code: "SF1624", nameSwedish: "Algebra och geometri", nameEnglish: "Algebra and Geometry",
+    keywords: "matrices, eigenvalues, quadratic forms",
+    credits: 7.5, creditUnit: "hp", state: "ESTABLISHED",
+    departmentCode: "SF", department: "Mathematics", educationLevelCode: "BASIC", gradeScaleCode: "AF",
+    goals: "Work with vectors, matrices and linear transformations.",
+    content: "Linear systems, matrix algebra, eigenvalues, quadratic forms.",
+    eligibility: "None",
+    rounds: [round("1", "HT2024", "P1–P2")] },
+  { code: "SF1626", nameSwedish: "Flervariabelanalys", nameEnglish: "Calculus in Several Variables",
+    keywords: "partial derivatives, optimisation, multiple integrals",
+    credits: 7.5, creditUnit: "hp", state: "ESTABLISHED",
+    departmentCode: "SF", department: "Mathematics", educationLevelCode: "BASIC", gradeScaleCode: "AF",
+    goals: "Differentiate and integrate functions of several variables.",
+    content: "Partial derivatives, optimisation, multiple integrals, vector fields.",
+    eligibility: "One-variable calculus",
+    rounds: [round("1", "VT2025", "P3–P4")] },
+  { code: "SF1918", nameSwedish: "Sannolikhetsteori och statistik", nameEnglish: "Probability Theory and Statistics",
+    keywords: "distributions, estimation, hypothesis testing",
+    credits: 6, creditUnit: "hp", state: "ESTABLISHED",
+    departmentCode: "SF", department: "Mathematics", educationLevelCode: "BASIC", gradeScaleCode: "AF",
+    goals: "Model uncertainty and draw conclusions from a sample.",
+    content: "Distributions, estimation, confidence intervals, hypothesis testing, labs.",
+    eligibility: "SF1626",
+    rounds: [round("1", "HT2025", "P1")] },
+  { code: "AK2030", nameSwedish: "Teori och metod i vetenskapsstudier",
+    nameEnglish: "Theory and Method in Science Studies",
+    keywords: "philosophy of science, method, essay writing",
+    credits: 7.5, creditUnit: "hp", state: "ESTABLISHED",
+    departmentCode: "AK", department: "Philosophy and History", educationLevelCode: "ADVANCED", gradeScaleCode: "PF",
+    goals: "Write a short study of a scientific practice.",
+    content: "Seminars and one essay.",
+    eligibility: "120 hp",
+    rounds: [round("1", "VT2026", "P3")] },
+  { code: "ME2053", nameSwedish: "Projektledning", nameEnglish: "Project Management",
+    keywords: "planning, stakeholders, group work",
+    credits: 6, creditUnit: "hp", state: "ESTABLISHED",
+    departmentCode: "ME", department: "Industrial Economics", educationLevelCode: "ADVANCED", gradeScaleCode: "AF",
+    goals: "Plan and follow up a project with a real stakeholder.",
+    content: "Group work and seminars.",
+    eligibility: "None",
+    rounds: [round("1", "VT2026", "P4")] },
+  { code: "DD2434", nameSwedish: "Maskininlärning, avancerad kurs", nameEnglish: "Machine Learning, Advanced Course",
+    keywords: "graphical models, variational inference",
+    credits: 7.5, creditUnit: "hp", state: "ESTABLISHED",
+    departmentCode: "JJ", department: "Computer Science", educationLevelCode: "ADVANCED", gradeScaleCode: "AF",
+    goals: "Build a probabilistic model and reason about its inference cost.",
+    content: "Probabilistic modelling from the ground up: latent variable models, variational inference and sampling, assessed by exam and a paper-reproduction project.",
+    eligibility: "DD2421",
+    rounds: [round("1", "VT2026", "P3")] },
+  { code: "SF2955", nameSwedish: "Datorintensiva metoder i matematisk statistik",
+    nameEnglish: "Computer Intensive Methods in Statistics",
+    keywords: "Monte Carlo, resampling, sequential methods",
+    credits: 7.5, creditUnit: "hp", state: "ESTABLISHED",
+    departmentCode: "SF", department: "Mathematics", educationLevelCode: "ADVANCED", gradeScaleCode: "AF",
+    goals: "Choose a simulation method for an inference problem and justify it.",
+    content: "Simulation-based inference: Monte Carlo, resampling and sequential methods, taught entirely through three long home assignments.",
+    eligibility: "SF1918",
+    rounds: [round("1", "VT2026", "P3–P4")] },
+  { code: "SF2942", nameSwedish: "Portföljteori och riskvärdering", nameEnglish: "Portfolio Theory and Risk Management",
+    keywords: "mean-variance, utility, risk measures",
+    credits: 7.5, creditUnit: "hp", state: "ESTABLISHED",
+    departmentCode: "SF", department: "Mathematics", educationLevelCode: "ADVANCED", gradeScaleCode: "AF",
+    goals: "Build and criticise a portfolio under a stated risk measure.",
+    content: "Mean-variance portfolios, utility and coherent risk measures, with hand-ins that use real return series.",
+    eligibility: "SF1918",
+    rounds: [round("1", "HT2025", "P2")] },
+  { code: "DH2642", nameSwedish: "Interaktionsprogrammering och den dynamiska webben",
+    nameEnglish: "Interaction Programming and the Dynamic Web",
+    keywords: "MVC, state, peer review, group project",
+    credits: 7.5, creditUnit: "hp", state: "ESTABLISHED",
+    departmentCode: "DH", department: "Human Centered Technology", educationLevelCode: "ADVANCED", gradeScaleCode: "AF",
+    goals: "Build a web client in a group and defend its interaction design.",
+    content: "Builds a real web client in a group of four, with seminars on interaction patterns and two rounds of peer evaluation.",
+    eligibility: "DD1337",
+    rounds: [round("1", "HT2025", "P1–P2")] },
+  { code: "EQ2300", nameSwedish: "Digital signalbehandling", nameEnglish: "Digital Signal Processing",
+    keywords: "discrete filters, sampling, spectral estimation",
+    credits: 7.5, creditUnit: "hp", state: "ESTABLISHED",
+    departmentCode: "EQ", department: "Information Science", educationLevelCode: "ADVANCED", gradeScaleCode: "AF",
+    goals: "Design and analyse discrete-time filters.",
+    content: "Discrete-time filters, sampling theory and spectral estimation, with weekly hand-ins feeding a written exam.",
+    eligibility: "SF1626",
+    rounds: [round("1", "HT2025", "P2")] },
+  { code: "EQ1110", nameSwedish: "Signaler och system", nameEnglish: "Signals and Systems",
+    keywords: "convolution, Fourier, sampling",
+    credits: 9, creditUnit: "hp", state: "ESTABLISHED",
+    departmentCode: "EQ", department: "Information Science", educationLevelCode: "BASIC", gradeScaleCode: "AF",
+    goals: "Analyse linear systems in time and frequency.",
+    content: "Convolution, Fourier and Laplace transforms, sampling.",
+    eligibility: "SF1626",
+    rounds: [round("1", "VT2026", "P3–P4")] }
+];
+
+/* One row per (user, course) the student has taken. Attendance only: whether
+   the student is happy they took it belongs to the published review. */
+export const userTakenCourses = [
+  { userId: "u1", courseCode: "DD1337", attendancePeriods: ["P1", "P2"], attendanceYear: "HT2024",
+    grade: "A", earnedCredits: 7.5, transcriptImportedAt: "2026-08-24T09:12:00Z",
+    createdAt: "2026-08-24T09:12:00Z", updatedAt: "2026-08-24T09:12:00Z" },
+  { userId: "u1", courseCode: "SF1624", attendancePeriods: ["P1", "P2"], attendanceYear: "HT2024",
+    grade: "C", earnedCredits: 7.5, transcriptImportedAt: "2026-08-24T09:12:00Z",
+    createdAt: "2026-08-24T09:12:00Z", updatedAt: "2026-08-24T09:12:00Z" },
+  { userId: "u1", courseCode: "DD1338", attendancePeriods: ["P3", "P4"], attendanceYear: "VT2025",
+    grade: "B", earnedCredits: 7.5, transcriptImportedAt: "2026-08-24T09:12:00Z",
+    createdAt: "2026-08-24T09:12:00Z", updatedAt: "2026-08-24T09:12:00Z" },
+  { userId: "u1", courseCode: "SF1626", attendancePeriods: ["P3", "P4"], attendanceYear: "VT2025",
+    grade: "D", earnedCredits: 7.5, transcriptImportedAt: "2026-08-24T09:12:00Z",
+    createdAt: "2026-08-24T09:12:00Z", updatedAt: "2026-08-24T09:12:00Z" },
+  { userId: "u1", courseCode: "SF1918", attendancePeriods: ["P1"], attendanceYear: "HT2025",
+    grade: "B", earnedCredits: 6, transcriptImportedAt: "2026-08-24T09:12:00Z",
+    createdAt: "2026-08-24T09:12:00Z", updatedAt: "2026-08-24T09:12:00Z" },
+  { userId: "u1", courseCode: "DD2421", attendancePeriods: ["P2"], attendanceYear: "HT2025",
+    grade: "A", earnedCredits: 6, transcriptImportedAt: "2026-08-24T09:12:00Z",
+    createdAt: "2026-08-24T09:12:00Z", updatedAt: "2026-08-24T09:12:00Z" },
+  { userId: "u1", courseCode: "DD2380", attendancePeriods: ["P2"], attendanceYear: "HT2025",
+    grade: "B", earnedCredits: 6, transcriptImportedAt: "2026-08-24T09:12:00Z",
+    createdAt: "2026-08-24T09:12:00Z", updatedAt: "2026-08-24T09:12:00Z" },
+  { userId: "u1", courseCode: "DD2424", attendancePeriods: ["P2"], attendanceYear: "HT2025",
+    grade: null, earnedCredits: 7.5, transcriptImportedAt: "2026-08-24T09:12:00Z",
+    createdAt: "2026-08-24T09:12:00Z", updatedAt: "2026-08-24T09:12:00Z" },
+  { userId: "u1", courseCode: "AK2030", attendancePeriods: ["P3"], attendanceYear: "VT2026",
+    grade: "P", earnedCredits: 7.5, transcriptImportedAt: "2026-08-24T09:12:00Z",
+    createdAt: "2026-08-24T09:12:00Z", updatedAt: "2026-08-24T09:12:00Z" },
+  { userId: "u1", courseCode: "ME2053", attendancePeriods: ["P4"], attendanceYear: "VT2026",
+    grade: "C", earnedCredits: 6, transcriptImportedAt: "2026-08-24T09:12:00Z",
+    createdAt: "2026-08-24T09:12:00Z", updatedAt: "2026-08-24T09:12:00Z" }
+];
+
+/* A review is text plus scores. Workload and learning are always 1–10.
+   "I don't remember" is null, never a zero. */
+export const reviews = [
+  { id: "r1", helpfulCount: 24, userId: "u1", courseCode: "DD2421",
+    examinationDistribution: { exam: 50, assignments: 30, labs: 20, projects: 0, other: 0 },
+    approachTheoryPercent: 65, workloadScore: 8, learningScore: 9,
+    happyTook: true,
+    message: "Do the assignments the week they open. The exam leans on the same derivations you meet there, so an assignment you rushed is an exam question you cannot answer.",
+    createdAt: "2026-01-12T10:00:00Z", updatedAt: "2026-01-12T10:00:00Z" },
+  { id: "r2", helpfulCount: 11, userId: "u1", courseCode: "DD2380",
+    examinationDistribution: { exam: 40, assignments: 0, labs: 0, projects: 60, other: 0 },
+    approachTheoryPercent: 45, workloadScore: 6, learningScore: 7,
+    happyTook: true,
+    message: "The project carries the course, so pick a group early. Search and planning are covered well; the probabilistic parts go fast.",
+    createdAt: "2026-01-08T10:00:00Z", updatedAt: "2026-01-08T10:00:00Z" },
+  { id: "r3", helpfulCount: 37, userId: "u1", courseCode: "SF1626",
+    examinationDistribution: { exam: 100, assignments: 0, labs: 0, projects: 0, other: 0 },
+    approachTheoryPercent: 90, workloadScore: 9, learningScore: 5,
+    happyTook: false,
+    message: "One exam, nothing else, and the practice exams are the only real preparation. Work old exams from week one rather than the textbook problems.",
+    createdAt: "2025-06-03T10:00:00Z", updatedAt: "2025-06-03T10:00:00Z" },
+  { id: "r4", helpfulCount: 8, userId: "u1", courseCode: "ME2053",
+    examinationDistribution: null, approachTheoryPercent: null, workloadScore: 3, learningScore: 6,
+    happyTook: true,
+    message: "Light on hours and genuinely useful if you have never run a project. Take it in a term where your other courses are heavy.",
+    createdAt: "2026-05-21T10:00:00Z", updatedAt: "2026-05-21T10:00:00Z" },
+  { id: "r5", helpfulCount: 5, userId: "u1", courseCode: "AK2030",
+    examinationDistribution: { exam: 0, assignments: 0, labs: 0, projects: 0, other: 100 },
+    approachTheoryPercent: 80, workloadScore: 4, learningScore: 4,
+    happyTook: false,
+    message: "Pass or fail, and the essay is the whole thing. Write about something from your own field or the reading becomes a slog.",
+    createdAt: "2026-04-14T10:00:00Z", updatedAt: "2026-04-14T10:00:00Z" },
+  { id: "r6", helpfulCount: 63, userId: "u7", courseCode: "DD2424",
+    examinationDistribution: { exam: 0, assignments: 60, labs: 0, projects: 40, other: 0 },
+    approachTheoryPercent: 55, workloadScore: 9, learningScore: 10,
+    happyTook: true,
+    message: "Four assignments in plain numpy before any framework shows up, and that is why the course works. Budget a full weekend per assignment.",
+    createdAt: "2026-02-02T10:00:00Z", updatedAt: "2026-02-02T10:00:00Z" },
+  { id: "r7", helpfulCount: 41, userId: "u9", courseCode: "SF1918",
+    examinationDistribution: { exam: 80, assignments: 0, labs: 20, projects: 0, other: 0 },
+    approachTheoryPercent: 75, workloadScore: 5, learningScore: 7,
+    happyTook: true,
+    message: "Straightforward and well organised. Take it before machine learning if you can choose the order.",
+    createdAt: "2025-12-18T10:00:00Z", updatedAt: "2025-12-18T10:00:00Z" },
+  { id: "r8", helpfulCount: 58, userId: "u4", courseCode: "DD1338",
+    examinationDistribution: { exam: 50, assignments: 50, labs: 0, projects: 0, other: 0 },
+    approachTheoryPercent: 60, workloadScore: 7, learningScore: 9,
+    happyTook: true,
+    message: "Assignments are graded on complexity, not on whether it runs, so read the requirements twice before writing anything.",
+    createdAt: "2025-06-09T10:00:00Z", updatedAt: "2025-06-09T10:00:00Z" },
+  { id: "r9", helpfulCount: 19, userId: "u5", courseCode: "EQ1110",
+    examinationDistribution: { exam: 100, assignments: 0, labs: 0, projects: 0, other: 0 },
+    approachTheoryPercent: 85, workloadScore: 8, learningScore: 6,
+    happyTook: false,
+    message: "Heavy maths and a fast pace. Doable, but only if calculus is fresh.",
+    createdAt: "2026-05-27T10:00:00Z", updatedAt: "2026-05-27T10:00:00Z" }
+];
+
+/* Who signs a review. `users.name` is required, so a review always carries a
+   name; there is no anonymity column in the target schema. */
+export const users = {
+  u1: { id: "u1", name: "Elsa Lindqvist", email: "elsa@kth.se", emailVerified: true,
+        image: null, personalizationTierEarned: 2 },
+  u4: { id: "u4", name: "Oskar Ahlin", personalizationTierEarned: 0 },
+  u5: { id: "u5", name: "Maja Ek", personalizationTierEarned: 0 },
+  u7: { id: "u7", name: "Nils Berg", personalizationTierEarned: 3 },
+  u9: { id: "u9", name: "Jonas Wall", personalizationTierEarned: 1 }
+};
+
+/* Aggregates a backend would compute. Never derived per page, never zero-filled. */
+export const courseMetrics = {
+  DD2380: { reviewCount: 214, writtenReviewCount: 154, enrolledCount: 1180, happyAnswerCount: 38,
+    themeLine: "Start the labs early; rewarding", missingNote: null, averageWorkloadScore: 7.4, averageLearningScore: 8.1, happyTookPercent: 82,
+    averageTheoryPercent: 58, examinationDistribution: { exam: 34, assignments: 29, labs: 37, projects: 0, other: 0 } },
+  DD2421: { reviewCount: 341, writtenReviewCount: 246, enrolledCount: 1640, happyAnswerCount: 57,
+    themeLine: "Lab 2 is the whole course", missingNote: null, averageWorkloadScore: 6.8, averageLearningScore: 8.8, happyTookPercent: 91,
+    averageTheoryPercent: 46, examinationDistribution: { exam: 22, assignments: 60, labs: 18, projects: 0, other: 0 } },
+  DD2424: { reviewCount: 96, writtenReviewCount: 69, enrolledCount: 940, happyAnswerCount: 44,
+    themeLine: "The hardest course I took, but worth it", missingNote: null, averageWorkloadScore: 9.0, averageLearningScore: 9.6, happyTookPercent: 88,
+    averageTheoryPercent: 55, examinationDistribution: { exam: 0, assignments: 60, labs: 0, projects: 40, other: 0 } },
+  DD1337: { reviewCount: 402, writtenReviewCount: 289, enrolledCount: 2450, happyAnswerCount: 96,
+    themeLine: "Start the assignments the week they open", missingNote: null, averageWorkloadScore: 6.2, averageLearningScore: 8.0, happyTookPercent: 86,
+    averageTheoryPercent: 35, examinationDistribution: { exam: 40, assignments: 40, labs: 20, projects: 0, other: 0 } },
+  DD1338: { reviewCount: 288, writtenReviewCount: 207, enrolledCount: 1720, happyAnswerCount: 74,
+    themeLine: "Complexity, not correctness, is graded", missingNote: null, averageWorkloadScore: 7.8, averageLearningScore: 9.0, happyTookPercent: 84,
+    averageTheoryPercent: 60, examinationDistribution: { exam: 50, assignments: 50, labs: 0, projects: 0, other: 0 } },
+  SF1624: { reviewCount: 356, writtenReviewCount: 256, enrolledCount: 2600, happyAnswerCount: 91,
+    themeLine: "Old exams are the preparation", missingNote: null, averageWorkloadScore: 7.0, averageLearningScore: 7.2, happyTookPercent: 71,
+    averageTheoryPercent: 88, examinationDistribution: { exam: 90, assignments: 10, labs: 0, projects: 0, other: 0 } },
+  SF1626: { reviewCount: 331, writtenReviewCount: 238, enrolledCount: 2380, happyAnswerCount: 84,
+    themeLine: "One exam and nothing else", missingNote: null, averageWorkloadScore: 8.6, averageLearningScore: 6.4, happyTookPercent: 54,
+    averageTheoryPercent: 90, examinationDistribution: { exam: 100, assignments: 0, labs: 0, projects: 0, other: 0 } },
+  SF1918: { reviewCount: 274, writtenReviewCount: 197, enrolledCount: 2310, happyAnswerCount: 88,
+    themeLine: "The lectures help, but old exams are essential", missingNote: null, averageWorkloadScore: 6.0, averageLearningScore: 7.6, happyTookPercent: 79,
+    averageTheoryPercent: 75, examinationDistribution: { exam: 80, assignments: 0, labs: 20, projects: 0, other: 0 } },
+  AK2030: { reviewCount: 118, writtenReviewCount: 85, enrolledCount: 690, happyAnswerCount: 28,
+    themeLine: "The seminars are the better half", missingNote: null, averageWorkloadScore: 4.4, averageLearningScore: 4.8, happyTookPercent: 41,
+    averageTheoryPercent: 80, examinationDistribution: { exam: 0, assignments: 0, labs: 0, projects: 0, other: 100 } },
+  ME2053: { reviewCount: 143, writtenReviewCount: 103, enrolledCount: 880, happyAnswerCount: 33,
+    themeLine: "Light load, useful in practice", missingNote: null, averageWorkloadScore: 4.0, averageLearningScore: 6.2, happyTookPercent: 77,
+    averageTheoryPercent: 25, examinationDistribution: { exam: 0, assignments: 0, labs: 0, projects: 70, other: 30 } },
+  EQ1110: { reviewCount: 87, writtenReviewCount: 63, enrolledCount: 520, happyAnswerCount: 19,
+    themeLine: "Only worth it with fresh calculus", missingNote: null, averageWorkloadScore: 8.4, averageLearningScore: 6.6, happyTookPercent: 58,
+    averageTheoryPercent: 85, examinationDistribution: { exam: 100, assignments: 0, labs: 0, projects: 0, other: 0 } },
+  DD2434: { reviewCount: 96, writtenReviewCount: 69, enrolledCount: 410, happyAnswerCount: 17,
+    themeLine: "Maths-first; read ahead", missingNote: null, averageWorkloadScore: 8.8, averageLearningScore: 7.9, happyTookPercent: 68,
+    averageTheoryPercent: 82, examinationDistribution: { exam: 58, assignments: 0, labs: 0, projects: 42, other: 0 } },
+  SF2955: { reviewCount: 87, writtenReviewCount: 63, enrolledCount: 330, happyAnswerCount: 14,
+    themeLine: "Do the hand-ins with someone", missingNote: "No examination breakdown yet", averageWorkloadScore: 7.6, averageLearningScore: 8.1, happyTookPercent: 79,
+    averageTheoryPercent: 64, examinationDistribution: null },
+  SF2942: { reviewCount: 118, writtenReviewCount: 85, enrolledCount: 470, happyAnswerCount: 21,
+    themeLine: "Clear lectures, light load", missingNote: null, averageWorkloadScore: 4.6, averageLearningScore: 7.0, happyTookPercent: 81,
+    averageTheoryPercent: 68, examinationDistribution: { exam: 64, assignments: 0, labs: 0, projects: 36, other: 0 } },
+  DH2642: { reviewCount: 176, writtenReviewCount: 127, enrolledCount: 820, happyAnswerCount: 31,
+    themeLine: "Pick your group in week one", missingNote: null, averageWorkloadScore: 6.4, averageLearningScore: 7.4, happyTookPercent: 84,
+    averageTheoryPercent: 28, examinationDistribution: { exam: 0, assignments: 0, labs: 0, projects: 100, other: 0 } },
+  EQ2300: { reviewCount: 143, writtenReviewCount: 103, enrolledCount: 610, happyAnswerCount: 26,
+    themeLine: "Do the hand-ins with someone", missingNote: null, averageWorkloadScore: 8.2, averageLearningScore: 7.3, happyTookPercent: 71,
+    averageTheoryPercent: 76, examinationDistribution: { exam: 70, assignments: 30, labs: 0, projects: 0, other: 0 } },
+  DD2437: { reviewCount: 0, writtenReviewCount: 0, enrolledCount: 560, happyAnswerCount: 0,
+    themeLine: "No themes yet", missingNote: "No reviews yet", averageWorkloadScore: null, averageLearningScore: null, happyTookPercent: null,
+    averageTheoryPercent: null, examinationDistribution: null },
+  DD2412: { reviewCount: 4, writtenReviewCount: 3, enrolledCount: 120, happyAnswerCount: 4,
+    themeLine: "Reading-heavy, small cohort", missingNote: "Not enough reviews for an examination split", averageWorkloadScore: 8.0, averageLearningScore: 9.0, happyTookPercent: null,
+    averageTheoryPercent: null, examinationDistribution: null }
+};
+
+/* A correction made on Taken courses is an edit to this user_taken_courses
+   row — persisted locally and reapplied on load, so credits, grade and term
+   read the same everywhere the course is taken from, not just on that page. */
+const TAKEN_OVERRIDES_KEY = "cc:takenOverrides";
+const overrideKey = (userId, code) => userId + ":" + code;
+
+/* Helpfulness and "liked" are joins between a user and a review, not fields
+   on the review itself — no dedicated table in the target schema, so the
+   pick rides in storage the same way personalization does. */
+const LIKED_REVIEWS_KEY = "cc:likedReviews";
+const DEFAULT_LIKED = { u1: ["r6", "r7", "r8", "r9"] };
+function loadLikedReviews() {
+  try {
+    const raw = window.localStorage.getItem(LIKED_REVIEWS_KEY);
+    return raw ? JSON.parse(raw) : DEFAULT_LIKED;
+  } catch (e) { return DEFAULT_LIKED; }
+}
+export const likedReviewIds = (userId) => (loadLikedReviews()[userId] || []).slice();
+export function setLikedReviewIds(userId, ids) {
+  const all = loadLikedReviews();
+  all[userId] = ids.slice();
+  try { window.localStorage.setItem(LIKED_REVIEWS_KEY, JSON.stringify(all)); } catch (e) {}
+}
+
+function loadTakenOverrides() {
+  try { return JSON.parse(window.localStorage.getItem(TAKEN_OVERRIDES_KEY) || "{}"); }
+  catch (e) { return {}; }
+}
+
+/** patch: any of { earnedCredits, grade, attendanceYear }. */
+export function setTakenOverride(userId, code, patch) {
+  const overrides = loadTakenOverrides();
+  const key = overrideKey(userId, code);
+  overrides[key] = { ...(overrides[key] || {}), ...patch };
+  try { window.localStorage.setItem(TAKEN_OVERRIDES_KEY, JSON.stringify(overrides)); } catch (e) { /* storage off */ }
+  const row = userTakenCourses.find((r) => r.userId === userId && r.courseCode === code);
+  if (row) Object.assign(row, patch, { updatedAt: new Date().toISOString() });
+}
+
+(function applyTakenOverrides() {
+  const overrides = loadTakenOverrides();
+  userTakenCourses.forEach((row) => {
+    const patch = overrides[overrideKey(row.userId, row.courseCode)];
+    if (patch) Object.assign(row, patch);
+  });
+})();
+
+/* Rows a transcript import produces, in userTakenCourse shape. A row whose code
+   is absent from `courses` is a genuine conflict, not a probability. */
+export const transcriptImports = {
+  first: {
+    fileName: "resultatintyg-2026-08-24.pdf", fileSize: "412 KB", pageCount: 3, readAt: "2026-08-24",
+    rows: userTakenCourses.map((r) => ({ ...r })).concat([
+      { userId: "u1", courseCode: "MJ2426", courseName: "Sustainable Energy Utilisation",
+        attendancePeriods: ["P3"], attendanceYear: "VT2026", grade: "B", earnedCredits: 7.5,
+        conflict: "unknown-course" },
+      { userId: "u1", courseCode: null, courseName: "Machine Perception (exchange, KU Leuven)",
+        attendancePeriods: ["P4"], attendanceYear: "VT2026", grade: "P", earnedCredits: 6,
+        conflict: "free-form" }
+    ])
+  },
+  second: {
+    fileName: "resultatintyg-2027-01-18.pdf", fileSize: "438 KB", pageCount: 3, readAt: "2027-01-18",
+    rows: [
+      { userId: "u1", courseCode: "DD2437", attendancePeriods: ["P1", "P2"], attendanceYear: "HT2026",
+        grade: "B", earnedCredits: 7.5 },
+      { userId: "u1", courseCode: "DD2412", attendancePeriods: ["P2"], attendanceYear: "HT2026",
+        grade: "A", earnedCredits: 7.5 },
+      { userId: "u1", courseCode: "DD2424", attendancePeriods: ["P2"], attendanceYear: "HT2025",
+        grade: "A", earnedCredits: 7.5 }
+    ]
+  }
+};
+
+/* Grade points are configuration, not data — the scale KTH publishes (A-E, with
+   F/P/FX carrying no grade point and excluded from the average). One named
+   function computes the GPA everywhere it is shown, rather than each page
+   re-deriving it from userTakenCourses inline. */
+export const GRADE_POINTS = { A: 5, B: 4, C: 3, D: 2, E: 1 };
+
+/** Credit-weighted average over graded courses only; ungraded rows (F/P/no
+    grade yet) are excluded from both the numerator and the denominator. */
+export function gpaFor(userId) {
+  let points = 0, gradedCredits = 0;
+  takenCourses(userId).forEach((t) => {
+    const p = GRADE_POINTS[t.grade];
+    if (p == null) return;
+    gradedCredits += t.earnedCredits || 0;
+    points += p * (t.earnedCredits || 0);
+  });
+  return { average: gradedCredits ? points / gradedCredits : null, gradedCredits: gradedCredits };
+}
+
+/** Every review draft assembles the same nullable-json shape: the five
+    EXAMINATION_KEYS, each a 0-100 share. Only the draft's own picked methods
+    get a value; every other key is explicitly 0, never omitted — so the
+    object this returns is always "full" (all 5 keys) even though a stored
+    review's examinationDistribution may also legitimately be null ("I don't
+    remember"). One constructor, called from every page that posts a review,
+    instead of three copies of the same literal. */
+export function examinationDistributionFrom(items, pcts) {
+  const out = {};
+  EXAMINATION_KEYS.forEach((k) => { out[k] = 0; });
+  items.forEach((m, i) => { out[m.key] = pcts[i] || 0; });
+  return out;
+}
+
+/* One row per contact-form submission — feedback_form: id, name, email,
+   message, created_at. Mirrors reviews: pages push straight onto this array
+   rather than keeping their own copy. */
+export const feedbackForm = [];
+export function submitFeedback(entry) {
+  const row = { id: "f" + Date.now(), name: entry.name, email: entry.email, message: entry.message, createdAt: new Date().toISOString() };
+  feedbackForm.push(row);
+  return row;
+}
+
+/* Shared page-content cap. Every top-level page shell reads this instead of
+   hardcoding its own 1216px literal, so the width stays one source of truth
+   across Explore/Saved/My Page. Side padding stays per-page (it already
+   varies with each page's own edge spacing) — only the cap itself is shared. */
+export const PAGE_MAX_WIDTH = "1216px";
+export const PAGE_SIDE_PADDING = "20px";
+
+export const savedCourses = {
+  local: ["DD2421", "DD2437"],
+  account: ["DD2380", "DD2424", "SF1918", "DD2412"]
+};
+
+export const collections = [
+  { id: "c1", name: "Autumn electives", codes: ["DD2424", "DD2412", "DD2437"], updated: "2 days ago" },
+  { id: "c2", name: "Might swap for ML", codes: ["DD2421", "DD2380"], updated: "1 week ago" },
+  { id: "c3", name: "Statistics electives", codes: ["SF1918", "DD2421"], updated: "3 weeks ago" }
+];
+
+/* Collection CRUD lives here, not in each page's own state — mutating this one
+   array in place, the same way STORE.reviews.push() is the single write path
+   for a review. Any page holding `collections` is just reading this array. */
+export function createCollection(name, codes) {
+  const col = { id: "c" + Date.now(), name: name, codes: (codes || []).slice(), updated: "just now" };
+  collections.unshift(col);
+  return col;
+}
+export function renameCollection(id, name) {
+  const c = collections.find((x) => x.id === id);
+  if (c && name && name.trim()) { c.name = name.trim(); c.updated = "just now"; }
+  return c || null;
+}
+export function deleteCollection(id) {
+  const i = collections.findIndex((x) => x.id === id);
+  if (i >= 0) collections.splice(i, 1);
+}
+export function addCourseToCollection(id, code) {
+  const c = collections.find((x) => x.id === id);
+  if (c && c.codes.indexOf(code) < 0) { c.codes.push(code); c.updated = "just now"; }
+  return c || null;
+}
+export function removeCourseFromCollection(id, code) {
+  const c = collections.find((x) => x.id === id);
+  if (c) { c.codes = c.codes.filter((k) => k !== code); c.updated = "just now"; }
+  return c || null;
+}
+
+/* ---------------------- course_explore (derived search) ----------------------
+   `courses` carries no keyword column in the target schema. The terms that fed
+   the search vector live here, one row per course, and the cards read tags from
+   this table rather than from the course record. */
+export const courseExplore = {};
+courses.forEach((c) => {
+  const terms = (c.keywords || "").trim();
+  courseExplore[c.code] = {
+    courseCode: c.code,
+    searchTerms: terms,
+    sourceHash: "h" + c.code,
+    embeddingModel: terms ? "text-embedding-3-small" : null,
+    embeddedAt: terms ? "2026-08-24T09:00:00Z" : null
+  };
+  delete c.keywords;
+});
+
+export const exploreTags = (code) => {
+  const row = courseExplore[code];
+  if (!row || !row.searchTerms) return [];
+  return row.searchTerms.split(",").map((s) => s.trim()).filter(Boolean);
+};
+
+/** Stand-in for `search_vector`: the text full-text search would match on. */
+export function searchDocument(code, locale) {
+  const c = getCourse(code);
+  if (!c) return "";
+  return [c.code, c.nameSwedish, c.nameEnglish, exploreTags(code).join(" "), c.content || ""]
+    .join(" ").toLowerCase();
+}
+
+/** Full-text-style match: every term in the query must appear in the document. */
+export function matchesQuery(code, query, locale) {
+  const q = String(query || "").trim().toLowerCase();
+  if (!q) return true;
+  const doc = searchDocument(code, locale);
+  return q.split(/\s+/).every((term) => doc.indexOf(term) >= 0);
+}
+
+/* ------------------------- course_prerequisites -------------------------
+   Directed pairs of course codes. `courses.eligibility` keeps the source prose;
+   these are the extracted relationships the UI links. */
+export const coursePrerequisites = [
+  { courseCode: "DD2380", prerequisiteCourseCode: "DD1337" },
+  { courseCode: "DD2380", prerequisiteCourseCode: "SF1918" },
+  { courseCode: "DD2421", prerequisiteCourseCode: "DD1337" },
+  { courseCode: "DD2421", prerequisiteCourseCode: "SF1918" },
+  { courseCode: "DD2424", prerequisiteCourseCode: "DD2421" },
+  { courseCode: "DD2424", prerequisiteCourseCode: "SF1624" },
+  { courseCode: "DD2434", prerequisiteCourseCode: "DD2421" },
+  { courseCode: "DD2412", prerequisiteCourseCode: "DD2424" },
+  { courseCode: "DD2437", prerequisiteCourseCode: "DD2421" },
+  { courseCode: "DD1338", prerequisiteCourseCode: "DD1337" },
+  { courseCode: "SF1626", prerequisiteCourseCode: "SF1624" },
+  { courseCode: "SF1918", prerequisiteCourseCode: "SF1624" },
+  { courseCode: "SF2955", prerequisiteCourseCode: "SF1918" },
+  { courseCode: "SF2942", prerequisiteCourseCode: "SF1918" },
+  { courseCode: "EQ2300", prerequisiteCourseCode: "SF1683" },
+  { courseCode: "EQ1110", prerequisiteCourseCode: "SF1624" },
+  { courseCode: "DH2642", prerequisiteCourseCode: "DD1337" }
+];
+
+/** The prerequisites of a course, each resolvable to a course page. */
+export const prerequisitesOf = (code, locale) =>
+  coursePrerequisites
+    .filter((p) => p.courseCode === code)
+    .map((p) => {
+      const c = getCourse(p.prerequisiteCourseCode);
+      return { code: p.prerequisiteCourseCode, name: c ? courseName(c, locale) : null, inCatalog: Boolean(c) };
+    });
+
+/* ------------------------------ term labels ------------------------------
+   `attendance_year` and `course_rounds.start_term` are integers: the suffix 1
+   is spring, 2 is autumn. Every surface writes them as HT25 / VT26. */
+export function termLabel(value) {
+  if (value == null) return null;
+  const s = String(value);
+  const m = /^(HT|VT)(\d{2})(\d{2})?$/i.exec(s);
+  if (m) return m[1].toUpperCase() + (m[3] || m[2]);
+  const n = /^(\d{4})([12])$/.exec(s);
+  if (!n) return s;
+  return (n[2] === "2" ? "HT" : "VT") + n[1].slice(2);
+}
+
+/** The academic-year integer a term label belongs to, for sorting. */
+export const termOrder = (value) => {
+  const l = termLabel(value);
+  if (!l) return 0;
+  const y = parseInt(l.slice(2), 10) + 2000;
+  return y * 10 + (l.slice(0, 2) === "HT" ? 2 : 1);
+};
+
+/** The 4-digit calendar year out of any of the formats a term has been
+    stored in — "HT2024", "HT24", "2024", or the raw "20242" round code. */
+export function yearOf(value) {
+  if (value == null) return null;
+  const s = String(value);
+  let m = /^(?:HT|VT)(\d{4})$/i.exec(s);
+  if (m) return parseInt(m[1], 10);
+  m = /^(?:HT|VT)(\d{2})$/i.exec(s);
+  if (m) return 2000 + parseInt(m[1], 10);
+  m = /^(\d{4})[12]?$/.exec(s);
+  if (m) return parseInt(m[1], 10);
+  return null;
+}
+
+/** P1/P2 fall in the autumn term, P3/P4 in the spring — the season is never
+    stored on its own, it is always derivable from the periods. */
+export function seasonFromPeriods(periods) {
+  if (!periods || !periods.length) return "HT";
+  return periods.some((p) => p === "P1" || p === "P2") ? "HT" : "VT";
+}
+
+/** The season+year label a stored attendance_year/attendance_periods pair
+    reads as — the only representation termLabel() and every display need. */
+export function termFromPeriodsYear(periods, year) {
+  if (year == null) return null;
+  return seasonFromPeriods(periods) + String(year).slice(-2);
+}
+
+/* ------------------------------- graph tables -------------------------------
+   The community is a persistent global graph in world coordinates. Positions,
+   anchors and node appearance are stored; screen coordinates are derived. */
+const rnd = (i, salt) => {
+  const x = Math.sin((i + 1) * 12.9898 + salt * 78.233) * 43758.5453;
+  return x - Math.floor(x);
+};
+
+export const NODE_STYLES = ["solid", "ring", "diamond"];
+export const NODE_SIGNAL_STYLES = ["fade", "comet", "dashed"];
+export const NODE_COLORS = ["#1751a6", "#2f9e8e", "#dfa53c", "#6a4ea8", "#c96a4a"];
+
+export const usersGraphNodes = [];
+export const usersNodeProfiles = {};
+export const usersGraphBackboneEdges = [];
+
+/* 60 accounts spread over a world box; the viewer's own node is u1 near the
+   middle, so a bounded viewport always has neighbours to show. */
+(function seedGraph() {
+  const ids = ["u1", "u4", "u5", "u7", "u9"];
+  for (let i = ids.length; i < 60; i++) ids.push("kth-" + (1000 + i));
+  ids.forEach((id, i) => {
+    const angle = rnd(i, 3) * Math.PI * 2;
+    const radius = i === 0 ? 0 : 120 + Math.sqrt(rnd(i, 5)) * 900;
+    usersGraphNodes.push({
+      userId: id,
+      x: Math.round(Math.cos(angle) * radius),
+      y: Math.round(Math.sin(angle) * radius),
+      createdAt: "2026-08-24T09:00:00Z",
+      updatedAt: "2026-08-24T09:00:00Z"
+    });
+  });
+  // Tier 0 accounts keep the default look; only personalized nodes carry a row.
+  usersNodeProfiles.u1 = { userId: "u1", color: "#2f9e8e", style: "ring", signalStyle: "comet" };
+  usersNodeProfiles.u9 = { userId: "u9", color: "#dfa53c", style: "solid", signalStyle: "fade" };
+  usersNodeProfiles.u7 = { userId: "u7", color: "#6a4ea8", style: "diamond", signalStyle: "dashed" };
+  // On joining, a node anchors to 3–5 established nodes near it.
+  usersGraphNodes.forEach((n, i) => {
+    if (i === 0) return;
+    const older = usersGraphNodes.slice(0, i)
+      .map((o) => ({ o, d: Math.hypot(o.x - n.x, o.y - n.y) }))
+      .sort((a, b) => a.d - b.d);
+    const want = 3 + Math.floor(rnd(i, 7) * 3);
+    older.slice(0, Math.min(want, older.length)).forEach((c) => {
+      usersGraphBackboneEdges.push({
+        nodeUserId: n.userId, anchorUserId: c.o.userId, createdAt: "2026-08-24T09:00:00Z"
+      });
+    });
+  });
+})();
+
+export const graphNode = (userId) => usersGraphNodes.find((n) => n.userId === userId) || null;
+export const nodeProfile = (userId) => usersNodeProfiles[userId] || null;
+
+/** The bounded neighbourhood the landing page renders: nearest nodes to the
+    viewer's persisted position, plus only the edges inside that set. */
+export function graphNeighborhood(userId, max) {
+  const me = graphNode(userId) || usersGraphNodes[0];
+  const limit = max || 48;
+  const near = usersGraphNodes
+    .map((n) => ({ n, d: Math.hypot(n.x - me.x, n.y - me.y) }))
+    .sort((a, b) => a.d - b.d)
+    .slice(0, limit)
+    .map((x) => x.n);
+  const inSet = {};
+  near.forEach((n) => { inSet[n.userId] = true; });
+  const edges = usersGraphBackboneEdges.filter((e) => inSet[e.nodeUserId] && inSet[e.anchorUserId]);
+  return {
+    origin: { x: me.x, y: me.y },
+    me: me.userId,
+    nodes: near.map((n) => ({
+      userId: n.userId, x: n.x, y: n.y,
+      profile: nodeProfile(n.userId)
+    })),
+    edges: edges.map((e) => ({ from: e.nodeUserId, to: e.anchorUserId }))
+  };
+}
+
+/* --------------------------- personalization tier ---------------------------
+   Tier 1 unlocks colour, 2 the signal trail, 3 the node shape. It is earned by
+   importing a transcript and reviewing every catalog course in it; free-form
+   rows are excluded. The effective tier may decay one step per six months
+   without a qualifying review, and never rewrites the earned value. */
+export const TIER_AXES = { 1: "color", 2: "signalStyle", 3: "style" };
+
+export const earnedTier = (userId) => {
+  const u = users[userId];
+  return u && u.personalizationTierEarned != null ? u.personalizationTierEarned : 0;
+};
+
+/* Personalization picks (dot color/style/signal) persist locally, the same
+   way taken-course edits do — no dedicated table in the target schema beyond
+   users.personalization_tier_unlocked, so the pick itself rides in storage. */
+const PERSONALIZATION_KEY = "cc:personalization";
+function loadPersonalization() {
+  try { return JSON.parse(window.localStorage.getItem(PERSONALIZATION_KEY) || "{}"); }
+  catch (e) { return {}; }
+}
+export function setPersonalization(userId, patch) {
+  const all = loadPersonalization();
+  all[userId] = { ...(all[userId] || {}), ...patch };
+  try { window.localStorage.setItem(PERSONALIZATION_KEY, JSON.stringify(all)); } catch (e) {}
+}
+
+export const DOT_COLORS = ["#1751a6", "#1c6b60", "#8a4fae", "#b3541e", "#57646f"];
+export const DOT_STYLES = ["solid", "ring", "diamond"];
+export const DOT_SIGNALS = ["ripple", "pulse", "spark"];
+
+/** Currently-picked value on one axis, falling back to the first option. */
+export function personalizationPicks(userId) {
+  return loadPersonalization()[userId] || {};
+}
+
+export function effectiveTier(userId, now) {
+  const earned = earnedTier(userId);
+  if (!earned) return 0;
+  const mine = reviewsByUser(userId);
+  if (!mine.length) return earned;
+  const latest = mine.map((r) => new Date(r.createdAt).getTime()).sort((a, b) => b - a)[0];
+  const months = (( (now ? new Date(now) : new Date()).getTime() - latest) / 2592000000);
+  const steps = Math.floor(months / 6);
+  return Math.max(0, earned - Math.max(0, steps));
+}
+
+/** Which axes a user may currently edit, and which have decayed away. */
+export function tierAxes(userId, now) {
+  const eff = effectiveTier(userId, now);
+  const earned = earnedTier(userId);
+  return {
+    earned, effective: eff,
+    unlocked: [1, 2, 3].filter((t) => t <= eff).map((t) => TIER_AXES[t]),
+    // Values stay stored while an axis is dormant; reviewing again restores them.
+    dormant: [1, 2, 3].filter((t) => t > eff && t <= earned).map((t) => TIER_AXES[t])
+  };
+}
+
+/* ------------------------------- selectors ------------------------------- */
+
+/* A course shows its summary line only past this many written reviews. */
+export const WRITTEN_THEME_THRESHOLD = 10;
+
+/** Initials for an avatar fallback; `users.image` holds the real one. */
+export const userInitials = (userId) => {
+  const u = users[userId];
+  if (!u || !u.name) return "?";
+  return u.name.split(/\s+/).map((p) => p[0]).slice(0, 2).join("").toUpperCase();
+};
+
+export const userName = (userId) => (users[userId] && users[userId].name) || null;
+
+/** The review a user published for a course, if any. */
+export const reviewFor = (userId, code) =>
+  reviews.find((r) => r.userId === userId && r.courseCode === code) || null;
+
+/** Whether the student said they were happy they took it — a review answer. */
+export const happyTookFor = (userId, code) => {
+  const r = reviewFor(userId, code);
+  return r ? r.happyTook : null;
+};
+const MONTHS = ["Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", "Sep", "Oct", "Nov", "Dec"];
+
+/** Dates are stored ISO and formatted in the view. */
+export function formatDate(iso) {
+  if (!iso) return null;
+  const d = new Date(iso);
+  if (isNaN(d.getTime())) return null;
+  return d.getUTCDate() + " " + MONTHS[d.getUTCMonth()] + " " + d.getUTCFullYear();
+}
+
+
+const byCode = {};
+courses.forEach((c) => { byCode[c.code] = c; });
+
+export const getCourse = (code) => byCode[code] || null;
+
+/** The one resolved localized name every component should read. */
+export const courseName = (course, locale) =>
+  !course ? null : locale === "sv" ? course.nameSwedish : course.nameEnglish;
+
+/** Formatting lives in the view, never in the record. */
+/* One decimal, the way KTH writes credits: 7.5 hp, 6.0 hp. */
+export const creditsLabel = (course) =>
+  !course ? null : Number(course.credits).toFixed(1) + " " + course.creditUnit;
+
+export const courseRound = (course, startTerm) => {
+  if (!course || !course.rounds.length) return null;
+  if (!startTerm) return course.rounds[course.rounds.length - 1];
+  return course.rounds.find((r) => r.startTerm === startTerm) || course.rounds[course.rounds.length - 1];
+};
+
+/** Presentation model for a course anywhere it is listed. */
+export function courseView(code, opts) {
+  const o = opts || {};
+  const course = getCourse(code);
+  if (!course) return null;
+  const r = courseRound(course, o.startTerm);
+  return {
+    code: course.code,
+    name: courseName(course, o.locale),
+    credits: course.credits,
+    creditsLabel: creditsLabel(course),
+    department: course.department,
+    departmentCode: course.departmentCode,
+    level: course.educationLevelCode,
+    gradeScaleCode: course.gradeScaleCode,
+    summary: course.content,
+    goals: course.goals,
+    eligibility: course.eligibility,
+    startTerm: r ? r.startTerm : null,
+    startTermLabel: r ? String(yearOf(r.startTerm) || "") : null,
+    periodLabel: r ? r.periodLabel : null,
+    language: r ? r.language : null,
+    rounds: course.rounds
+  };
+}
+
+export const getMetrics = (code) => courseMetrics[code] || null;
+
+/** Aggregate view. Nulls stay null so the UI can say "not enough reviews". */
+export function metricsView(code) {
+  // Derived live from the reviews table — not a separate stored aggregate —
+  // so a course with zero reviews can never show a workload, learning, or
+  // happy-percent number, and the review count always matches what a card's
+  // own "Read all N reviews" link actually opens.
+  const rows = reviews.filter((r) => r.courseCode === code);
+  if (!rows.length) return null;
+  const avg = (key) => {
+    const vals = rows.map((r) => r[key]).filter((v) => v != null);
+    return vals.length ? vals.reduce((a, v) => a + v, 0) / vals.length : null;
+  };
+  const happyRows = rows.filter((r) => r.happyTook != null);
+  const written = rows.filter((r) => r.message && r.message.trim()).length;
+  const examKeys = ["exam", "assignments", "labs", "projects", "other"];
+  const examRows = rows.filter((r) => r.examinationDistribution);
+  const examination = examRows.length
+    ? examKeys.reduce((acc, k) => {
+        acc[k] = Math.round(examRows.reduce((a, r) => a + (r.examinationDistribution[k] || 0), 0) / examRows.length);
+        return acc;
+      }, {})
+    : null;
+  return {
+    reviewCount: rows.length,
+    writtenReviewCount: written,
+    hasThemeLine: written >= WRITTEN_THEME_THRESHOLD,
+    workload: avg("workloadScore"),
+    learning: avg("learningScore"),
+    happyTookPercent: happyRows.length ? Math.round(100 * happyRows.filter((r) => r.happyTook).length / happyRows.length) : null,
+    theoryPercent: avg("approachTheoryPercent"),
+    examination,
+    hasScores: avg("workloadScore") != null && avg("learningScore") != null,
+    hasExamination: examination != null
+  };
+}
+
+/** Examination split as ordered segments, labels from configuration. */
+export function examinationSegments(distribution, locale) {
+  if (!distribution) return [];
+  const labels = EXAMINATION_LABELS[locale === "sv" ? "sv" : "en"];
+  return EXAMINATION_KEYS
+    .filter((k) => (distribution[k] || 0) > 0)
+    .map((k) => ({
+      key: k, label: labels[k], percent: distribution[k],
+      color: EXAMINATION_COLORS[k], ink: EXAMINATION_INK[k]
+    }));
+}
+
+/* "Exam + labs" style summary, derived from the distribution, never stored. */
+export function assessmentLabel(distribution, locale) {
+  const segs = examinationSegments(distribution, locale);
+  if (!segs.length) return null;
+  const top = segs.slice().sort((a, b) => b.percent - a.percent).slice(0, 2);
+  return top.map((x) => x.label).join(" + ");
+}
+
+/* The card model both Explore and Saved render. One place, one shape: pages
+   pass course codes and read this. */
+export function catalogCardView(code, opts) {
+  const o = opts || {};
+  const course = getCourse(code);
+  if (!course) return null;
+  const view = courseView(code, o);
+  const m = metricsView(code);
+  const raw = getMetrics(code) || {};
+  const segs = m ? examinationSegments(m.examination, o.locale) : [];
+  return {
+    code: course.code,
+    title: view.name,
+    hp: view.creditsLabel,
+    school: schoolOf(course),
+    period: view.periodLabel,
+    startTerm: view.startTerm,
+    meta: view.creditsLabel + " · " + course.code + " · " + schoolOf(course),
+    // Tags come from course_explore; the course record has no keyword column.
+    keywords: exploreTags(code).join(", "),
+    keywordTags: exploreTags(code),
+    // Extracted code pairs; `eligibility` keeps the source prose.
+    prereqCourses: prerequisitesOf(code, o.locale),
+    prereq: prerequisitesOf(code, o.locale).map((p) => p.code).join(", "),
+    eligibility: course.eligibility,
+    summary: course.content,
+    content: course.content,
+    assessment: assessmentLabel(m ? m.examination : null, o.locale) || "—",
+    // The one-line summary only appears once a course has 10 written reviews.
+    themes: m && m.hasThemeLine ? raw.themeLine || null : null,
+    missing: raw.missingNote || null,
+    // Percentage shares, in the fixed category order the cards draw.
+    ex: segs.map((x) => x.percent),
+    exSegments: segs,
+    th: m ? m.theoryPercent : null,
+    // 1–10 scores, rendered as a 0–100 bar width by the cards.
+    workloadScore: m ? m.workload : null,
+    learningScore: m ? m.learning : null,
+    wl: m && m.workload != null ? Math.round(m.workload * 10) : null,
+    le: m && m.learning != null ? Math.round(m.learning * 10) : null,
+    happy: m ? m.happyTookPercent : null,
+    reviewCount: m ? m.reviewCount : 0,
+    enrolledCount: raw.enrolledCount != null ? raw.enrolledCount : null,
+    happyAnswerCount: raw.happyAnswerCount != null ? raw.happyAnswerCount : null,
+    stats: [
+      String(m ? m.reviewCount : 0),
+      raw.enrolledCount == null ? "—" : String(raw.enrolledCount),
+      m ? String(m.reviewCount) : "0"
+    ]
+  };
+}
+
+export const catalogCards = (opts) => courses.map((c) => catalogCardView(c.code, opts)).filter(Boolean);
+
+export const takenCourses = (userId) =>
+  userTakenCourses.filter((r) => r.userId === (userId || "u1"));
+
+/** A taken course joined with its course record. */
+export function takenView(row, opts) {
+  const o = opts || {};
+  const view = row.courseCode ? courseView(row.courseCode, { locale: o.locale, startTerm: row.attendanceYear }) : null;
+  return {
+    courseCode: row.courseCode,
+    name: view ? view.name : row.courseName || null,
+    // Earned credits are the student's own record, not the catalog's fixed
+    // value — self-reported and editable, so it wins when present.
+    credits: row.earnedCredits != null ? row.earnedCredits : (view ? view.credits : null),
+    creditsLabel: (row.earnedCredits != null ? row.earnedCredits : (view ? view.credits : "—")) + " hp",
+    attendanceYear: row.attendanceYear,
+    attendancePeriods: row.attendancePeriods,
+    periodLabel: row.attendancePeriods ? row.attendancePeriods.join("–") : null,
+    grade: row.grade,
+    attendanceTerm: row.attendanceYear != null ? String(yearOf(row.attendanceYear) || "") : null,
+    // `happy_took` belongs to the published review, never to attendance.
+    happyTook: happyTookFor(row.userId || "u1", row.courseCode),
+    reviewed: Boolean(reviewFor(row.userId || "u1", row.courseCode)),
+    inCatalog: Boolean(view),
+    conflict: row.conflict || (row.courseCode && !view ? "unknown-course" : null)
+  };
+}
+
+export const reviewsByUser = (userId) => reviews.filter((r) => r.userId === userId);
+export const reviewsByCourse = (code) => reviews.filter((r) => r.courseCode === code);
+
+export const takenRecord = (userId, code) =>
+  userTakenCourses.find((r) => r.userId === userId && r.courseCode === code) || null;
+
+/** A single review joined with its course and the attendance it belongs to. */
+export function reviewView(review, opts) {
+  const o = opts || {};
+  const course = courseView(review.courseCode, { locale: o.locale });
+  const taken = takenRecord(review.userId, review.courseCode);
+  // A reviewer outside the mock student's own records still has a round to name.
+  const fallbackTerm = course ? course.startTerm : null;
+  // `users.name` is required and there is no anonymity column, so a review is
+  // always signed with the account name.
+  const signedName = userName(review.userId) || "KTH student";
+  return {
+    id: review.id,
+    courseCode: review.courseCode,
+    name: course ? course.name : review.courseCode,
+    credits: course ? course.credits : null,
+    startTerm: taken ? taken.attendanceYear : fallbackTerm,
+    startTermLabel: String(yearOf(taken ? taken.attendanceYear : fallbackTerm) || ""),
+    // A review with no message is counted but never listed.
+    isWritten: Boolean(review.message && review.message.trim()),
+    workloadScore: review.workloadScore,   // 1–10
+    learningScore: review.learningScore,   // 1–10
+    theoryPercent: review.approachTheoryPercent,
+    examination: review.examinationDistribution,
+    happyTook: review.happyTook,
+    message: review.message,
+    createdAt: review.createdAt,
+    createdAtLabel: formatDate(review.createdAt),
+    helpfulCount: review.helpfulCount || 0,
+    isOwn: review.userId === (o.userId || "u1"),
+    author: signedName
+  };
+}
+
+/* ------------------------- session & scenario stores ------------------------- */
+
+const SESSION_KEY = "cc:session";
+const SCENARIO_KEY = "cc:scenario";
+
+/** Shared runtime session. Logging out anywhere means guest everywhere. */
+export const sessionStore = {
+  read() {
+    try {
+      const v = window.localStorage.getItem(SESSION_KEY);
+      return v === "member" ? "member" : "guest";
+    } catch (e) { return "guest"; }
+  },
+  write(session) {
+    try { window.localStorage.setItem(SESSION_KEY, session === "member" ? "member" : "guest"); } catch (e) { /* no storage */ }
+    return session;
+  }
+};
+
+/** Review-harness override. Travels between pages, never touches mock data. */
+export const scenarioStore = {
+  read() {
+    try {
+      const url = new URL(window.location.href);
+      const q = url.searchParams.get("scenario");
+      if (q && SCENARIOS.indexOf(q) >= 0) return q;
+      const v = window.localStorage.getItem(SCENARIO_KEY);
+      return SCENARIOS.indexOf(v) >= 0 ? v : "populated";
+    } catch (e) { return "populated"; }
+  },
+  write(scenario) {
+    try {
+      if (SCENARIOS.indexOf(scenario) >= 0) window.localStorage.setItem(SCENARIO_KEY, scenario);
+    } catch (e) { /* no storage */ }
+    return scenario;
+  }
+};
+
+/** Resolve the two shared axes, props winning over stored values. */
+export function resolveHarness(props) {
+  const p = props || {};
+  const session = p.session === "member" || p.session === "guest" ? p.session : sessionStore.read();
+  const scenario = SCENARIOS.indexOf(p.scenario) >= 0 ? p.scenario : scenarioStore.read();
+  return {
+    session, scenario,
+    isMember: session === "member",
+    isGuest: session === "guest",
+    isPopulated: scenario === "populated",
+    isEmpty: scenario === "empty",
+    isLoading: scenario === "loading",
+    isError: scenario === "error",
+    isEdgeCase: scenario === "edge-case"
+  };
+}

--- a/docs/design/cc-theme.css
+++ b/docs/design/cc-theme.css
@@ -1,0 +1,73 @@
+/* Course Community — theme tokens.
+   The single definition of the light and dark palettes. Pages link this file
+   from their helmet and consume the variables inline; nothing else belongs here.
+
+   pg      page background            surface  cards, fields, menus
+   inset   recessed panel             pill     chips, tracks, hover fills
+   rail    the sidebar (brand blue in both themes)
+   ink     primary text               ink2     secondary text
+   muted   supporting text            dim/dim2 labels and hints
+   chipInk text on a pill             rule/2/3 hairline, border, strong border
+   hov     hover border               brand    links and brand text
+   btn/btnFg  filled button and its foreground */
+
+:root {
+  --pg: #faf8f1;
+  --surface: #ffffff;
+  --inset: #faf8f1;
+  --pill: #f2efe6;
+  --rail: #1751a6;
+  --ink: #16202b;
+  --ink2: #3d4650;
+  --muted: #5c6570;
+  --dim: #6b6355;
+  --dim2: #8a857a;
+  --chipInk: #4a5560;
+  --rule: #eae6da;
+  --rule2: #e5e0d2;
+  --rule3: #ddd8c9;
+  --hov: #b9c9de;
+  --brand: #1751a6;
+  --btn: #1751a6;
+  --btnFg: #ffffff;
+  --info: rgba(23, 81, 166, .07);
+  --warn: #fdf7ea;
+  --warnBorder: #f0e6d2;
+  --warnInk: #7a5309;
+  --warnBtn: #1751a6;
+  --warnBtnFg: #ffffff;
+}
+
+[data-cc-theme="dark"] {
+  --pg: #0d2d5b;
+  --surface: #143a72;
+  --inset: #0a2449;
+  --pill: rgba(244, 238, 226, .16);
+  --rail: #1751a6;
+  --ink: #f6f1e6;
+  --ink2: #eae4d7;
+  --muted: #d3e0f4;
+  --dim: #c6d5ee;
+  --dim2: #b0c1de;
+  --chipInk: #f0ebdf;
+  --rule: rgba(244, 238, 226, .22);
+  --rule2: rgba(244, 238, 226, .3);
+  --rule3: rgba(244, 238, 226, .42);
+  --hov: #dbe8fa;
+  --brand: #e2ecfb;
+  --btn: #f4eee2;
+  --btnFg: #1751a6;
+  --info: rgba(226, 236, 251, .10);
+  --warn: rgba(223, 165, 60, .16);
+  --warnBorder: rgba(223, 165, 60, .3);
+  --warnInk: #f2c879;
+  --warnBtn: #dfa53c;
+  --warnBtnFg: #1a1305;
+}
+
+/* Colour changes cross-fade; nothing else about a page animates from here. */
+[data-cc-theme] * {
+  transition: background-color .34s ease, color .34s ease, border-color .34s ease;
+}
+
+input::placeholder { color: var(--dim); }

--- a/docs/design/reference/Course Community - Design System.dc.html
+++ b/docs/design/reference/Course Community - Design System.dc.html
@@ -1,0 +1,154 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<script src="./support.js"></script>
+</head>
+<body>
+<x-dc>
+<helmet data-dc-atomics><link rel="preconnect" href="https://fonts.googleapis.com"><link rel="preconnect" href="https://fonts.gstatic.com" crossorigin><link href="https://fonts.googleapis.com/css2?family=Geist:wght@400;500;600;700&family=Geist+Mono:wght@400;500&display=swap" rel="stylesheet"><link rel="stylesheet" href="cc-theme.css"><style>body{margin:0;background:var(--pg);color:var(--ink);font-family:Geist,system-ui,sans-serif;font-size:14px}a{color:var(--brand)}a:hover{color:#10386f}</style></helmet>
+
+<div style="min-height:100%;box-sizing:border-box;padding:0 0 60px;background:var(--pg);color:var(--ink)">
+
+<div style="display:flex;align-items:center;justify-content:space-between;gap:20px;height:66px;padding:0 32px;box-sizing:border-box;border-bottom:1px solid var(--rule);background:var(--pg)">
+<div style="display:flex;align-items:center;gap:10px">
+<div style="width:34px;height:34px;flex:none;border-radius:9px;background:var(--rail);display:flex;align-items:center;justify-content:center"><img src="assets/ais-symbol-white.png" alt="KTH AI Society" style="height:22px;width:22px;object-fit:contain"></div>
+<div style="font-size:15px;font-weight:600;line-height:1.15">Course<br>Community</div>
+</div>
+<div onClick="{{ onTheme }}" role="button" tabIndex="0" title="{{ themeTitle }}" style="display:flex;align-items:center;gap:9px;height:34px;padding:0 13px;border-radius:8px;border:1px solid var(--rule3);background:var(--surface);font-size:13px;font-weight:500;color:var(--chipInk);cursor:pointer" style-hover="border-color:var(--hov)">{{ themeLabel }}</div>
+</div>
+
+<div style="max-width:1080px;margin:0 auto;padding:34px 32px 0">
+<h1 style="margin:0;font-size:28px;font-weight:600;letter-spacing:-.02em">Design system</h1>
+<div style="margin-top:7px;max-width:620px;font-size:13.5px;line-height:1.55;color:var(--muted)">Every colour below is a variable in <span style="font:500 12.5px Geist Mono,ui-monospace,monospace">cc-theme.css</span>. Pages read the variables inline and define nothing of their own.</div>
+
+<div style="margin-top:36px;font-size:11px;font-weight:600;letter-spacing:.09em;text-transform:uppercase;color:var(--dim)">Surfaces</div>
+<div style="margin-top:12px;display:grid;grid-template-columns:repeat(auto-fill,minmax(196px,1fr));gap:12px">
+<sc-for list="{{ surfaces }}" as="s" hint-placeholder-count="6">
+<div style="border:1px solid var(--rule);border-radius:12px;background:var(--surface);overflow:hidden">
+<div style="height:58px;background:{{ s.value }};border-bottom:1px solid var(--rule)"></div>
+<div style="padding:11px 13px 12px">
+<div style="font:500 12.5px Geist Mono,ui-monospace,monospace;color:var(--ink)">{{ s.token }}</div>
+<div style="margin-top:4px;font-size:12px;color:var(--muted)">{{ s.use }}</div>
+</div>
+</div>
+</sc-for>
+</div>
+
+<div style="margin-top:34px;font-size:11px;font-weight:600;letter-spacing:.09em;text-transform:uppercase;color:var(--dim)">Text</div>
+<div style="margin-top:12px;border:1px solid var(--rule);border-radius:12px;background:var(--surface);overflow:hidden">
+<sc-for list="{{ inks }}" as="k" hint-placeholder-count="6">
+<div style="display:flex;align-items:baseline;gap:16px;padding:12px 16px;border-bottom:1px solid var(--rule)">
+<div style="flex:none;width:96px;font:500 12.5px Geist Mono,ui-monospace,monospace;color:var(--dim2)">{{ k.token }}</div>
+<div style="flex:1;min-width:0;font-size:14.5px;color:{{ k.value }}">{{ k.sample }}</div>
+<div style="flex:none;font-size:12px;color:var(--dim2)">{{ k.use }}</div>
+</div>
+</sc-for>
+</div>
+
+<div style="margin-top:34px;font-size:11px;font-weight:600;letter-spacing:.09em;text-transform:uppercase;color:var(--dim)">Lines</div>
+<div style="margin-top:12px;display:grid;grid-template-columns:repeat(3,1fr);gap:12px">
+<sc-for list="{{ rules }}" as="r" hint-placeholder-count="3">
+<div style="padding:15px 16px;border:1px solid {{ r.value }};border-radius:12px;background:var(--surface)">
+<div style="font:500 12.5px Geist Mono,ui-monospace,monospace">{{ r.token }}</div>
+<div style="margin-top:5px;font-size:12px;color:var(--muted)">{{ r.use }}</div>
+</div>
+</sc-for>
+</div>
+
+<div style="margin-top:34px;font-size:11px;font-weight:600;letter-spacing:.09em;text-transform:uppercase;color:var(--dim)">Controls</div>
+<div style="margin-top:12px;padding:22px;border:1px solid var(--rule);border-radius:12px;background:var(--surface);display:flex;flex-wrap:wrap;align-items:center;gap:12px">
+<div style="display:flex;align-items:center;height:38px;padding:0 16px;border-radius:9px;background:var(--btn);color:var(--btnFg);font-size:13.5px;font-weight:600;cursor:pointer" style-hover="opacity:.88">Primary action</div>
+<div style="display:flex;align-items:center;height:38px;padding:0 15px;border-radius:9px;border:1px solid var(--rule3);background:var(--surface);font-size:13.5px;font-weight:500;color:var(--ink);cursor:pointer" style-hover="border-color:var(--hov)">Secondary</div>
+<div style="display:flex;align-items:center;height:38px;padding:0 15px;border-radius:9px;font-size:13.5px;font-weight:500;color:var(--brand);cursor:pointer" style-hover="background:var(--pill)">Quiet</div>
+<div style="display:flex;align-items:center;height:38px;padding:0 15px;border-radius:9px;background:var(--pill);font-size:13.5px;font-weight:500;color:var(--dim2);cursor:not-allowed">Disabled</div>
+<div style="height:28px;display:flex;align-items:center;padding:0 11px;border-radius:14px;border:1px solid var(--rule2);background:var(--surface);font-size:12.5px;color:var(--chipInk)">Chip</div>
+<div style="padding:3px 9px;border-radius:6px;background:var(--pill);color:var(--chipInk);font-size:11.5px">Pill · 34 reviews</div>
+<div style="display:flex;align-items:center;gap:10px;height:40px;padding:0 14px;border-radius:10px;border:1px solid var(--rule3);background:var(--surface);min-width:240px;font-size:14px;color:var(--dim)">Field placeholder</div>
+</div>
+
+<div style="margin-top:34px;font-size:11px;font-weight:600;letter-spacing:.09em;text-transform:uppercase;color:var(--dim)">The sidebar keeps brand blue in both themes</div>
+<div style="margin-top:12px;display:flex;gap:0;border:1px solid var(--rule);border-radius:12px;overflow:hidden">
+<div style="width:236px;flex:none;padding:16px 12px;background:var(--rail);color:#fff">
+<div style="font-size:15px;font-weight:600;line-height:1.15">Course<br>Community</div>
+<div style="margin-top:16px;display:flex;flex-direction:column;gap:2px;font-size:14px">
+<div style="padding:9px 10px;border-radius:8px;background:rgba(255,255,255,.16);font-weight:600">Explore</div>
+<div style="padding:9px 10px;border-radius:8px;color:rgba(255,255,255,.82)">Saved courses</div>
+</div>
+</div>
+<div style="flex:1;padding:22px;background:var(--pg);color:var(--muted);font-size:13px;line-height:1.55">Page content sits on <span style="font:500 12.5px Geist Mono,ui-monospace,monospace;color:var(--ink)">--pg</span>; cards and menus sit on <span style="font:500 12.5px Geist Mono,ui-monospace,monospace;color:var(--ink)">--surface</span>.</div>
+</div>
+
+<div style="margin-top:34px;font-size:11px;font-weight:600;letter-spacing:.09em;text-transform:uppercase;color:var(--dim)">Type</div>
+<div style="margin-top:12px;padding:22px;border:1px solid var(--rule);border-radius:12px;background:var(--surface);display:flex;flex-direction:column;gap:14px">
+<div style="font-size:28px;font-weight:600;letter-spacing:-.02em;line-height:1.15">Page title · Geist 600, 28/1.15, −.02em</div>
+<div style="font-size:19px;font-weight:600;line-height:1.25">Section title · 19/1.25</div>
+<div style="font-size:15px;font-weight:600">Card title · 15\u201317, 600</div>
+<div style="font-size:13.5px;line-height:1.55;color:var(--muted)">Body · 13.5/1.55 in --muted. Long-form copy stays under about 70 characters a line.</div>
+<div style="font-size:11px;font-weight:600;letter-spacing:.09em;text-transform:uppercase;color:var(--dim)">Eyebrow · 11, 600, .09em, uppercase</div>
+<div style="font:500 13px Geist Mono,ui-monospace,monospace;color:var(--brand)">DD2380 · Geist Mono for codes</div>
+</div>
+</div>
+</div>
+
+</x-dc>
+<script type="text/x-dc" data-dc-script data-props="{&quot;$preview&quot;:{&quot;width&quot;:1120,&quot;height&quot;:1400}}">
+/* A live reading of cc-theme.css: every swatch renders the variable itself, so
+   this page cannot drift from the token file. */
+const SURFACES = [
+  ["--pg", "Page background"],
+  ["--surface", "Cards, menus, fields"],
+  ["--inset", "Recessed panel"],
+  ["--pill", "Chips, tracks, hover"],
+  ["--rail", "Sidebar, both themes"],
+  ["--btn", "Filled button"]
+];
+const INKS = [
+  ["--ink", "Primary text", "Find the course you will be happy you took"],
+  ["--ink2", "Secondary text", "Assignments are graded on complexity"],
+  ["--muted", "Supporting copy", "Filter by school, credits or examination"],
+  ["--dim", "Labels and hints", "PDF from Ladok · up to 10 MB"],
+  ["--dim2", "Faintest text", "Read by KTH AI Society"],
+  ["--chipInk", "Text on a pill", "School EECS"],
+  ["--brand", "Links and brand", "Find your dot"]
+];
+const RULES = [
+  ["--rule", "Hairline between rows"],
+  ["--rule2", "Card border"],
+  ["--rule3", "Control border"]
+];
+
+class Component extends DCLogic {
+  state = { dark: null };
+
+  dark() {
+    if (this.state.dark !== null) return this.state.dark;
+    try { return window.localStorage.getItem("cc:theme") === "dark"; } catch (e) { return false; }
+  }
+
+  apply(next) {
+    document.documentElement.setAttribute("data-cc-theme", next ? "dark" : "light");
+    try { window.localStorage.setItem("cc:theme", next ? "dark" : "light"); } catch (e) { /* storage off */ }
+  }
+
+  componentDidMount() {
+    this.apply(this.dark());
+  }
+
+  renderVals() {
+    const dark = this.dark();
+    return {
+      themeLabel: dark ? "Dark theme" : "Light theme",
+      themeTitle: dark ? "Switch to light" : "Switch to dark",
+      onTheme: () => { this.apply(!dark); this.setState({ dark: !dark }); },
+      surfaces: SURFACES.map((s) => ({ token: s[0], use: s[1], value: "var(" + s[0] + ")" })),
+      inks: INKS.map((k) => ({ token: k[0], use: k[1], sample: k[2], value: "var(" + k[0] + ")" })),
+      rules: RULES.map((r) => ({ token: r[0], use: r[1], value: "var(" + r[0] + ")" }))
+    };
+  }
+}
+
+</script>
+</body>
+</html>

--- a/docs/design/reference/Course Community - Mobile Preview.dc.html
+++ b/docs/design/reference/Course Community - Mobile Preview.dc.html
@@ -1,0 +1,573 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<script src="./support.js"></script>
+</head>
+<body>
+<x-dc>
+<helmet data-dc-atomics><link rel="preconnect" href="https://fonts.googleapis.com"><link rel="preconnect" href="https://fonts.gstatic.com" crossorigin><link href="https://fonts.googleapis.com/css2?family=Geist:wght@400;500;600;700&family=Geist+Mono:wght@400;500&display=swap" rel="stylesheet"><link rel="stylesheet" href="cc-theme.css"><style>body{margin:0;background:#e7e2d3;font-family:Geist,system-ui,sans-serif}@keyframes slideUp{from{transform:translateY(100%)}to{transform:translateY(0)}}@keyframes slideIn{from{transform:translateX(-100%)}to{transform:translateX(0)}}@keyframes pulse{0%,100%{opacity:.45}50%{opacity:1}}.cc-mobile-sheet-scroll{scrollbar-width:none}.cc-mobile-sheet-scroll::-webkit-scrollbar{display:none}
+.cc-landing-mobile [style*="z-index: 35"][style*="width: 236px"]{transform:translateX(-236px) !important;pointer-events:none !important}
+.cc-landing-mobile [style*="height: 66px"]{display:none !important}
+.cc-landing-mobile [style*="grid-template-columns: repeat(3, 1fr)"]{display:flex !important;flex-direction:column !important}
+.cc-landing-mobile .omx-th{scrollbar-width:none}
+.cc-landing-mobile .omx-th::-webkit-scrollbar{display:none}
+</style></helmet>
+
+<div style="display:flex;flex-direction:column;align-items:center;gap:14px;padding:40px 20px">
+<div style="font-size:13px;font-weight:600;color:#6b6355;text-align:center;max-width:420px">Mobile concept — collapsed sidebar (tap the icon, top left) switches between Explore, Saved, My Page and Taken courses. Tapping a course opens its own sheet from the bottom (details, or "Write a review"). Sheets stack — open several, dismiss each with the × or by dragging it all the way down. Draft only, does not change the desktop pages.</div>
+
+<x-import component-from-global-scope="IOSDevice" from="./ios-frame.jsx" hint-size="390px,844px">
+<div data-cc-theme="{{ theme }}" style="position:relative;height:100%;display:flex;flex-direction:column;background:var(--pg);color:var(--ink);font-size:14px;overflow:hidden;transition:background-color .3s ease,color .3s ease">
+
+<div style="flex:none;display:flex;align-items:center;gap:10px;padding:56px 14px 10px;border-bottom:1px solid var(--rule)">
+<sc-if value="{{ notLanding }}" hint-placeholder-val="{{ true }}">
+<div onClick="{{ onOpenDrawer }}" role="button" tabIndex="0" aria-label="Open menu" style="flex:none;width:36px;height:36px;display:flex;align-items:center;justify-content:center;border-radius:9px;color:var(--brand);cursor:pointer" style-hover="background:var(--pill)">
+<svg width="19" height="19" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"><path d="M4 6h16M4 12h16M4 18h16"></path></svg>
+</div>
+</sc-if>
+<div style="flex:1;min-width:0">
+<div style="font-size:16px;font-weight:600;line-height:1.2">{{ pageTitle }}</div>
+</div>
+<div onClick="{{ onTheme }}" role="button" tabIndex="0" aria-label="{{ themeTitle }}" title="{{ themeTitle }}" style="flex:none;width:34px;height:34px;display:flex;align-items:center;justify-content:center;border-radius:9px;color:var(--chipInk)">
+<sc-if value="{{ notNight }}" hint-placeholder-val="{{ true }}"><svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><path d="M20.5 14.5A8.5 8.5 0 1 1 9.5 3.5a7 7 0 0 0 11 11z"></path></svg></sc-if>
+<sc-if value="{{ night }}" hint-placeholder-val="{{ false }}"><svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round"><circle cx="12" cy="12" r="4.2"></circle><path d="M12 3v2M12 19v2M3 12h2M19 12h2M5.6 5.6l1.4 1.4M17 17l1.4 1.4M18.4 5.6 17 7M7 17l-1.4 1.4"></path></svg></sc-if>
+</div>
+</div>
+
+<sc-if value="{{ isExplore }}" hint-placeholder-val="{{ true }}">
+<div style="flex:none;padding:10px 14px 12px">
+<div style="width:100%;box-sizing:border-box;display:flex;align-items:center;gap:9px;height:40px;padding:0 13px;border-radius:10px;border:1px solid var(--rule3);background:var(--surface)">
+<svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="#5c6570" stroke-width="2" stroke-linecap="round"><circle cx="11" cy="11" r="7"></circle><line x1="16.5" y1="16.5" x2="21" y2="21"></line></svg>
+<span style="font-size:13.5px;color:var(--muted);white-space:nowrap;overflow:hidden;text-overflow:ellipsis">Search a course, code or subject</span>
+</div>
+</div>
+</sc-if>
+
+<sc-if value="{{ isExplore }}" hint-placeholder-val="{{ true }}">
+<div style="flex:1;min-height:0;overflow-y:auto;padding:0 14px 20px;display:flex;flex-direction:column;gap:12px">
+<sc-if value="{{ isLoading }}" hint-placeholder-val="{{ false }}">
+<sc-for list="{{ skeletonRows }}" as="k" hint-placeholder-count="3">
+<div style="height:168px;border-radius:12px;background:var(--surface);border:1px solid var(--rule2);padding:13px;display:flex;flex-direction:column;gap:10px">
+<div style="height:12px;width:60%;border-radius:4px;background:var(--pill);animation:pulse 1.2s ease-in-out infinite"></div>
+<div style="height:20px;width:80%;border-radius:5px;background:var(--pill);animation:pulse 1.2s ease-in-out infinite"></div>
+</div>
+</sc-for>
+</sc-if>
+<sc-if value="{{ isError }}" hint-placeholder-val="{{ false }}">
+<div style="padding:20px;border:1px solid #f0d7cf;border-radius:12px;background:var(--surface);text-align:center">
+<div style="font-size:14px;font-weight:600">Could not load courses</div>
+<div style="margin-top:5px;font-size:12.5px;color:var(--muted)">Something went wrong. Try again.</div>
+</div>
+</sc-if>
+<sc-if value="{{ isEmptyExplore }}" hint-placeholder-val="{{ false }}">
+<div style="padding:24px;border:1px dashed var(--rule3);border-radius:12px;text-align:center">
+<div style="font-size:14px;font-weight:600">No courses found</div>
+<div style="margin-top:5px;font-size:12.5px;color:var(--muted)">Try a different search.</div>
+</div>
+</sc-if>
+<sc-if value="{{ isPopulatedExplore }}" hint-placeholder-val="{{ true }}">
+<sc-for list="{{ mobileCourses }}" as="c" hint-placeholder-count="3">
+<dc-import name="Course Community - Course Card" c="{{ c }}" geo="{{ geo }}" action="save" is-guest="{{ isGuest }}" is-member="{{ true }}" on-sign-up="{{ c.onSignUp }}" on-log-in="{{ c.onLogIn }}" pick-above="{{ true }}" hide-facts="{{ true }}" compact="{{ true }}" hint-size="100%,168px"></dc-import>
+</sc-for>
+</sc-if>
+</div>
+</sc-if>
+
+<sc-if value="{{ isLanding }}" hint-placeholder-val="{{ false }}">
+<div class="cc-landing-mobile cc-mobile-sheet-scroll" style="flex:1;min-height:0;overflow-y:auto;overflow-x:hidden;position:relative">
+<dc-import name="Course Community - Landing" account-count="{{ 14 }}" mobile="{{ true }}" hint-size="100%,100%" style="position:absolute;inset:0"></dc-import>
+</div>
+</sc-if>
+
+<sc-if value="{{ isSaved }}" hint-placeholder-val="{{ false }}">
+<div style="flex:1;min-height:0;overflow-y:auto;padding:12px 14px 20px;display:flex;flex-direction:column;gap:16px">
+<div>
+<div style="font-size:11px;font-weight:600;letter-spacing:.06em;text-transform:uppercase;color:var(--dim)">Collections</div>
+<div style="margin-top:8px;display:flex;flex-wrap:wrap;gap:8px">
+<sc-for list="{{ collectionChips }}" as="col" hint-placeholder-count="3">
+<div style="flex:none;height:34px;display:flex;align-items:center;gap:6px;padding:0 12px;border-radius:9px;border:1px solid var(--rule2);background:var(--surface);font-size:12.5px;font-weight:500;color:var(--chipInk);white-space:nowrap">{{ col.name }}<span style="color:var(--dim2);font-weight:400">{{ col.count }}</span></div>
+</sc-for>
+<div style="flex:none;height:34px;display:flex;align-items:center;gap:6px;padding:0 12px;border-radius:9px;border:1px dashed #9dbfe4;background:rgba(23,81,166,.06);color:var(--brand);font-size:12.5px;font-weight:600">+ New</div>
+</div>
+</div>
+<div style="display:flex;flex-direction:column;gap:12px">
+<div style="font-size:11px;font-weight:600;letter-spacing:.06em;text-transform:uppercase;color:var(--dim)">Saved courses</div>
+<sc-for list="{{ mobileCourses }}" as="c" hint-placeholder-count="3">
+<dc-import name="Course Community - Course Card" c="{{ c }}" geo="{{ geo }}" action="add" is-guest="{{ isGuest }}" is-member="{{ true }}" on-sign-up="{{ c.onSignUp }}" on-log-in="{{ c.onLogIn }}" pick-above="{{ true }}" hide-facts="{{ true }}" compact="{{ true }}" hint-size="100%,168px"></dc-import>
+</sc-for>
+</div>
+</div>
+</sc-if>
+
+<sc-if value="{{ isMyPage }}" hint-placeholder-val="{{ false }}">
+<div style="flex:1;min-height:0;overflow-y:auto;padding:12px 14px 20px;display:flex;flex-direction:column;gap:16px">
+<div style="display:flex;align-items:center;gap:12px">
+<div style="width:46px;height:46px;flex:none;border-radius:999px;background:var(--pill);display:flex;align-items:center;justify-content:center;font-size:16px;font-weight:600;color:var(--brand)">EL</div>
+<div style="min-width:0">
+<div style="font-size:15px;font-weight:600">Elsa Lindqvist</div>
+<div style="margin-top:2px;font-size:12px;color:var(--muted)">At KTH since 2023 · reviews signed Elsa Lindqvist</div>
+</div>
+</div>
+
+<div style="display:flex;gap:4px;overflow-x:auto;border-bottom:1px solid var(--rule)">
+<sc-for list="{{ myPageTabs }}" as="tb" hint-placeholder-count="4">
+<div onClick="{{ tb.onClick }}" role="button" tabIndex="0" style="flex:none;display:flex;align-items:center;padding:0 11px;height:36px;border-bottom:2px solid {{ tb.line }};color:{{ tb.fg }};font-size:13px;font-weight:{{ tb.weight }};white-space:nowrap">{{ tb.label }}</div>
+</sc-for>
+</div>
+
+<sc-if value="{{ isMyPageOverview }}" hint-placeholder-val="{{ true }}">
+<div style="display:grid;grid-template-columns:repeat(3,1fr);gap:8px">
+<div style="border:1px solid var(--rule);border-radius:10px;background:var(--surface);padding:10px 11px">
+<div style="font-size:10.5px;color:var(--dim)">Credits</div>
+<div style="margin-top:4px;font-size:15px;font-weight:600">37.5</div>
+</div>
+<div style="border:1px solid var(--rule);border-radius:10px;background:var(--surface);padding:10px 11px">
+<div style="font-size:10.5px;color:var(--dim)">Average</div>
+<div style="margin-top:4px;font-size:15px;font-weight:600">4.2</div>
+</div>
+<div style="border:1px solid var(--rule);border-radius:10px;background:var(--surface);padding:10px 11px">
+<div style="font-size:10.5px;color:var(--dim)">Reviews</div>
+<div style="margin-top:4px;font-size:15px;font-weight:600">3</div>
+</div>
+</div>
+</sc-if>
+
+<sc-if value="{{ isMyPageReviews }}" hint-placeholder-val="{{ false }}">
+<div style="display:flex;flex-direction:column;gap:12px">
+<div style="font-size:11px;font-weight:600;letter-spacing:.06em;text-transform:uppercase;color:var(--dim)">Your reviews</div>
+<sc-for list="{{ myReviews }}" as="r" hint-placeholder-count="2">
+<div style="border:1px solid var(--rule2);border-radius:12px;background:var(--surface);padding:13px 14px;display:flex;flex-direction:column;gap:5px">
+<div style="font-family:'Geist Mono',ui-monospace,monospace;font-size:11px;color:var(--brand);font-weight:500">{{ r.code }}</div>
+<div style="font-size:13.5px;font-weight:600">{{ r.title }}</div>
+<div style="font-size:12.5px;color:var(--muted);line-height:1.4">{{ r.snippet }}</div>
+</div>
+</sc-for>
+</div>
+
+<div style="display:flex;flex-direction:column;gap:12px">
+<div style="font-size:11px;font-weight:600;letter-spacing:.06em;text-transform:uppercase;color:var(--dim)">Liked reviews</div>
+<sc-for list="{{ likedReviews }}" as="r" hint-placeholder-count="1">
+<div style="border:1px solid var(--rule2);border-radius:12px;background:var(--surface);padding:13px 14px;display:flex;flex-direction:column;gap:5px">
+<div style="font-family:'Geist Mono',ui-monospace,monospace;font-size:11px;color:var(--brand);font-weight:500">{{ r.code }}</div>
+<div style="font-size:13.5px;font-weight:600">{{ r.title }}</div>
+<div style="font-size:12.5px;color:var(--muted);line-height:1.4">{{ r.snippet }}</div>
+</div>
+</sc-for>
+</div>
+</sc-if>
+
+<sc-if value="{{ isMyPageDot }}" hint-placeholder-val="{{ false }}">
+<div style="border:1px solid var(--rule);border-radius:12px;background:var(--surface);padding:14px 15px">
+<div style="font-size:14px;font-weight:600">Your node on the landing page</div>
+<div style="margin-top:5px;font-size:12.5px;line-height:1.5;color:var(--muted)">Review courses to unlock how your dot looks. Go quiet for a while and it settles back to default.</div>
+</div>
+<div style="border:1px solid var(--rule);border-radius:12px;background:var(--surface);overflow:hidden">
+<sc-for list="{{ dotTiers }}" as="dt" hint-placeholder-count="3">
+<div style="padding:13px 15px;border-bottom:{{ dt.divider }}">
+<div style="display:flex;align-items:center;justify-content:space-between;gap:10px">
+<div style="font-size:13px;font-weight:600;color:{{ dt.titleColor }}">{{ dt.title }}</div>
+<span style="flex:none;padding:3px 9px;border-radius:999px;background:{{ dt.badgeBg }};color:{{ dt.badgeFg }};font-size:11px;font-weight:600;white-space:nowrap">{{ dt.badgeLabel }}</span>
+</div>
+<sc-if value="{{ dt.unlocked }}" hint-placeholder-val="{{ false }}">
+<div style="margin-top:10px;display:flex;flex-wrap:wrap;gap:7px">
+<sc-for list="{{ dt.options }}" as="o" hint-placeholder-count="3">
+<div onClick="{{ o.onClick }}" role="button" tabIndex="0" style="display:flex;align-items:center;gap:8px;height:32px;padding:0 12px;border-radius:8px;border:1px solid {{ o.border }};background:{{ o.bg }};color:{{ o.fg }};font-size:12.5px;font-weight:{{ o.weight }}">
+<span style="width:13px;height:13px;border-radius:50%;background:{{ o.swatch }};flex:none"></span>{{ o.swatch }}
+</div>
+</sc-for>
+</div>
+</sc-if>
+<sc-if value="{{ dt.locked }}" hint-placeholder-val="{{ true }}">
+<div style="margin-top:5px;font-size:12px;color:var(--dim)">{{ dt.hint }}</div>
+</sc-if>
+</div>
+</sc-for>
+</div>
+</sc-if>
+
+<sc-if value="{{ isMyPageSettings }}" hint-placeholder-val="{{ false }}">
+<div style="border:1px solid var(--rule);border-radius:12px;background:var(--surface);overflow:hidden">
+<div style="padding:13px 15px;border-bottom:1px solid var(--rule);display:flex;align-items:center;justify-content:space-between;gap:10px">
+<div style="font-size:13px;font-weight:600">Store grades from my transcript</div>
+<div style="flex:none;width:42px;height:24px;border-radius:99px;background:#1751a6;padding:3px;display:flex;justify-content:flex-end"><div style="width:18px;height:18px;border-radius:50%;background:var(--surface);box-shadow:0 1px 2px rgba(20,30,45,.28)"></div></div>
+</div>
+<div style="padding:13px 15px;display:flex;align-items:center;justify-content:space-between;gap:10px">
+<div style="font-size:13px;font-weight:600;color:#a4402a">Delete account</div>
+</div>
+</div>
+</sc-if>
+</div>
+</sc-if>
+
+<sc-if value="{{ isTaken }}" hint-placeholder-val="{{ false }}">
+<div style="flex:1;min-height:0;overflow-y:auto;padding:12px 14px 20px;display:flex;flex-direction:column;gap:12px">
+<div style="display:flex;align-items:center;justify-content:space-between;gap:10px">
+<div style="font-size:11px;font-weight:600;letter-spacing:.06em;text-transform:uppercase;color:var(--dim)">Your course list</div>
+<div role="button" tabIndex="0" aria-label="Reupload transcript" title="Reupload transcript" style="flex:none;width:34px;height:34px;display:flex;align-items:center;justify-content:center;border-radius:9px;border:1px solid var(--rule3);background:var(--surface);color:var(--chipInk)">
+<svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.9" stroke-linecap="round" stroke-linejoin="round"><path d="M12 16V4"></path><path d="m7.5 8.5 4.5-4.5 4.5 4.5"></path><path d="M4 15v3a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2v-3"></path></svg>
+</div>
+</div>
+<sc-for list="{{ takenCourses }}" as="t" hint-placeholder-count="3">
+<div style="border:1px solid var(--rule2);border-radius:12px;background:var(--surface);padding:13px 14px;display:flex;align-items:center;justify-content:space-between;gap:10px">
+<div style="min-width:0">
+<div style="font-family:'Geist Mono',ui-monospace,monospace;font-size:11px;color:var(--brand);font-weight:500">{{ t.code }}</div>
+<div style="margin-top:3px;font-size:13.5px;font-weight:600;line-height:1.3;min-height:34px">{{ t.title }}</div>
+<div style="margin-top:2px;font-size:12px;color:var(--muted)">{{ t.hp }} · {{ t.year }}</div>
+</div>
+<div style="flex:none;padding:4px 10px;border-radius:7px;background:var(--pill);color:var(--brand);font-size:13px;font-weight:600">{{ t.grade }}</div>
+</div>
+</sc-for>
+<div onClick="{{ onAddCourse }}" role="button" tabIndex="0" style="display:flex;align-items:center;justify-content:center;gap:7px;height:40px;border-radius:9px;border:1px dashed #9dbfe4;background:rgba(23,81,166,.06);color:var(--brand);font-size:13px;font-weight:600">
+<svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"><path d="M5 12h14"></path><path d="M12 5v14"></path></svg>Add a course
+</div>
+</div>
+</sc-if>
+
+<sc-if value="{{ addCourseOpen }}" hint-placeholder-val="{{ false }}">
+<div onClick="{{ onCloseAddCourse }}" style="position:absolute;inset:0;z-index:60;background:rgba(20,30,45,.4)"></div>
+<div style="position:absolute;left:16px;right:16px;top:50%;transform:translateY(-50%);z-index:61;box-sizing:border-box;padding:20px;border-radius:14px;background:var(--surface);box-shadow:0 18px 48px rgba(20,30,45,.24)">
+<div style="font-size:16px;font-weight:600">Add a course by hand</div>
+<div style="margin-top:5px;font-size:12.5px;color:var(--muted)">Type the course in yourself — same as "Add a course by hand" on desktop.</div>
+<input placeholder="Course code, e.g. DD1337" style="margin-top:14px;box-sizing:border-box;width:100%;height:40px;padding:0 12px;border-radius:9px;border:1px solid var(--rule3);outline:none;font-family:inherit;font-size:13.5px;color:var(--ink)">
+<div style="margin-top:14px;display:flex;gap:8px">
+<div onClick="{{ onCloseAddCourse }}" role="button" tabIndex="0" style="flex:1;display:flex;align-items:center;justify-content:center;height:40px;border-radius:9px;background:var(--btn);color:var(--btnFg);font-size:13.5px;font-weight:600">Add course</div>
+<div onClick="{{ onCloseAddCourse }}" role="button" tabIndex="0" style="display:flex;align-items:center;justify-content:center;height:40px;padding:0 16px;border-radius:9px;border:1px solid var(--rule3);background:var(--surface);font-size:13.5px;font-weight:500">Cancel</div>
+</div>
+</div>
+</sc-if>
+
+<sc-if value="{{ drawerOpen }}" hint-placeholder-val="{{ false }}">
+<div onClick="{{ onCloseDrawer }}" style="position:absolute;inset:0;z-index:40;background:rgba(20,30,45,.4)"></div>
+<div style="position:absolute;top:0;left:0;bottom:0;z-index:41;width:250px;box-sizing:border-box;display:flex;flex-direction:column;gap:6px;padding:56px 12px 16px;background:#1751a6;color:#fff;animation:slideIn .18s ease-out">
+<div style="display:flex;align-items:center;justify-content:space-between;padding:6px 8px 16px">
+<div onClick="{{ onGoLanding }}" role="button" tabIndex="0" style="display:flex;align-items:center;gap:9px;cursor:pointer">
+<img src="assets/ais-symbol-white.png" alt="KTH AI Society" style="height:28px;width:28px;object-fit:contain">
+<div style="font-size:15px;font-weight:600;line-height:1.15">Course<br>Community</div>
+</div>
+<div onClick="{{ onCloseDrawer }}" role="button" tabIndex="0" aria-label="Close menu" style="width:30px;height:30px;display:flex;align-items:center;justify-content:center;border-radius:8px;color:#fff;cursor:pointer" style-hover="background:rgba(255,255,255,.16)">
+<svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"><path d="M6 6l12 12M18 6 6 18"></path></svg>
+</div>
+</div>
+<sc-for list="{{ navLinks }}" as="n" hint-placeholder-count="4">
+<div onClick="{{ n.onClick }}" role="button" tabIndex="0" style="display:flex;align-items:center;gap:10px;padding:10px 10px;border-radius:8px;background:{{ n.bg }};font-weight:{{ n.weight }};cursor:pointer">{{ n.label }}</div>
+</sc-for>
+<div style="margin-top:auto;display:flex;align-items:center;justify-content:space-between;gap:8px;padding:10px 10px">
+<div style="font-size:12px;color:rgba(255,255,255,.7)">Signed in as Elsa Lindqvist</div>
+<div onClick="{{ onSignOut }}" role="button" tabIndex="0" aria-label="Sign out" title="Sign out" style="flex:none;width:28px;height:28px;display:flex;align-items:center;justify-content:center;border-radius:7px;color:rgba(255,255,255,.75)">
+<svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.9" stroke-linecap="round" stroke-linejoin="round"><path d="M9 21H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h4"></path><path d="M16 17l5-5-5-5"></path><path d="M21 12H9"></path></svg>
+</div>
+</div>
+</div>
+</sc-if>
+
+<sc-for list="{{ sheets }}" as="s" hint-placeholder-count="0">
+<div style="position:absolute;left:0;right:0;bottom:{{ s.bottomOffset }}px;z-index:{{ s.zIndex }};max-height:82%;box-sizing:border-box;display:flex;flex-direction:column;overflow:hidden;border-radius:18px 18px 0 0;background:{{ s.headerTint }};box-shadow:0 -8px 30px rgba(20,30,45,.24),inset 0 3px 0 0 {{ s.accent }};transform:translateY({{ s.dragY }}px);transition:{{ s.transition }}">
+<div onPointerDown="{{ s.onDragStart }}" style="position:absolute;top:8px;left:0;right:0;z-index:3;display:flex;justify-content:center;cursor:grab;touch-action:none">
+<div style="width:36px;height:4px;border-radius:2px;background:var(--rule3)"></div>
+</div>
+<div onClick="{{ s.onClose }}" role="button" tabIndex="0" aria-label="Close" style="flex:none;position:absolute;top:8px;right:10px;z-index:2;width:30px;height:30px;display:flex;align-items:center;justify-content:center;border-radius:8px;background:var(--surface);color:var(--dim);cursor:pointer;box-shadow:0 1px 3px rgba(20,30,45,.15)" style-hover="background:var(--pill)">
+<svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"><path d="M6 6l12 12M18 6 6 18"></path></svg>
+</div>
+
+<div class="cc-mobile-sheet-scroll" style="flex:1;min-height:0;overflow-y:auto;overflow-x:hidden;padding:28px 0 18px">
+<dc-import name="Course Community - Workspace Pane" pane-width="100%" pane-grow="1 1 auto" courses="{{ workspaceCourses }}" store-module="{{ workspaceStore }}" locale="en" is-guest="{{ isGuest }}" open-signal="{{ s.openSignal }}" hide-tabs="{{ true }}" on-tabs-change="{{ noop }}" on-authed="{{ noop }}" hint-size="100%,560px"></dc-import>
+</div>
+</sc-for>
+
+</div>
+</x-import>
+</div>
+
+</x-dc>
+<script type="text/x-dc" data-dc-script data-props="{&quot;$preview&quot;:{&quot;width&quot;:480,&quot;height&quot;:900},&quot;session&quot;:{&quot;editor&quot;:&quot;enum&quot;,&quot;default&quot;:&quot;member&quot;,&quot;options&quot;:[&quot;guest&quot;,&quot;member&quot;],&quot;tsType&quot;:&quot;\&quot;guest\&quot; | \&quot;member\&quot;&quot;,&quot;section&quot;:&quot;Session&quot;},&quot;scenario&quot;:{&quot;editor&quot;:&quot;enum&quot;,&quot;default&quot;:&quot;populated&quot;,&quot;options&quot;:[&quot;populated&quot;,&quot;empty&quot;,&quot;loading&quot;,&quot;error&quot;],&quot;tsType&quot;:&quot;string&quot;,&quot;section&quot;:&quot;Prototype state&quot;}}">
+let STORE = null;
+
+function examLabel(segments) {
+  if (!segments || segments.length === 0) return null;
+  const total = segments.reduce((a, x) => a + (x.percent || 0), 0);
+  if (total === 0) return null;
+  let top = 0;
+  for (let i = 1; i < segments.length; i++) if (segments[i].percent > segments[top].percent) top = i;
+  const share = (segments[top].percent / total) * 100;
+  if (share === 100) return "Only " + segments[top].label;
+  if (share > 50) return "Mainly " + segments[top].label;
+  return "Mixed Evaluation Methods";
+}
+const countOf = (v) => parseInt(String(v).replace(/\D/g, ""), 10) || 0;
+const fmtCount = (n) => String(n).replace(/\B(?=(\d{3})+(?!\d))/g, "\u2009");
+const CARD_GEO = {
+  tween: "none", titleSize: "15px", cardGap: "7px", cardPad: "12px",
+  factsGap: "10px", reviewPad: "0 8px", labelMax: "0px", labelOpacity: 0,
+  saveW: "0px", savePad: "8px", railW: "118px", railPad: "12px 11px",
+  summaryMax: "0px", summaryOpacity: 0,
+  showLabel: false, reviewFlex: "0 0 34px", saveFlex: "0 0 68px",
+  cardHeight: "168px"
+};
+
+class Component extends DCLogic {
+  ccDark() {
+    if (this.state.ccNight !== undefined) return this.state.ccNight === true;
+    try { return window.localStorage.getItem("cc:theme") === "dark"; } catch (e) { return false; }
+  }
+  ccSetDark(next) {
+    document.documentElement.setAttribute("data-cc-theme", next ? "dark" : "light");
+    try { window.localStorage.setItem("cc:theme", next ? "dark" : "light"); } catch (e) { /* storage off */ }
+    this.setState({ ccNight: next });
+  }
+  ccApplyTheme() {
+    document.documentElement.setAttribute("data-cc-theme", this.ccDark() ? "dark" : "light");
+  }
+
+  state = { drawerOpen: false, page: "explore", myPageTab: "overview", courses: [], sheets: [], nextId: 1, drags: {}, flags: {}, pickerFor: null, loading: false, error: false, addCourseOpen: false, signedIn: true };
+  DISMISS_THRESHOLD = 130;
+
+  componentDidMount() {
+    this.ccApplyTheme();
+    import("./cc-store.js").then((mod) => {
+      STORE = mod;
+      const scenario = this.props.scenario || "populated";
+      this.setState({
+        loading: scenario === "loading",
+        error: scenario === "error",
+        courses: scenario === "empty" || scenario === "loading" || scenario === "error"
+          ? []
+          : STORE.catalogCards({ locale: "en" }).slice(0, 3)
+      });
+    });
+  }
+
+  openSheet(code, kind) {
+    const id = this.state.nextId;
+    // kind: "r" opens straight to the review draft, "c" to course details —
+    // same shape Explore/Saved use for Workspace Pane's own open-signal.
+    const sheet = { id, openSignal: { code, kind, nonce: Date.now() } };
+    this.setState({ sheets: this.state.sheets.concat([sheet]), nextId: id + 1 });
+  }
+
+  closeSheet(id) {
+    this.setState({ sheets: this.state.sheets.filter((s) => s.id !== id) });
+  }
+
+  onSheetDragStart = (id) => (e) => {
+    e.preventDefault();
+    const startY = e.clientY;
+    const drags = { ...this.state.drags };
+    drags[id] = { dragY: 0, dragging: true };
+    this.setState({ drags });
+    const move = (ev) => {
+      const dy = Math.max(0, ev.clientY - startY);
+      const d = { ...this.state.drags };
+      d[id] = { dragY: dy, dragging: true };
+      this.setState({ drags: d });
+    };
+    const up = () => {
+      window.removeEventListener("pointermove", move);
+      window.removeEventListener("pointerup", up);
+      const dy = (this.state.drags[id] || {}).dragY || 0;
+      if (dy > this.DISMISS_THRESHOLD) { this.closeSheet(id); return; }
+      const d = { ...this.state.drags };
+      d[id] = { dragY: 0, dragging: false };
+      this.setState({ drags: d });
+    };
+    window.addEventListener("pointermove", move);
+    window.addEventListener("pointerup", up);
+  };
+
+  renderVals() {
+    const s = this.state;
+
+    return {
+      drawerOpen: s.drawerOpen,
+      onOpenDrawer: () => this.setState({ drawerOpen: true }),
+      onCloseDrawer: () => this.setState({ drawerOpen: false }),
+
+      navLinks: [
+        ["explore", "Explore"], ["saved", "Saved courses"], ["my-page", "My Page"], ["taken", "Taken courses"]
+      ].map(([key, label]) => ({
+        label,
+        bg: s.page === key ? "rgba(255,255,255,.16)" : "transparent",
+        weight: s.page === key ? "600" : "400",
+        onClick: () => this.setState({ page: key, drawerOpen: false })
+      })),
+
+      theme: this.ccDark() ? "dark" : "light",
+      night: this.ccDark(),
+      notNight: !this.ccDark(),
+      themeTitle: this.ccDark() ? "Switch to light mode" : "Switch to dark mode",
+      onTheme: () => this.ccSetDark(!this.ccDark()),
+      onSignOut: () => this.setState({ signedIn: false, drawerOpen: false, page: "landing" }),
+      onGoLanding: () => this.setState({ page: "landing", drawerOpen: false }),
+      isGuest: !s.signedIn || (this.props.session || "member") === "guest",
+      isLoading: s.loading,
+      isError: s.error,
+      isEmptyExplore: !s.loading && !s.error && s.courses.length === 0,
+      isPopulatedExplore: !s.loading && !s.error && s.courses.length > 0,
+      skeletonRows: [0, 1, 2],
+      isExplore: s.page === "explore",
+      isSaved: s.page === "saved",
+      isMyPage: s.page === "my-page",
+      isTaken: s.page === "taken",
+      isLanding: s.page === "landing",
+      notLanding: s.page !== "landing",
+      pageTitle: { landing: "Course Community", explore: "Explore courses", saved: "Saved courses", "my-page": "My Page", taken: "Taken courses" }[s.page],
+
+      collectionChips: [
+        { name: "Autumn electives", count: " · 3" },
+        { name: "Might swap for ML", count: " · 2" }
+      ],
+      myPageTabs: [
+        ["overview", "Overview"], ["reviews", "Reviews"], ["my-dot", "My dot"], ["settings", "Settings"]
+      ].map(([key, label]) => ({
+        label,
+        line: s.myPageTab === key ? "#1751a6" : "transparent",
+        fg: s.myPageTab === key ? "var(--ink)" : "var(--dim)",
+        weight: s.myPageTab === key ? "600" : "500",
+        onClick: () => this.setState({ myPageTab: key })
+      })),
+      isMyPageOverview: s.myPageTab === "overview",
+      isMyPageReviews: s.myPageTab === "reviews",
+      isMyPageDot: s.myPageTab === "my-dot",
+      isMyPageSettings: s.myPageTab === "settings",
+      dotTiers: (() => {
+        const list = [
+          { title: "Dot color", unlocked: true, hint: "", options: (STORE ? STORE.DOT_COLORS : ["#1751a6", "#1c6b60", "#8a4fae", "#b3541e", "#57646f"]).map((hex, i) => ({ swatch: hex, weight: i === 0 ? "600" : "500", border: i === 0 ? "var(--brand)" : "var(--rule3)", bg: i === 0 ? "var(--pill)" : "var(--surface)", fg: i === 0 ? "var(--brand)" : "var(--ink)", onClick: () => {} })) },
+          { title: "Dot style", unlocked: false, hint: "Unlocks once your uploaded transcript is fully reviewed." },
+          { title: "Signal on click", unlocked: false, hint: "Unlocks once you have referred friends to Course Community." }
+        ];
+        return list.map((t, i) => ({
+          ...t,
+          // Locked tiers say what unlocks them, but not what they actually are.
+          title: t.unlocked ? t.title : "Unknown",
+          locked: !t.unlocked,
+          titleColor: t.unlocked ? "var(--ink)" : "var(--dim)",
+          badgeLabel: t.unlocked ? "Unlocked" : "Locked",
+          badgeBg: t.unlocked ? "var(--pill)" : "var(--pg)",
+          badgeFg: t.unlocked ? "var(--brand)" : "var(--dim)",
+          divider: i < list.length - 1 ? "1px solid var(--rule)" : "none"
+        }));
+      })(),
+      myReviews: [
+        { code: "SK1105", title: "Experimental Physics", snippet: "Labs are the real workload here — budget time for write-ups." },
+        { code: "SF1918", title: "Statistics", snippet: "Manageable if you keep up with the weekly problem sets." }
+      ],
+      addCourseOpen: s.addCourseOpen,
+      // Same mechanism as desktop's "Add a course by hand" — a manual-entry
+      // form for a course the transcript import didn't cover.
+      onAddCourse: () => this.setState({ addCourseOpen: true }),
+      onCloseAddCourse: () => this.setState({ addCourseOpen: false }),
+      likedReviews: [
+        { code: "DD2380", title: "Artificial Intelligence", snippet: "Clear labs, fair exam — a good first AI course." }
+      ],
+      takenCourses: s.courses.map((c, i) => ({
+        code: c.code, title: c.title, hp: c.hp, year: "2025",
+        grade: ["A", "B", "P"][i % 3]
+      })),
+
+      geo: CARD_GEO,
+      mobileCourses: s.courses.map((c) => {
+        const flags = s.flags[c.code] || {};
+        const saved = Boolean(flags.saved);
+        const taken = Boolean(flags.taken);
+        const takenCount = countOf(c.stats ? c.stats[1] : 0) + (taken ? 1 : 0);
+        return {
+          code: c.code,
+          title: c.title,
+          meta: c.hp + " · " + c.code + " · " + c.school,
+          borderColor: "var(--rule2)",
+          keywords: c.keywords || "",
+          hasPrereq: Boolean(c.prereqCourses && c.prereqCourses.length),
+          noPrereq: !(c.prereqCourses && c.prereqCourses.length),
+          prereqCourses: (c.prereqCourses || []).map((p) => {
+            const taken = Boolean((s.flags[p.code] || {}).taken);
+            return { code: p.code, name: p.name, taken: taken, bg: taken ? "rgba(23,81,166,.08)" : "transparent", radius: taken ? "999px" : "6px", padding: "0 8px 0 5px", gap: "5px" };
+          }),
+          summaryClipped: "",
+          hasStats: Boolean(examLabel(c.exSegments)),
+          noStats: !examLabel(c.exSegments),
+          examLabel: examLabel(c.exSegments),
+          hasReviewStats: c.happy != null,
+          noReviewStats: c.happy == null,
+          happyPct: c.happy != null ? c.happy + "%" : "—",
+          statReviews: c.stats ? c.stats[2] : "0",
+          workload: c.wl != null ? (c.wl / 10).toFixed(1) : "—",
+          learning: c.le != null ? (c.le / 10).toFixed(1) : "—",
+          wlW: (c.wl || 0) + "%",
+          leW: (c.le || 0) + "%",
+          statTaken: fmtCount(takenCount),
+          takenTitle: fmtCount(takenCount) + " students have taken this course · " + (taken ? "you marked it as taken" : "click to mark as taken"),
+          takenPickerOpen: false,
+          takenFill: "none",
+          takenBg: taken ? "rgba(23,81,166,.08)" : "transparent",
+          takenCountFg: taken ? "var(--brand)" : "var(--muted)",
+          takenHoverBg: taken ? "rgba(23,81,166,.14)" : "var(--pill)",
+          onTaken: (e) => {
+            if (e && e.stopPropagation) e.stopPropagation();
+            const next = { ...s.flags };
+            next[c.code] = { ...flags, taken: !taken };
+            this.setState({ flags: next });
+          },
+          onSignUp: () => {},
+          onLogIn: () => {},
+          saveLabel: saved ? "Saved" : "Save course",
+          saveFill: "none",
+          saveBorder: saved ? "var(--brand)" : "var(--rule3)",
+          saveBg: saved ? "rgba(23,81,166,.08)" : "var(--surface)",
+          saveFg: saved ? "var(--brand)" : "var(--chipInk)",
+          onSave: (e) => {
+            if (e && e.stopPropagation) e.stopPropagation();
+            const next = { ...s.flags };
+            next[c.code] = { ...flags, saved: !saved };
+            this.setState({ flags: next });
+          },
+          pickerOpen: s.pickerFor === c.code,
+          onPicker: (e) => { if (e && e.stopPropagation) e.stopPropagation(); this.setState({ pickerFor: s.pickerFor === c.code ? null : c.code }); },
+          addLabel: "Add " + c.code + " to a comparison",
+          creating: false,
+          notCreating: true,
+          hasComparisons: (STORE ? STORE.collections.length : 0) > 0,
+          comparisons: (STORE ? STORE.collections : []).map((col) => ({
+            name: col.name,
+            fill: col.codes.indexOf(c.code) >= 0 ? "currentColor" : "none",
+            tick: col.codes.indexOf(c.code) >= 0 ? "M5 12l4 4L19 6" : "",
+            onClick: () => {
+              const inIt = col.codes.indexOf(c.code) >= 0;
+              if (inIt) STORE.removeCourseFromCollection(col.id, c.code); else STORE.addCourseToCollection(col.id, c.code);
+              this.setState({ pickerFor: null });
+            }
+          })),
+          onNewComparison: () => { if (STORE) STORE.createCollection("Collection " + (STORE.collections.length + 1), [c.code]); this.setState({ pickerFor: null }); },
+          onReview: (e) => { if (e && e.stopPropagation) e.stopPropagation(); this.openSheet(c.code, "r"); },
+          onOpen: () => this.openSheet(c.code, "c")
+        };
+      }),
+
+      workspaceCourses: s.courses,
+      workspaceStore: STORE,
+      noop: () => {},
+
+      sheets: s.sheets.map((sh, i) => {
+        const drag = s.drags[sh.id] || { dragY: 0, dragging: false };
+        return {
+          id: sh.id,
+          openSignal: sh.openSignal,
+          accent: sh.openSignal.kind === "r" ? "#dfa53c" : "#1751a6",
+          headerTint: sh.openSignal.kind === "r" ? "var(--warn)" : "var(--info)",
+          zIndex: 50 + i,
+          // Newest sheet sits flush at the bottom; older ones stack behind it,
+          // pushed up a little further each, so their rounded top peeks above it.
+          bottomOffset: (s.sheets.length - 1 - i) * 16,
+          dragY: drag.dragY,
+          transition: drag.dragging ? "none" : "transform .2s ease-out",
+          onDragStart: this.onSheetDragStart(sh.id),
+          onClose: () => this.closeSheet(sh.id)
+        };
+      })
+    };
+  }
+}
+
+</script>
+</body>
+</html>

--- a/docs/design/reference/Course Community - Review Card Options.dc.html
+++ b/docs/design/reference/Course Community - Review Card Options.dc.html
@@ -1,0 +1,438 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<script src="./support.js"></script>
+</head>
+<body>
+<x-dc>
+<helmet><meta name="design_doc_mode" content="canvas"><link rel="preconnect" href="https://fonts.googleapis.com"><link rel="preconnect" href="https://fonts.gstatic.com" crossorigin><link href="https://fonts.googleapis.com/css2?family=Geist:wght@400;500;600;700&family=Geist+Mono:wght@400;500&display=swap" rel="stylesheet"><link rel="stylesheet" href="cc-theme.css"><style>body{margin:0;background:#eef1f4;color:var(--ink);font-family:Geist,system-ui,sans-serif}*{box-sizing:border-box}</style></helmet>
+
+<template id="__bundler_thumbnail"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 120 56"><rect width="120" height="56" fill="#1751a6"/><text x="60" y="32" font-size="14" fill="#fff" text-anchor="middle" font-family="sans-serif" font-weight="700">RC</text></svg></template>
+
+<section style="padding:40px 40px 80px;display:flex;flex-direction:column;gap:8px">
+
+<div style="font-size:13px;color:#5c6570">Round 2 — minimal, no card chrome, reusing the site's thin progress bars and segmented format bar in place of badges.</div>
+
+<div style="margin-top:20px;display:flex;gap:28px;align-items:flex-start;flex-wrap:wrap">
+
+<article id="2a" style="position:relative;width:520px;flex:none;background:#fff;border-radius:14px;box-shadow:0 4px 20px rgba(20,30,45,.08);overflow:hidden">
+<div style="position:absolute;top:12px;left:12px;width:26px;height:26px;border-radius:7px;background:#1751a6;color:#fff;font-size:12px;font-weight:700;display:flex;align-items:center;justify-content:center">2a</div>
+<div style="padding:20px 20px 10px 52px;font-size:11px;font-weight:600;letter-spacing:.07em;text-transform:uppercase;color:#8a857a">Sparkline row — two hairline bars, no boxes</div>
+
+<div style="padding:4px 20px 20px">
+<div style="font-size:11px;font-weight:600;letter-spacing:.06em;text-transform:uppercase;color:#8a857a;margin-bottom:10px">Course details · Reviews</div>
+<div style="display:flex;flex-direction:column">
+<div style="padding:14px 0;border-bottom:1px solid #eae6da">
+<div style="display:flex;align-items:center;justify-content:space-between;gap:10px">
+<span style="display:flex;align-items:baseline;gap:8px"><span style="font-size:11.5px;font-weight:500;color:#8a857a">Elsa L.</span><span style="display:flex;align-items:center;gap:4px;font-size:11px;font-weight:600;color:#1c6b60"><svg width="11" height="11" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.6" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="9.5"></circle><path d="m8.5 12.2 2.4 2.4 4.6-5"></path></svg>Happy</span></span>
+<span style="display:flex;align-items:center;gap:10px"><span style="font-size:11.5px;color:#8a857a">HT24 · 2 weeks ago</span><span style="display:flex;align-items:center;gap:3px"><svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="#1751a6" stroke-width="2.4" stroke-linecap="round" stroke-linejoin="round"><path d="M12 19V6"></path><path d="m6 11 6-6 6 6"></path></svg><span style="font-size:11px;font-weight:700;color:#3d4650">12</span><svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="#8a857a" stroke-width="2.4" stroke-linecap="round" stroke-linejoin="round"><path d="M12 5v13"></path><path d="m18 13-6 6-6-6"></path></svg></span></span>
+</div>
+<div style="margin-top:8px;font-size:13px;line-height:1.5;color:#3d4650">Exam-heavy but fair. The problem sets carry over almost directly, so keep up with them from week one.</div>
+<div style="margin-top:10px;display:flex;align-items:center;gap:14px">
+<div style="flex:1">
+<div style="display:flex;justify-content:space-between;font-size:10.5px;color:#8a857a;margin-bottom:3px"><span>Workload</span><span style="font-weight:600;color:#16202b">8/10</span></div>
+<div style="height:4px;border-radius:2px;background:#eae6da;overflow:hidden"><div style="height:100%;width:80%;background:#dfa53c"></div></div>
+</div>
+<div style="flex:1">
+<div style="display:flex;justify-content:space-between;font-size:10.5px;color:#8a857a;margin-bottom:3px"><span>Learning</span><span style="font-weight:600;color:#16202b">9/10</span></div>
+<div style="height:4px;border-radius:2px;background:#eae6da;overflow:hidden"><div style="height:100%;width:90%;background:#1751a6"></div></div>
+</div>
+</div>
+</div>
+<div style="padding:14px 0">
+<div style="display:flex;align-items:center;justify-content:space-between;gap:10px">
+<span style="display:flex;align-items:baseline;gap:8px"><span style="font-size:11.5px;font-weight:500;color:#8a857a">Marcus B.</span><span style="display:flex;align-items:center;gap:4px;font-size:11px;font-weight:600;color:#a3452a"><svg width="11" height="11" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.6" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="9.5"></circle><path d="M8.5 8.5l7 7M15.5 8.5l-7 7"></path></svg>Not happy</span></span>
+<span style="display:flex;align-items:center;gap:10px"><span style="font-size:11.5px;color:#8a857a">VT25 · 1 month ago</span><span style="display:flex;align-items:center;gap:3px"><svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="#8a857a" stroke-width="2.4" stroke-linecap="round" stroke-linejoin="round"><path d="M12 19V6"></path><path d="m6 11 6-6 6 6"></path></svg><span style="font-size:11px;font-weight:700;color:#3d4650">4</span><svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="#8a857a" stroke-width="2.4" stroke-linecap="round" stroke-linejoin="round"><path d="M12 5v13"></path><path d="m18 13-6 6-6-6"></path></svg></span></span>
+</div>
+<div style="margin-top:8px;font-size:13px;line-height:1.5;color:#3d4650">Solid content, slow pace. Could have been condensed into ten weeks easily.</div>
+<div style="margin-top:10px;display:flex;align-items:center;gap:14px">
+<div style="flex:1">
+<div style="display:flex;justify-content:space-between;font-size:10.5px;color:#8a857a;margin-bottom:3px"><span>Workload</span><span style="font-weight:600;color:#16202b">5/10</span></div>
+<div style="height:4px;border-radius:2px;background:#eae6da;overflow:hidden"><div style="height:100%;width:50%;background:#dfa53c"></div></div>
+</div>
+<div style="flex:1">
+<div style="display:flex;justify-content:space-between;font-size:10.5px;color:#8a857a;margin-bottom:3px"><span>Learning</span><span style="font-weight:600;color:#16202b">3/10</span></div>
+<div style="height:4px;border-radius:2px;background:#eae6da;overflow:hidden"><div style="height:100%;width:30%;background:#1751a6"></div></div>
+</div>
+</div>
+</div>
+</div>
+</div>
+
+<div style="height:1px;background:#eae6da"></div>
+
+<div style="padding:16px 20px 20px">
+<div style="font-size:11px;font-weight:600;letter-spacing:.06em;text-transform:uppercase;color:#8a857a;margin-bottom:10px">My Page · Reviews</div>
+<div style="display:grid;grid-template-columns:1fr 1px 1fr;gap:14px">
+<div style="display:flex;flex-direction:column">
+<div style="font-size:10.5px;font-weight:600;letter-spacing:.06em;text-transform:uppercase;color:#5c6570;margin-bottom:6px">Your reviews</div>
+<div style="padding:9px 0;border-bottom:1px solid #eae6da">
+<div style="padding:9px 0;border-bottom:1px solid #eae6da">
+<div style="display:flex;align-items:center;justify-content:space-between;gap:8px">
+<div style="display:flex;align-items:center;gap:6px;font-size:11px;font-weight:600;color:#1c6b60"><svg width="11" height="11" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.6" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="9.5"></circle><path d="m8.5 12.2 2.4 2.4 4.6-5"></path></svg>Happy they took it</div>
+<span style="display:flex;align-items:center;gap:3px"><svg width="11" height="11" viewBox="0 0 24 24" fill="none" stroke="#1751a6" stroke-width="2.4" stroke-linecap="round" stroke-linejoin="round"><path d="M12 19V6"></path><path d="m6 11 6-6 6 6"></path></svg><span style="font-size:10.5px;font-weight:700;color:#3d4650">12</span><svg width="11" height="11" viewBox="0 0 24 24" fill="none" stroke="#8a857a" stroke-width="2.4" stroke-linecap="round" stroke-linejoin="round"><path d="M12 5v13"></path><path d="m18 13-6 6-6-6"></path></svg></span>
+</div>
+<div style="margin-top:6px;font-size:12px;line-height:1.4;color:#3d4650">Exam-heavy but fair, plan around the problem sets.</div>
+</div>
+</div>
+<div style="background:#eae6da"></div>
+<div style="display:flex;flex-direction:column">
+<div style="font-size:10.5px;font-weight:600;letter-spacing:.06em;text-transform:uppercase;color:#5c6570;margin-bottom:6px">Liked reviews</div>
+<div style="padding:9px 0;border-bottom:1px solid #eae6da">
+<div style="display:flex;align-items:center;justify-content:space-between;gap:8px">
+<div style="display:flex;align-items:center;gap:6px;font-size:11px;font-weight:600;color:#1c6b60"><svg width="11" height="11" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.6" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="9.5"></circle><path d="m8.5 12.2 2.4 2.4 4.6-5"></path></svg>Happy they took it</div>
+<span style="display:flex;align-items:center;gap:3px"><svg width="11" height="11" viewBox="0 0 24 24" fill="none" stroke="#1751a6" stroke-width="2.4" stroke-linecap="round" stroke-linejoin="round"><path d="M12 19V6"></path><path d="m6 11 6-6 6 6"></path></svg><span style="font-size:10.5px;font-weight:700;color:#3d4650">7</span><svg width="11" height="11" viewBox="0 0 24 24" fill="none" stroke="#8a857a" stroke-width="2.4" stroke-linecap="round" stroke-linejoin="round"><path d="M12 5v13"></path><path d="m18 13-6 6-6-6"></path></svg></span>
+</div>
+<div style="margin-top:6px;font-size:12px;line-height:1.4;color:#3d4650">A clear grading breakdown, saved a lot of guessing.</div>
+</div>
+</div>
+</div>
+</div>
+</article>
+
+<article id="2b" style="position:relative;width:520px;flex:none;background:#fff;border-radius:14px;box-shadow:0 4px 20px rgba(20,30,45,.08);overflow:hidden">
+<div style="position:absolute;top:12px;left:12px;width:26px;height:26px;border-radius:7px;background:#1751a6;color:#fff;font-size:12px;font-weight:700;display:flex;align-items:center;justify-content:center">2b</div>
+<div style="padding:20px 20px 10px 52px;font-size:11px;font-weight:600;letter-spacing:.07em;text-transform:uppercase;color:#8a857a">Format bar as headline — reuses the exam-mix bar itself</div>
+
+<div style="padding:4px 20px 20px">
+<div style="font-size:11px;font-weight:600;letter-spacing:.06em;text-transform:uppercase;color:#8a857a;margin-bottom:10px">Course details · Reviews</div>
+<div style="display:flex;flex-direction:column">
+<div style="padding:14px 0;border-bottom:1px solid #eae6da">
+<div style="display:flex;height:6px;border-radius:3px;overflow:hidden">
+<div style="width:60%;background:#1751a6"></div><div style="width:40%;background:#dfa53c"></div>
+</div>
+<div style="margin-top:9px;display:flex;align-items:center;justify-content:space-between;gap:10px">
+<span style="display:flex;align-items:baseline;gap:8px"><span style="font-size:11.5px;font-weight:500;color:#8a857a">Elsa L.</span><span style="display:flex;align-items:center;gap:4px;font-size:11px;font-weight:600;color:#1c6b60"><svg width="11" height="11" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.6" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="9.5"></circle><path d="m8.5 12.2 2.4 2.4 4.6-5"></path></svg>Happy</span></span>
+<div style="flex:none;display:flex;align-items:center;gap:3px"><svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="#1751a6" stroke-width="2.4" stroke-linecap="round" stroke-linejoin="round"><path d="M12 19V6"></path><path d="m6 11 6-6 6 6"></path></svg><span style="font-size:11px;font-weight:700;color:#3d4650">12</span><svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="#8a857a" stroke-width="2.4" stroke-linecap="round" stroke-linejoin="round"><path d="M12 5v13"></path><path d="m18 13-6 6-6-6"></path></svg></div>
+</div>
+<div style="margin-top:7px;font-size:13px;line-height:1.5;color:#3d4650">Exam-heavy but fair. The problem sets carry over almost directly, so keep up with them from week one.</div>
+<div style="margin-top:9px;font-size:11.5px;color:#8a857a">HT24 · Workload 8/10</div>
+</div>
+<div style="padding:14px 0">
+<div style="display:flex;height:6px;border-radius:3px;overflow:hidden">
+<div style="width:30%;background:#1751a6"></div><div style="width:45%;background:#dfa53c"></div><div style="width:25%;background:#2f9e8e"></div>
+</div>
+<div style="margin-top:9px;display:flex;align-items:center;justify-content:space-between;gap:10px">
+<span style="display:flex;align-items:baseline;gap:8px"><span style="font-size:11.5px;font-weight:500;color:#8a857a">Marcus B.</span><span style="display:flex;align-items:center;gap:4px;font-size:11px;font-weight:600;color:#a3452a"><svg width="11" height="11" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.6" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="9.5"></circle><path d="M8.5 8.5l7 7M15.5 8.5l-7 7"></path></svg>Not happy</span></span>
+<div style="flex:none;display:flex;align-items:center;gap:3px"><svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="#8a857a" stroke-width="2.4" stroke-linecap="round" stroke-linejoin="round"><path d="M12 19V6"></path><path d="m6 11 6-6 6 6"></path></svg><span style="font-size:11px;font-weight:700;color:#3d4650">4</span><svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="#8a857a" stroke-width="2.4" stroke-linecap="round" stroke-linejoin="round"><path d="M12 5v13"></path><path d="m18 13-6 6-6-6"></path></svg></div>
+</div>
+<div style="margin-top:7px;font-size:13px;line-height:1.5;color:#3d4650">Solid content, slow pace. Could have been condensed into ten weeks easily.</div>
+<div style="margin-top:9px;font-size:11.5px;color:#8a857a">VT25 · Workload 5/10</div>
+</div>
+</div>
+</div>
+
+<div style="height:1px;background:#eae6da"></div>
+
+<div style="padding:16px 20px 20px">
+<div style="font-size:11px;font-weight:600;letter-spacing:.06em;text-transform:uppercase;color:#8a857a;margin-bottom:10px">My Page · Reviews</div>
+<div style="display:grid;grid-template-columns:1fr 1px 1fr;gap:14px">
+<div style="display:flex;flex-direction:column">
+<div style="font-size:10.5px;font-weight:600;letter-spacing:.06em;text-transform:uppercase;color:#5c6570;margin-bottom:6px">Your reviews</div>
+<div style="padding:9px 0;border-bottom:1px solid #eae6da">
+<div style="display:flex;height:5px;border-radius:3px;overflow:hidden"><div style="width:60%;background:#1751a6"></div><div style="width:40%;background:#dfa53c"></div></div>
+<div style="margin-top:7px;display:flex;align-items:center;justify-content:space-between;gap:8px">
+<div style="display:flex;align-items:center;gap:5px;font-size:10.5px;font-weight:600;color:#1c6b60"><svg width="10" height="10" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.6" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="9.5"></circle><path d="m8.5 12.2 2.4 2.4 4.6-5"></path></svg>Happy</div>
+<span style="display:flex;align-items:center;gap:3px"><svg width="10" height="10" viewBox="0 0 24 24" fill="none" stroke="#1751a6" stroke-width="2.4" stroke-linecap="round" stroke-linejoin="round"><path d="M12 19V6"></path><path d="m6 11 6-6 6 6"></path></svg><span style="font-size:10.5px;font-weight:700;color:#3d4650">12</span><svg width="10" height="10" viewBox="0 0 24 24" fill="none" stroke="#8a857a" stroke-width="2.4" stroke-linecap="round" stroke-linejoin="round"><path d="M12 5v13"></path><path d="m18 13-6 6-6-6"></path></svg></span>
+</div>
+<div style="margin-top:6px;font-size:12px;line-height:1.4;color:#3d4650">Exam-heavy but fair, plan around the problem sets.</div>
+</div>
+</div>
+<div style="background:#eae6da"></div>
+<div style="display:flex;flex-direction:column">
+<div style="font-size:10.5px;font-weight:600;letter-spacing:.06em;text-transform:uppercase;color:#5c6570;margin-bottom:6px">Liked reviews</div>
+<div style="padding:9px 0;border-bottom:1px solid #eae6da">
+<div style="display:flex;height:5px;border-radius:3px;overflow:hidden"><div style="width:70%;background:#1751a6"></div><div style="width:30%;background:#2f9e8e"></div></div>
+<div style="margin-top:7px;display:flex;align-items:center;justify-content:space-between;gap:8px">
+<div style="display:flex;align-items:center;gap:5px;font-size:10.5px;font-weight:600;color:#1c6b60"><svg width="10" height="10" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.6" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="9.5"></circle><path d="m8.5 12.2 2.4 2.4 4.6-5"></path></svg>Happy</div>
+<span style="display:flex;align-items:center;gap:3px"><svg width="10" height="10" viewBox="0 0 24 24" fill="none" stroke="#1751a6" stroke-width="2.4" stroke-linecap="round" stroke-linejoin="round"><path d="M12 19V6"></path><path d="m6 11 6-6 6 6"></path></svg><span style="font-size:10.5px;font-weight:700;color:#3d4650">7</span><svg width="10" height="10" viewBox="0 0 24 24" fill="none" stroke="#8a857a" stroke-width="2.4" stroke-linecap="round" stroke-linejoin="round"><path d="M12 5v13"></path><path d="m18 13-6 6-6-6"></path></svg></span>
+</div>
+<div style="margin-top:7px;font-size:12px;line-height:1.4;color:#3d4650">A clear grading breakdown, saved a lot of guessing.</div>
+</div>
+</div>
+</div>
+</div>
+</article>
+
+<article id="2c" style="position:relative;width:520px;flex:none;background:#fff;border-radius:14px;box-shadow:0 4px 20px rgba(20,30,45,.08);overflow:hidden">
+<div style="position:absolute;top:12px;left:12px;width:26px;height:26px;border-radius:7px;background:#1751a6;color:#fff;font-size:12px;font-weight:700;display:flex;align-items:center;justify-content:center">2c</div>
+<div style="padding:20px 20px 10px 52px;font-size:11px;font-weight:600;letter-spacing:.07em;text-transform:uppercase;color:#8a857a">Vote-led — arrows carry the margin, bars sit in the meta line</div>
+
+<div style="padding:4px 20px 20px">
+<div style="font-size:11px;font-weight:600;letter-spacing:.06em;text-transform:uppercase;color:#8a857a;margin-bottom:10px">Course details · Reviews</div>
+<div style="display:flex;flex-direction:column">
+<div style="padding:14px 0 14px 12px;border-bottom:1px solid #eae6da;border-left:3px solid #2f9e8e;display:flex;gap:12px">
+<div style="flex:1;min-width:0;display:flex;flex-direction:column">
+<div style="font-size:11.5px;font-weight:500;color:#8a857a">Student from 2024</div>
+<div style="margin-top:8px;font-size:13px;line-height:1.5;color:#3d4650">Exam-heavy but fair. The problem sets carry over almost directly, so keep up with them from week one.</div>
+<div style="margin-top:9px;display:flex;align-items:flex-end;gap:14px">
+<div style="flex:none"><div style="font-size:10.5px;color:#8a857a;margin-bottom:3px">Workload</div><div style="width:70px;height:4px;border-radius:2px;background:#eae6da;overflow:hidden"><div style="height:100%;width:80%;background:#dfa53c"></div></div></div>
+<div style="flex:none"><div style="font-size:10.5px;color:#8a857a;margin-bottom:3px">Learning</div><div style="width:70px;height:4px;border-radius:2px;background:#eae6da;overflow:hidden"><div style="height:100%;width:90%;background:#1751a6"></div></div></div>
+</div>
+<div style="margin-top:8px;text-align:right;font-size:11px;color:#a49f92">2 weeks ago</div>
+</div>
+<div style="flex:none;display:flex;align-items:center"><div style="display:flex;flex-direction:column;align-items:center;border:1px solid #eae6da;border-radius:8px;overflow:hidden"><span style="display:flex;align-items:center;justify-content:center;width:24px;height:22px;color:#1751a6"><svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.3" stroke-linecap="round" stroke-linejoin="round"><path d="M12 19V6"></path><path d="m6 11 6-6 6 6"></path></svg></span><span style="min-width:20px;text-align:center;font-size:11px;font-weight:700;color:#3d4650">12</span><span style="display:flex;align-items:center;justify-content:center;width:24px;height:22px;color:#8a857a"><svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.3" stroke-linecap="round" stroke-linejoin="round"><path d="M12 5v13"></path><path d="m18 13-6 6-6-6"></path></svg></span></div></div>
+</div>
+<div style="padding:14px 0 14px 12px;border-left:3px solid #a3452a;display:flex;gap:12px">
+<div style="flex:1;min-width:0;display:flex;flex-direction:column">
+<div style="font-size:11.5px;font-weight:500;color:#8a857a">Student from 2025</div>
+<div style="margin-top:8px;font-size:13px;line-height:1.5;color:#3d4650">Solid content, slow pace. Could have been condensed into ten weeks easily.</div>
+<div style="margin-top:9px;display:flex;align-items:flex-end;gap:14px">
+<div style="flex:none"><div style="font-size:10.5px;color:#8a857a;margin-bottom:3px">Workload</div><div style="width:70px;height:4px;border-radius:2px;background:#eae6da;overflow:hidden"><div style="height:100%;width:50%;background:#dfa53c"></div></div></div>
+<div style="flex:none"><div style="font-size:10.5px;color:#8a857a;margin-bottom:3px">Learning</div><div style="width:70px;height:4px;border-radius:2px;background:#eae6da;overflow:hidden"><div style="height:100%;width:30%;background:#1751a6"></div></div></div>
+</div>
+<div style="margin-top:8px;text-align:right;font-size:11px;color:#a49f92">1 month ago</div>
+</div>
+<div style="flex:none;display:flex;align-items:center"><div style="display:flex;flex-direction:column;align-items:center;border:1px solid #eae6da;border-radius:8px;overflow:hidden"><span style="display:flex;align-items:center;justify-content:center;width:24px;height:22px;color:#8a857a"><svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.3" stroke-linecap="round" stroke-linejoin="round"><path d="M12 19V6"></path><path d="m6 11 6-6 6 6"></path></svg></span><span style="min-width:20px;text-align:center;font-size:11px;font-weight:700;color:#3d4650">4</span><span style="display:flex;align-items:center;justify-content:center;width:24px;height:22px;color:#8a857a"><svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.3" stroke-linecap="round" stroke-linejoin="round"><path d="M12 5v13"></path><path d="m18 13-6 6-6-6"></path></svg></span></div></div>
+</div>
+</div>
+</div>
+
+<div style="height:1px;background:#eae6da"></div>
+
+<div style="padding:16px 20px 20px">
+<div style="font-size:11px;font-weight:600;letter-spacing:.06em;text-transform:uppercase;color:#8a857a;margin-bottom:10px">My Page · Reviews</div>
+<div style="display:grid;grid-template-columns:1fr 1px 1fr;gap:14px">
+<div style="display:flex;flex-direction:column">
+<div style="font-size:10.5px;font-weight:600;letter-spacing:.06em;text-transform:uppercase;color:#5c6570;margin-bottom:6px">Your reviews</div>
+<div style="padding:9px 0;border-bottom:1px solid #eae6da">
+<div style="display:flex;align-items:center;justify-content:space-between;gap:8px">
+<div style="display:flex;align-items:center;gap:5px;font-size:10.5px;font-weight:600;color:#1c6b60"><svg width="10" height="10" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.6" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="9.5"></circle><path d="m8.5 12.2 2.4 2.4 4.6-5"></path></svg>Happy</div>
+<div style="flex:none;font-size:11px;font-weight:700;color:#1751a6">▲12</div>
+</div>
+<div style="margin-top:6px;font-size:12px;line-height:1.4;color:#3d4650">Exam-heavy but fair, plan around the problem sets.</div>
+</div>
+</div>
+<div style="background:#eae6da"></div>
+<div style="display:flex;flex-direction:column">
+<div style="font-size:10.5px;font-weight:600;letter-spacing:.06em;text-transform:uppercase;color:#5c6570;margin-bottom:6px">Liked reviews</div>
+<div style="padding:9px 0;border-bottom:1px solid #eae6da">
+<div style="display:flex;align-items:center;justify-content:space-between;gap:8px">
+<div style="display:flex;align-items:center;gap:5px;font-size:10.5px;font-weight:600;color:#1c6b60"><svg width="10" height="10" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.6" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="9.5"></circle><path d="m8.5 12.2 2.4 2.4 4.6-5"></path></svg>Happy</div>
+<div style="flex:none;font-size:11px;font-weight:700;color:#1751a6">▲7</div>
+</div>
+<div style="margin-top:6px;font-size:12px;line-height:1.4;color:#3d4650">A clear grading breakdown, saved a lot of guessing.</div>
+</div>
+</div>
+</div>
+</div>
+</article>
+
+</div>
+</section>
+
+<section style="padding:40px 40px 80px;display:flex;flex-direction:column;gap:8px">
+
+<div style="font-size:13px;color:#5c6570">Three review-card layouts, each shown in both places it's reused: the course-details pane and My Page's Reviews tab (now two columns side by side with a divider).</div>
+
+<div style="margin-top:20px;display:flex;gap:28px;align-items:flex-start;flex-wrap:wrap">
+
+<article id="1a" style="position:relative;width:520px;flex:none;background:#fff;border-radius:14px;box-shadow:0 4px 20px rgba(20,30,45,.08);overflow:hidden">
+<div style="position:absolute;top:12px;left:12px;width:26px;height:26px;border-radius:7px;background:#1751a6;color:#fff;font-size:12px;font-weight:700;display:flex;align-items:center;justify-content:center">1a</div>
+<div style="padding:20px 20px 10px 52px;font-size:11px;font-weight:600;letter-spacing:.07em;text-transform:uppercase;color:#8a857a">Badge row — current style, tightened</div>
+
+<div style="padding:4px 20px 20px">
+<div style="font-size:11px;font-weight:600;letter-spacing:.06em;text-transform:uppercase;color:#8a857a;margin-bottom:8px">Course details · Reviews</div>
+<div style="display:flex;flex-direction:column;gap:10px">
+<div style="border:1px solid #eae6da;border-radius:12px;padding:14px 15px 12px">
+<div style="display:flex;align-items:center;gap:6px">
+<span style="font-size:11px;font-weight:600;padding:3px 7px;border-radius:5px;background:#e3f2ef;color:#1c6b60">Happy they took it</span>
+<span style="font-size:11px;font-weight:600;padding:3px 7px;border-radius:5px;background:#f6ecd8;color:#6b4c0d">Workload 8</span>
+</div>
+<div style="margin-top:9px;font-size:13px;line-height:1.5;color:#3d4650">Exam-heavy but fair. The problem sets carry over almost directly, so keep up with them from week one.</div>
+<div style="margin-top:10px;padding-top:9px;border-top:1px solid #eae6da;display:flex;align-items:center;justify-content:space-between;font-size:11.5px;color:#8a857a">
+<span>Elsa L. · HT24</span>
+<span style="display:flex;gap:10px;align-items:center"><span>2 weeks ago</span><span style="display:flex;align-items:center;gap:3px"><svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="#1751a6" stroke-width="2.4" stroke-linecap="round" stroke-linejoin="round"><path d="M12 19V6"></path><path d="m6 11 6-6 6 6"></path></svg><span style="font-weight:700;color:#3d4650">12</span><svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="#8a857a" stroke-width="2.4" stroke-linecap="round" stroke-linejoin="round"><path d="M12 5v13"></path><path d="m18 13-6 6-6-6"></path></svg></span></span>
+</div>
+</div>
+<div style="border:1px solid #eae6da;border-radius:12px;padding:14px 15px 12px">
+<div style="display:flex;align-items:center;gap:6px">
+<span style="font-size:11px;font-weight:600;padding:3px 7px;border-radius:5px;background:#f6ecd8;color:#6b4c0d">Not really</span>
+</div>
+<div style="margin-top:9px;font-size:13px;line-height:1.5;color:#3d4650">Solid content, slow pace. Could have been condensed into ten weeks easily.</div>
+<div style="margin-top:10px;padding-top:9px;border-top:1px solid #eae6da;display:flex;align-items:center;justify-content:space-between;font-size:11.5px;color:#8a857a">
+<span>Marcus B. · VT25</span>
+<span style="display:flex;gap:10px;align-items:center"><span>1 month ago</span><span style="display:flex;align-items:center;gap:3px"><svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="#8a857a" stroke-width="2.4" stroke-linecap="round" stroke-linejoin="round"><path d="M12 19V6"></path><path d="m6 11 6-6 6 6"></path></svg><span style="font-weight:700;color:#3d4650">4</span><svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="#8a857a" stroke-width="2.4" stroke-linecap="round" stroke-linejoin="round"><path d="M12 5v13"></path><path d="m18 13-6 6-6-6"></path></svg></span></span>
+</div>
+</div>
+</div>
+</div>
+
+<div style="height:1px;background:#eae6da"></div>
+
+<div style="padding:16px 20px 20px">
+<div style="font-size:11px;font-weight:600;letter-spacing:.06em;text-transform:uppercase;color:#8a857a;margin-bottom:8px">My Page · Reviews</div>
+<div style="display:grid;grid-template-columns:1fr 1px 1fr;gap:14px">
+<div style="display:flex;flex-direction:column;gap:8px">
+<div style="font-size:10.5px;font-weight:600;letter-spacing:.06em;text-transform:uppercase;color:#5c6570">Your reviews</div>
+<div style="border:1px solid #eae6da;border-radius:11px;padding:12px 13px 10px">
+<div style="display:flex;align-items:center;justify-content:space-between;gap:8px">
+<span style="font-size:10.5px;font-weight:600;padding:2px 6px;border-radius:4px;background:#e3f2ef;color:#1c6b60">Happy they took it</span>
+<span style="display:flex;align-items:center;gap:3px"><svg width="11" height="11" viewBox="0 0 24 24" fill="none" stroke="#1751a6" stroke-width="2.4" stroke-linecap="round" stroke-linejoin="round"><path d="M12 19V6"></path><path d="m6 11 6-6 6 6"></path></svg><span style="font-size:10.5px;font-weight:700;color:#3d4650">12</span><svg width="11" height="11" viewBox="0 0 24 24" fill="none" stroke="#8a857a" stroke-width="2.4" stroke-linecap="round" stroke-linejoin="round"><path d="M12 5v13"></path><path d="m18 13-6 6-6-6"></path></svg></span>
+</div>
+<div style="margin-top:7px;font-size:12px;line-height:1.45;color:#3d4650">Exam-heavy but fair, plan your weeks around the problem sets.</div>
+</div>
+<div style="border:1px solid #eae6da;border-radius:11px;padding:12px 13px 10px">
+<span style="font-size:10.5px;font-weight:600;padding:2px 6px;border-radius:4px;background:#f6ecd8;color:#6b4c0d">Not really</span>
+<div style="margin-top:7px;font-size:12px;line-height:1.45;color:#3d4650">Solid content, could be condensed.</div>
+</div>
+</div>
+<div style="background:#eae6da"></div>
+<div style="display:flex;flex-direction:column;gap:8px">
+<div style="font-size:10.5px;font-weight:600;letter-spacing:.06em;text-transform:uppercase;color:#5c6570">Liked reviews</div>
+<div style="border:1px solid #eae6da;border-radius:11px;padding:12px 13px 10px">
+<div style="display:flex;align-items:center;justify-content:space-between;gap:8px">
+<span style="font-size:10.5px;font-weight:600;padding:2px 6px;border-radius:4px;background:#e3f2ef;color:#1c6b60">Happy they took it</span>
+<span style="display:flex;align-items:center;gap:3px"><svg width="11" height="11" viewBox="0 0 24 24" fill="none" stroke="#1751a6" stroke-width="2.4" stroke-linecap="round" stroke-linejoin="round"><path d="M12 19V6"></path><path d="m6 11 6-6 6 6"></path></svg><span style="font-size:10.5px;font-weight:700;color:#3d4650">7</span><svg width="11" height="11" viewBox="0 0 24 24" fill="none" stroke="#8a857a" stroke-width="2.4" stroke-linecap="round" stroke-linejoin="round"><path d="M12 5v13"></path><path d="m18 13-6 6-6-6"></path></svg></span>
+</div>
+<div style="margin-top:7px;font-size:12px;line-height:1.45;color:#3d4650">A clear breakdown of the grading, saved me a lot of guessing.</div>
+</div>
+</div>
+</div>
+</div>
+</article>
+
+<article id="1b" style="position:relative;width:520px;flex:none;background:#fff;border-radius:14px;box-shadow:0 4px 20px rgba(20,30,45,.08);overflow:hidden">
+<div style="position:absolute;top:12px;left:12px;width:26px;height:26px;border-radius:7px;background:#1751a6;color:#fff;font-size:12px;font-weight:700;display:flex;align-items:center;justify-content:center">1b</div>
+<div style="padding:20px 20px 10px 52px;font-size:11px;font-weight:600;letter-spacing:.07em;text-transform:uppercase;color:#8a857a">Quote lead — text first, meta compact</div>
+
+<div style="padding:4px 20px 20px">
+<div style="font-size:11px;font-weight:600;letter-spacing:.06em;text-transform:uppercase;color:#8a857a;margin-bottom:8px">Course details · Reviews</div>
+<div style="display:flex;flex-direction:column;gap:10px">
+<div style="border:1px solid #eae6da;border-radius:12px;padding:16px 16px 12px;position:relative;border-left:3px solid #2f9e8e">
+<div style="display:flex;align-items:center;gap:5px;font-size:11px;font-weight:600;color:#1c6b60"><svg width="11" height="11" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.6" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="9.5"></circle><path d="m8.5 12.2 2.4 2.4 4.6-5"></path></svg>Happy they took it</div>
+<div style="margin-top:9px;font-size:13.5px;line-height:1.5;color:#16202b">Exam-heavy but fair. The problem sets carry over almost directly, so keep up with them from week one.</div>
+<div style="margin-top:11px;display:flex;align-items:center;justify-content:space-between;font-size:11.5px;color:#8a857a">
+<span>Elsa L. · DD2380 · HT24</span>
+<span style="display:flex;align-items:center;border:1px solid #eae6da;border-radius:8px;overflow:hidden"><span style="display:flex;align-items:center;justify-content:center;width:24px;height:22px;color:#1751a6"><svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.3" stroke-linecap="round" stroke-linejoin="round"><path d="M12 19V6"></path><path d="m6 11 6-6 6 6"></path></svg></span><span style="min-width:20px;text-align:center;font-size:11px;font-weight:700;color:#3d4650">12</span><span style="display:flex;align-items:center;justify-content:center;width:24px;height:22px;color:#8a857a"><svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.3" stroke-linecap="round" stroke-linejoin="round"><path d="M12 5v13"></path><path d="m18 13-6 6-6-6"></path></svg></span></span>
+</div>
+</div>
+<div style="border:1px solid #eae6da;border-radius:12px;padding:16px 16px 12px;position:relative;border-left:3px solid #dfa53c">
+<div style="display:flex;align-items:center;gap:5px;font-size:11px;font-weight:600;color:#a3452a"><svg width="11" height="11" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.6" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="9.5"></circle><path d="M8.5 8.5l7 7M15.5 8.5l-7 7"></path></svg>Not really</div>
+<div style="margin-top:9px;font-size:13.5px;line-height:1.5;color:#16202b">Solid content, slow pace. Could have been condensed into ten weeks easily.</div>
+<div style="margin-top:11px;display:flex;align-items:center;justify-content:space-between;font-size:11.5px;color:#8a857a">
+<span>Marcus B. · DD2380 · VT25</span>
+<span style="display:flex;align-items:center;border:1px solid #eae6da;border-radius:8px;overflow:hidden"><span style="display:flex;align-items:center;justify-content:center;width:24px;height:22px;color:#8a857a"><svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.3" stroke-linecap="round" stroke-linejoin="round"><path d="M12 19V6"></path><path d="m6 11 6-6 6 6"></path></svg></span><span style="min-width:20px;text-align:center;font-size:11px;font-weight:700;color:#3d4650">4</span><span style="display:flex;align-items:center;justify-content:center;width:24px;height:22px;color:#8a857a"><svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.3" stroke-linecap="round" stroke-linejoin="round"><path d="M12 5v13"></path><path d="m18 13-6 6-6-6"></path></svg></span></span>
+</div>
+</div>
+</div>
+</div>
+
+<div style="height:1px;background:#eae6da"></div>
+
+<div style="padding:16px 20px 20px">
+<div style="font-size:11px;font-weight:600;letter-spacing:.06em;text-transform:uppercase;color:#8a857a;margin-bottom:8px">My Page · Reviews</div>
+<div style="display:grid;grid-template-columns:1fr 1px 1fr;gap:14px">
+<div style="display:flex;flex-direction:column;gap:8px">
+<div style="font-size:10.5px;font-weight:600;letter-spacing:.06em;text-transform:uppercase;color:#5c6570">Your reviews</div>
+<div style="border:1px solid #eae6da;border-left:3px solid #2f9e8e;border-radius:11px;padding:11px 12px 9px">
+<div style="display:flex;align-items:center;justify-content:space-between;gap:8px">
+<div style="display:flex;align-items:center;gap:5px;font-size:10.5px;font-weight:600;color:#1c6b60"><svg width="10" height="10" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.6" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="9.5"></circle><path d="m8.5 12.2 2.4 2.4 4.6-5"></path></svg>Happy</div>
+<span style="display:flex;align-items:center;gap:3px"><svg width="10" height="10" viewBox="0 0 24 24" fill="none" stroke="#1751a6" stroke-width="2.4" stroke-linecap="round" stroke-linejoin="round"><path d="M12 19V6"></path><path d="m6 11 6-6 6 6"></path></svg><span style="font-size:10.5px;font-weight:700;color:#3d4650">12</span><svg width="10" height="10" viewBox="0 0 24 24" fill="none" stroke="#8a857a" stroke-width="2.4" stroke-linecap="round" stroke-linejoin="round"><path d="M12 5v13"></path><path d="m18 13-6 6-6-6"></path></svg></span>
+</div>
+<div style="margin-top:7px;font-size:12px;line-height:1.45;color:#16202b">Exam-heavy but fair, plan your weeks around the problem sets.</div>
+<div style="margin-top:7px;font-size:10.5px;color:#8a857a">DD2380 · HT24</div>
+</div>
+<div style="border:1px solid #eae6da;border-left:3px solid #dfa53c;border-radius:11px;padding:11px 12px 9px">
+<div style="font-size:12px;line-height:1.45;color:#16202b">Solid content, could be condensed.</div>
+<div style="margin-top:7px;font-size:10.5px;color:#8a857a">DD2380 · VT25</div>
+</div>
+</div>
+<div style="background:#eae6da"></div>
+<div style="display:flex;flex-direction:column;gap:8px">
+<div style="font-size:10.5px;font-weight:600;letter-spacing:.06em;text-transform:uppercase;color:#5c6570">Liked reviews</div>
+<div style="border:1px solid #eae6da;border-left:3px solid #2f9e8e;border-radius:11px;padding:11px 12px 9px">
+<div style="display:flex;align-items:center;justify-content:space-between;gap:8px">
+<div style="display:flex;align-items:center;gap:5px;font-size:10.5px;font-weight:600;color:#1c6b60"><svg width="10" height="10" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.6" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="9.5"></circle><path d="m8.5 12.2 2.4 2.4 4.6-5"></path></svg>Happy</div>
+<span style="display:flex;align-items:center;gap:3px"><svg width="10" height="10" viewBox="0 0 24 24" fill="none" stroke="#1751a6" stroke-width="2.4" stroke-linecap="round" stroke-linejoin="round"><path d="M12 19V6"></path><path d="m6 11 6-6 6 6"></path></svg><span style="font-size:10.5px;font-weight:700;color:#3d4650">7</span><svg width="10" height="10" viewBox="0 0 24 24" fill="none" stroke="#8a857a" stroke-width="2.4" stroke-linecap="round" stroke-linejoin="round"><path d="M12 5v13"></path><path d="m18 13-6 6-6-6"></path></svg></span>
+</div>
+<div style="margin-top:7px;font-size:12px;line-height:1.45;color:#16202b">A clear breakdown of the grading, saved me a lot of guessing.</div>
+<div style="margin-top:7px;font-size:10.5px;color:#8a857a">SF1624 · HT24</div>
+</div>
+</div>
+</div>
+</div>
+</article>
+
+<article id="1c" style="position:relative;width:520px;flex:none;background:#fff;border-radius:14px;box-shadow:0 4px 20px rgba(20,30,45,.08);overflow:hidden">
+<div style="position:absolute;top:12px;left:12px;width:26px;height:26px;border-radius:7px;background:#1751a6;color:#fff;font-size:12px;font-weight:700;display:flex;align-items:center;justify-content:center">1c</div>
+<div style="padding:20px 20px 10px 52px;font-size:11px;font-weight:600;letter-spacing:.07em;text-transform:uppercase;color:#8a857a">Split rail — checkmark glyph, upvote/downvote footer</div>
+
+<div style="padding:4px 20px 20px">
+<div style="font-size:11px;font-weight:600;letter-spacing:.06em;text-transform:uppercase;color:#8a857a;margin-bottom:8px">Course details · Reviews</div>
+<div style="display:flex;flex-direction:column;gap:10px">
+<div style="border:1px solid #eae6da;border-radius:12px;display:flex;overflow:hidden">
+<div style="flex:none;width:54px;background:#f0f6f4;display:flex;flex-direction:column;align-items:center;gap:6px;padding:12px 0 10px">
+<svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="#1c6b60" stroke-width="2.1" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="9.5"></circle><path d="m8.5 12.2 2.4 2.4 4.6-5"></path></svg>
+<span style="font-size:10.5px;font-weight:700;color:#6b4c0d">8/10</span>
+</div>
+<div style="flex:1;min-width:0;padding:13px 14px 11px">
+<div style="font-size:13px;line-height:1.5;color:#3d4650">Exam-heavy but fair. The problem sets carry over almost directly, so keep up with them from week one.</div>
+<div style="margin-top:9px;display:flex;align-items:center;justify-content:space-between;gap:12px">
+<span style="font-size:11.5px;color:#8a857a">Elsa L. · HT24 · 2 weeks ago</span>
+<div style="flex:none;display:flex;align-items:center;border:1px solid #eae6da;border-radius:8px;overflow:hidden">
+<div style="display:flex;align-items:center;justify-content:center;width:26px;height:24px;color:#1751a6"><svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.3" stroke-linecap="round" stroke-linejoin="round"><path d="M12 19V6"></path><path d="m6 11 6-6 6 6"></path></svg></div>
+<span style="min-width:22px;text-align:center;font-size:11.5px;font-weight:700;color:#3d4650">12</span>
+<div style="display:flex;align-items:center;justify-content:center;width:26px;height:24px;color:#8a857a"><svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.3" stroke-linecap="round" stroke-linejoin="round"><path d="M12 5v13"></path><path d="m18 13-6 6-6-6"></path></svg></div>
+</div>
+</div>
+</div>
+</div>
+<div style="border:1px solid #eae6da;border-radius:12px;display:flex;overflow:hidden">
+<div style="flex:none;width:54px;background:#fbeceb;display:flex;flex-direction:column;align-items:center;gap:6px;padding:12px 0 10px">
+<svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="#a3452a" stroke-width="2.1" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="9.5"></circle><path d="M8.5 8.5l7 7M15.5 8.5l-7 7"></path></svg>
+<span style="font-size:10.5px;font-weight:700;color:#6b4c0d">5/10</span>
+</div>
+<div style="flex:1;min-width:0;padding:13px 14px 11px">
+<div style="font-size:13px;line-height:1.5;color:#3d4650">Solid content, slow pace. Could have been condensed into ten weeks easily.</div>
+<div style="margin-top:9px;display:flex;align-items:center;justify-content:space-between;gap:12px">
+<span style="font-size:11.5px;color:#8a857a">Marcus B. · VT25 · 1 month ago</span>
+<div style="flex:none;display:flex;align-items:center;border:1px solid #eae6da;border-radius:8px;overflow:hidden">
+<div style="display:flex;align-items:center;justify-content:center;width:26px;height:24px;color:#8a857a"><svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.3" stroke-linecap="round" stroke-linejoin="round"><path d="M12 19V6"></path><path d="m6 11 6-6 6 6"></path></svg></div>
+<span style="min-width:22px;text-align:center;font-size:11.5px;font-weight:700;color:#3d4650">4</span>
+<div style="display:flex;align-items:center;justify-content:center;width:26px;height:24px;color:#8a857a"><svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.3" stroke-linecap="round" stroke-linejoin="round"><path d="M12 5v13"></path><path d="m18 13-6 6-6-6"></path></svg></div>
+</div>
+</div>
+</div>
+</div>
+</div>
+</div>
+
+<div style="height:1px;background:#eae6da"></div>
+
+<div style="padding:16px 20px 20px">
+<div style="font-size:11px;font-weight:600;letter-spacing:.06em;text-transform:uppercase;color:#8a857a;margin-bottom:8px">My Page · Reviews</div>
+<div style="display:grid;grid-template-columns:1fr 1px 1fr;gap:14px">
+<div style="display:flex;flex-direction:column;gap:8px">
+<div style="font-size:10.5px;font-weight:600;letter-spacing:.06em;text-transform:uppercase;color:#5c6570">Your reviews</div>
+<div style="border:1px solid #eae6da;border-radius:11px;display:flex;overflow:hidden">
+<div style="flex:none;width:36px;background:#f0f6f4;display:flex;align-items:center;justify-content:center"><svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="#1c6b60" stroke-width="2.1" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="9.5"></circle><path d="m8.5 12.2 2.4 2.4 4.6-5"></path></svg></div>
+<div style="flex:1;min-width:0;padding:9px 11px;display:flex;align-items:center;justify-content:space-between;gap:8px">
+<div style="font-size:12px;line-height:1.4;color:#3d4650">Exam-heavy but fair, plan around the problem sets.</div>
+<div style="flex:none;display:flex;align-items:center;gap:4px;font-size:11px;font-weight:700;color:#8a857a"><svg width="11" height="11" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="M12 19V6"></path><path d="m6 11 6-6 6 6"></path></svg>12</div>
+</div>
+</div>
+</div>
+<div style="background:#eae6da"></div>
+<div style="display:flex;flex-direction:column;gap:8px">
+<div style="font-size:10.5px;font-weight:600;letter-spacing:.06em;text-transform:uppercase;color:#5c6570">Liked reviews</div>
+<div style="border:1px solid #eae6da;border-radius:11px;display:flex;overflow:hidden">
+<div style="flex:none;width:36px;background:#f0f6f4;display:flex;align-items:center;justify-content:center"><svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="#1c6b60" stroke-width="2.1" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="9.5"></circle><path d="m8.5 12.2 2.4 2.4 4.6-5"></path></svg></div>
+<div style="flex:1;min-width:0;padding:9px 11px;display:flex;align-items:center;justify-content:space-between;gap:8px">
+<div style="font-size:12px;line-height:1.4;color:#3d4650">A clear grading breakdown, saved a lot of guessing.</div>
+<div style="flex:none;display:flex;align-items:center;gap:4px;font-size:11px;font-weight:700;color:#8a857a"><svg width="11" height="11" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="M12 19V6"></path><path d="m6 11 6-6 6 6"></path></svg>7</div>
+</div>
+</div>
+</div>
+</div>
+</div>
+</article>
+
+</div>
+</section>
+
+</x-dc>
+</body>
+</html>

--- a/docs/design/reference/Course Community - Unreviewed Card Options.dc.html
+++ b/docs/design/reference/Course Community - Unreviewed Card Options.dc.html
@@ -1,0 +1,146 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<script src="./support.js"></script>
+</head>
+<body>
+<x-dc>
+<helmet data-dc-atomics><meta name="design_doc_mode" content="canvas"><link rel="preconnect" href="https://fonts.googleapis.com"><link rel="preconnect" href="https://fonts.gstatic.com" crossorigin><link href="https://fonts.googleapis.com/css2?family=Geist:wght@400;500;600;700&family=Geist+Mono:wght@400;500&display=swap" rel="stylesheet"><link rel="stylesheet" href="cc-theme.css"><style>body{margin:0;background:var(--pg);color:var(--ink);font-family:Geist,system-ui,sans-serif;font-size:14px}a{color:var(--brand)}a:hover{color:#10386f}</style></helmet>
+
+<section style="padding:40px 44px 44px">
+<div style="display:flex;align-items:baseline;gap:10px;margin-bottom:6px">
+<span style="font:600 10px ui-monospace,Menlo,monospace;padding:3px 7px;background:var(--ink);color:var(--pg);border-radius:4px">1</span>
+<span style="font-size:13px;font-weight:600">Unreviewed courses — bullet list with the fast track on the right</span>
+</div>
+<div style="font-size:12.5px;color:var(--muted);max-width:620px">One component for My Page and Taken courses. Same data in all three: five courses with no review yet.</div>
+
+<div style="margin-top:26px;display:flex;flex-wrap:wrap;gap:28px;align-items:flex-start">
+
+<div id="1a" style="flex:none;width:600px;display:flex;flex-direction:column;gap:9px;scroll-margin-top:16px">
+<div style="display:flex;align-items:baseline;gap:8px">
+<span style="font:600 10.5px ui-monospace,Menlo,monospace;padding:3px 7px;background:var(--pill);color:var(--ink);border-radius:5px">1a</span>
+<span style="font-size:11px;color:var(--muted)">Bulleted rows, one Review per course</span>
+</div>
+<div style="box-sizing:border-box;width:100%;border:1px solid var(--rule);border-radius:12px;background:var(--surface);padding:15px 16px 8px">
+<div style="display:flex;align-items:baseline;justify-content:space-between;gap:12px">
+<div style="font-size:10.5px;font-weight:600;letter-spacing:.09em;text-transform:uppercase;color:var(--dim)">Still unreviewed</div>
+<div style="font-size:12px;color:var(--dim2)">{{ countLabel }}</div>
+</div>
+<div style="margin-top:10px">
+<sc-for list="{{ courses }}" as="c" hint-placeholder-count="5">
+<div style="display:flex;align-items:center;gap:11px;padding:9px 0;border-bottom:1px solid var(--rule)">
+<span style="flex:none;width:5px;height:5px;border-radius:50%;background:var(--rule3)"></span>
+<span style="flex:none;font:500 12px Geist Mono,ui-monospace,monospace;color:var(--brand)">{{ c.code }}</span>
+<span style="flex:1;min-width:0;font-size:13.5px;overflow:hidden;text-overflow:ellipsis;white-space:nowrap">{{ c.name }}</span>
+<span style="flex:none;font-size:12px;color:var(--dim2);font-variant-numeric:tabular-nums">{{ c.term }}</span>
+<div style="flex:none;display:flex;align-items:center;gap:6px;height:28px;padding:0 11px;border-radius:8px;border:1px solid var(--rule3);background:var(--surface);font-size:12px;font-weight:500;color:var(--brand);cursor:pointer" style-hover="border-color:var(--hov);background:var(--pill)">Review</div>
+</div>
+</sc-for>
+</div>
+<div style="display:flex;align-items:center;justify-content:space-between;gap:12px;padding:11px 0 10px">
+<div style="font-size:12.5px;color:var(--muted)">Two minutes each, or run them back to back.</div>
+<div style="display:flex;align-items:center;gap:7px;height:32px;padding:0 13px;border-radius:8px;background:var(--btn);color:var(--btnFg);font-size:12.5px;font-weight:600;cursor:pointer" style-hover="opacity:.9">{{ fastTrackLabel }}</div>
+</div>
+</div>
+</div>
+
+<div id="1b" style="flex:none;width:600px;display:flex;flex-direction:column;gap:9px;scroll-margin-top:16px">
+<div style="display:flex;align-items:baseline;gap:8px">
+<span style="font:600 10.5px ui-monospace,Menlo,monospace;padding:3px 7px;background:var(--pill);color:var(--ink);border-radius:5px">1b</span>
+<span style="font-size:11px;color:var(--muted)">Plain bullets, one fast-track button beside the heading</span>
+</div>
+<div style="box-sizing:border-box;width:100%;border:1px solid var(--rule);border-radius:12px;background:var(--surface);padding:16px 17px 15px">
+<div style="display:flex;flex-wrap:wrap;align-items:center;justify-content:space-between;gap:12px 16px">
+<div style="min-width:200px;flex:1">
+<div style="font-size:15px;font-weight:600">{{ headline }}</div>
+<div style="margin-top:4px;font-size:12.5px;color:var(--muted)">Your reviews are what the next student reads.</div>
+</div>
+<div style="flex:none;display:flex;align-items:center;gap:8px;height:38px;padding:0 16px;border-radius:9px;background:var(--btn);color:var(--btnFg);font-size:13px;font-weight:600;cursor:pointer" style-hover="opacity:.9"><svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linejoin="round"><path d="M21 12a8 8 0 0 1-8 8H4l2-3.2A8 8 0 1 1 21 12z"></path></svg>Open the fast track</div>
+</div>
+<div style="margin-top:13px;padding-top:13px;border-top:1px solid var(--rule);display:flex;flex-direction:column;gap:7px">
+<sc-for list="{{ courses }}" as="c" hint-placeholder-count="5">
+<div style="display:flex;align-items:center;gap:10px">
+<span style="flex:none;width:4px;height:4px;border-radius:50%;background:var(--brand);opacity:.5"></span>
+<span style="flex:none;font:500 12px Geist Mono,ui-monospace,monospace;color:var(--brand)">{{ c.code }}</span>
+<span style="flex:1;min-width:0;font-size:13px;color:var(--ink2);overflow:hidden;text-overflow:ellipsis;white-space:nowrap">{{ c.name }}</span>
+<span style="flex:none;font-size:12px;font-weight:500;color:var(--brand);cursor:pointer" style-hover="text-decoration:underline">Review</span>
+</div>
+</sc-for>
+</div>
+</div>
+</div>
+
+<div id="1c" style="flex:none;width:600px;display:flex;flex-direction:column;gap:9px;scroll-margin-top:16px">
+<div style="display:flex;align-items:baseline;gap:8px">
+<span style="font:600 10.5px ui-monospace,Menlo,monospace;padding:3px 7px;background:var(--pill);color:var(--ink);border-radius:5px">1c</span>
+<span style="font-size:11px;color:var(--muted)">No card, hairline rows, arrow action</span>
+</div>
+<div style="box-sizing:border-box;width:100%">
+<div style="display:flex;align-items:baseline;justify-content:space-between;gap:12px;padding-bottom:9px">
+<div style="font-size:10.5px;font-weight:600;letter-spacing:.09em;text-transform:uppercase;color:var(--dim)">Still unreviewed · {{ pendingCount }}</div>
+<div style="display:flex;align-items:center;gap:6px;font-size:12.5px;font-weight:500;color:var(--brand);cursor:pointer" style-hover="text-decoration:underline">Fast track all<svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M5 12h13"></path><path d="m12.5 5.5 6.5 6.5-6.5 6.5"></path></svg></div>
+</div>
+<div style="border-top:1px solid var(--rule)">
+<sc-for list="{{ courses }}" as="c" hint-placeholder-count="5">
+<div style="display:flex;align-items:center;gap:12px;padding:11px 8px;border-bottom:1px solid var(--rule);cursor:pointer" style-hover="background:var(--surface)">
+<span style="flex:none;font:500 12px Geist Mono,ui-monospace,monospace;color:var(--brand);width:64px">{{ c.code }}</span>
+<span style="flex:1;min-width:0;font-size:13.5px;overflow:hidden;text-overflow:ellipsis;white-space:nowrap">{{ c.name }}</span>
+<span style="flex:none;font-size:12px;color:var(--dim2)">{{ c.term }}</span>
+<span style="flex:none;display:flex;align-items:center;gap:5px;font-size:12px;font-weight:500;color:var(--brand)">Review<svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M5 12h13"></path><path d="m12.5 5.5 6.5 6.5-6.5 6.5"></path></svg></span>
+</div>
+</sc-for>
+</div>
+</div>
+</div>
+
+</div>
+</section>
+
+</x-dc>
+<script type="text/x-dc" data-dc-script data-props="{&quot;$preview&quot;:{&quot;width&quot;:1360,&quot;height&quot;:620}}">
+/* Three treatments of the same list, drawn from the real store so the widths
+   and code lengths are honest. */
+const FALLBACK = [
+  { code: "DD2424", name: "Deep Learning in Data Science", term: "HT25" },
+  { code: "SF1918", name: "Probability and Statistics", term: "HT25" },
+  { code: "AK2030", name: "Theory and Methodology of Science", term: "VT26" },
+  { code: "DD1338", name: "Algorithms and Data Structures", term: "VT25" },
+  { code: "ME2053", name: "Project Management", term: "VT26" }
+];
+
+class Component extends DCLogic {
+  state = { courses: FALLBACK, taken: 12 };
+
+  componentDidMount() {
+    import("./cc-store.js").then((S) => {
+      const locale = "en";
+      const reviewed = {};
+      S.reviewsByUser("u1").forEach((r) => { reviewed[r.courseCode] = true; });
+      const rows = S.takenCourses("u1")
+        .filter((r) => !reviewed[r.courseCode])
+        .map((r) => {
+          const v = S.takenView(r, { locale });
+          return { code: r.courseCode, name: v.name || r.courseCode, term: S.termLabel(r.attendanceYear) };
+        })
+        .slice(0, 5);
+      if (rows.length) this.setState({ courses: rows, taken: S.takenCourses("u1").length });
+    });
+  }
+
+  renderVals() {
+    const n = this.state.courses.length;
+    return {
+      courses: this.state.courses,
+      pendingCount: n,
+      countLabel: n + " of " + this.state.taken + " courses",
+      headline: n === 1 ? "One course has no review yet" : n + " courses have no review yet",
+      fastTrackLabel: n === 1 ? "Fast track it" : "Fast track all " + n
+    };
+  }
+}
+
+</script>
+</body>
+</html>

--- a/docs/design/support.js
+++ b/docs/design/support.js
@@ -1,0 +1,1911 @@
+// GENERATED from dc-runtime/src/*.ts — do not edit. Rebuild with `cd dc-runtime && bun run build`.
+"use strict";
+(() => {
+  var __defProp = Object.defineProperty;
+  var __defNormalProp = (obj, key, value) => key in obj ? __defProp(obj, key, { enumerable: true, configurable: true, writable: true, value }) : obj[key] = value;
+  var __publicField = (obj, key, value) => __defNormalProp(obj, typeof key !== "symbol" ? key + "" : key, value);
+
+  // src/react.ts
+  function getReact() {
+    const R = window.React;
+    if (!R) throw new Error("dc-runtime: window.React is not available yet");
+    return R;
+  }
+  function getReactDOM() {
+    const RD = window.ReactDOM;
+    if (!RD) throw new Error("dc-runtime: window.ReactDOM is not available yet");
+    return RD;
+  }
+  var h = ((...args) => getReact().createElement(
+    ...args
+  ));
+
+  // src/parse.ts
+  function parseDcDocument(doc) {
+    const dc = doc.querySelector("x-dc");
+    if (!dc) return null;
+    const scriptEl = doc.querySelector("script[data-dc-script]");
+    const { props, preview } = parseDataProps(
+      scriptEl?.getAttribute("data-props") ?? null
+    );
+    return {
+      template: dc.innerHTML,
+      js: scriptEl ? scriptEl.textContent || "" : "",
+      props,
+      preview
+    };
+  }
+  function parseDcText(src) {
+    const openMatch = /<x-dc(?:\s[^>]*)?>/.exec(src);
+    if (!openMatch) return null;
+    const close = src.lastIndexOf("</x-dc>");
+    if (close === -1 || close < openMatch.index) return null;
+    const template = src.slice(openMatch.index + openMatch[0].length, close);
+    const doc = new DOMParser().parseFromString(src, "text/html");
+    const scriptEl = doc.querySelector("script[data-dc-script]");
+    const { props, preview } = parseDataProps(
+      scriptEl?.getAttribute("data-props") ?? null
+    );
+    return {
+      template,
+      js: scriptEl ? scriptEl.textContent || "" : "",
+      props,
+      preview
+    };
+  }
+  function parseDataProps(raw) {
+    if (!raw) return { props: null, preview: null };
+    let parsed;
+    try {
+      parsed = JSON.parse(raw);
+    } catch {
+      return { props: null, preview: null };
+    }
+    if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+      return { props: null, preview: null };
+    }
+    const obj = parsed;
+    const preview = obj.$preview && typeof obj.$preview === "object" ? obj.$preview : null;
+    const rest = {};
+    for (const k of Object.keys(obj)) {
+      if (k[0] !== "$") rest[k] = obj[k];
+    }
+    return { props: Object.keys(rest).length ? rest : null, preview };
+  }
+  function dcNameFromPath(pathname) {
+    let p = pathname || "";
+    try {
+      p = decodeURIComponent(p);
+    } catch {
+    }
+    const base = p.split("/").pop() || "Root";
+    return base.replace(/\.dc\.html$/, "").replace(/\.html?$/, "") || "Root";
+  }
+
+  // src/boot.ts
+  var BASE_CSS = `
+    .sc-placeholder{background:color-mix(in srgb,currentColor 8%,transparent);
+      border:1px solid color-mix(in srgb,currentColor 50%,transparent);
+      border-radius:2px;box-sizing:border-box;overflow:hidden}
+    @keyframes sc-shine{0%{background-position:100% 50%}100%{background-position:0% 50%}}
+    html.sc-dc-streaming .sc-placeholder,
+    html.sc-dc-streaming .sc-interp.sc-missing{position:relative;
+      background:color-mix(in srgb,currentColor 5%,transparent);
+      border-color:transparent}
+    html.sc-dc-streaming .sc-placeholder::before,
+    html.sc-dc-streaming .sc-interp.sc-missing::before{content:'';
+      position:absolute;inset:0;pointer-events:none;
+      background:linear-gradient(90deg,rgba(217,119,87,0) 25%,rgba(247,225,211,.95) 37%,rgba(217,119,87,0) 63%);
+      background-size:400% 100%;animation:sc-shine 1.4s ease infinite}
+    html.sc-dc-streaming .sc-placeholder:nth-child(n+9 of .sc-placeholder)::before,
+    html.sc-dc-streaming .sc-interp.sc-missing:nth-child(n+9 of .sc-interp.sc-missing)::before{animation:none;
+      background:color-mix(in srgb,currentColor 8%,transparent)}
+    .sc-placeholder-error{padding:4px 8px;font:11px/1.4 ui-monospace,monospace;
+      color:color-mix(in srgb,currentColor 70%,transparent);word-break:break-word}
+    .sc-interp.sc-missing{display:inline-block;width:2em;height:1em;overflow:hidden;
+      vertical-align:text-bottom;background:rgba(255,255,255,.3);border:1px solid rgba(0,0,0,.5);
+      border-radius:2px;box-sizing:border-box;color:transparent;
+      user-select:none}
+    .sc-interp.sc-unresolved{font-family:ui-monospace,monospace;font-size:.85em;
+      color:color-mix(in srgb,currentColor 50%,transparent);
+      background:color-mix(in srgb,currentColor 10%,transparent);border-radius:3px;
+      padding:0 3px}
+    .sc-host.sc-has-error{position:relative}
+    .sc-logic-error{position:absolute;top:8px;left:8px;z-index:2147483647;max-width:60ch;
+      padding:6px 10px;background:#b00020;color:#fff;font:12px/1.4 ui-monospace,monospace;
+      border-radius:4px;white-space:pre-wrap;pointer-events:none}
+    /* Mirrors PRINT_BASELINE_CSS in apps/web deck-stage-export.ts \u2014 keep both
+       in sync until dc-runtime regains a build step. */
+    @media print {
+      @page { margin: 0.5cm; }
+      figure, table { break-inside: avoid; }
+      #dc-root, #dc-root > .sc-host { height: auto; }
+      *, *::before, *::after {
+        print-color-adjust: exact; -webkit-print-color-adjust: exact;
+        backdrop-filter: none !important; -webkit-backdrop-filter: none !important;
+        animation-delay: -99s !important; animation-duration: .001s !important;
+        animation-iteration-count: 1 !important; animation-fill-mode: both !important;
+        animation-play-state: running !important; transition-duration: 0s !important;
+      }
+    }
+  `;
+  var FULL_PAGE_CSS = "html,body{height:100%;margin:0}#dc-root,#dc-root>.sc-host{height:100%}";
+  function rootNameForDocument(doc, loc) {
+    let bootPath = loc.pathname || "";
+    if (!/\.dc\.html?$/i.test(safeDecode(bootPath))) {
+      try {
+        bootPath = new URL(doc.baseURI || "/").pathname;
+      } catch {
+      }
+    }
+    return dcNameFromPath(bootPath);
+  }
+  function safeDecode(s) {
+    try {
+      return decodeURIComponent(s);
+    } catch {
+      return s;
+    }
+  }
+  function boot(runtime, doc = document) {
+    const parsed = parseDcDocument(doc);
+    if (!parsed) return null;
+    const React = getReact();
+    const rootName = rootNameForDocument(doc, location);
+    runtime.markFetched(rootName);
+    runtime.setRootName(rootName);
+    runtime.adoptParsed(rootName, parsed);
+    if (!window.__resources) {
+      fetch(location.href).then((res) => res.ok ? res.text() : "").then((t) => {
+        const raw = t ? parseDcText(t) : null;
+        if (raw?.template) runtime.updateHtml(rootName, raw.template);
+      }).catch(() => {
+      });
+    }
+    const dc = doc.querySelector("x-dc");
+    const hostEl = doc.createElement("div");
+    hostEl.id = "dc-root";
+    dc.replaceWith(hostEl);
+    if (!parsed.preview) {
+      const s = doc.createElement("style");
+      s.textContent = FULL_PAGE_CSS;
+      doc.head.appendChild(s);
+    }
+    const Root = runtime.getDC(rootName);
+    const entry = runtime.registry.get(rootName);
+    function StandaloneRoot() {
+      const [, setTick] = React.useState(0);
+      React.useEffect(() => {
+        const sub = () => setTick((n) => n + 1);
+        entry.subs.add(sub);
+        return () => {
+          entry.subs.delete(sub);
+        };
+      }, []);
+      const defaults = React.useMemo(() => {
+        const d = {};
+        for (const k in entry.propsMeta || {}) {
+          const v = entry.propsMeta?.[k]?.default;
+          if (v !== void 0) d[k] = v;
+        }
+        return d;
+      }, [entry.propsMeta]);
+      return h(Root, { ...defaults, ...entry.propOverrides || {} });
+    }
+    const ReactDOM = getReactDOM();
+    if (ReactDOM.createRoot)
+      ReactDOM.createRoot(hostEl).render(h(StandaloneRoot));
+    else ReactDOM.render(h(StandaloneRoot), hostEl);
+    return rootName;
+  }
+
+  // src/expr.ts
+  var IDENT_RE = /^[A-Za-z_$][A-Za-z0-9_$]*/;
+  var NUMBER_RE = /^-?\d+(\.\d+)?$/;
+  function resolve(vals, src) {
+    const expr = String(src).trim();
+    if (!expr) return void 0;
+    if (expr[0] === "(" && expr[expr.length - 1] === ")" && parensWrapWhole(expr)) {
+      return resolve(vals, expr.slice(1, -1));
+    }
+    const eq = findTopLevelEquality(expr);
+    if (eq) {
+      const lv = resolve(vals, expr.slice(0, eq.index));
+      const rv = resolve(vals, expr.slice(eq.index + eq.op.length));
+      switch (eq.op) {
+        case "===":
+          return lv === rv;
+        case "!==":
+          return lv !== rv;
+        case "==":
+          return lv == rv;
+        default:
+          return lv != rv;
+      }
+    }
+    if (expr[0] === "!") return !resolve(vals, expr.slice(1));
+    if (expr === "true") return true;
+    if (expr === "false") return false;
+    if (expr === "null") return null;
+    if (expr === "undefined") return void 0;
+    if (NUMBER_RE.test(expr)) return Number(expr);
+    if (expr.length >= 2 && (expr[0] === '"' || expr[0] === "'") && expr[expr.length - 1] === expr[0]) {
+      return expr.slice(1, -1);
+    }
+    return resolvePath(vals, expr);
+  }
+  function parensWrapWhole(expr) {
+    let depth = 0;
+    for (let i = 0; i < expr.length - 1; i++) {
+      if (expr[i] === "(") depth++;
+      else if (expr[i] === ")") {
+        depth--;
+        if (depth === 0) return false;
+      }
+    }
+    return true;
+  }
+  function findTopLevelEquality(expr) {
+    let depth = 0;
+    for (let i = 0; i < expr.length; i++) {
+      const c = expr[i];
+      if (c === "[" || c === "(") depth++;
+      else if (c === "]" || c === ")") depth--;
+      else if (depth === 0 && (c === "=" || c === "!") && expr[i + 1] === "=") {
+        if (i > 0 && (expr[i - 1] === "=" || expr[i - 1] === "!")) continue;
+        if (!expr.slice(0, i).trim()) continue;
+        const op = expr[i + 2] === "=" ? c + "==" : c + "=";
+        return { index: i, op };
+      }
+    }
+    return null;
+  }
+  function resolvePath(vals, expr) {
+    const head = expr.match(IDENT_RE);
+    if (!head) return void 0;
+    let cur = vals == null ? void 0 : vals[head[0]];
+    let i = head[0].length;
+    while (i < expr.length) {
+      if (expr[i] === ".") {
+        const m = expr.slice(i + 1).match(IDENT_RE) || expr.slice(i + 1).match(/^\d+/);
+        if (!m) return void 0;
+        cur = cur == null ? void 0 : cur[m[0]];
+        i += 1 + m[0].length;
+      } else if (expr[i] === "[") {
+        let depth = 1;
+        let j = i + 1;
+        while (j < expr.length && depth > 0) {
+          if (expr[j] === "[") depth++;
+          else if (expr[j] === "]") {
+            depth--;
+            if (depth === 0) break;
+          }
+          j++;
+        }
+        if (depth !== 0) return void 0;
+        const key = resolve(vals, expr.slice(i + 1, j));
+        cur = cur == null ? void 0 : cur[key];
+        i = j + 1;
+      } else {
+        return void 0;
+      }
+    }
+    return cur;
+  }
+
+  // src/encode.ts
+  var CAMEL_ATTR = "sc-camel-";
+  var INLINE_TEXT_TAGS = new Set(
+    "a abbr b bdi bdo br cite code del dfn em i ins kbd mark q s samp small span strike strong sub sup u var wbr".split(
+      " "
+    )
+  );
+  var RAW_WRAP = {
+    select: "sc-raw-select",
+    table: "sc-raw-table",
+    tbody: "sc-raw-tbody",
+    thead: "sc-raw-thead",
+    tfoot: "sc-raw-tfoot",
+    tr: "sc-raw-tr",
+    td: "sc-raw-td",
+    th: "sc-raw-th",
+    caption: "sc-raw-caption"
+  };
+  var RAW_UNWRAP = Object.fromEntries(
+    Object.entries(RAW_WRAP).map(([k, v]) => [v, k])
+  );
+  var EVENT_MAP = {
+    onclick: "onClick",
+    onchange: "onChange",
+    oninput: "onInput",
+    onsubmit: "onSubmit",
+    onkeydown: "onKeyDown",
+    onkeyup: "onKeyUp",
+    onkeypress: "onKeyPress",
+    onmousedown: "onMouseDown",
+    onmouseup: "onMouseUp",
+    onmouseenter: "onMouseEnter",
+    onmouseleave: "onMouseLeave",
+    onfocus: "onFocus",
+    onblur: "onBlur",
+    ondoubleclick: "onDoubleClick",
+    oncontextmenu: "onContextMenu",
+    onmousemove: "onMouseMove",
+    onmouseover: "onMouseOver",
+    onmouseout: "onMouseOut",
+    onpointerdown: "onPointerDown",
+    onpointerup: "onPointerUp",
+    onpointermove: "onPointerMove",
+    onpointerenter: "onPointerEnter",
+    onpointerleave: "onPointerLeave",
+    onpointercancel: "onPointerCancel",
+    onpointerover: "onPointerOver",
+    onpointerout: "onPointerOut",
+    ongotpointercapture: "onGotPointerCapture",
+    onlostpointercapture: "onLostPointerCapture",
+    ontouchstart: "onTouchStart",
+    ontouchend: "onTouchEnd",
+    ontouchmove: "onTouchMove",
+    ontouchcancel: "onTouchCancel",
+    ondragstart: "onDragStart",
+    ondragend: "onDragEnd",
+    ondragenter: "onDragEnter",
+    ondragleave: "onDragLeave",
+    ondragover: "onDragOver",
+    onanimationstart: "onAnimationStart",
+    onanimationend: "onAnimationEnd",
+    onanimationiteration: "onAnimationIteration",
+    ontransitionend: "onTransitionEnd"
+  };
+  var ATTRS = `(?:[^>"']|"[^"]*"|'[^']*')*`;
+  var IMPORT_SELF_CLOSE_RE = new RegExp(
+    "<(x-import|dc-import)(" + ATTRS + ")/>",
+    "gi"
+  );
+  var CAMEL_ATTR_RE = /(\s)([a-z]+[A-Z][A-Za-z0-9]*)(\s*=)/g;
+  function encodeCamelAttrs(html) {
+    return html.replace(
+      CAMEL_ATTR_RE,
+      (_, sp, name, eq) => sp + CAMEL_ATTR + name.replace(/[A-Z]/g, (c) => "-" + c.toLowerCase()) + eq
+    );
+  }
+  function encodeCase(html) {
+    html = html.replace(
+      IMPORT_SELF_CLOSE_RE,
+      (_, t, a) => "<" + t + a + "></" + t + ">"
+    );
+    html = html.replace(/<helmet(\s|>)/gi, "<sc-helmet$1");
+    html = html.replace(/<\/helmet\s*>/gi, "</sc-helmet>");
+    html = encodeCamelAttrs(html);
+    for (const [real, alias] of Object.entries(RAW_WRAP)) {
+      html = html.replace(
+        new RegExp("(</?)" + real + "(?=[\\s>])", "gi"),
+        "$1" + alias
+      );
+    }
+    return html;
+  }
+  function kebabToCamel(s) {
+    return s.replace(/-([a-z])/g, (_, c) => c.toUpperCase());
+  }
+  function cssToObj(css) {
+    const o = {};
+    for (const decl of css.split(";")) {
+      const i = decl.indexOf(":");
+      if (i < 0) continue;
+      const prop = decl.slice(0, i).trim();
+      o[prop.startsWith("--") ? prop : kebabToCamel(prop)] = decl.slice(i + 1).trim();
+    }
+    return o;
+  }
+  function compileAttr(raw) {
+    const whole = raw.match(/^\s*\{\{([\s\S]+?)\}\}\s*$/);
+    if (whole) {
+      const path = whole[1];
+      return (vals) => resolve(vals, path);
+    }
+    if (raw.includes("{{")) {
+      const parts = raw.split(/\{\{([\s\S]+?)\}\}/g);
+      return (vals) => parts.map((s, i) => i & 1 ? resolve(vals, s) ?? "" : s).join("");
+    }
+    return () => raw;
+  }
+
+  // src/compile.ts
+  function collectProps(node, kind, host) {
+    const propGetters = [];
+    const pseudoClasses = [];
+    let hintSize = null;
+    for (const { name, value } of [...node.attributes]) {
+      if (name === "sc-name" || name === "data-dc-tpl") continue;
+      let key = name;
+      if (key.startsWith(CAMEL_ATTR))
+        key = kebabToCamel(key.slice(CAMEL_ATTR.length));
+      if (key === "hint-size") {
+        hintSize = value;
+        continue;
+      }
+      if (key.startsWith("style-")) {
+        pseudoClasses.push(host.pseudoClass(key.slice(6), value));
+        continue;
+      }
+      if (kind !== "dom") {
+        if (key.includes("-") && !(kind === "x-import" && (key.startsWith("aria-") || key.startsWith("data-"))))
+          key = kebabToCamel(key);
+      } else {
+        if (key === "class") key = "className";
+        else if (key === "for") key = "htmlFor";
+        else if (key.startsWith("on"))
+          key = EVENT_MAP[key] || "on" + key[2].toUpperCase() + key.slice(3);
+      }
+      propGetters.push([key, compileAttr(value)]);
+    }
+    return { propGetters, pseudoClasses, hintSize };
+  }
+  var HOST_STYLE_PROPS = /* @__PURE__ */ new Set([
+    "position",
+    "left",
+    "right",
+    "top",
+    "bottom",
+    "inset",
+    "width",
+    "height",
+    "z-index",
+    "transform"
+  ]);
+  function hostPositionStyle(style) {
+    const all = typeof style === "string" ? cssToObj(style) : style != null && typeof style === "object" ? style : null;
+    if (!all) return void 0;
+    const out = {};
+    for (const [k, v] of Object.entries(all)) {
+      const kebab = k.replace(/[A-Z]/g, (c) => "-" + c.toLowerCase());
+      if (HOST_STYLE_PROPS.has(kebab)) out[k] = v;
+    }
+    return Object.keys(out).length ? out : void 0;
+  }
+  function compileTemplate(html, host) {
+    const tpl = document.createElement("template");
+    //! nosemgrep: direct-inner-html-assignment
+    tpl.innerHTML = encodeCase(html);
+    let tplN = 0;
+    (function stamp(node) {
+      if (node.nodeType === Node.ELEMENT_NODE) {
+        node.setAttribute("data-dc-tpl", String(tplN++));
+      }
+      for (const c of node.childNodes) stamp(c);
+    })(tpl.content);
+    const builders = walkChildren(tpl.content, host);
+    const render = ((vals, ctx) => builders.map((b, i) => b(vals || {}, ctx, i)));
+    render.__annotated = tpl.innerHTML;
+    return render;
+  }
+  function walkChildren(node, host) {
+    return [...node.childNodes].map((c) => walk(c, host)).filter((b) => b != null);
+  }
+  var SLIDE_ID_VALUE_RE = /^[0-9a-f]{8}$/;
+  var DECK_CONTROL_FLOW_RE = /^(sc-if|sc-for|sc-else|dc-import|x-import)$/;
+  var DECK_AUX_RE = /^(template|script|style|sc-helmet|helmet)$/;
+  function isDeckMountTag(el) {
+    if (el.localName === "deck-stage") return true;
+    return el.localName === "x-import" && (el.getAttribute("component-from-global-scope") || "") === "deck-stage";
+  }
+  function walkDeckChildren(el, host) {
+    const pairs = [...el.childNodes].map((c) => ({ c, b: walk(c, host) })).filter((p) => p.b !== null);
+    const kids = pairs.map((p) => p.b);
+    const seen = /* @__PURE__ */ new Set();
+    const wsSeen = /* @__PURE__ */ new Map();
+    const keys = [];
+    const nextSlideId = new Array(pairs.length);
+    {
+      let upcoming = null;
+      for (let j = pairs.length - 1; j >= 0; j--) {
+        const n = pairs[j].c;
+        if (n.nodeType === Node.ELEMENT_NODE) {
+          const t = n.localName;
+          upcoming = !DECK_AUX_RE.test(t) && !DECK_CONTROL_FLOW_RE.test(t) ? n.getAttribute("data-om-slide-id") : null;
+        }
+        nextSlideId[j] = upcoming;
+      }
+    }
+    for (let j = 0; j < pairs.length; j++) {
+      const { c } = pairs[j];
+      if (c.nodeType === Node.TEXT_NODE) {
+        if ((c.nodeValue ?? "").trim() === "") {
+          const base = nextSlideId[j] ? "omid-ws:" + nextSlideId[j] : "omid-ws:aux";
+          const n = wsSeen.get(base) ?? 0;
+          wsSeen.set(base, n + 1);
+          keys.push(n === 0 ? base : base + ":" + n);
+          continue;
+        }
+        return { kids, keys: null };
+      }
+      if (c.nodeType !== Node.ELEMENT_NODE) {
+        keys.push(j);
+        continue;
+      }
+      const child = c;
+      const tag = child.localName;
+      if (DECK_AUX_RE.test(tag)) {
+        keys.push(j);
+        continue;
+      }
+      if (DECK_CONTROL_FLOW_RE.test(tag)) return { kids, keys: null };
+      const v = child.getAttribute("data-om-slide-id");
+      if (!v || !SLIDE_ID_VALUE_RE.test(v) || seen.has(v)) {
+        return { kids, keys: null };
+      }
+      seen.add(v);
+      keys.push("omid:" + v);
+    }
+    return { kids, keys };
+  }
+  function renderDeckKids(kids, kidKeys, vals, ctx) {
+    return kids.map((b, j) => {
+      const k = kidKeys ? kidKeys[j] : j;
+      const out = b(vals, ctx, k);
+      return kidKeys != null && typeof out === "string" ? h(getReact().Fragment, { key: k }, out) : out;
+    });
+  }
+  function walk(node, host) {
+    if (node.nodeType === Node.TEXT_NODE) return walkText(node);
+    if (node.nodeType !== Node.ELEMENT_NODE) return null;
+    const el = node;
+    const tag = el.tagName.toLowerCase();
+    if (tag === "sc-for") return walkFor(el, host);
+    if (tag === "sc-if") return walkIf(el, host);
+    if (tag === "x-import") return walkXImport(el, host);
+    if (tag === "sc-helmet") return host.helmet(el);
+    if (tag === "dc-import") return walkComponent(el, host);
+    return walkElement(el, host);
+  }
+  var warnedHoles = /* @__PURE__ */ new Set();
+  function warnUnresolved(ctx, what) {
+    const key = (ctx?.__name || "?") + "\0" + what;
+    if (warnedHoles.has(key)) return;
+    warnedHoles.add(key);
+    console.warn("[dc-runtime] " + (ctx?.__name || "template") + ": " + what);
+  }
+  function walkText(node) {
+    const txt = node.nodeValue ?? "";
+    if (!txt.includes("{{")) {
+      if (!txt.trim() && !txt.includes(" ")) return null;
+      return () => txt;
+    }
+    const parts = txt.split(/\{\{([\s\S]+?)\}\}/g);
+    return (vals, ctx, key) => h(
+      getReact().Fragment,
+      { key },
+      ...parts.map((p, i) => {
+        if (!(i & 1)) return p;
+        const v = resolve(vals, p);
+        if (v === void 0) {
+          if (!ctx?.__streamingNow) {
+            if (document.body?.hasAttribute("data-dc-editor-on")) {
+              return h(
+                "span",
+                { key: i, className: "sc-interp sc-unresolved" },
+                "{{ " + p.trim() + " }}"
+              );
+            }
+            warnUnresolved(
+              ctx,
+              "{{ " + p.trim() + " }} never resolved \u2014 rendered as empty"
+            );
+            return null;
+          }
+          return h(
+            "span",
+            { key: i, className: "sc-interp sc-missing" },
+            p.trim()
+          );
+        }
+        if (getReact().isValidElement(v) || Array.isArray(v)) {
+          return h(getReact().Fragment, { key: i }, v);
+        }
+        if (v === null || typeof v === "boolean") return null;
+        return h("span", { key: i, className: "sc-interp" }, String(v));
+      })
+    );
+  }
+  function walkFor(el, host) {
+    const listGet = compileAttr(el.getAttribute("list") || "");
+    const asName = el.getAttribute("as") || "item";
+    const hintN = parseInt(el.getAttribute("hint-placeholder-count") || "0", 10);
+    const kids = walkChildren(el, host);
+    const listSrc = el.getAttribute("list") || "";
+    return (vals, ctx, key) => {
+      let list = listGet(vals);
+      if (!Array.isArray(list)) {
+        if (!ctx?.__streamingNow) {
+          if (list !== void 0 && list !== null) {
+            warnUnresolved(
+              ctx,
+              'sc-for list="' + listSrc + '" is not an array (' + typeof list + ")"
+            );
+          }
+          list = [];
+        } else {
+          list = hintN > 0 ? Array(hintN).fill(void 0) : [];
+        }
+      }
+      return h(
+        getReact().Fragment,
+        { key },
+        list.map((item, i) => {
+          const sub = { ...vals, [asName]: item, $index: i };
+          return h(
+            getReact().Fragment,
+            { key: i },
+            kids.map((b, j) => b(sub, ctx, j))
+          );
+        })
+      );
+    };
+  }
+  function walkIf(el, host) {
+    const valGet = compileAttr(el.getAttribute("value") || "");
+    const hintRaw = el.getAttribute("hint-placeholder-val");
+    const hintGet = hintRaw != null ? compileAttr(hintRaw) : null;
+    const kids = walkChildren(el, host);
+    return (vals, ctx, key) => {
+      let v = valGet(vals);
+      if (v === void 0 && hintGet && ctx?.__streamingNow) v = hintGet(vals);
+      return v ? h(
+        getReact().Fragment,
+        { key },
+        kids.map((b, j) => b(vals, ctx, j))
+      ) : null;
+    };
+  }
+  function walkComponent(el, host) {
+    const name = el.getAttribute("name") || el.getAttribute("component") || "";
+    el.removeAttribute("name");
+    el.removeAttribute("component");
+    const tplId = el.getAttribute("data-dc-tpl");
+    const styleRaw = el.getAttribute("style");
+    el.removeAttribute("style");
+    const styleGet = styleRaw != null ? compileAttr(styleRaw) : null;
+    const { propGetters, hintSize } = collectProps(el, "dc-import", host);
+    const kids = walkChildren(el, host);
+    return (vals, ctx, key) => {
+      const props = {
+        key,
+        __hintSize: hintSize,
+        __tplId: tplId,
+        __hostStyle: styleGet ? hostPositionStyle(styleGet(vals)) : void 0
+      };
+      for (const [k, g] of propGetters) {
+        const v = g(vals);
+        if (k === "dcProps") {
+          if (v && typeof v === "object") Object.assign(props, v);
+          continue;
+        }
+        props[k] = v;
+      }
+      if (kids.length) props.children = kids.map((b, j) => b(vals, ctx, j));
+      return h(host.component(name), props);
+    };
+  }
+  function walkXImport(el, host) {
+    const globalNameGet = compileAttr(
+      el.getAttribute("component-from-global-scope") || ""
+    );
+    const exportNameGet = compileAttr(
+      el.getAttribute("component") || el.getAttribute("name") || ""
+    );
+    const fromRaw = el.getAttribute("from") || (el.getAttribute("component-from-global-scope") ? "" : el.getAttribute("src") || el.getAttribute("import") || "");
+    const urls = fromRaw.trim() ? fromRaw.trim().split(/\s+/) : [];
+    const url = urls.length ? urls[urls.length - 1] : "";
+    const kindOf = (u) => /\.(jsx|tsx)(\?|#|$)/i.test(u) ? "jsx" : "js";
+    const tplId = el.getAttribute("data-dc-tpl");
+    const styleRaw = el.getAttribute("style");
+    el.removeAttribute("style");
+    const styleGet = styleRaw != null ? compileAttr(styleRaw) : null;
+    const wrap = tplId != null || styleGet != null;
+    const { propGetters, hintSize } = collectProps(el, "x-import", host);
+    const hasContent = el.children.length > 0 || !!(el.textContent || "").trim();
+    const deckKeyed = hasContent && isDeckMountTag(el) ? walkDeckChildren(el, host) : null;
+    const kids = deckKeyed ? deckKeyed.kids : hasContent ? walkChildren(el, host) : [];
+    const kidKeys = deckKeyed?.keys ?? null;
+    const urlBindable = fromRaw.includes("{{");
+    if (urls.length && !urlBindable) {
+      let prev;
+      for (const u of urls) prev = host.loadExternal(kindOf(u), u, prev);
+    }
+    const evalName = (g, vals) => {
+      const v = g(vals);
+      const s = v == null ? "" : String(v);
+      return s.includes("{{") ? "" : s;
+    };
+    return (vals, ctx, key) => {
+      const globalName = evalName(globalNameGet, vals);
+      const name = globalName || evalName(exportNameGet, vals);
+      const C = !name || urlBindable ? null : globalName ? host.resolveExternalGlobal(url, globalName) : host.resolveExternal(url, name);
+      const hostStyle = styleGet ? hostPositionStyle(styleGet(vals)) : void 0;
+      const wrapper = wrap ? {
+        key,
+        className: "sc-host-x",
+        "data-dc-tpl": tplId,
+        style: hostStyle || { display: "contents" }
+      } : null;
+      if (!C) {
+        const error = urlBindable ? "x-import `from` cannot contain {{ \u2026 }} \u2014 module URLs are resolved at parse time; use a literal URL" : host.resolveExternalError(url, name);
+        const ph = host.placeholder({
+          key: wrapper ? void 0 : key,
+          name,
+          hintSize,
+          error
+        });
+        return wrapper ? h("div", wrapper, ph) : ph;
+      }
+      const props = wrapper ? {} : { key };
+      let unresolvedHole = false;
+      for (const [k, g] of propGetters) {
+        if (k === "component" || k === "componentFromGlobalScope" || k === "from") {
+          continue;
+        }
+        const v = g(vals);
+        if (v === void 0) unresolvedHole = true;
+        if (k === "dcProps") {
+          if (v && typeof v === "object") Object.assign(props, v);
+          continue;
+        }
+        props[k] = v;
+      }
+      if (unresolvedHole && ctx?.__htmlStreamingNow) {
+        const ph = host.placeholder({
+          key: wrapper ? void 0 : key,
+          name,
+          hintSize,
+          error: null
+        });
+        return wrapper ? h("div", wrapper, ph) : ph;
+      }
+      if (kids.length) {
+        props.children = renderDeckKids(kids, kidKeys, vals, ctx);
+      }
+      return wrapper ? h("div", wrapper, h(C, props)) : h(C, props);
+    };
+  }
+  function contentKey(el) {
+    const clone = el.cloneNode(true);
+    for (const d of clone.querySelectorAll("*")) {
+      while (d.attributes.length) d.removeAttribute(d.attributes[0].name);
+    }
+    const s = clone.innerHTML;
+    let h2 = 5381;
+    for (let i = 0; i < s.length; i++) h2 = (h2 << 5) + h2 + s.charCodeAt(i) | 0;
+    return s.length + "." + (h2 >>> 0).toString(36);
+  }
+  var NEVER_CONTENT_KEYED = new Set(
+    "script style textarea option title select canvas iframe video audio".split(
+      " "
+    )
+  );
+  var NOT_INLINE_SELECTOR = ":not(" + [...INLINE_TEXT_TAGS].join(",") + ")";
+  function walkElement(el, host) {
+    const realTag = RAW_UNWRAP[el.localName] || el.localName;
+    const tplId = el.getAttribute("data-dc-tpl");
+    const inlineOnly = el.childNodes.length > 0 && !NEVER_CONTENT_KEYED.has(realTag) && el.querySelector(NOT_INLINE_SELECTOR) === null;
+    const keySuffix = inlineOnly ? "|" + contentKey(el) : "";
+    const { propGetters, pseudoClasses } = collectProps(el, "dom", host);
+    const deckKeyed = isDeckMountTag(el) ? walkDeckChildren(el, host) : null;
+    const kids = deckKeyed ? deckKeyed.kids : walkChildren(el, host);
+    const kidKeys = deckKeyed?.keys ?? null;
+    return (vals, ctx, key) => {
+      const props = {
+        key: key + keySuffix,
+        "data-dc-tpl": tplId
+      };
+      for (const [k, g] of propGetters) {
+        let v = g(vals);
+        if (k === "style" && typeof v === "string") v = cssToObj(v);
+        if ((k === "value" || k === "checked") && v === void 0) {
+          v = k === "checked" ? false : "";
+        }
+        props[k] = v;
+      }
+      if (pseudoClasses.length) {
+        props.className = [props.className, ...pseudoClasses].filter(Boolean).join(" ");
+      }
+      return h(realTag, props, ...renderDeckKids(kids, kidKeys, vals, ctx));
+    };
+  }
+
+  // src/logic.ts
+  var StreamableLogic = class {
+    constructor(props) {
+      __publicField(this, "props");
+      __publicField(this, "state", {});
+      /** Back-pointer to the wrapper component, installed after construction. */
+      __publicField(this, "__host");
+      this.props = props || {};
+    }
+    setState(update, cb) {
+      this.__host && this.__host.__setLogicState(update, cb);
+    }
+    forceUpdate() {
+      this.__host && this.__host.forceUpdate();
+    }
+    componentDidMount() {
+    }
+    componentDidUpdate(_prevProps) {
+    }
+    componentWillUnmount() {
+    }
+    /** The flat object the template renders against (merged over props). */
+    renderVals() {
+      return {};
+    }
+  };
+  function evalDcLogic(src) {
+    //! nosemgrep: eval-and-function-constructor
+    const fn = new Function(
+      "DCLogic",
+      "StreamableLogic",
+      "React",
+      src + '\n;return (typeof Component!=="undefined"&&Component)||undefined;'
+    );
+    return fn(StreamableLogic, StreamableLogic, getReact());
+  }
+
+  // src/component.ts
+  function shallowEqual(a, b) {
+    if (!b) return false;
+    const ak = Object.keys(a).filter((k) => k !== "children");
+    const bk = Object.keys(b).filter((k) => k !== "children");
+    if (ak.length !== bk.length) return false;
+    for (const k of ak) if (a[k] !== b[k]) return false;
+    return true;
+  }
+  function Placeholder({
+    name,
+    hintSize,
+    streaming,
+    error
+  }) {
+    const [w, hgt] = (hintSize || "100%,60px").split(",");
+    return h(
+      "div",
+      {
+        className: "sc-placeholder" + (streaming ? " sc-streaming" : ""),
+        style: { width: w.trim(), height: hgt && hgt.trim() },
+        title: name
+      },
+      error ? h(
+        "div",
+        { className: "sc-placeholder-error" },
+        (name ? name + ": " : "") + error
+      ) : null
+    );
+  }
+  function hintToMin(hint) {
+    if (!hint) return void 0;
+    const [w, hgt] = hint.split(",");
+    return { minWidth: w.trim(), minHeight: hgt && hgt.trim() };
+  }
+  function createComponentFactory(registry, ensureFetched) {
+    const React = getReact();
+    const AncestorContext = React.createContext([]);
+    class StreamableComponent extends React.Component {
+      constructor(props) {
+        super(props);
+        __publicField(this, "__name");
+        __publicField(this, "__sub");
+        __publicField(this, "__needsDidMount", false);
+        /** Snapshot of the registry's streaming flags taken at render time —
+         *  builders read it off the RenderCtx (this) to pick placeholder vs
+         *  render-nothing for unresolved values. */
+        __publicField(this, "__streamingNow", false);
+        __publicField(this, "__htmlStreamingNow", false);
+        /** When a construct throws, remember the (class, registry.ver, props)
+         *  triple so render-time reconcile doesn't re-attempt it on every parent
+         *  re-render. A registry bump (new class, template, external module
+         *  resolving via bumpAll) changes `ver` and breaks the memo so an
+         *  env-dependent constructor can self-heal. */
+        __publicField(this, "__failedLogic", null);
+        __publicField(this, "__failedUserProps", null);
+        __publicField(this, "__failedVer", -1);
+        /** Per-instance constructor error — kept here (not on the registry entry)
+         *  so one instance's successful construct can't hide a sibling's failure,
+         *  and a construct can never wipe an eval error `updateJs` recorded on
+         *  `r.logicError`. */
+        __publicField(this, "__ctorError", null);
+        __publicField(this, "logic");
+        this.__name = props.__name;
+        this.state = { __v: 0, __err: null };
+        this.__sub = () => {
+          if (this.state.__err) this.setState({ __err: null });
+          this.forceUpdate();
+        };
+        this.__makeLogic(registry.get(this.__name).Logic, null);
+        ensureFetched(this.__name);
+      }
+      /** Error-boundary hook: a render crash anywhere in this DC's subtree
+       *  (its own template, an x-import'd component, a child DC without its
+       *  own deeper boundary) lands here instead of unmounting the page. */
+      static getDerivedStateFromError(e) {
+        return { __err: e instanceof Error && e.message ? e.message : String(e) };
+      }
+      componentDidCatch(e, info) {
+        console.error(
+          "[dc-runtime] render error in <" + this.__name + ">:",
+          e,
+          info?.componentStack || ""
+        );
+      }
+      /** Instantiate the logic class (or the no-op base) and adopt `prevState`
+       *  over its initial state — used both at mount and on hot-swap. */
+      __makeLogic(Logic, prevState) {
+        const L = Logic || StreamableLogic;
+        try {
+          this.logic = new L(this.__userProps());
+          this.__failedLogic = null;
+          this.__failedUserProps = null;
+          this.__ctorError = null;
+        } catch (e) {
+          console.error(e);
+          this.__failedLogic = Logic;
+          this.__failedUserProps = this.__userProps();
+          this.__failedVer = registry.get(this.__name).ver;
+          this.__ctorError = this.__name + ": " + (e instanceof Error && e.message ? e.message : String(e));
+          this.logic = new StreamableLogic(
+            this.__userProps()
+          );
+        }
+        this.logic.__host = this;
+        if (prevState)
+          this.logic.state = { ...this.logic.state || {}, ...prevState };
+      }
+      /** The props the author's logic + template see — internal __-prefixed
+       *  wiring stripped. */
+      __userProps() {
+        const { __name, __hintSize, __tplId, __hostStyle, ...rest } = this.props;
+        return rest;
+      }
+      __setLogicState(update, cb) {
+        const prev = this.logic.state;
+        const patch = typeof update === "function" ? update(prev) : update;
+        this.logic.state = { ...prev, ...patch };
+        this.setState((s) => ({ __v: s.__v + 1 }), cb);
+      }
+      /** Swap the logic instance when the registry's Logic class changed
+       *  (streaming completion, hot reload). State carries over; didMount
+       *  re-fires after the swap commits so refs exist. */
+      __reconcileLogic() {
+        const r = registry.get(this.__name);
+        const Next = r.Logic;
+        const Cur = this.logic.constructor;
+        if (Next === Cur || !Next && Cur === StreamableLogic || Next === this.__failedLogic && r.ver === this.__failedVer && shallowEqual(this.__userProps(), this.__failedUserProps)) {
+          return;
+        }
+        if (!this.__needsDidMount) {
+          try {
+            this.logic.componentWillUnmount();
+          } catch (e) {
+            console.error(e);
+          }
+        }
+        this.__makeLogic(Next, this.logic.state);
+        this.__needsDidMount = true;
+      }
+      componentDidMount() {
+        registry.get(this.__name).subs.add(this.__sub);
+        try {
+          this.logic.componentDidMount();
+        } catch (e) {
+          console.error(e);
+        }
+      }
+      componentDidUpdate(prevProps) {
+        this.logic.props = this.__userProps();
+        if (this.__needsDidMount) {
+          if (this.state.__err || !registry.get(this.__name).tpl) return;
+          this.__needsDidMount = false;
+          try {
+            this.logic.componentDidMount();
+          } catch (e) {
+            console.error(e);
+          }
+        } else {
+          try {
+            this.logic.componentDidUpdate(prevProps);
+          } catch (e) {
+            console.error(e);
+          }
+        }
+      }
+      componentWillUnmount() {
+        registry.get(this.__name).subs.delete(this.__sub);
+        if (!this.__needsDidMount) {
+          try {
+            this.logic.componentWillUnmount();
+          } catch (e) {
+            console.error(e);
+          }
+        }
+      }
+      render() {
+        const r = registry.get(this.__name);
+        const cls = "sc-host" + (r.htmlStreaming ? " sc-streaming-html" : "") + (r.jsStreaming ? " sc-streaming-js" : "");
+        const hintStyle = r.htmlStreaming ? hintToMin(this.props.__hintSize) : void 0;
+        const hostStyle = this.props.__hostStyle || hintStyle ? { ...hintStyle || {}, ...this.props.__hostStyle || {} } : void 0;
+        const hostBase = {
+          className: cls,
+          style: hostStyle,
+          "data-sc-name": this.__name,
+          "data-dc-tpl": this.props.__tplId
+        };
+        const chain = Array.isArray(this.context) ? this.context : [];
+        if (chain.includes(this.__name)) {
+          const cycle = [
+            ...chain.slice(chain.indexOf(this.__name)),
+            this.__name
+          ].join(" \u2192 ");
+          return h(
+            "div",
+            { ...hostBase, className: cls + " sc-has-error" },
+            h(Placeholder, {
+              name: this.__name,
+              hintSize: this.props.__hintSize,
+              error: "circular import: " + cycle
+            })
+          );
+        }
+        if (this.state.__err) {
+          return h(
+            "div",
+            { ...hostBase, className: cls + " sc-has-error" },
+            h(
+              "div",
+              { className: "sc-logic-error", "data-omelette-chrome": "" },
+              this.__name + ": " + this.state.__err
+            ),
+            h(Placeholder, {
+              name: this.__name,
+              hintSize: this.props.__hintSize,
+              error: this.state.__err
+            })
+          );
+        }
+        this.__reconcileLogic();
+        if (!r.tpl) {
+          return h(
+            "div",
+            hostBase,
+            h(Placeholder, { name: this.__name, hintSize: this.props.__hintSize })
+          );
+        }
+        const userProps = this.__userProps();
+        this.logic.props = userProps;
+        let vals = userProps;
+        let renderErr = r.logicError || this.__ctorError;
+        try {
+          vals = { ...userProps, ...this.logic.renderVals() || {} };
+        } catch (e) {
+          console.error(e);
+          renderErr = this.__name + ".renderVals(): " + (e instanceof Error && e.message ? e.message : String(e));
+        }
+        this.__streamingNow = !!(r.htmlStreaming || r.jsStreaming);
+        this.__htmlStreamingNow = !!r.htmlStreaming;
+        return h(
+          "div",
+          { ...hostBase, className: cls + (renderErr ? " sc-has-error" : "") },
+          renderErr && h(
+            "div",
+            { className: "sc-logic-error", "data-omelette-chrome": "" },
+            renderErr
+          ),
+          h(
+            AncestorContext.Provider,
+            { value: [...chain, this.__name] },
+            r.tpl(vals, this)
+          )
+        );
+      }
+    }
+    __publicField(StreamableComponent, "contextType", AncestorContext);
+    const named = /* @__PURE__ */ new Map();
+    function getDC(name) {
+      const hit = named.get(name);
+      if (hit) return hit;
+      function Dispatcher(p) {
+        const [, setTick] = React.useState(0);
+        React.useEffect(() => {
+          const sub = () => setTick((n) => n + 1);
+          registry.get(name).subs.add(sub);
+          return () => {
+            registry.get(name).subs.delete(sub);
+          };
+        }, []);
+        ensureFetched(name);
+        return h(StreamableComponent, { ...p, __name: name });
+      }
+      Dispatcher.displayName = name;
+      named.set(name, Dispatcher);
+      return Dispatcher;
+    }
+    return {
+      getDC,
+      StreamableComponent
+    };
+  }
+
+  // src/bundled.ts
+  function bundledBlob(url) {
+    const blobs = window.__resourceBlobs;
+    const b = blobs ? blobs[url.split("#")[0]] : void 0;
+    return b instanceof Blob ? b : null;
+  }
+
+  // src/cdn.ts
+  var REACT_URL = "https://unpkg.com/react@18.3.1/umd/react.production.min.js";
+  var REACT_SRI = "sha384-DGyLxAyjq0f9SPpVevD6IgztCFlnMF6oW/XQGmfe+IsZ8TqEiDrcHkMLKI6fiB/Z";
+  var REACT_DOM_URL = "https://unpkg.com/react-dom@18.3.1/umd/react-dom.production.min.js";
+  var REACT_DOM_SRI = "sha384-gTGxhz21lVGYNMcdJOyq01Edg0jhn/c22nsx0kyqP0TxaV5WVdsSH1fSDUf5YJj1";
+  var BABEL_URL = "https://unpkg.com/@babel/standalone@7.29.0/babel.min.js";
+  var BABEL_SRI = "sha384-m08KidiNqLdpJqLq95G/LEi8Qvjl/xUYll3QILypMoQ65QorJ9Lvtp2RXYGBFj1y";
+  function cdnScriptFor(url, sri) {
+    const res = window.__resources;
+    const v = res ? res[url] : void 0;
+    return typeof v === "string" && v ? { src: v } : { src: url, integrity: sri };
+  }
+
+  // src/external.ts
+  var isCustomElementName = (n) => !n.includes(".") && n.includes("-");
+  function isRenderableType(g) {
+    if (typeof g === "function") return !isElementClass(g);
+    return typeof g === "object" && g !== null && typeof g.$$typeof === "symbol";
+  }
+  function resolveDottedPath(root, name) {
+    let cur = root;
+    for (const seg of name.split(".")) {
+      if (cur == null) return void 0;
+      cur = cur[seg];
+    }
+    return cur;
+  }
+  var GLOBAL_POLL_INTERVAL_MS = 50;
+  var GLOBAL_POLL_TIMEOUT_MS = 3e4;
+  function createExternalModules(onResolved) {
+    const cache = /* @__PURE__ */ new Map();
+    let babelLoading = null;
+    const reportedMissing = /* @__PURE__ */ new Map();
+    const polling = /* @__PURE__ */ new Set();
+    function ensureBabel() {
+      if (window.Babel) return Promise.resolve();
+      if (babelLoading) return babelLoading;
+      const babel = cdnScriptFor(BABEL_URL, BABEL_SRI);
+      babelLoading = new Promise((res, rej) => {
+        const s = document.createElement("script");
+        s.src = babel.src;
+        if (babel.integrity) {
+          s.integrity = babel.integrity;
+          s.crossOrigin = "anonymous";
+        }
+        s.onload = () => res();
+        s.onerror = rej;
+        document.head.appendChild(s);
+      });
+      return babelLoading;
+    }
+    const pending = /* @__PURE__ */ new Map();
+    function load(kind, url, after) {
+      const existing = pending.get(url);
+      if (existing) return existing;
+      cache.set(url, null);
+      console.info("[dc-runtime] x-import: loading", url, "(" + kind + ")");
+      const ready = Promise.all([
+        kind === "jsx" ? ensureBabel() : Promise.resolve(),
+        after ?? Promise.resolve()
+      ]);
+      const p = ready.then(() => {
+        const pre = bundledBlob(url);
+        if (pre) return pre.text();
+        return fetch(url).then((r) => {
+          if (!r.ok) throw new Error("HTTP " + r.status);
+          return r.text();
+        });
+      }).then((src) => {
+        const code = kind === "jsx" ? window.Babel.transform(src, {
+          filename: url,
+          presets: ["react", "typescript"]
+        }).code : src;
+        const module = { exports: {} };
+        const before = new Set(Object.keys(window));
+        //! nosemgrep: eval-and-function-constructor
+        new Function("React", "module", "exports", "require", code)(
+          getReact(),
+          module,
+          module.exports,
+          () => ({})
+        );
+        const globals = {};
+        for (const k of Object.keys(window)) {
+          if (!before.has(k) && typeof window[k] === "function") {
+            globals[k] = window[k];
+          }
+        }
+        cache.set(url, { mod: module.exports, globals });
+        console.info(
+          "[dc-runtime] x-import: loaded",
+          url,
+          "\u2014 exports:",
+          Object.keys(module.exports),
+          "window globals:",
+          Object.keys(globals)
+        );
+        onResolved();
+      }).catch((e) => {
+        cache.set(url, {
+          mod: {},
+          globals: {},
+          error: "failed to load: " + (e instanceof Error && e.message ? e.message : String(e))
+        });
+        console.error(
+          "[dc-runtime] x-import: FAILED to load",
+          url,
+          "(" + kind + ")",
+          e
+        );
+        onResolved();
+      });
+      pending.set(url, p);
+      return p;
+    }
+    function resolve2(url, name) {
+      const entry = cache.get(url);
+      if (!entry) return null;
+      const { mod, globals } = entry;
+      const C = mod && mod[name] || globals && globals[name] || typeof window !== "undefined" && window[name] || mod && mod.default;
+      if (typeof C === "function") return C;
+      const key = url + "\0" + name;
+      if (!reportedMissing.has(key)) {
+        reportedMissing.set(
+          key,
+          entry.error || 'no export named "' + name + '" (has: ' + Object.keys(mod).join(", ") + ")"
+        );
+        console.error(
+          "[dc-runtime] x-import: module",
+          url,
+          "loaded but has no component named",
+          JSON.stringify(name),
+          "\u2014 available exports:",
+          Object.keys(mod),
+          "window globals:",
+          Object.keys(globals),
+          ". The module must `module.exports = {" + name + "}` or set `window." + name + "`."
+        );
+      }
+      return null;
+    }
+    function waitForGlobal(name) {
+      if (polling.has(name)) return;
+      polling.add(name);
+      const started = Date.now();
+      const isCE = isCustomElementName(name);
+      const tick = () => {
+        const found = isCE ? customElements.get(name) : isRenderableType(resolveDottedPath(window, name));
+        if (found) {
+          polling.delete(name);
+          onResolved();
+          return;
+        }
+        if (Date.now() - started >= GLOBAL_POLL_TIMEOUT_MS) {
+          console.warn(
+            "[dc-runtime] x-import: global",
+            JSON.stringify(name),
+            "never appeared on window after " + GLOBAL_POLL_TIMEOUT_MS + "ms"
+          );
+          return;
+        }
+        setTimeout(tick, GLOBAL_POLL_INTERVAL_MS);
+      };
+      setTimeout(tick, GLOBAL_POLL_INTERVAL_MS);
+    }
+    function resolveGlobal(url, name) {
+      const isCE = isCustomElementName(name);
+      if (!url) {
+        if (isCE) {
+          if (customElements.get(name)) return name;
+          waitForGlobal(name);
+          return null;
+        }
+        const g2 = resolveDottedPath(window, name);
+        if (isRenderableType(g2)) return g2;
+        waitForGlobal(name);
+        return null;
+      }
+      const entry = cache.get(url);
+      if (!entry) return null;
+      if (isCE && customElements.get(name)) return name;
+      const g = entry.globals[name] ?? resolveDottedPath(window, name);
+      if (isRenderableType(g)) return g;
+      if (name.includes(".")) return null;
+      const key = url + "\0global\0" + name;
+      if (!reportedMissing.has(key)) {
+        reportedMissing.set(key, null);
+        if (isCE && !customElements.get(name)) {
+          console.warn(
+            "[dc-runtime] x-import:",
+            url,
+            "loaded but no custom element",
+            JSON.stringify(name),
+            "is registered and window." + name + " is not a function \u2014 rendering <" + name + "> as an unknown element."
+          );
+        }
+      }
+      return name;
+    }
+    function getError(url, name) {
+      const entry = cache.get(url);
+      if (entry?.error) return entry.error;
+      return reportedMissing.get(url + "\0" + name) || null;
+    }
+    return { load, resolve: resolve2, resolveGlobal, getError };
+  }
+  function isElementClass(g) {
+    try {
+      return typeof g === "function" && typeof HTMLElement !== "undefined" && g.prototype instanceof HTMLElement;
+    } catch {
+      return false;
+    }
+  }
+
+  // src/atomics.ts
+  var ATOMIC_CSS = (
+    // layout
+    ".fx{display:flex}.col{display:flex;flex-direction:column}.grid{display:grid}.ac{align-items:center}.jc{justify-content:center}.jb{justify-content:space-between}.f1{flex:1}.noshrink{flex-shrink:0}.wrap{flex-wrap:wrap}.fw5{font-weight:500}.fw6{font-weight:600}.fw7{font-weight:700}.fw8{font-weight:800}.fs11{font-size:11px}.fs12{font-size:12px}.fs13{font-size:13px}.fs14{font-size:14px}.fs15{font-size:15px}.fs16{font-size:16px}.fs20{font-size:20px}.fs22{font-size:22px}.upper{text-transform:uppercase}.tc{text-align:center}.nowrap{white-space:nowrap}.gap8{gap:8px}.gap10{gap:10px}.gap12{gap:12px}.gap16{gap:16px}.gap24{gap:24px}.m0{margin:0}.mt8{margin-top:8px}.mt12{margin-top:12px}.mt16{margin-top:16px}.mb8{margin-bottom:8px}.mb12{margin-bottom:12px}.mb16{margin-bottom:16px}.posrel{position:relative}.posabs{position:absolute}.round{border-radius:50%}.ohide{overflow:hidden}.bbox{box-sizing:border-box}.pointer{cursor:pointer}.w100{width:100%}.b0{border:none}"
+  );
+
+  // src/helmet.ts
+  var DESIGN_DOC_MODE_RE = /<meta\b[^>]*\bname\s*=\s*["']design_doc_mode["'][^>]*\b(?:content|value)\s*=\s*["'](\w+)["']/i;
+  var CANVAS_BG_LIGHT = "#f0eee6";
+  var CANVAS_BG_DARK = "#2e2c26";
+  function createHelmetManager(doc, isStreaming) {
+    const mounted = /* @__PURE__ */ new Set();
+    const live = /* @__PURE__ */ new Map();
+    let designDocMode = null;
+    let canvasStyleEl = null;
+    let appTheme = "light";
+    try {
+      const ds = doc.documentElement.dataset.theme;
+      appTheme = ds === "dark" || ds === "light" ? ds : new URLSearchParams(doc.defaultView?.location.search ?? "").get(
+        "theme"
+      ) === "dark" ? "dark" : "light";
+    } catch {
+    }
+    function applyCanvasBg() {
+      if (!canvasStyleEl) return;
+      const bg = appTheme === "dark" ? CANVAS_BG_DARK : CANVAS_BG_LIGHT;
+      canvasStyleEl.textContent = `html,body{background:${bg}}#dc-root>.sc-host{position:relative}`;
+    }
+    function postDesignMode(mode) {
+      if (window.parent === window) return;
+      try {
+        window.parent.postMessage({ type: "__dc_design_mode", mode }, "*");
+      } catch {
+      }
+    }
+    function setDesignDocMode(mode) {
+      if (mode === designDocMode) return;
+      designDocMode = mode;
+      postDesignMode(mode);
+      if (mode === "canvas") {
+        doc.documentElement.setAttribute("data-dc-canvas", "");
+        canvasStyleEl = doc.createElement("style");
+        canvasStyleEl.setAttribute("data-dc-canvas", "");
+        applyCanvasBg();
+        doc.head.appendChild(canvasStyleEl);
+      } else {
+        doc.documentElement.removeAttribute("data-dc-canvas");
+        canvasStyleEl?.remove();
+        canvasStyleEl = null;
+      }
+    }
+    window.addEventListener("message", (e) => {
+      const type = e.data && e.data.type;
+      if (type === "__dc_theme") {
+        const t = e.data.theme;
+        if (t === "light" || t === "dark") {
+          appTheme = t;
+          applyCanvasBg();
+        }
+        return;
+      }
+      if (!designDocMode || type !== "__dc_probe") return;
+      postDesignMode(designDocMode);
+    });
+    function compile(node) {
+      const raw = [...node.children];
+      const helmetClosed = node.nextSibling != null || node.parentNode?.nextSibling != null;
+      if (node.hasAttribute("data-dc-atomics") && !mounted.has("__dc-atomics")) {
+        mounted.add("__dc-atomics");
+        const el = doc.createElement("style");
+        el.id = "__dc-atomics";
+        el.textContent = ATOMIC_CSS;
+        doc.head.appendChild(el);
+      }
+      return (_vals, ctx) => {
+        const name = ctx && ctx.__name || "";
+        const streaming = !!(name && isStreaming(name));
+        for (let i = 0; i < raw.length; i++) {
+          const child = raw[i];
+          const tag = child.tagName;
+          const mayBePartial = streaming && !helmetClosed && i === raw.length - 1;
+          if (tag === "SCRIPT") {
+            if (mayBePartial) continue;
+            const key = "SCRIPT|" + (child.getAttribute("src") || child.textContent || "");
+            if (mounted.has(key)) continue;
+            mounted.add(key);
+            const el = doc.createElement("script");
+            for (const { name: an, value } of [...child.attributes])
+              el.setAttribute(an, value);
+            if (child.textContent) el.textContent = child.textContent;
+            doc.head.appendChild(el);
+          } else if (tag === "LINK" || tag === "META") {
+            if (mayBePartial) continue;
+            const key = tag + "|" + (child.getAttribute("href") || child.getAttribute("src") || child.outerHTML);
+            if (mounted.has(key)) continue;
+            mounted.add(key);
+            if (tag === "LINK") {
+              const rel = (child.getAttribute("rel") || "").toLowerCase().split(/\s+/);
+              const href = (child.getAttribute("href") || "").trim();
+              const res = window.__resources;
+              const pre = res && rel.includes("stylesheet") && !rel.includes("alternate") ? res[href] : void 0;
+              const blob = typeof pre === "string" && pre ? bundledBlob(pre) : null;
+              if (blob) {
+                const el = doc.createElement("style");
+                if (child.hasAttribute("disabled")) {
+                  el.setAttribute("media", "not all");
+                } else if (child.getAttribute("media")) {
+                  el.setAttribute("media", child.getAttribute("media"));
+                }
+                if (child.getAttribute("title"))
+                  el.setAttribute("title", child.getAttribute("title"));
+                void blob.text().then((css) => {
+                  el.textContent = css;
+                });
+                doc.head.appendChild(el);
+                continue;
+              }
+            }
+            doc.head.appendChild(child.cloneNode(true));
+          } else {
+            const key = name + "|" + i;
+            let el = live.get(key);
+            if (!el || el.tagName !== tag) {
+              if (el) el.remove();
+              el = doc.createElement(tag.toLowerCase());
+              live.set(key, el);
+              doc.head.appendChild(el);
+            }
+            for (const { name: an, value } of [...child.attributes]) {
+              if (el.getAttribute(an) !== value) el.setAttribute(an, value);
+            }
+            if (el.textContent !== child.textContent)
+              el.textContent = child.textContent;
+          }
+        }
+        return null;
+      };
+    }
+    return { compile, setDesignDocMode };
+  }
+
+  // src/pseudo.ts
+  function scanUnquotedUrl(css, i) {
+    if (css[i] !== "u" && css[i] !== "U" || css.slice(i, i + 4).toLowerCase() !== "url(" || /[a-z0-9_-]/i.test(css[i - 1] ?? "")) {
+      return -1;
+    }
+    let j = i + 4;
+    while (j < css.length && /\s/.test(css[j])) j++;
+    if (css[j] === '"' || css[j] === "'") return -1;
+    while (j < css.length && css[j] !== ")") {
+      if (css[j] === "\\") j++;
+      j++;
+    }
+    return j < css.length ? j + 1 : css.length;
+  }
+  function stripComments(css) {
+    let out = "";
+    let quote = "";
+    for (let i = 0; i < css.length; i++) {
+      const c = css[i];
+      if (quote) {
+        if (c === "\\") {
+          out += c + (css[i + 1] ?? "");
+          i++;
+          continue;
+        }
+        if (c === quote) quote = "";
+        out += c;
+      } else if (c === "'" || c === '"') {
+        quote = c;
+        out += c;
+      } else if (c === "/" && css[i + 1] === "*") {
+        const end = css.indexOf("*/", i + 2);
+        i = end === -1 ? css.length : end + 1;
+        out += " ";
+      } else {
+        const end = scanUnquotedUrl(css, i);
+        if (end === -1) out += c;
+        else {
+          out += css.slice(i, end);
+          i = end - 1;
+        }
+      }
+    }
+    return out;
+  }
+  function importantify(css) {
+    css = stripComments(css);
+    const decls = [];
+    let start = 0;
+    let depth = 0;
+    let quote = "";
+    for (let i = 0; i < css.length; i++) {
+      const c = css[i];
+      if (quote) {
+        if (c === "\\") i++;
+        else if (c === quote) quote = "";
+      } else if (c === "'" || c === '"') quote = c;
+      else if (c === "(") depth++;
+      else if (c === ")") depth = Math.max(0, depth - 1);
+      else if (c === ";" && depth === 0) {
+        decls.push(css.slice(start, i));
+        start = i + 1;
+      } else {
+        const end = scanUnquotedUrl(css, i);
+        if (end !== -1) i = end - 1;
+      }
+    }
+    decls.push(css.slice(start));
+    return decls.map((d) => d.trim()).filter(Boolean).map((d) => /!\s*important$/i.test(d) ? d : d + " !important").join(";");
+  }
+  function createPseudoSheet(doc) {
+    let el = null;
+    const cache = /* @__PURE__ */ new Map();
+    let n = 0;
+    return (pseudo, css) => {
+      const k = pseudo + "|" + css;
+      const hit = cache.get(k);
+      if (hit) return hit;
+      if (!el) {
+        el = doc.createElement("style");
+        doc.head.appendChild(el);
+      }
+      const cls = "scp" + (n++).toString(36);
+      const isPseudoElement = pseudo === "before" || pseudo === "after";
+      const sel = isPseudoElement ? "." + cls + "::" + pseudo : "." + cls + ":" + pseudo;
+      el.sheet.insertRule(
+        sel + "{" + (isPseudoElement ? css : importantify(css)) + "}",
+        el.sheet.cssRules.length
+      );
+      cache.set(k, cls);
+      return cls;
+    };
+  }
+
+  // src/registry.ts
+  function createRegistry() {
+    const entries = /* @__PURE__ */ Object.create(null);
+    function get(name) {
+      return entries[name] || (entries[name] = {
+        html: "",
+        tpl: null,
+        Logic: null,
+        jsStreaming: false,
+        htmlStreaming: false,
+        ver: 0,
+        subs: /* @__PURE__ */ new Set(),
+        fetched: false
+      });
+    }
+    function bump(name) {
+      const r = get(name);
+      r.ver++;
+      for (const fn of r.subs) fn();
+    }
+    return {
+      entries,
+      get,
+      bump,
+      bumpAll() {
+        for (const n in entries) bump(n);
+      }
+    };
+  }
+
+  // src/runtime.ts
+  var COMPONENT_DIR = ".";
+  function createRuntime(doc = document) {
+    const registry = createRegistry();
+    const pseudoClass = createPseudoSheet(doc);
+    const helmet = createHelmetManager(
+      doc,
+      (name) => registry.get(name).htmlStreaming
+    );
+    const external = createExternalModules(() => registry.bumpAll());
+    const factory = createComponentFactory(registry, ensureFetched);
+    const host = {
+      component: (name) => factory.getDC(name),
+      placeholder: (props) => h(Placeholder, props),
+      helmet: (node) => helmet.compile(node),
+      loadExternal: (kind, url, after) => external.load(kind, url, after),
+      resolveExternal: (url, name) => external.resolve(url, name),
+      resolveExternalGlobal: (url, name) => external.resolveGlobal(url, name),
+      resolveExternalError: (url, name) => external.getError(url, name),
+      pseudoClass
+    };
+    function ensureFetched(name) {
+      const r = registry.get(name);
+      if (r.fetched) return;
+      r.fetched = true;
+      const url = COMPONENT_DIR + "/" + encodeURIComponent(name) + ".dc.html";
+      const res = window.__resources;
+      const pre = res ? res[url] : void 0;
+      const target = typeof pre === "string" && pre ? pre : url;
+      const blob = bundledBlob(target);
+      (blob ? blob.text() : fetch(target).then((res2) => {
+        if (!res2.ok) {
+          console.error(
+            '[dc-runtime] sibling fetch for "' + name + '" failed:',
+            url,
+            "returned",
+            res2.status,
+            "\u2014 the reference renders as an empty placeholder."
+          );
+          return "";
+        }
+        return res2.text();
+      })).then((t) => {
+        if (!t) return;
+        const parsed = parseDcText(t);
+        if (!parsed) {
+          console.error(
+            '[dc-runtime] sibling fetch for "' + name + '":',
+            url,
+            "has no <x-dc> block \u2014 not a Design Component."
+          );
+          return;
+        }
+        if (parsed.props) r.propsMeta = parsed.props;
+        if (parsed.preview) r.preview = parsed.preview;
+        if (parsed.template && !r.html) updateHtml(name, parsed.template);
+        if (parsed.js && !r.Logic) updateJs(name, parsed.js);
+      }).catch(
+        (e) => console.error(
+          '[dc-runtime] sibling fetch for "' + name + '" threw:',
+          url,
+          e
+        )
+      );
+    }
+    let rootName = null;
+    function updateHtml(name, html) {
+      const r = registry.get(name);
+      r.html = html;
+      if (name === rootName) {
+        const mode = DESIGN_DOC_MODE_RE.exec(html)?.[1] ?? null;
+        if (mode || !r.htmlStreaming) helmet.setDesignDocMode(mode);
+      }
+      try {
+        r.tpl = compileTemplate(html, host);
+      } catch (e) {
+        console.error("[dc-runtime] template compile FAILED for", name, e);
+      }
+      registry.bump(name);
+    }
+    function updateJs(name, src) {
+      const r = registry.get(name);
+      const seq = r.jsSeq = (r.jsSeq || 0) + 1;
+      try {
+        const Cls = evalDcLogic(src);
+        if (r.jsSeq !== seq) return;
+        if (typeof Cls !== "function") {
+          r.logicError = name + ".dc.html: <script data-dc-script> must define `class Component extends DCLogic`";
+        } else {
+          r.logicError = null;
+          r.Logic = Cls;
+        }
+      } catch (e) {
+        if (r.jsSeq !== seq) return;
+        console.error(
+          "[dc-runtime] logic class eval FAILED for",
+          name,
+          "\u2014 the template renders with props only.",
+          e
+        );
+        r.logicError = name + ": " + (e instanceof Error && e.message ? e.message : String(e));
+      }
+      registry.bump(name);
+    }
+    function setStreaming(name, kind, on) {
+      const r = registry.get(name);
+      if (kind === "html") r.htmlStreaming = !!on;
+      else r.jsStreaming = !!on;
+      let any = false;
+      for (const n in registry.entries) {
+        const e = registry.entries[n];
+        if (e && (e.htmlStreaming || e.jsStreaming)) {
+          any = true;
+          break;
+        }
+      }
+      doc.documentElement.classList.toggle("sc-dc-streaming", any);
+      registry.bump(name);
+    }
+    function dcUpdate(name, kind, content, streaming) {
+      if (streaming) registry.get(name).fetched = true;
+      if (kind === "html") {
+        setStreaming(name, "html", !!streaming);
+        updateHtml(name, content);
+      } else if (kind === "js") {
+        setStreaming(name, "js", !!streaming);
+        if (!streaming) updateJs(name, content);
+      } else if (kind === "props") {
+        const { props, preview } = parseDataProps(content);
+        const r = registry.get(name);
+        r.propsMeta = props ?? void 0;
+        r.preview = preview;
+        registry.bump(name);
+      }
+    }
+    function setProps(name, overrides) {
+      registry.get(name).propOverrides = overrides && typeof overrides === "object" ? { ...overrides } : null;
+      registry.bump(name);
+    }
+    function adoptParsed(name, parsed) {
+      if (!parsed) return;
+      const r = registry.get(name);
+      if (parsed.props) r.propsMeta = parsed.props;
+      if (parsed.preview) r.preview = parsed.preview;
+      if (parsed.template) updateHtml(name, parsed.template);
+      if (parsed.js) updateJs(name, parsed.js);
+    }
+    return {
+      registry,
+      getDC: factory.getDC,
+      updateHtml,
+      updateJs,
+      dcUpdate,
+      setProps,
+      adoptParsed,
+      setRootName: (name) => {
+        rootName = name;
+      },
+      markFetched: (name) => {
+        registry.get(name).fetched = true;
+      },
+      annotatedTemplate: (name) => {
+        const r = registry.get(name);
+        return r.tpl && r.tpl.__annotated || null;
+      },
+      templateSource: (name) => registry.get(name).html || null,
+      StreamableLogic
+    };
+  }
+
+  // src/stream-state.ts
+  function createStreamTracker(staleMs = 6e4, now = Date.now) {
+    const since = /* @__PURE__ */ new Map();
+    const liveOne = (n) => {
+      const t = since.get(n);
+      if (t === void 0) return false;
+      if (now() - t > staleMs) {
+        since.delete(n);
+        return false;
+      }
+      return true;
+    };
+    return {
+      push(name, streaming, viewportKey) {
+        if (viewportKey === "dc-model") return;
+        if (streaming) since.set(name, now());
+        else since.delete(name);
+      },
+      live(name) {
+        if (name !== void 0) return liveOne(name);
+        for (const n of [...since.keys()]) if (liveOne(n)) return true;
+        return false;
+      }
+    };
+  }
+
+  // src/index.ts
+  function hideRawTemplate() {
+    const s = document.createElement("style");
+    s.textContent = "x-dc{display:none!important}";
+    document.head.appendChild(s);
+  }
+  function loadScript(src, integrity) {
+    return new Promise((resolve2, reject) => {
+      //! nosemgrep: create-script-element
+      const s = document.createElement("script");
+      s.src = src;
+      if (integrity) {
+        s.integrity = integrity;
+        s.crossOrigin = "anonymous";
+      }
+      s.async = false;
+      s.onload = () => resolve2();
+      s.onerror = () => reject(new Error(`failed to load ${src}`));
+      document.head.appendChild(s);
+    });
+  }
+  function loadReactUmd() {
+    const w = window;
+    if (w.React && w.ReactDOM) return Promise.resolve();
+    const react = cdnScriptFor(REACT_URL, REACT_SRI);
+    const reactDom = cdnScriptFor(REACT_DOM_URL, REACT_DOM_SRI);
+    return Promise.all([
+      loadScript(react.src, react.integrity),
+      loadScript(reactDom.src, reactDom.integrity)
+    ]).then(() => void 0);
+  }
+  function init() {
+    const runtime = createRuntime(document);
+    let rootName = "Root";
+    const baseCss = document.createElement("style");
+    baseCss.textContent = BASE_CSS;
+    document.head.prepend(baseCss);
+    const notifyHost = () => {
+      if (window.parent === window) return;
+      const r = runtime.registry.entries[rootName];
+      try {
+        window.parent.postMessage(
+          {
+            type: "__dc_booted",
+            rootName,
+            propsMeta: r && r.propsMeta || null,
+            preview: r && r.preview || null
+          },
+          "*"
+        );
+      } catch {
+      }
+    };
+    const streams = createStreamTracker();
+    const api = {
+      __dcUpdate: (name, kind, content, streaming, viewportKey) => {
+        streams.push(name, streaming, viewportKey);
+        runtime.dcUpdate(name, kind, content, streaming);
+        if (name === rootName && !streaming && kind === "props") notifyHost();
+      },
+      __dcStreaming: (name) => streams.live(name),
+      __dcSetProps: (name, overrides) => runtime.setProps(name, overrides),
+      /** Name of the component currently mounted as the page root — DC tools
+       *  push their template-stream here when targeting "the open page". */
+      __dcRootName: () => rootName,
+      /** Editor bridge — the encoded, `data-dc-tpl`-annotated template source.
+       *  The host editor parses this into its own template DOM so it can map a
+       *  rendered node (carrying the same `data-dc-tpl`) back to the source
+       *  node that emitted it. Returns the encoded form (`sc-camel-*` attrs,
+       *  `<sc-raw-*>`/`<sc-helmet>` tags); the editor decodes on serialize. */
+      __dcAnnotatedTemplate: (name) => runtime.annotatedTemplate(name),
+      /** Editor bridge — the *original* (decoded) template source. */
+      __dcTemplateSource: (name) => runtime.templateSource(name),
+      __dcBoot: () => {
+        rootName = boot(runtime, document) ?? rootName;
+        notifyHost();
+      },
+      __dcRegistry: runtime.registry.entries,
+      getDC: (name) => runtime.getDC(name),
+      // `DCLogic` is the documented base class name; `StreamableLogic` is the
+      // implementation alias kept for any project that already references it.
+      DCLogic: runtime.StreamableLogic,
+      StreamableLogic: runtime.StreamableLogic
+    };
+    Object.assign(window, api);
+    window.__dcContentKeyed = true;
+    if (document.readyState !== "loading") api.__dcBoot();
+    else document.addEventListener("DOMContentLoaded", () => api.__dcBoot());
+  }
+  hideRawTemplate();
+  loadReactUmd().then(init).catch((err) => {
+    console.error("[dc] failed to load React or boot:", err);
+    throw err;
+  });
+})();


### PR DESCRIPTION
Groundwork for the frontend track. No UI is built here.

Targets `feat/frontend`, per the branch model in #68. Closes #97.

## What landed

**1. `docs/design/` — the mirror (already on the branch as `0b71160`)**

13 deliverable artboards, 4 non-deliverables under `reference/`, plus
`cc-theme.css`, `support.js` and `cc-store.js`. Filenames keep their spaces:
they are the artboard names in the design project, which is what makes the
mirror greppable against it.

**2. `docs/design/README.md` — what the mirror is**

Records that this is a read-only snapshot of
`https://claude.ai/design/p/d7c051c6-9911-493e-aedd-1c42261f30b1`, that the
design project is upstream and this is downstream of it, which artboards are
deliverables and which are `reference/`, that `cc-store.js` is a sketch rather
than a data contract, and how to re-sync.

It also records *why* formatters are kept off the folder. lefthook runs
`biome check --write` on staged files and re-stages the result, and it had
already silently rewritten `support.js` — stripping its generated-file header
and its `"use strict"`, and rewrapping it from 1911 to 2105 lines. A
reformatted mirror is no longer a mirror. Hence the `biome.json` exclusion, the
`.gitattributes` `-diff linguist-generated` marking, and taking `cc-theme.css`,
`support.js` and `cc-store.js` from the design source rather than from the
export.

`.gitattributes` gains one line putting the README itself back in diffs — it is
ours rather than mirrored, and it has to stay reviewable.

**3. `apps/web/data/course-card-sample.ts` — the card fixtures**

`SAMPLE_COURSE`, `SAMPLE_GEO`, `CourseCardModel` and `CardGeometry`, extracted
from the `<script type="text/x-dc">` block of
`docs/design/Course Community - Course Card.dc.html` and that tag's `data-props`
`tsType` values. Every field name, order and value is copied verbatim and
verified against the artboard mechanically — 18 keys in `SAMPLE_GEO`, 37 in
`SAMPLE_COURSE`, same names, same order, same values.

Nothing is renamed or corrected, including the things the schema overrules. The
divergences are recorded in the file header instead, so the card built on this
inherits the note rather than the mistake.

**4. Five theme tokens in `apps/web/app/globals.css`**

`--cc-warn`, `--cc-warn-border`, `--cc-warn-ink`, `--cc-warn-btn`,
`--cc-warn-btn-fg`, added to all three parallel blocks (the `--color-cc-*`
Tailwind bridge, light, dark) — 19 entries each becomes 24 each, same order.
Values checked against `cc-theme.css` mechanically.

The Course Card's "Write a review" button is
`background:var(--warnBtn);color:var(--warnBtnFg)` and had nothing to style
against. Dark `--cc-warn-btn` is amber `#dfa53c` where light is blue `#1751a6`;
that hue change is the design's, and it is kept — on the dark blue surface a
blue button disappears.

## Contradictions found — reported, not fixed

Per the precedence rule on #68, the schema wins in every one of these. None is
fixed here; this list is how the design gets corrected at source.

### Already known

1. **Examination keys: five in the design, six in the schema.**
   `cc-store.js` declares `["exam","assignments","labs","projects","other"]`
   (twice — `EXAMINATION_KEYS` at line 26 and a local `examKeys` at line 957).
   `apps/web/types/review.ts` has six, including **`seminars`**, and the
   `examinationDistributionSchema` refinement requires all six to sum to 100.
   The schema wins.

   The product owner has settled the Swedish label as **"seminarier"**. The repo
   has no Swedish labels at all today — `EXAMINATION_DISTRIBUTION_LABELS` is
   English only, while the design carries an `EXAMINATION_LABELS.sv` map — so
   this is recorded here for whoever adds i18n. No i18n is built in this PR.

   `EXAMINATION_COLORS` and `EXAMINATION_INK` likewise have five entries and no
   sixth. Per the product owner's latest call this is **the implementing
   agent's choice, not an open question** — #87 picks it. The five taken values
   and their inks:

   | key | fill | ink |
   | --- | --- | --- |
   | `exam` | `#1751a6` blue | `#ffffff` |
   | `assignments` | `#dfa53c` amber | `#3a2a06` |
   | `labs` | `#2f9e8e` teal | `#06251f` |
   | `projects` | `#6a4ea8` purple | `#ffffff` |
   | `other` | `#57646f` slate | `#ffffff` |

   Constraints the sixth inherits: it must be distinguishable from all five at a
   glance in a stacked bar (a second blue reads as `exam`), and its
   `EXAMINATION_INK` foreground must pass contrast on its own fill.

2. **Reviews carry an author; the schema and the Review Card do not.**
   `cc-store.js`'s `reviewView` computes
   `const signedName = userName(review.userId) || "KTH student"` and returns it
   as `author`, commenting that "`users.name` is required and there is no
   anonymity column, so a review is always signed". The Review Card artboard
   renders neither `r.author` nor `r.date` anywhere in its markup — it is
   anonymous, agreeing with the schema. Follow the artboard.

   Worth flagging for #87: the Review Card's own `data-props` `tsType` still
   *declares* `author` and `date` even though its markup renders neither, so a
   prop table copied straight from the artboard would reintroduce them.

3. **`likedReviewIds` in `localStorage`.** `cc-store.js` keeps liked review ids
   per user in browser storage (`likedReviewIds` / `setLikedReviewIds`, line
   459). The real backing is `review_votes` — server-side, `(voter_user_id,
   review_id)` primary key, with an `up`/`down` enum. There is no local vote
   state; use `reviews.vote`.

### Additional contradictions found

4. **One `helpfulCount`/`likes` scalar versus two vote directions.** Store
   reviews carry a single `helpfulCount`, and `reviewView` returns it as
   `helpfulCount`. `apps/web/types/review.ts`'s `Review` exposes
   `upvoteCount`, `downvoteCount` and `userVote`. The Review Card artboard is
   caught mid-migration between the two models: its markup reads `r.likes`,
   `r.onUnlike` **and** `r.upvotes` / `r.downvotes` / `r.netScore` /
   `r.onUpvote` / `r.onDownvote`. Only the up/down half has schema backing.
   `CONTEXT.md` also bans "like" as a word for this.

5. **Collections are denormalised and carry a fake `updated`.**
   `cc-store.js`'s `collections` are `{ id, name, codes: [...], updated: "2
   days ago" }`. The schema has `collections` + `collection_courses` (with a
   `position` column the design has no equivalent for) and **no `updated_at`
   column** — only `created_at`. Do not render a "last updated" with nothing
   behind it.

6. **`comparison` versus `collection` in the Course Card's own field names.**
   The artboard's model has `comparisons`, `hasComparisons` and
   `onNewComparison`, and a button reading "Add to comparison". `CONTEXT.md`
   bans "comparison" in identifiers and #68 settles the concept as Collection.
   The fixture keeps the three artboard field names verbatim because #97
   requires it (`Fidelity is the whole point: no invented fields, no renames`)
   and records the divergence in its header; every identifier the file coins
   itself (`CollectionPickerRow`) follows the glossary. **The card and
   everything downstream say `Collection`.** If you would rather the fixture
   renamed them too, say so and I will — the two instructions genuinely
   conflict on this one field.

7. **`educationLevelCode` versus `educationalLevelCode`.** `cc-store.js`'s
   course records use `educationLevelCode`; `schema.ts` has
   `educationalLevelCode` (`educational_level_code`). One letter, and it will
   bite whoever maps the store's shape by hand.

8. **The design's course "summary" is `courses.content`, which does exist.**
   #68 says "keywords and summary have no schema backing at all". Neither half
   is quite right. `cc-store.js` maps `summary: course.content` in both
   `courseView` and `catalogCardView` — that is `courses.content`, a real
   column populated from KOPPS syllabus prose. So the summary section can
   render real (if long) source prose rather than an empty state, if #73 would
   rather clip `courses.content` than wait for a generator. Worth settling
   before #86/#87 build the empty states.

9. **Keywords point at a `course_explore` column that does not exist.**
   `catalogCardView` sets `keywords: exploreTags(code).join(", ")` and comments
   "Tags come from `course_explore`; the course record has no keyword column",
   and `exploreTags` reads `courseExplore[code].searchTerms`. The real
   `course_explore` table has `embedding`, `source_hash`, `search_vector`,
   `embedding_model` and `embedded_at` — **no `search_terms`**, and nothing in
   `server/` writes one. This is sharper than "keywords are unbacked": the
   design names the table it expects them in, so #73 has a concrete place to
   put them if that is the decision.

10. **`statTaken` conflates enrolment with app users.** The fixture's
   `statTaken: "1.2k"` and `takenTitle: "1.2k students have taken this course"`
   come from `cc-store.js`'s `enrolledCount` (e.g. `2450` for DD1337), which is
   KTH enrolment. The schema only knows `user_taken_courses` — app users who
   self-reported. `CourseStats.takenCount` is documented as exactly that, and
   it will be two or three orders of magnitude smaller. The number is real, the
   sentence around it is not: "1.2k students have taken this course" should not
   be said of a count of app users.

11. **`happyAnswerCount` has nothing to count.** Store metrics carry
    `happyAnswerCount` separately from `reviewCount` (e.g. 38 of 214), implying
    `happyTook` can go unanswered. `reviews.happy_took` is `boolean NOT NULL`,
    so every review answers it and the two counts are always equal.
    `CourseReviewStats` has only `happyCount` / `reviewCount`, correctly.

12. **`themeLine` and `missingNote` have no writer.** Store metrics carry a
    one-line editorial summary of a course's reviews (`"Lab 2 is the whole
    course"`) gated on `WRITTEN_THEME_THRESHOLD`, plus a `missingNote`. Neither
    exists in the schema or in #67, and both look generated. Same class as
    `keywords`: flag rather than invent.

13. **`prereqCourses` items disagree with themselves.** The sample literal sets
    `{ code, name, inCatalog }`, but the artboard markup renders `p.taken`,
    `p.gap`, `p.padding`, `p.radius` and `p.bg` and never reads `inCatalog`.
    Both sets are typed in the fixture (`inCatalog` required, the markup-only
    ones optional) since neither is invented. Per #68 the tick is display-only:
    marking a course taken never cascades into its prerequisites.

14. **Scores are on the artboard's 1–5 scale.** `workload: "3.8"`,
    `learning: "4.2"`, `wlW: "76%"`. Settled on #68: scores are 1–10 displayed
    raw, and `76%` is the same bar width for a 7.6 out of 10. Kept verbatim in
    the fixture and flagged in its header; nothing converts.

## Gates

`bun run test:web` (19 files, 176 tests), `npx tsc --noEmit` and `bun run lint`
all pass. `/code-review` run on both axes; findings applied.

`dev` has not moved under `feat/frontend` during this work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01D3d7V2JceJZvtJED18HXFJ
