### PR TITLE
feat(search): move course search state to course_explore (#77)

### DIFF
--- a/apps/web/server/ai.ts
+++ b/apps/web/server/ai.ts
@@ -1,6 +1,8 @@
 import { cosineSimilarity, embed, embedMany, gateway } from "ai";
 
-const embeddingModel = gateway.embeddingModel("openai/text-embedding-3-small");
+export const EMBEDDING_MODEL = "openai/text-embedding-3-small";
+
+const embeddingModel = gateway.embeddingModel(EMBEDDING_MODEL);
 
 export async function embedSingle(
   value: string,

--- a/apps/web/server/course/service.spec.ts
+++ b/apps/web/server/course/service.spec.ts
@@ -226,7 +226,6 @@ describe("getStatsByCodes", () => {
 
 const course = {
   code: "SF1625",
-  name: "Envariabelanalys",
   titleSwe: "Envariabelanalys",
   titleEng: "Calculus in One Variable",
   state: "ESTABLISHED",
@@ -241,9 +240,6 @@ const course = {
   eligibility: null,
   createdAt: new Date("2026-01-01T00:00:00.000Z"),
   updatedAt: new Date("2026-01-01T00:00:00.000Z"),
-  embedding: null,
-  embeddingHash: null,
-  searchVector: null,
 } as unknown as SelectCourse;
 
 describe("getSummary", () => {

--- a/apps/web/server/db/drizzle/0013_damp_viper.sql
+++ b/apps/web/server/db/drizzle/0013_damp_viper.sql
@@ -1,0 +1,34 @@
+-- Contract phase for course search state (#77). Search and ingest now use
+-- course_explore directly, so the compatibility trigger from 0009 and the
+-- four legacy course columns can be removed.
+--
+-- Refuse to discard the legacy copy if the target row or any moved value has
+-- drifted. The trigger should make this impossible; failing here turns a
+-- broken assumption into an explicit migration error instead of data loss.
+DO $$
+BEGIN
+	IF EXISTS (
+		SELECT 1
+		FROM "courses"
+		LEFT JOIN "course_explore"
+			ON "course_explore"."course_code" = "courses"."code"
+		WHERE "course_explore"."course_code" IS NULL
+			OR "course_explore"."embedding" IS DISTINCT FROM "courses"."embedding"
+			OR "course_explore"."source_hash" IS DISTINCT FROM "courses"."embedding_hash"
+			OR "course_explore"."search_vector" IS DISTINCT FROM "courses"."search_vector"
+	) THEN
+		RAISE EXCEPTION 'Cannot contract courses: course_explore search state differs from the legacy columns';
+	END IF;
+END
+$$;--> statement-breakpoint
+
+DROP TRIGGER "courses_explore_target_sync" ON "courses";--> statement-breakpoint
+DROP FUNCTION "sync_courses_to_course_explore"();--> statement-breakpoint
+
+DROP INDEX "courses_search_vector_idx";--> statement-breakpoint
+DROP INDEX "courses_embedding_idx";--> statement-breakpoint
+DROP INDEX "courses_name_trgm_idx";--> statement-breakpoint
+ALTER TABLE "courses" DROP COLUMN "name";--> statement-breakpoint
+ALTER TABLE "courses" DROP COLUMN "embedding";--> statement-breakpoint
+ALTER TABLE "courses" DROP COLUMN "embedding_hash";--> statement-breakpoint
+ALTER TABLE "courses" DROP COLUMN "search_vector";

--- a/apps/web/server/db/drizzle/meta/0013_snapshot.json
+++ b/apps/web/server/db/drizzle/meta/0013_snapshot.json
@@ -1,0 +1,1729 @@
+{
+  "id": "df1cfcf1-2975-4f27-9a27-7abd57d06cc8",
+  "prevId": "ab856fe0-aa82-400a-9c09-cc556bb9a8dd",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.collection_courses": {
+      "name": "collection_courses",
+      "schema": "",
+      "columns": {
+        "collection_id": {
+          "name": "collection_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "collection_user_id": {
+          "name": "collection_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "course_code": {
+          "name": "course_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "collection_courses_collection_owner_idx": {
+          "name": "collection_courses_collection_owner_idx",
+          "columns": [
+            {
+              "expression": "collection_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "collection_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "collection_courses_saved_course_idx": {
+          "name": "collection_courses_saved_course_idx",
+          "columns": [
+            {
+              "expression": "collection_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "course_code",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "collection_courses_collection_owner_fk": {
+          "name": "collection_courses_collection_owner_fk",
+          "tableFrom": "collection_courses",
+          "tableTo": "collections",
+          "columnsFrom": ["collection_id", "collection_user_id"],
+          "columnsTo": ["id", "user_id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "collection_courses_saved_course_fk": {
+          "name": "collection_courses_saved_course_fk",
+          "tableFrom": "collection_courses",
+          "tableTo": "user_saved_courses",
+          "columnsFrom": ["collection_user_id", "course_code"],
+          "columnsTo": ["user_id", "course_code"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "collection_courses_collection_id_course_code_pk": {
+          "name": "collection_courses_collection_id_course_code_pk",
+          "columns": ["collection_id", "course_code"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "position_nonnegative": {
+          "name": "position_nonnegative",
+          "value": "\"collection_courses\".\"position\" >= 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.collections": {
+      "name": "collections",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "collections_user_id_idx": {
+          "name": "collections_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "collections_user_id_users_id_fk": {
+          "name": "collections_user_id_users_id_fk",
+          "tableFrom": "collections",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "collections_id_user_id_unique": {
+          "name": "collections_id_user_id_unique",
+          "nullsNotDistinct": false,
+          "columns": ["id", "user_id"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.course_examinations": {
+      "name": "course_examinations",
+      "schema": "",
+      "columns": {
+        "course_code": {
+          "name": "course_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "exam_code": {
+          "name": "exam_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "credits": {
+          "name": "credits",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "grade_scale_code": {
+          "name": "grade_scale_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "course_examinations_course_code_courses_code_fk": {
+          "name": "course_examinations_course_code_courses_code_fk",
+          "tableFrom": "course_examinations",
+          "tableTo": "courses",
+          "columnsFrom": ["course_code"],
+          "columnsTo": ["code"],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "course_examinations_course_code_exam_code_pk": {
+          "name": "course_examinations_course_code_exam_code_pk",
+          "columns": ["course_code", "exam_code"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.course_explore": {
+      "name": "course_explore",
+      "schema": "",
+      "columns": {
+        "course_code": {
+          "name": "course_code",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "embedding": {
+          "name": "embedding",
+          "type": "vector(1536)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_hash": {
+          "name": "source_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "search_vector": {
+          "name": "search_vector",
+          "type": "tsvector",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "embedding_model": {
+          "name": "embedding_model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "embedded_at": {
+          "name": "embedded_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "course_explore_search_vector_idx": {
+          "name": "course_explore_search_vector_idx",
+          "columns": [
+            {
+              "expression": "search_vector",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        },
+        "course_explore_embedding_idx": {
+          "name": "course_explore_embedding_idx",
+          "columns": [
+            {
+              "expression": "embedding",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "vector_cosine_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "hnsw",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "course_explore_course_code_courses_code_fk": {
+          "name": "course_explore_course_code_courses_code_fk",
+          "tableFrom": "course_explore",
+          "tableTo": "courses",
+          "columnsFrom": ["course_code"],
+          "columnsTo": ["code"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.course_prerequisites": {
+      "name": "course_prerequisites",
+      "schema": "",
+      "columns": {
+        "course_code": {
+          "name": "course_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "prerequisite_course_code": {
+          "name": "prerequisite_course_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "course_prerequisites_prerequisite_course_code_idx": {
+          "name": "course_prerequisites_prerequisite_course_code_idx",
+          "columns": [
+            {
+              "expression": "prerequisite_course_code",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "course_prerequisites_course_code_courses_code_fk": {
+          "name": "course_prerequisites_course_code_courses_code_fk",
+          "tableFrom": "course_prerequisites",
+          "tableTo": "courses",
+          "columnsFrom": ["course_code"],
+          "columnsTo": ["code"],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "course_prerequisites_prerequisite_course_code_courses_code_fk": {
+          "name": "course_prerequisites_prerequisite_course_code_courses_code_fk",
+          "tableFrom": "course_prerequisites",
+          "tableTo": "courses",
+          "columnsFrom": ["prerequisite_course_code"],
+          "columnsTo": ["code"],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "course_prerequisites_course_code_prerequisite_course_code_pk": {
+          "name": "course_prerequisites_course_code_prerequisite_course_code_pk",
+          "columns": ["course_code", "prerequisite_course_code"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.course_rounds": {
+      "name": "course_rounds",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "course_code": {
+          "name": "course_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "start_term": {
+          "name": "start_term",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "study_pace": {
+          "name": "study_pace",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "schema_url": {
+          "name": "schema_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "language": {
+          "name": "language",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tutoring_form": {
+          "name": "tutoring_form",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tutoring_time_of_day": {
+          "name": "tutoring_time_of_day",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "formatted_periods_and_credits": {
+          "name": "formatted_periods_and_credits",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_pu": {
+          "name": "is_pu",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_vu": {
+          "name": "is_vu",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "course_rounds_course_code_idx": {
+          "name": "course_rounds_course_code_idx",
+          "columns": [
+            {
+              "expression": "course_code",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "course_rounds_course_code_courses_code_fk": {
+          "name": "course_rounds_course_code_courses_code_fk",
+          "tableFrom": "course_rounds",
+          "tableTo": "courses",
+          "columnsFrom": ["course_code"],
+          "columnsTo": ["code"],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "study_pace_range": {
+          "name": "study_pace_range",
+          "value": "\"course_rounds\".\"study_pace\" between 1 and 100"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.courses": {
+      "name": "courses",
+      "schema": "",
+      "columns": {
+        "code": {
+          "name": "code",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name_swedish": {
+          "name": "name_swedish",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name_english": {
+          "name": "name_english",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "state": {
+          "name": "state",
+          "type": "course_state",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "credits": {
+          "name": "credits",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "credit_unit": {
+          "name": "credit_unit",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "department_code": {
+          "name": "department_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "department": {
+          "name": "department",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "educational_level_code": {
+          "name": "educational_level_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "grade_scale_code": {
+          "name": "grade_scale_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "goals": {
+          "name": "goals",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "eligibility": {
+          "name": "eligibility",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "courses_code_trgm_idx": {
+          "name": "courses_code_trgm_idx",
+          "columns": [
+            {
+              "expression": "code",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "gin_trgm_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.feedback_form": {
+      "name": "feedback_form",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "message": {
+          "name": "message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.review_votes": {
+      "name": "review_votes",
+      "schema": "",
+      "columns": {
+        "voter_user_id": {
+          "name": "voter_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "review_id": {
+          "name": "review_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "vote_type": {
+          "name": "vote_type",
+          "type": "review_vote_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "review_votes_review_id_idx": {
+          "name": "review_votes_review_id_idx",
+          "columns": [
+            {
+              "expression": "review_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "review_votes_voter_user_id_users_id_fk": {
+          "name": "review_votes_voter_user_id_users_id_fk",
+          "tableFrom": "review_votes",
+          "tableTo": "users",
+          "columnsFrom": ["voter_user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "review_votes_review_id_reviews_id_fk": {
+          "name": "review_votes_review_id_reviews_id_fk",
+          "tableFrom": "review_votes",
+          "tableTo": "reviews",
+          "columnsFrom": ["review_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "review_votes_voter_user_id_review_id_pk": {
+          "name": "review_votes_voter_user_id_review_id_pk",
+          "columns": ["voter_user_id", "review_id"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.reviews": {
+      "name": "reviews",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "course_code": {
+          "name": "course_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "examination_distribution": {
+          "name": "examination_distribution",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "approach_theory_percent": {
+          "name": "approach_theory_percent",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "workload_score": {
+          "name": "workload_score",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "learning_score": {
+          "name": "learning_score",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "happy_took": {
+          "name": "happy_took",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "message": {
+          "name": "message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "reviews_user_id_idx": {
+          "name": "reviews_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "reviews_course_code_idx": {
+          "name": "reviews_course_code_idx",
+          "columns": [
+            {
+              "expression": "course_code",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "reviews_user_id_users_id_fk": {
+          "name": "reviews_user_id_users_id_fk",
+          "tableFrom": "reviews",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "reviews_course_code_courses_code_fk": {
+          "name": "reviews_course_code_courses_code_fk",
+          "tableFrom": "reviews",
+          "tableTo": "courses",
+          "columnsFrom": ["course_code"],
+          "columnsTo": ["code"],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "approach_theory_percent_range": {
+          "name": "approach_theory_percent_range",
+          "value": "\"reviews\".\"approach_theory_percent\" between 0 and 100"
+        },
+        "workload_score_range": {
+          "name": "workload_score_range",
+          "value": "\"reviews\".\"workload_score\" between 1 and 10"
+        },
+        "learning_score_range": {
+          "name": "learning_score_range",
+          "value": "\"reviews\".\"learning_score\" between 1 and 10"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.user_saved_courses": {
+      "name": "user_saved_courses",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "course_code": {
+          "name": "course_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "user_saved_courses_course_code_idx": {
+          "name": "user_saved_courses_course_code_idx",
+          "columns": [
+            {
+              "expression": "course_code",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_saved_courses_user_id_users_id_fk": {
+          "name": "user_saved_courses_user_id_users_id_fk",
+          "tableFrom": "user_saved_courses",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "user_saved_courses_course_code_courses_code_fk": {
+          "name": "user_saved_courses_course_code_courses_code_fk",
+          "tableFrom": "user_saved_courses",
+          "tableTo": "courses",
+          "columnsFrom": ["course_code"],
+          "columnsTo": ["code"],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "user_saved_courses_user_id_course_code_pk": {
+          "name": "user_saved_courses_user_id_course_code_pk",
+          "columns": ["user_id", "course_code"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_taken_courses": {
+      "name": "user_taken_courses",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "course_code": {
+          "name": "course_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "attendance_periods": {
+          "name": "attendance_periods",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "attendance_year": {
+          "name": "attendance_year",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "grade": {
+          "name": "grade",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "earned_credits": {
+          "name": "earned_credits",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "transcript_imported_at": {
+          "name": "transcript_imported_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "user_taken_courses_course_code_idx": {
+          "name": "user_taken_courses_course_code_idx",
+          "columns": [
+            {
+              "expression": "course_code",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_taken_courses_user_id_users_id_fk": {
+          "name": "user_taken_courses_user_id_users_id_fk",
+          "tableFrom": "user_taken_courses",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "user_taken_courses_course_code_courses_code_fk": {
+          "name": "user_taken_courses_course_code_courses_code_fk",
+          "tableFrom": "user_taken_courses",
+          "tableTo": "courses",
+          "columnsFrom": ["course_code"],
+          "columnsTo": ["code"],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "user_taken_courses_user_id_course_code_pk": {
+          "name": "user_taken_courses_user_id_course_code_pk",
+          "columns": ["user_id", "course_code"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users_graph_backbone_edges": {
+      "name": "users_graph_backbone_edges",
+      "schema": "",
+      "columns": {
+        "node_user_id": {
+          "name": "node_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "anchor_user_id": {
+          "name": "anchor_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "users_graph_backbone_edges_anchor_user_id_idx": {
+          "name": "users_graph_backbone_edges_anchor_user_id_idx",
+          "columns": [
+            {
+              "expression": "anchor_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "users_graph_backbone_edges_node_user_id_users_graph_nodes_user_id_fk": {
+          "name": "users_graph_backbone_edges_node_user_id_users_graph_nodes_user_id_fk",
+          "tableFrom": "users_graph_backbone_edges",
+          "tableTo": "users_graph_nodes",
+          "columnsFrom": ["node_user_id"],
+          "columnsTo": ["user_id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "users_graph_backbone_edges_anchor_user_id_users_graph_nodes_user_id_fk": {
+          "name": "users_graph_backbone_edges_anchor_user_id_users_graph_nodes_user_id_fk",
+          "tableFrom": "users_graph_backbone_edges",
+          "tableTo": "users_graph_nodes",
+          "columnsFrom": ["anchor_user_id"],
+          "columnsTo": ["user_id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "users_graph_backbone_edges_node_user_id_anchor_user_id_pk": {
+          "name": "users_graph_backbone_edges_node_user_id_anchor_user_id_pk",
+          "columns": ["node_user_id", "anchor_user_id"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "no_self_backbone_edge": {
+          "name": "no_self_backbone_edge",
+          "value": "\"users_graph_backbone_edges\".\"node_user_id\" <> \"users_graph_backbone_edges\".\"anchor_user_id\""
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.users_graph_nodes": {
+      "name": "users_graph_nodes",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "x": {
+          "name": "x",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "y": {
+          "name": "y",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "users_graph_nodes_user_id_users_id_fk": {
+          "name": "users_graph_nodes_user_id_users_id_fk",
+          "tableFrom": "users_graph_nodes",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users_node_profiles": {
+      "name": "users_node_profiles",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "color": {
+          "name": "color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'default'"
+        },
+        "style": {
+          "name": "style",
+          "type": "node_style",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'default'"
+        },
+        "signal_style": {
+          "name": "signal_style",
+          "type": "node_signal_style",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'default'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "users_node_profiles_user_id_users_id_fk": {
+          "name": "users_node_profiles_user_id_users_id_fk",
+          "tableFrom": "users_node_profiles",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.accounts": {
+      "name": "accounts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "issuer": {
+          "name": "issuer",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "accounts_issuer_accountId_uidx": {
+          "name": "accounts_issuer_accountId_uidx",
+          "columns": [
+            {
+              "expression": "issuer",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "accounts_userId_idx": {
+          "name": "accounts_userId_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "accounts_user_id_users_id_fk": {
+          "name": "accounts_user_id_users_id_fk",
+          "tableFrom": "accounts",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sessions": {
+      "name": "sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "sessions_userId_idx": {
+          "name": "sessions_userId_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "sessions_user_id_users_id_fk": {
+          "name": "sessions_user_id_users_id_fk",
+          "tableFrom": "sessions",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "sessions_token_unique": {
+          "name": "sessions_token_unique",
+          "nullsNotDistinct": false,
+          "columns": ["token"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "personalization_tier_earned": {
+          "name": "personalization_tier_earned",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "nullsNotDistinct": false,
+          "columns": ["email"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "personalization_tier_earned_range": {
+          "name": "personalization_tier_earned_range",
+          "value": "\"users\".\"personalization_tier_earned\" between 0 and 3"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.verifications": {
+      "name": "verifications",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "verifications_identifier_idx": {
+          "name": "verifications_identifier_idx",
+          "columns": [
+            {
+              "expression": "identifier",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.course_state": {
+      "name": "course_state",
+      "schema": "public",
+      "values": ["CANCELLED", "ESTABLISHED", "DEACTIVATED"]
+    },
+    "public.node_signal_style": {
+      "name": "node_signal_style",
+      "schema": "public",
+      "values": ["default"]
+    },
+    "public.node_style": {
+      "name": "node_style",
+      "schema": "public",
+      "values": ["default"]
+    },
+    "public.review_vote_type": {
+      "name": "review_vote_type",
+      "schema": "public",
+      "values": ["up", "down"]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/apps/web/server/db/drizzle/meta/_journal.json
+++ b/apps/web/server/db/drizzle/meta/_journal.json
@@ -64,6 +64,13 @@
       "when": 1788480553747,
       "tag": "0012_review_contract",
       "breakpoints": true
+    },
+    {
+      "idx": 13,
+      "version": "7",
+      "when": 1788509154355,
+      "tag": "0013_damp_viper",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/web/server/db/schema.ts
+++ b/apps/web/server/db/schema.ts
@@ -54,7 +54,6 @@ export const courses = pgTable(
   "courses",
   {
     code: text("code").primaryKey(),
-    name: text("name").notNull(), // TODO: remove this, redudant info
     titleSwe: text("name_swedish").notNull(),
     titleEng: text("name_english").notNull(),
     state: courseState("state").notNull(),
@@ -77,19 +76,8 @@ export const courses = pgTable(
     updatedAt: timestamp("updated_at", { withTimezone: true })
       .defaultNow()
       .notNull(),
-    embedding: vector("embedding", { dimensions: 1536 }),
-    embeddingHash: text("embedding_hash"),
-    searchVector: tsvector("search_vector").generatedAlwaysAs(
-      sql`to_tsvector('simple', coalesce(name_english, '') || ' ' || coalesce(name_swedish, '') || ' ' || coalesce(code, '') || ' ' || coalesce(goals, '') || ' ' || coalesce(content, ''))`,
-    ),
   },
   (table) => [
-    index("courses_search_vector_idx").using("gin", table.searchVector),
-    index("courses_embedding_idx").using(
-      "hnsw",
-      table.embedding.op("vector_cosine_ops"),
-    ),
-    index("courses_name_trgm_idx").using("gin", table.name.op("gin_trgm_ops")),
     index("courses_code_trgm_idx").using("gin", table.code.op("gin_trgm_ops")),
   ],
 );

--- a/apps/web/server/ingest/ingest.ts
+++ b/apps/web/server/ingest/ingest.ts
@@ -1,7 +1,7 @@
 import { createHash } from "node:crypto";
 import { inArray, sql } from "drizzle-orm";
 import type { z } from "zod";
-import { embedBatch } from "../ai";
+import { EMBEDDING_MODEL, embedBatch } from "../ai";
 import { db } from "../db";
 import {
   courseExaminations as courseExaminationsTable,
@@ -12,6 +12,10 @@ import {
   type InsertCourseRound,
 } from "../db/schema";
 import { getCourseInformation, getCourses } from "./kopps";
+import {
+  findCourseExploreSourceHashes,
+  upsertCourseExploreSearchState,
+} from "./repository";
 import type { CoursesSchema } from "./schemas";
 
 const status = {
@@ -146,7 +150,6 @@ async function convertCourses(courses: z.infer<typeof CoursesSchema>): Promise<{
 
       const insertCourse: InsertCourse = {
         code: detail.course.courseCode,
-        name: detail.course.titleOther,
         titleSwe: detail.course.title,
         titleEng: detail.course.titleOther,
         state: course.state,
@@ -214,7 +217,6 @@ async function upsertCourses(courses: InsertCourse[]) {
       .onConflictDoUpdate({
         target: coursesTable.code,
         set: {
-          name: sql`excluded.name`,
           titleSwe: sql`excluded.name_swedish`,
           titleEng: sql`excluded.name_english`,
           state: sql`excluded.state`,
@@ -277,38 +279,30 @@ async function generateAndStoreEmbeddings(courses: InsertCourse[]) {
     );
 
     const batchWithHash = batch.map((course) => {
-      const text = [
-        course.code,
-        course.titleEng,
-        course.titleSwe,
-        course.goals,
-        course.content,
-      ]
+      const { code, titleEng, titleSwe, goals, content } = course;
+      // Preserve the legacy embedding-hash input byte for byte so moving its
+      // storage does not cause an unnecessary re-embed.
+      const embeddingText = [code, titleEng, titleSwe, goals, content]
         .filter(Boolean)
         .join(" ");
-      const hash = createHash("sha256").update(text).digest("hex");
-      return { course, text, hash };
+      const sourceHash = createHash("sha256")
+        .update(embeddingText)
+        .digest("hex");
+      // This order matches the generated courses.search_vector expression
+      // being retired by migration 0013, preserving full-text rank positions.
+      const searchText = [titleEng, titleSwe, code, goals, content]
+        .map((value) => value ?? "")
+        .join(" ");
+      return { course, embeddingText, sourceHash, searchText };
     });
 
-    const existingRows = await db
-      .select({
-        code: coursesTable.code,
-        embeddingHash: coursesTable.embeddingHash,
-      })
-      .from(coursesTable)
-      .where(
-        inArray(
-          coursesTable.code,
-          batch.map((c) => c.code),
-        ),
-      );
-
-    const existingHashByCode = new Map(
-      existingRows.map((row) => [row.code, row.embeddingHash]),
+    const existingSourceHashByCode = await findCourseExploreSourceHashes(
+      batch.map((course) => course.code),
     );
 
     const toEmbed = batchWithHash.filter(
-      ({ course, hash }) => existingHashByCode.get(course.code) !== hash,
+      ({ course, sourceHash }) =>
+        existingSourceHashByCode.get(course.code) !== sourceHash,
     );
 
     if (toEmbed.length === 0) {
@@ -318,17 +312,19 @@ async function generateAndStoreEmbeddings(courses: InsertCourse[]) {
       continue;
     }
 
-    const { embeddings } = await embedBatch(toEmbed.map((x) => x.text));
+    const { embeddings } = await embedBatch(
+      toEmbed.map((item) => item.embeddingText),
+    );
 
     await Promise.all(
       toEmbed.map((item, idx) =>
-        db
-          .update(coursesTable)
-          .set({
-            embedding: sql`${JSON.stringify(embeddings[idx])}::vector`,
-            embeddingHash: item.hash,
-          })
-          .where(sql`code = ${item.course.code}`),
+        upsertCourseExploreSearchState({
+          courseCode: item.course.code,
+          embedding: embeddings[idx],
+          sourceHash: item.sourceHash,
+          searchText: item.searchText,
+          embeddingModel: EMBEDDING_MODEL,
+        }),
       ),
     );
   }

--- a/apps/web/server/ingest/repository.ts
+++ b/apps/web/server/ingest/repository.ts
@@ -1,0 +1,49 @@
+import { inArray, sql } from "drizzle-orm";
+import { db } from "../db";
+import { courseExplore } from "../db/schema";
+
+export async function findCourseExploreSourceHashes(
+  courseCodes: string[],
+): Promise<Map<string, string | null>> {
+  if (courseCodes.length === 0) return new Map();
+
+  const rows = await db
+    .select({
+      courseCode: courseExplore.courseCode,
+      sourceHash: courseExplore.sourceHash,
+    })
+    .from(courseExplore)
+    .where(inArray(courseExplore.courseCode, courseCodes));
+
+  return new Map(rows.map((row) => [row.courseCode, row.sourceHash]));
+}
+
+export async function upsertCourseExploreSearchState(input: {
+  courseCode: string;
+  embedding: number[];
+  sourceHash: string;
+  searchText: string;
+  embeddingModel: string;
+}): Promise<void> {
+  await db
+    .insert(courseExplore)
+    .values({
+      courseCode: input.courseCode,
+      embedding: sql`${JSON.stringify(input.embedding)}::vector`,
+      sourceHash: input.sourceHash,
+      searchVector: sql`to_tsvector('simple', ${input.searchText})`,
+      embeddingModel: input.embeddingModel,
+      embeddedAt: sql`now()`,
+    })
+    .onConflictDoUpdate({
+      target: courseExplore.courseCode,
+      set: {
+        embedding: sql`excluded.embedding`,
+        sourceHash: sql`excluded.source_hash`,
+        searchVector: sql`excluded.search_vector`,
+        embeddingModel: sql`excluded.embedding_model`,
+        embeddedAt: sql`excluded.embedded_at`,
+        updatedAt: sql`now()`,
+      },
+    });
+}

--- a/apps/web/server/search/repository.spec.ts
+++ b/apps/web/server/search/repository.spec.ts
@@ -1,0 +1,30 @@
+import type { SQL } from "drizzle-orm";
+import { PgDialect } from "drizzle-orm/pg-core";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { db } from "../db";
+import { searchByKeyword } from "./repository";
+
+vi.mock("../db", () => ({
+  db: {
+    execute: vi.fn(),
+  },
+}));
+
+describe("searchByKeyword", () => {
+  beforeEach(() => {
+    vi.mocked(db.execute).mockReset();
+    vi.mocked(db.execute).mockResolvedValue({ rows: [] } as never);
+  });
+
+  it("does not require a course_explore row for code and title matches", async () => {
+    await searchByKeyword("machine learning", 10, null, false);
+
+    const query = vi.mocked(db.execute).mock.calls[0]?.[0] as SQL | undefined;
+    expect(query).toBeDefined();
+
+    const queryText = new PgDialect()
+      .sqlToQuery(query as SQL)
+      .sql.toLowerCase();
+    expect(queryText).toContain('left join "course_explore"');
+  });
+});

--- a/apps/web/server/search/repository.ts
+++ b/apps/web/server/search/repository.ts
@@ -42,7 +42,7 @@ export async function searchByKeyword(
   const result = await db.execute(sql`
       SELECT ${schema.courses.code} AS code
       FROM ${schema.courses}
-      INNER JOIN ${schema.courseExplore}
+      LEFT JOIN ${schema.courseExplore}
         ON ${schema.courseExplore.courseCode} = ${schema.courses.code}
       WHERE ${whereSql}
       ORDER BY

--- a/apps/web/server/search/repository.ts
+++ b/apps/web/server/search/repository.ts
@@ -22,44 +22,48 @@ export async function searchByKeyword(
 
   const conditions = [
     sql`(
-        code ILIKE ${codePrefix}
-        OR code ILIKE ${codeContains}
-        OR name_swedish ILIKE ${textPattern}
-        OR name_english ILIKE ${textPattern}
+        ${schema.courses.code} ILIKE ${codePrefix}
+        OR ${schema.courses.code} ILIKE ${codeContains}
+        OR ${schema.courses.titleSwe} ILIKE ${textPattern}
+        OR ${schema.courses.titleEng} ILIKE ${textPattern}
         OR (
           ${normalizedQuery} <> ''
-          AND search_vector @@ plainto_tsquery('simple', ${normalizedQuery})
+          AND ${schema.courseExplore.searchVector} @@ plainto_tsquery('simple', ${normalizedQuery})
         )
       )`,
   ];
   if (departmentFilter) {
-    conditions.push(sql`department ILIKE ${`%${departmentFilter}%`}`);
+    conditions.push(
+      sql`${schema.courses.department} ILIKE ${`%${departmentFilter}%`}`,
+    );
   }
 
   const whereSql = sql.join(conditions, sql` AND `);
   const result = await db.execute(sql`
-      SELECT code
+      SELECT ${schema.courses.code} AS code
       FROM ${schema.courses}
+      INNER JOIN ${schema.courseExplore}
+        ON ${schema.courseExplore.courseCode} = ${schema.courses.code}
       WHERE ${whereSql}
       ORDER BY
         CASE
-          WHEN code ILIKE ${codePrefix} THEN 0
-          WHEN code ILIKE ${codeContains} THEN 1
+          WHEN ${schema.courses.code} ILIKE ${codePrefix} THEN 0
+          WHEN ${schema.courses.code} ILIKE ${codeContains} THEN 1
           WHEN (
             ${normalizedQuery} <> ''
-            AND search_vector @@ plainto_tsquery('simple', ${normalizedQuery})
+            AND ${schema.courseExplore.searchVector} @@ plainto_tsquery('simple', ${normalizedQuery})
           ) THEN 2
           ELSE 3
         END,
         CASE
           WHEN (
             ${normalizedQuery} <> ''
-            AND search_vector @@ plainto_tsquery('simple', ${normalizedQuery})
+            AND ${schema.courseExplore.searchVector} @@ plainto_tsquery('simple', ${normalizedQuery})
           )
-            THEN ts_rank(search_vector, plainto_tsquery('simple', ${normalizedQuery}))
+            THEN ts_rank(${schema.courseExplore.searchVector}, plainto_tsquery('simple', ${normalizedQuery}))
           ELSE 0
         END DESC,
-        code ASC
+        ${schema.courses.code} ASC
       LIMIT ${fetchSize}
     `);
 
@@ -75,18 +79,25 @@ export async function searchByEmbedding(
   departmentFilter: string | null,
 ): Promise<SearchHit[]> {
   const vectorLiteral = JSON.stringify(embedding);
-  const conditions = [sql`embedding IS NOT NULL`];
+  const conditions = [sql`${schema.courseExplore.embedding} IS NOT NULL`];
   if (departmentFilter) {
-    conditions.push(sql`department ILIKE ${`%${departmentFilter}%`}`);
+    conditions.push(
+      sql`${schema.courses.department} ILIKE ${`%${departmentFilter}%`}`,
+    );
   }
   const whereSql = sql.join(conditions, sql` AND `);
 
   const result = await db.execute(sql`
         WITH q AS (SELECT ${vectorLiteral}::vector AS v)
-        SELECT code, 1 - (embedding <=> q.v) AS score
-        FROM ${schema.courses}, q
+        SELECT
+          ${schema.courses.code} AS code,
+          1 - (${schema.courseExplore.embedding} <=> q.v) AS score
+        FROM ${schema.courses}
+        INNER JOIN ${schema.courseExplore}
+          ON ${schema.courseExplore.courseCode} = ${schema.courses.code}
+        CROSS JOIN q
         WHERE ${whereSql}
-        ORDER BY embedding <=> q.v
+        ORDER BY ${schema.courseExplore.embedding} <=> q.v
         LIMIT ${limit}
       `);
 

--- a/apps/web/server/search/service.spec.ts
+++ b/apps/web/server/search/service.spec.ts
@@ -1,11 +1,12 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { CourseSummary } from "@/types";
+import { embedSingle } from "../ai";
 import { getSummariesByCodes } from "../course/service";
 import {
   getAggregatesByCourseCodes,
   type ReviewAggregate,
 } from "../reviews/service";
-import { searchByKeyword } from "./repository";
+import { searchByEmbedding, searchByKeyword } from "./repository";
 import { searchCourses } from "./service";
 
 vi.mock("./repository");
@@ -132,5 +133,28 @@ describe("searchCourses minimum-rating filter", () => {
 
     expect(results.map((r) => r.courseCode)).toEqual(["SF1625", "DD2421"]);
     expect(getAggregatesByCourseCodes).not.toHaveBeenCalled();
+  });
+
+  it("keeps keyword order and appends only new semantic hits", async () => {
+    vi.mocked(embedSingle).mockResolvedValueOnce({
+      embedding: [0.25, 0.5],
+      usage: { tokens: 2 },
+    });
+    vi.mocked(searchByKeyword).mockResolvedValueOnce([
+      { courseCode: "SF1625", score: null },
+      { courseCode: "DD2421", score: null },
+    ]);
+    vi.mocked(searchByEmbedding).mockResolvedValueOnce([
+      { courseCode: "DD2421", score: 0.95 },
+      { courseCode: "ID2209", score: 0.9 },
+    ]);
+
+    const results = await searchCourses("distributed systems", 3);
+
+    expect(results.map((result) => result.courseCode)).toEqual([
+      "SF1625",
+      "DD2421",
+      "ID2209",
+    ]);
   });
 });


### PR DESCRIPTION
## Summary

- Move keyword and semantic search reads from legacy `courses` columns to `course_explore`.
- Write embeddings, source hashes, full-text vectors, model provenance, and timestamps to `course_explore` during ingest.
- Contract the `courses` table by removing the redundant name and legacy search columns and indexes.
- Preserve existing search ordering and deduplication behavior with a characterization test.

## Migration

Adds migration `0013_damp_viper.sql`. It verifies that `course_explore` matches the legacy search state before dropping the compatibility trigger, function, columns, and dependent indexes.

The migration is committed only and has not been applied to a Neon branch.

## Verification

- `bun run test`: 177 tests passed across 19 files
- `npx tsc --noEmit`: passed
- `bun run lint apps/web`: passed with four pre-existing image optimization warnings
- `bun run db:generate`: no schema drift

Closes #77