### PR TITLE
feat(landing): the designed landing page, and Find your dot against the real graph

### DIFF
--- a/apps/web/app/globals.css
+++ b/apps/web/app/globals.css
@@ -150,6 +150,24 @@
   --cc-success-fg: #ffffff;
   --cc-danger: #b3261e;
   --cc-danger-fg: #ffffff;
+
+  /* Community graph node colours — light.
+     `server/graph/placement.ts` stores a colour *name*, never a hex, so these
+     six tokens are the client half of that contract and the palette can be
+     re-skinned here without a data migration.
+
+     They are additions to `cc-theme.css` rather than a mirror of it: the design
+     has no node token at all (`cc-store.js` carries five raw hexes against the
+     schema's six names). Five of these are the design's own hexes reused;
+     `moss` is the sixth the design never assigned. Provisional, like the
+     examination palette's `seminars` — the only requirement is that no two of
+     the six read as each other. */
+  --cc-node-aurora: #2f9e8e;
+  --cc-node-ember: #c96a4a;
+  --cc-node-frost: #1751a6;
+  --cc-node-moss: #4a7c2f;
+  --cc-node-slate: #57646f;
+  --cc-node-violet: #6a4ea8;
 }
 
 .dark {
@@ -219,6 +237,17 @@
   --cc-success-fg: #0c2417;
   --cc-danger: #ff8a80;
   --cc-danger-fg: #2b0a08;
+
+  /* Community graph node colours — dark. The light hues are mixed for the cream
+     page and disappear into `--cc-pg`'s deep blue, so each is lifted to the same
+     hue at a much higher lightness. The names, and which name means which hue,
+     do not change. */
+  --cc-node-aurora: #5fd8c4;
+  --cc-node-ember: #f2946f;
+  --cc-node-frost: #8ec2ff;
+  --cc-node-moss: #a5d47c;
+  --cc-node-slate: #b3c1d0;
+  --cc-node-violet: #bda2f0;
 }
 
 @layer base {

--- a/apps/web/app/page.tsx
+++ b/apps/web/app/page.tsx
@@ -1,5 +1,12 @@
+import { Suspense } from "react";
 import { Landing } from "@/features/landing/components/landing";
 
 export default function Home() {
-  return <Landing />;
+  return (
+    // The private link comes back with its outcome in the query string, which
+    // the page reads on the client.
+    <Suspense fallback={null}>
+      <Landing />
+    </Suspense>
+  );
 }

--- a/apps/web/features/landing/api/queries.ts
+++ b/apps/web/features/landing/api/queries.ts
@@ -1,0 +1,39 @@
+"use client";
+
+import { useQuery } from "@tanstack/react-query";
+import { isTRPCClientError } from "@trpc/client";
+import type { AppRouter } from "@/server/api/root";
+import { type RouterOutputs, useTRPC } from "@/trpc/client";
+
+/** A bounded slice of the community graph around the signed-in app user. */
+export type Neighbourhood = RouterOutputs["graph"]["neighbourhood"];
+
+/**
+ * The app user is signed in but has no node in the community graph yet.
+ *
+ * `graph.neighbourhood` is personal — every read is relative to the caller's own
+ * node — so "not found" here means one thing only: nobody has placed them.
+ * Placement is `graph.join`'s job and nothing calls it yet, which makes this the
+ * state every member actually sees today, not an edge case.
+ */
+export function isUnplaced(error: unknown): boolean {
+  return (
+    isTRPCClientError<AppRouter>(error) && error.data?.code === "NOT_FOUND"
+  );
+}
+
+/**
+ * Read the caller's own neighbourhood.
+ *
+ * Off by default: a visitor has no session and the procedure is protected, so
+ * asking before they are signed in would only ever earn a 401. Retries are off
+ * because the one error worth showing — being unplaced — is not transient.
+ */
+export function useNeighbourhood(enabled: boolean) {
+  const trpc = useTRPC();
+  return useQuery({
+    ...trpc.graph.neighbourhood.queryOptions(),
+    enabled,
+    retry: false,
+  });
+}

--- a/apps/web/features/landing/components/find-your-dot.tsx
+++ b/apps/web/features/landing/components/find-your-dot.tsx
@@ -1,0 +1,358 @@
+"use client";
+
+import { useState } from "react";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Spinner } from "@/components/ui/spinner";
+import { authClient } from "@/lib/auth-client";
+import { cn } from "@/lib/utils";
+
+/**
+ * **Find your dot**: the landing flow in which a member locates their own node.
+ *
+ * "Dot" is copy for this flow alone — the thing it finds is a **Node**, and the
+ * panel never claims to have found one it did not.
+ *
+ * The artboard mocks this as a private link that reveals a dot without signing
+ * anybody in. No such channel exists and nothing in `server/` could answer it,
+ * so the private link here is the magic link Better Auth already sends: it
+ * signs the member in and returns them to `/`, where the reveal runs against
+ * `graph.neighbourhood` for real. The artboard's two "Prototype — simulate the
+ * link" buttons go with the prototype.
+ */
+
+/** Where the flow has got to. The parent owns everything but the email form. */
+export type FindYourDotStatus =
+  /** No session: the dot belongs to an account, so ask for one. */
+  | "sign-in"
+  /** Came back through a link that had already been used, or timed out. */
+  | "expired"
+  /** Signed in, reading the neighbourhood. */
+  | "locating"
+  /** Read, and there is a node: it is drawn behind this panel. */
+  | "placed"
+  /** Read, and there is no node for this app user yet. */
+  | "unplaced"
+  /** The read failed for some other reason. */
+  | "unavailable";
+
+/** Where the private link comes back to, and what it says when it fails. */
+export const DOT_CALLBACK = "/?dot=1";
+export const DOT_ERROR_CALLBACK = "/?dot=expired";
+
+const EMAIL = /^[^@\s]+@[^@\s.]+\.[^@\s]{2,}$/;
+
+type Props = {
+  open: boolean;
+  status: FindYourDotStatus;
+  onClose: () => void;
+  /**
+   * Start this over: from `expired` it asks for a fresh link, from
+   * `unavailable` it reads the neighbourhood again.
+   */
+  onRetry: () => void;
+};
+
+export function FindYourDot({ open, status, onClose, onRetry }: Props) {
+  const [email, setEmail] = useState("");
+  const [invalid, setInvalid] = useState(false);
+  const [sending, setSending] = useState(false);
+  const [sentTo, setSentTo] = useState<string | null>(null);
+
+  // The reveal is the point: while the dot is on screen the panel steps aside
+  // and the scrim lifts, exactly as the artboard does it.
+  const revealing = status === "placed";
+
+  async function sendLink() {
+    const address = email.trim();
+    if (!EMAIL.test(address)) {
+      setInvalid(true);
+      return;
+    }
+    setInvalid(false);
+    setSending(true);
+    const { error } = await authClient.signIn.magicLink({
+      email: address,
+      callbackURL: DOT_CALLBACK,
+      errorCallbackURL: DOT_ERROR_CALLBACK,
+    });
+    setSending(false);
+    if (error) {
+      setInvalid(true);
+      return;
+    }
+    setSentTo(address);
+  }
+
+  function close() {
+    setSentTo(null);
+    setInvalid(false);
+    onClose();
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={(next) => !next && close()}>
+      <DialogContent
+        showCloseButton={false}
+        overlayClassName={cn(
+          "supports-backdrop-filter:backdrop-blur-none",
+          revealing ? "bg-[rgba(14,26,44,0.08)]" : "bg-[rgba(14,26,44,0.34)]",
+        )}
+        className={cn(
+          "cc-theme w-[396px] max-w-[calc(100vw-2rem)] gap-0 rounded-[14px] border border-cc-rule2 bg-cc-surface p-6 text-cc-ink shadow-[0_20px_56px_rgba(14,26,44,0.26)] sm:max-w-[396px]",
+          revealing && "top-auto bottom-9 translate-y-0",
+        )}
+      >
+        {status === "sign-in" && sentTo === null ? (
+          <SignIn
+            email={email}
+            invalid={invalid}
+            sending={sending}
+            onEmail={(value) => {
+              setEmail(value);
+              setInvalid(false);
+            }}
+            onSubmit={sendLink}
+            onClose={close}
+          />
+        ) : null}
+
+        {status === "sign-in" && sentTo !== null ? (
+          <Panel
+            title="Check your inbox"
+            onClose={close}
+            body={`A private link is on its way to ${sentTo}. It expires in five minutes, and it only works once.`}
+          />
+        ) : null}
+
+        {status === "expired" ? (
+          <Panel
+            title="This link no longer works"
+            alert
+            onClose={close}
+            body="Private links expire after a short while, and each one can be used once. Request a new link to try again."
+          >
+            <FilledButton
+              onClick={() => {
+                setSentTo(null);
+                onRetry();
+              }}
+            >
+              Request a new link
+            </FilledButton>
+          </Panel>
+        ) : null}
+
+        {status === "locating" ? (
+          <div>
+            <DialogTitle className="font-semibold text-[19px] leading-[1.2] tracking-[-0.012em]">
+              Find your place in the community
+            </DialogTitle>
+            <DialogDescription
+              aria-live="polite"
+              className="mt-2 text-[13.5px] text-cc-muted leading-[1.55]"
+            >
+              Locating your dot in the network…
+            </DialogDescription>
+            <div className="mt-4 h-[3px] overflow-hidden rounded-[2px] bg-cc-pill">
+              <div className="h-full w-3/5 rounded-[2px] bg-cc-brand opacity-80" />
+            </div>
+          </div>
+        ) : null}
+
+        {status === "placed" ? (
+          <Panel
+            title="This one is yours"
+            onClose={close}
+            body="Your dot is marked in the network behind this panel. It stays yours — you keep the same place every time you come back."
+          >
+            <OutlineButton onClick={close}>Done</OutlineButton>
+          </Panel>
+        ) : null}
+
+        {status === "unplaced" ? <Unplaced onClose={close} /> : null}
+
+        {status === "unavailable" ? (
+          <Panel
+            title="The network did not answer"
+            alert
+            onClose={close}
+            body="Your place is safe — this read failed, not your dot. Try again in a moment."
+          >
+            <FilledButton onClick={onRetry}>Try again</FilledButton>
+          </Panel>
+        ) : null}
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+function SignIn(props: {
+  email: string;
+  invalid: boolean;
+  sending: boolean;
+  onEmail: (value: string) => void;
+  onSubmit: () => void;
+  onClose: () => void;
+}) {
+  return (
+    <form
+      // The panel validates and reports in its own words; the browser's bubble
+      // would interrupt with a second, different message.
+      noValidate
+      onSubmit={(event) => {
+        event.preventDefault();
+        if (!props.sending) props.onSubmit();
+      }}
+    >
+      <Header
+        title="Find your place in the community"
+        onClose={props.onClose}
+      />
+      <DialogDescription className="mt-2 text-[13.5px] text-cc-muted leading-[1.55]">
+        Your dot belongs to your account. Enter your email and we’ll send a
+        private link that signs you in and takes you straight to it.
+      </DialogDescription>
+      <input
+        type="email"
+        value={props.email}
+        onChange={(event) => props.onEmail(event.target.value)}
+        placeholder="you@kth.se"
+        aria-label="Email address"
+        aria-invalid={props.invalid}
+        aria-describedby={props.invalid ? "find-your-dot-error" : undefined}
+        className={cn(
+          "mt-4 h-10 w-full rounded-[9px] border bg-cc-inset px-3 text-[13.5px] text-cc-ink outline-none",
+          props.invalid ? "border-cc-warn-ink" : "border-cc-rule3",
+        )}
+      />
+      {props.invalid ? (
+        <p
+          id="find-your-dot-error"
+          role="alert"
+          className="mt-2 text-[12.5px] text-cc-warn-ink"
+        >
+          Enter a valid email address.
+        </p>
+      ) : null}
+      <button
+        type="submit"
+        disabled={props.sending}
+        className="mt-3.5 flex h-10 w-full items-center justify-center gap-2 rounded-[9px] bg-cc-btn font-semibold text-[13.5px] text-cc-btn-fg hover:opacity-[0.88] disabled:opacity-70"
+      >
+        {props.sending ? <Spinner /> : null}
+        {props.sending ? "Sending…" : "Send private link"}
+      </button>
+    </form>
+  );
+}
+
+/**
+ * Signed in, and no node exists for this app user.
+ *
+ * This is the state every member sees today: `graph.join` places a node and
+ * nothing calls it yet. The panel says so plainly rather than drawing a dot
+ * that is not there — an invented position would be a lie about where somebody
+ * stands in the community, and it would be the first thing to go wrong when
+ * placement does land.
+ */
+function Unplaced({ onClose }: { onClose: () => void }) {
+  return (
+    <div>
+      <Header title="You don’t have a dot yet" onClose={onClose} />
+      <div
+        aria-hidden
+        className="mt-4 flex h-[92px] items-center justify-center rounded-[10px] border border-cc-rule2 border-dashed bg-cc-inset"
+      >
+        <span className="size-[15px] rounded-full border border-cc-rule3 border-dashed" />
+      </div>
+      <DialogDescription
+        aria-live="polite"
+        className="mt-3.5 text-[13.5px] text-cc-muted leading-[1.55]"
+      >
+        Everyone in the community keeps one place that stays theirs. Yours has
+        not been created yet — nothing is missing on your side, and nothing here
+        is hidden from you.
+      </DialogDescription>
+      <p className="mt-2 text-[12.5px] text-cc-dim2 leading-[1.5]">
+        Come back once placement is switched on and this is where your dot
+        appears.
+      </p>
+      <OutlineButton onClick={onClose}>Done</OutlineButton>
+    </div>
+  );
+}
+
+function Header({ title, onClose }: { title: string; onClose: () => void }) {
+  return (
+    <div className="flex items-start justify-between gap-3">
+      <DialogTitle className="font-semibold text-[19px] leading-[1.2] tracking-[-0.012em]">
+        {title}
+      </DialogTitle>
+      <button
+        type="button"
+        onClick={onClose}
+        aria-label="Close"
+        className="flex size-[26px] shrink-0 items-center justify-center rounded-[7px] text-[17px] text-cc-dim leading-none hover:bg-cc-pill"
+      >
+        ×
+      </button>
+    </div>
+  );
+}
+
+function Panel(props: {
+  title: string;
+  body: string;
+  alert?: boolean;
+  onClose: () => void;
+  children?: React.ReactNode;
+}) {
+  return (
+    <div>
+      <Header title={props.title} onClose={props.onClose} />
+      <DialogDescription
+        role={props.alert ? "alert" : undefined}
+        aria-live={props.alert ? undefined : "polite"}
+        className="mt-2 text-[13.5px] text-cc-muted leading-[1.55]"
+      >
+        {props.body}
+      </DialogDescription>
+      {props.children}
+    </div>
+  );
+}
+
+function FilledButton(props: {
+  onClick: () => void;
+  children: React.ReactNode;
+}) {
+  return (
+    <button
+      type="button"
+      onClick={props.onClick}
+      className="mt-4 flex h-[38px] w-full items-center justify-center rounded-[9px] bg-cc-btn font-semibold text-[13px] text-cc-btn-fg hover:opacity-[0.88]"
+    >
+      {props.children}
+    </button>
+  );
+}
+
+function OutlineButton(props: {
+  onClick: () => void;
+  children: React.ReactNode;
+}) {
+  return (
+    <button
+      type="button"
+      onClick={props.onClick}
+      className="mt-4 flex h-[38px] w-full items-center justify-center rounded-[9px] border border-cc-rule3 bg-cc-surface font-medium text-[13px] text-cc-ink hover:border-cc-hov"
+    >
+      {props.children}
+    </button>
+  );
+}

--- a/apps/web/features/landing/components/find-your-dot.tsx
+++ b/apps/web/features/landing/components/find-your-dot.tsx
@@ -96,6 +96,9 @@ export function FindYourDot({ open, status, onClose, onRetry }: Props) {
 
   return (
     <Dialog open={open} onOpenChange={(next) => !next && close()}>
+      {/* The scrim and the panel shadow are the artboard's own literals and have
+          no token in `cc-theme.css`; `AuthReasonDialog` already ships this exact
+          scrim, so the two dialogs match rather than each inventing a value. */}
       <DialogContent
         showCloseButton={false}
         overlayClassName={cn(

--- a/apps/web/features/landing/components/find-your-dot.tsx
+++ b/apps/web/features/landing/components/find-your-dot.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState } from "react";
+import { useRef, useState } from "react";
 import {
   Dialog,
   DialogContent,
@@ -64,6 +64,17 @@ export function FindYourDot({ open, status, onClose, onRetry }: Props) {
   const [sending, setSending] = useState(false);
   const [sentTo, setSentTo] = useState<string | null>(null);
 
+  /**
+   * Which submission the panel is currently showing the result of.
+   *
+   * A send that is still in flight when the panel closes, or when a second
+   * address is submitted, is **stale**: it must not land. Without this a
+   * visitor who sends to one address, reopens and sends to another can be told
+   * "Check your inbox" over the *first* address if the first request happens to
+   * resolve last — the panel would be reporting on a submission they abandoned.
+   */
+  const submission = useRef(0);
+
   // The reveal is the point: while the dot is on screen the panel steps aside
   // and the scrim lifts, exactly as the artboard does it.
   const revealing = status === "placed";
@@ -87,26 +98,33 @@ export function FindYourDot({ open, status, onClose, onRetry }: Props) {
     setInvalid(false);
     setFailed(false);
     setSending(true);
+    const mine = ++submission.current;
     try {
       const { error } = await authClient.signIn.magicLink({
         email: address,
         callbackURL: DOT_CALLBACK,
         errorCallbackURL: DOT_ERROR_CALLBACK,
       });
+      if (mine !== submission.current) return;
       if (error) {
         setFailed(true);
         return;
       }
       setSentTo(address);
     } catch (error) {
+      if (mine !== submission.current) return;
       console.error(error);
       setFailed(true);
     } finally {
-      setSending(false);
+      // Only the submission still on screen owns the button. A superseded one
+      // clearing it would re-enable the form under a request still running.
+      if (mine === submission.current) setSending(false);
     }
   }
 
   function close() {
+    // Whatever is in flight belongs to the panel being closed, not the next one.
+    submission.current++;
     setSentTo(null);
     setInvalid(false);
     setFailed(false);

--- a/apps/web/features/landing/components/find-your-dot.tsx
+++ b/apps/web/features/landing/components/find-your-dot.tsx
@@ -273,14 +273,14 @@ function SignIn(props: {
         }
         className={cn(
           "mt-4 h-10 w-full rounded-[9px] border bg-cc-inset px-3 text-[13.5px] text-cc-ink outline-none",
-          props.invalid ? "border-cc-warn-ink" : "border-cc-rule3",
+          props.invalid ? "border-cc-danger" : "border-cc-rule3",
         )}
       />
       {props.invalid || props.failed ? (
         <p
           id="find-your-dot-error"
           role="alert"
-          className="mt-2 text-[12.5px] text-cc-warn-ink"
+          className="mt-2 text-[12.5px] text-cc-danger"
         >
           {props.invalid
             ? "Enter a valid email address."
@@ -307,6 +307,12 @@ function SignIn(props: {
  * that is not there — an invented position would be a lie about where somebody
  * stands in the community, and it would be the first thing to go wrong when
  * placement does land.
+ *
+ * Deliberately **informational, not an error**. Nobody has failed at anything
+ * here and nothing went wrong, so there is no `--cc-danger`, no `role="alert"`
+ * and no retry: dressing an ordinary state as a fault would tell the reader
+ * they had done something to deserve it. The dashed ring stands where the dot
+ * will be, and stays unlabelled — a label is the one thing being refused.
  */
 function Unplaced({ onClose }: { onClose: () => void }) {
   return (

--- a/apps/web/features/landing/components/find-your-dot.tsx
+++ b/apps/web/features/landing/components/find-your-dot.tsx
@@ -60,6 +60,7 @@ type Props = {
 export function FindYourDot({ open, status, onClose, onRetry }: Props) {
   const [email, setEmail] = useState("");
   const [invalid, setInvalid] = useState(false);
+  const [failed, setFailed] = useState(false);
   const [sending, setSending] = useState(false);
   const [sentTo, setSentTo] = useState<string | null>(null);
 
@@ -67,30 +68,49 @@ export function FindYourDot({ open, status, onClose, onRetry }: Props) {
   // and the scrim lifts, exactly as the artboard does it.
   const revealing = status === "placed";
 
+  /**
+   * Two different failures, told apart because they ask different things of the
+   * reader: an address that cannot be one is theirs to correct, a request that
+   * did not go through is ours and only wants trying again.
+   *
+   * The button re-enables in `finally` whatever happened. A request that
+   * rejects rather than resolving — the tab went offline mid-send — must not
+   * leave "Sending…" standing over a form nobody can use again.
+   */
   async function sendLink() {
     const address = email.trim();
     if (!EMAIL.test(address)) {
       setInvalid(true);
+      setFailed(false);
       return;
     }
     setInvalid(false);
+    setFailed(false);
     setSending(true);
-    const { error } = await authClient.signIn.magicLink({
-      email: address,
-      callbackURL: DOT_CALLBACK,
-      errorCallbackURL: DOT_ERROR_CALLBACK,
-    });
-    setSending(false);
-    if (error) {
-      setInvalid(true);
-      return;
+    try {
+      const { error } = await authClient.signIn.magicLink({
+        email: address,
+        callbackURL: DOT_CALLBACK,
+        errorCallbackURL: DOT_ERROR_CALLBACK,
+      });
+      if (error) {
+        setFailed(true);
+        return;
+      }
+      setSentTo(address);
+    } catch (error) {
+      console.error(error);
+      setFailed(true);
+    } finally {
+      setSending(false);
     }
-    setSentTo(address);
   }
 
   function close() {
     setSentTo(null);
     setInvalid(false);
+    setFailed(false);
+    setSending(false);
     onClose();
   }
 
@@ -114,10 +134,12 @@ export function FindYourDot({ open, status, onClose, onRetry }: Props) {
           <SignIn
             email={email}
             invalid={invalid}
+            failed={failed}
             sending={sending}
             onEmail={(value) => {
               setEmail(value);
               setInvalid(false);
+              setFailed(false);
             }}
             onSubmit={sendLink}
             onClose={close}
@@ -197,6 +219,7 @@ export function FindYourDot({ open, status, onClose, onRetry }: Props) {
 function SignIn(props: {
   email: string;
   invalid: boolean;
+  failed: boolean;
   sending: boolean;
   onEmail: (value: string) => void;
   onSubmit: () => void;
@@ -227,19 +250,23 @@ function SignIn(props: {
         placeholder="you@kth.se"
         aria-label="Email address"
         aria-invalid={props.invalid}
-        aria-describedby={props.invalid ? "find-your-dot-error" : undefined}
+        aria-describedby={
+          props.invalid || props.failed ? "find-your-dot-error" : undefined
+        }
         className={cn(
           "mt-4 h-10 w-full rounded-[9px] border bg-cc-inset px-3 text-[13.5px] text-cc-ink outline-none",
           props.invalid ? "border-cc-warn-ink" : "border-cc-rule3",
         )}
       />
-      {props.invalid ? (
+      {props.invalid || props.failed ? (
         <p
           id="find-your-dot-error"
           role="alert"
           className="mt-2 text-[12.5px] text-cc-warn-ink"
         >
-          Enter a valid email address.
+          {props.invalid
+            ? "Enter a valid email address."
+            : "We could not send the link just now. Try again."}
         </p>
       ) : null}
       <button

--- a/apps/web/features/landing/components/hero-network.tsx
+++ b/apps/web/features/landing/components/hero-network.tsx
@@ -1,0 +1,603 @@
+"use client";
+
+import { useEffect, useRef } from "react";
+import type { Neighbourhood } from "../api/queries";
+import {
+  buildField,
+  clearAt,
+  DRIFT_BOX,
+  envelope,
+  type Field,
+  type FieldEdge,
+  type FieldNode,
+  fallbackRects,
+  INSET,
+  lineClearance,
+  quadPoint,
+  type Rect,
+  SAFETY,
+} from "../lib/hero-field";
+import {
+  FALLBACK_NODE_COLOR_VAR,
+  type NeighbourhoodView,
+  NODE_COLOR_VARS,
+  projectNeighbourhood,
+} from "../lib/neighbourhood-view";
+
+/**
+ * The network behind the hero copy.
+ *
+ * It draws one of two things, and the difference matters:
+ *
+ * - **Ambient** — a decorative field of drifting dots. It is an illustration of
+ *   a community, not the community: no dot carries an account, none is ever
+ *   labelled, and nothing about it comes from the database.
+ * - **Revealed** — the caller's real bounded neighbourhood, projected from the
+ *   stored world positions. Their own node is marked "You".
+ *
+ * The revealed graph is still: real world positions must not appear to wander,
+ * and its lines carry no travelling signals because a **backbone edge records
+ * placement history and is not a friendship** — animating a recommendation
+ * along one would give it a social meaning the data does not have.
+ *
+ * Everything the projection derives — the scale, the centre, the screen
+ * coordinates — is thrown away on the next resize. None of it is ever sent back.
+ */
+
+/** How many dots the ambient field draws inside the frame. */
+const AMBIENT_COUNT = 50;
+
+type Signal = {
+  edge: FieldEdge;
+  from: FieldNode;
+  to: FieldNode;
+  ax: number;
+  ay: number;
+  bx: number;
+  by: number;
+  cx: number;
+  cy: number;
+  headX: number;
+  headY: number;
+  len: number;
+  p: number;
+  dur: number;
+  prominence: number;
+};
+
+type Scene = {
+  canvas: HTMLCanvasElement;
+  ctx: CanvasRenderingContext2D;
+  root: HTMLElement;
+  w: number;
+  h: number;
+  dpr: number;
+  rects: Rect[];
+  field: Field;
+  signals: Signal[];
+  spawnAt: number;
+  last: number;
+  raf: number;
+  reduced: boolean;
+  clearCursor: number;
+  /** 0 ambient, 1 the real graph — eased so the swap is not a jump cut. */
+  reveal: number;
+  pulse: number;
+  neighbourhood: Neighbourhood | null;
+  view: NeighbourhoodView | null;
+};
+
+/**
+ * The keep-out: one padded rect per content block rather than one box around
+ * them all, measured off the real rendered elements so a centred headline in a
+ * wide column does not claim the empty sides.
+ */
+function measureRects(root: HTMLElement, canvas: HTMLCanvasElement): Rect[] {
+  const box = canvas.getBoundingClientRect();
+  if (!box.width || !box.height) return [];
+  const out: Rect[] = [];
+  const push = (r: DOMRect) => {
+    if (!r.width || !r.height) return;
+    out.push({
+      x: r.left - box.left - SAFETY,
+      y: r.top - box.top - SAFETY,
+      w: r.width + SAFETY * 2,
+      h: r.height + SAFETY * 2,
+    });
+  };
+
+  for (const el of root.querySelectorAll<HTMLElement>("[data-hero-clear]")) {
+    // A text block reserves its actual lines, not the width of its box.
+    if (!el.children.length && el.textContent?.trim()) {
+      const range = document.createRange();
+      range.selectNodeContents(el);
+      const lines = range.getClientRects();
+      if (lines.length) {
+        for (const line of lines) push(line);
+        continue;
+      }
+    }
+    push(el.getBoundingClientRect());
+  }
+  return out;
+}
+
+function prefersReducedMotion() {
+  return (
+    typeof window.matchMedia === "function" &&
+    window.matchMedia("(prefers-reduced-motion: reduce)").matches
+  );
+}
+
+/**
+ * Every colour the frame needs, read from the `--cc-*` tokens in one pass.
+ *
+ * `getComputedStyle` is the expensive half, so it is called once a frame rather
+ * than once a node — a 150-node neighbourhood would otherwise force 150 style
+ * recalculations every 16ms.
+ */
+type Palette = {
+  line: string;
+  dot: string;
+  ink: string;
+  surface: string;
+  node: Record<string, string>;
+};
+
+function readPalette(canvas: HTMLCanvasElement): Palette {
+  const style = getComputedStyle(canvas);
+  const read = (name: string) =>
+    style.getPropertyValue(name).trim() || "currentColor";
+  const node: Record<string, string> = {};
+  for (const variable of Object.values(NODE_COLOR_VARS)) {
+    node[variable] = read(variable);
+  }
+  return {
+    line: read("--cc-hov"),
+    dot: read("--cc-brand"),
+    ink: read("--cc-ink"),
+    surface: read("--cc-surface"),
+    node,
+  };
+}
+
+function layout(scene: Scene) {
+  scene.rects = measureRects(scene.root, scene.canvas);
+  if (!scene.rects.length) scene.rects = fallbackRects(scene.w, scene.h);
+  scene.field = buildField({
+    w: scene.w,
+    h: scene.h,
+    rects: scene.rects,
+    count: AMBIENT_COUNT,
+  });
+  scene.signals = [];
+  scene.clearCursor = 0;
+  scene.view = scene.neighbourhood
+    ? projectNeighbourhood({
+        neighbourhood: scene.neighbourhood,
+        width: scene.w,
+        height: scene.h,
+        keepOut: scene.rects,
+      })
+    : null;
+}
+
+function resize(scene: Scene) {
+  const box = scene.canvas.parentElement?.getBoundingClientRect();
+  if (!box) return;
+  const w = Math.max(320, Math.round(box.width));
+  const h = Math.max(220, Math.round(box.height));
+  const dpr = Math.min(2, window.devicePixelRatio || 1);
+  if (w === scene.w && h === scene.h && dpr === scene.dpr) return;
+  scene.w = w;
+  scene.h = h;
+  scene.dpr = dpr;
+  scene.canvas.width = Math.round(w * dpr);
+  scene.canvas.height = Math.round(h * dpr);
+  layout(scene);
+}
+
+function spawnSignal(scene: Scene) {
+  const edges = scene.field.edges;
+  if (!edges.length) return;
+  for (let attempt = 0; attempt < 14; attempt++) {
+    const edge = edges[Math.floor(Math.random() * edges.length)];
+    if (scene.signals.some((s) => s.edge === edge)) continue;
+    const from = Math.random() < 0.5 ? edge.a : edge.b;
+    const to = from === edge.a ? edge.b : edge.a;
+    const len = Math.max(1, Math.hypot(to.x - from.x, to.y - from.y));
+    scene.signals.push({
+      edge,
+      from,
+      to,
+      ax: from.x,
+      ay: from.y,
+      bx: to.x,
+      by: to.y,
+      cx: (from.x + to.x) / 2,
+      cy: (from.y + to.y) / 2,
+      headX: from.x,
+      headY: from.y,
+      len,
+      p: 0,
+      // A constant pace, whatever the length of the line.
+      dur: Math.max(2.6, len / (26 + Math.random() * 22)),
+      prominence: 0.72 + Math.random() * 0.28,
+    });
+    return;
+  }
+}
+
+function drift(scene: Scene, dt: number) {
+  const { field, w, h, rects } = scene;
+  for (const n of field.nodes) {
+    n.x += n.vx * dt;
+    n.y += n.vy * dt;
+    if (n.x < n.hx - DRIFT_BOX) {
+      n.x = n.hx - DRIFT_BOX;
+      n.vx = Math.abs(n.vx);
+    }
+    if (n.x > n.hx + DRIFT_BOX) {
+      n.x = n.hx + DRIFT_BOX;
+      n.vx = -Math.abs(n.vx);
+    }
+    if (n.y < n.hy - DRIFT_BOX) {
+      n.y = n.hy - DRIFT_BOX;
+      n.vy = Math.abs(n.vy);
+    }
+    if (n.y > n.hy + DRIFT_BOX) {
+      n.y = n.hy + DRIFT_BOX;
+      n.vy = -Math.abs(n.vy);
+    }
+    // Drawn dots stay on screen and off the copy; off-frame nodes stay off it.
+    if (!n.offFrame) {
+      if (n.x < INSET) {
+        n.x = INSET;
+        n.vx = Math.abs(n.vx);
+      }
+      if (n.x > w - INSET) {
+        n.x = w - INSET;
+        n.vx = -Math.abs(n.vx);
+      }
+      if (n.y < INSET) {
+        n.y = INSET;
+        n.vy = Math.abs(n.vy);
+      }
+      if (n.y > h - INSET) {
+        n.y = h - INSET;
+        n.vy = -Math.abs(n.vy);
+      }
+      if (clearAt(n.x, n.y, rects, n.r + 1) < 1) {
+        n.x -= n.vx * dt * 2;
+        n.y -= n.vy * dt * 2;
+        n.vx = -n.vx;
+        n.vy = -n.vy;
+      }
+    }
+  }
+}
+
+function drawAmbient(scene: Scene, palette: Palette, alpha: number) {
+  const { ctx, field, rects } = scene;
+
+  // Clearance barely moves — drift is clamped to a few px — so it is cached and
+  // refreshed on a rolling slice rather than recomputed for every line, every
+  // frame. Four alpha buckets let the whole field draw in four strokes.
+  const edges = field.edges;
+  if (edges.length) {
+    const slice = Math.max(1, Math.ceil(edges.length / 30));
+    for (let i = 0; i < slice; i++) {
+      const edge = edges[(scene.clearCursor + i) % edges.length];
+      edge.clear = lineClearance(edge.a, edge.b, rects);
+    }
+    scene.clearCursor = (scene.clearCursor + slice) % edges.length;
+  }
+
+  const buckets: FieldEdge[][] = [[], [], [], []];
+  for (const edge of edges) {
+    const clear = edge.clear ?? lineClearance(edge.a, edge.b, rects);
+    if (clear <= 0.02) continue;
+    buckets[Math.min(3, Math.floor(clear * 4 - 0.0001))].push(edge);
+  }
+  ctx.lineWidth = 1;
+  ctx.strokeStyle = palette.line;
+  for (let bucket = 0; bucket < buckets.length; bucket++) {
+    if (!buckets[bucket].length) continue;
+    ctx.globalAlpha = alpha * 0.26 * ((bucket + 1) / 4);
+    ctx.beginPath();
+    for (const edge of buckets[bucket]) {
+      ctx.moveTo(edge.a.x, edge.a.y);
+      ctx.lineTo(edge.b.x, edge.b.y);
+    }
+    ctx.stroke();
+  }
+
+  ctx.fillStyle = palette.dot;
+  for (const node of field.nodes) {
+    if (node.offFrame) continue;
+    ctx.globalAlpha = alpha * 0.82 * clearAt(node.x, node.y, rects);
+    ctx.beginPath();
+    ctx.arc(node.x, node.y, node.r, 0, Math.PI * 2);
+    ctx.fill();
+  }
+  ctx.globalAlpha = 1;
+}
+
+function drawSignals(
+  scene: Scene,
+  palette: Palette,
+  dt: number,
+  ts: number,
+  alpha: number,
+) {
+  const { ctx, field } = scene;
+  if (ts > scene.spawnAt && scene.signals.length < field.maxSignals) {
+    spawnSignal(scene);
+    scene.spawnAt = ts + 260 + Math.random() * 900;
+  }
+
+  for (let i = scene.signals.length - 1; i >= 0; i--) {
+    const s = scene.signals[i];
+    s.p += dt / s.dur;
+    if (s.p >= 1) {
+      scene.signals.splice(i, 1);
+      continue;
+    }
+    // The ends follow their dots, so the flash still lands on one.
+    s.ax = s.from.x;
+    s.ay = s.from.y;
+    s.bx = s.to.x;
+    s.by = s.to.y;
+    s.cx = (s.ax + s.bx) / 2;
+    s.cy = (s.ay + s.by) / 2;
+    s.len = Math.max(1, Math.hypot(s.bx - s.ax, s.by - s.ay));
+    const head = quadPoint(s, s.p);
+    s.headX = head.x;
+    s.headY = head.y;
+
+    const k = Math.min(1, envelope(s.p) * s.prominence) * alpha;
+    if (k <= 0.002) continue;
+    const tail = quadPoint(s, s.p - Math.min(s.p, (16 + 74 * k) / s.len));
+
+    const grad = ctx.createLinearGradient(tail.x, tail.y, s.headX, s.headY);
+    grad.addColorStop(0, "transparent");
+    grad.addColorStop(0.9, palette.dot);
+    grad.addColorStop(1, palette.ink);
+    ctx.globalAlpha = k;
+    ctx.strokeStyle = grad;
+    ctx.lineWidth = 1.1 + 1.9 * k;
+    ctx.lineCap = "round";
+    ctx.beginPath();
+    ctx.moveTo(tail.x, tail.y);
+    ctx.lineTo(s.headX, s.headY);
+    ctx.stroke();
+  }
+  ctx.globalAlpha = 1;
+}
+
+/** Motion off: two dots hold a steady glow instead of anything travelling. */
+function drawGlows(scene: Scene, palette: Palette, alpha: number) {
+  const { ctx, field } = scene;
+  for (const node of field.glows) {
+    ctx.globalAlpha = alpha * 0.7;
+    ctx.fillStyle = palette.dot;
+    ctx.beginPath();
+    ctx.arc(node.x, node.y, node.r + 2.5, 0, Math.PI * 2);
+    ctx.fill();
+  }
+  ctx.globalAlpha = 1;
+}
+
+function drawNeighbourhood(scene: Scene, palette: Palette, alpha: number) {
+  const { ctx, view } = scene;
+  if (!view) return;
+
+  ctx.strokeStyle = palette.line;
+  ctx.lineWidth = 1;
+  for (const [from, to] of view.edges) {
+    ctx.globalAlpha = alpha * 0.3 * Math.min(from.clearance, to.clearance);
+    ctx.beginPath();
+    ctx.moveTo(from.screenX, from.screenY);
+    ctx.lineTo(to.screenX, to.screenY);
+    ctx.stroke();
+  }
+
+  for (const node of view.nodes) {
+    if (node.isViewer) continue;
+    ctx.globalAlpha = alpha * 0.85 * node.clearance;
+    ctx.fillStyle =
+      palette.node[node.colorVar] ?? palette.node[FALLBACK_NODE_COLOR_VAR];
+    ctx.beginPath();
+    ctx.arc(node.screenX, node.screenY, 4, 0, Math.PI * 2);
+    ctx.fill();
+  }
+
+  const you = view.nodes.find((n) => n.isViewer);
+  if (you) drawYou(scene, palette, you, alpha);
+  ctx.globalAlpha = 1;
+}
+
+/** The caller's own node: a restrained pulse and a small label, no fanfare. */
+function drawYou(
+  scene: Scene,
+  palette: Palette,
+  you: { screenX: number; screenY: number; colorVar: string },
+  alpha: number,
+) {
+  const { ctx } = scene;
+  const x = you.screenX;
+  const y = you.screenY;
+  const colour =
+    palette.node[you.colorVar] ?? palette.node[FALLBACK_NODE_COLOR_VAR];
+
+  if (!scene.reduced) {
+    const phase = (scene.pulse % 1.9) / 1.9;
+    const ease = Math.max(0, phase * (2 - phase));
+    ctx.globalAlpha = alpha * 0.34 * (1 - ease);
+    ctx.strokeStyle = colour;
+    ctx.lineWidth = 1.3;
+    ctx.beginPath();
+    ctx.arc(x, y, 7.5 + ease * 17, 0, Math.PI * 2);
+    ctx.stroke();
+  }
+
+  ctx.globalAlpha = alpha;
+  ctx.fillStyle = colour;
+  ctx.beginPath();
+  ctx.arc(x, y, 7.5, 0, Math.PI * 2);
+  ctx.fill();
+  ctx.globalAlpha = alpha * 0.5;
+  ctx.strokeStyle = colour;
+  ctx.lineWidth = 1;
+  ctx.beginPath();
+  ctx.arc(x, y, 12.5, 0, Math.PI * 2);
+  ctx.stroke();
+
+  const label = "You";
+  ctx.font = "600 11px Geist, system-ui, sans-serif";
+  const width = ctx.measureText(label).width;
+  const lx = Math.min(Math.max(x - width / 2 - 7, 6), scene.w - width - 20);
+  const ly = y + 17;
+  ctx.globalAlpha = alpha;
+  ctx.fillStyle = palette.ink;
+  ctx.beginPath();
+  if (ctx.roundRect) ctx.roundRect(lx, ly, width + 14, 19, 9.5);
+  else ctx.rect(lx, ly, width + 14, 19);
+  ctx.fill();
+  ctx.fillStyle = palette.surface;
+  ctx.textBaseline = "middle";
+  ctx.fillText(label, lx + 7, ly + 10);
+}
+
+type Props = {
+  /**
+   * The caller's own neighbourhood, once `graph.neighbourhood` has answered.
+   * `null` while they are a visitor, unplaced, or simply have not asked.
+   */
+  neighbourhood: Neighbourhood | null;
+};
+
+export function HeroNetwork({ neighbourhood }: Props) {
+  const canvasRef = useRef<HTMLCanvasElement | null>(null);
+  const sceneRef = useRef<Scene | null>(null);
+
+  useEffect(() => {
+    const canvas = canvasRef.current;
+    const ctx = canvas?.getContext("2d");
+    // jsdom and any browser without a 2d context: the hero is decoration, so
+    // its absence is a missing flourish rather than a broken page.
+    if (!canvas || !ctx) return;
+    const root = canvas.closest<HTMLElement>("[data-hero]") ?? canvas;
+
+    const scene: Scene = {
+      canvas,
+      ctx,
+      root,
+      w: 0,
+      h: 0,
+      dpr: 1,
+      rects: [],
+      field: {
+        nodes: [],
+        edges: [],
+        byNode: new Map(),
+        glows: [],
+        minGap: 0,
+        maxSignals: 3,
+        marginX: 0,
+        marginY: 0,
+      },
+      signals: [],
+      spawnAt: 0,
+      last: 0,
+      raf: 0,
+      reduced: prefersReducedMotion(),
+      clearCursor: 0,
+      reveal: 0,
+      pulse: 0,
+      neighbourhood: null,
+      view: null,
+    };
+    sceneRef.current = scene;
+    resize(scene);
+
+    const tick = (ts: number) => {
+      const dt = Math.max(0, Math.min(0.05, (ts - scene.last) / 1000 || 0.016));
+      scene.last = ts;
+      scene.pulse += dt;
+
+      const want = scene.view ? 1 : 0;
+      scene.reveal +=
+        (want - scene.reveal) * (scene.reduced ? 1 : Math.min(1, dt / 0.45));
+
+      ctx.setTransform(scene.dpr, 0, 0, scene.dpr, 0, 0);
+      ctx.clearRect(0, 0, scene.w, scene.h);
+
+      const palette = readPalette(canvas);
+      const ambient = 1 - scene.reveal;
+      if (ambient > 0.01) {
+        if (!scene.reduced) drift(scene, dt);
+        drawAmbient(scene, palette, ambient);
+        if (scene.reduced) drawGlows(scene, palette, ambient);
+        else drawSignals(scene, palette, dt, ts, ambient);
+      }
+      if (scene.reveal > 0.01) drawNeighbourhood(scene, palette, scene.reveal);
+
+      scene.raf = requestAnimationFrame(tick);
+    };
+
+    const observer =
+      typeof ResizeObserver === "function"
+        ? new ResizeObserver(() => resize(scene))
+        : null;
+    if (observer && canvas.parentElement)
+      observer.observe(canvas.parentElement);
+    const onWindowResize = () => resize(scene);
+    if (!observer) window.addEventListener("resize", onWindowResize);
+
+    const media =
+      typeof window.matchMedia === "function"
+        ? window.matchMedia("(prefers-reduced-motion: reduce)")
+        : null;
+    const onMedia = () => {
+      scene.reduced = prefersReducedMotion();
+      layout(scene);
+    };
+    media?.addEventListener?.("change", onMedia);
+
+    scene.last = performance.now();
+    scene.spawnAt = scene.last + 500;
+    scene.raf = requestAnimationFrame(tick);
+
+    return () => {
+      cancelAnimationFrame(scene.raf);
+      observer?.disconnect();
+      window.removeEventListener("resize", onWindowResize);
+      media?.removeEventListener?.("change", onMedia);
+      sceneRef.current = null;
+    };
+  }, []);
+
+  useEffect(() => {
+    const scene = sceneRef.current;
+    if (!scene) return;
+    scene.neighbourhood = neighbourhood;
+    scene.view = neighbourhood
+      ? projectNeighbourhood({
+          neighbourhood,
+          width: scene.w,
+          height: scene.h,
+          keepOut: scene.rects,
+        })
+      : null;
+  }, [neighbourhood]);
+
+  return (
+    <canvas
+      ref={canvasRef}
+      aria-hidden
+      className="block size-full"
+      data-testid="hero-network"
+    />
+  );
+}

--- a/apps/web/features/landing/components/hero-network.tsx
+++ b/apps/web/features/landing/components/hero-network.tsx
@@ -44,8 +44,19 @@ import {
  * coordinates — is thrown away on the next resize. None of it is ever sent back.
  */
 
-/** How many dots the ambient field draws inside the frame. */
+/**
+ * How many dots the ambient field draws inside the frame.
+ *
+ * A phone gets a much sparser field, as the design's own Mobile Preview does —
+ * it embeds this page with `account-count="14"` against the desktop default.
+ */
 const AMBIENT_COUNT = 50;
+const AMBIENT_COUNT_NARROW = 14;
+const NARROW_WIDTH = 500;
+
+function ambientCount(width: number) {
+  return width < NARROW_WIDTH ? AMBIENT_COUNT_NARROW : AMBIENT_COUNT;
+}
 
 type Signal = {
   edge: FieldEdge;
@@ -168,10 +179,21 @@ function layout(scene: Scene) {
     w: scene.w,
     h: scene.h,
     rects: scene.rects,
-    count: AMBIENT_COUNT,
+    count: ambientCount(scene.w),
   });
   scene.signals = [];
   scene.clearCursor = 0;
+  refreshView(scene);
+}
+
+/**
+ * Re-derive where the real neighbourhood lands, for the frame as it is now.
+ *
+ * Called on every relayout and whenever the read answers, so the projection is
+ * always a function of the current frame — which is why it can be thrown away
+ * and why none of it is ever persisted.
+ */
+function refreshView(scene: Scene) {
   scene.view = scene.neighbourhood
     ? projectNeighbourhood({
         neighbourhood: scene.neighbourhood,
@@ -555,6 +577,19 @@ export function HeroNetwork({ neighbourhood }: Props) {
     const onWindowResize = () => resize(scene);
     if (!observer) window.addEventListener("resize", onWindowResize);
 
+    // A hidden tab has nothing to animate for. Browsers throttle rAF there, but
+    // stopping outright means no work at all rather than less of it.
+    const onVisibility = () => {
+      if (document.hidden) {
+        cancelAnimationFrame(scene.raf);
+        scene.raf = 0;
+      } else if (!scene.raf) {
+        scene.last = performance.now();
+        scene.raf = requestAnimationFrame(tick);
+      }
+    };
+    document.addEventListener("visibilitychange", onVisibility);
+
     const media =
       typeof window.matchMedia === "function"
         ? window.matchMedia("(prefers-reduced-motion: reduce)")
@@ -572,6 +607,7 @@ export function HeroNetwork({ neighbourhood }: Props) {
     return () => {
       cancelAnimationFrame(scene.raf);
       observer?.disconnect();
+      document.removeEventListener("visibilitychange", onVisibility);
       window.removeEventListener("resize", onWindowResize);
       media?.removeEventListener?.("change", onMedia);
       sceneRef.current = null;
@@ -582,14 +618,7 @@ export function HeroNetwork({ neighbourhood }: Props) {
     const scene = sceneRef.current;
     if (!scene) return;
     scene.neighbourhood = neighbourhood;
-    scene.view = neighbourhood
-      ? projectNeighbourhood({
-          neighbourhood,
-          width: scene.w,
-          height: scene.h,
-          keepOut: scene.rects,
-        })
-      : null;
+    refreshView(scene);
   }, [neighbourhood]);
 
   return (

--- a/apps/web/features/landing/components/landing.spec.tsx
+++ b/apps/web/features/landing/components/landing.spec.tsx
@@ -270,6 +270,51 @@ describe("Landing", () => {
         ).not.toBeInTheDocument();
       });
 
+      // Greptile reproduced this: a send left in flight when the panel closed
+      // could land afterwards and report on an address the visitor abandoned.
+      it("ignores a send the visitor walked away from", async () => {
+        let settleFirst: (value: { error: null }) => void = () => {};
+        sendMagicLink.mockImplementationOnce(
+          () =>
+            new Promise<{ error: null }>((resolve) => {
+              settleFirst = resolve;
+            }),
+        );
+        const user = userEvent.setup();
+        render(<Landing />);
+
+        await openFindYourDot(user);
+        await user.type(
+          await screen.findByLabelText(/email address/i),
+          "first@kth.se",
+        );
+        await user.click(
+          screen.getByRole("button", { name: /send private link/i }),
+        );
+
+        // Away, back, and a different address this time.
+        await user.click(screen.getByRole("button", { name: "Close" }));
+        await waitFor(() =>
+          expect(screen.queryByRole("dialog")).not.toBeInTheDocument(),
+        );
+        sendMagicLink.mockResolvedValue({ error: null });
+        await openFindYourDot(user);
+        const field = await screen.findByLabelText(/email address/i);
+        await user.clear(field);
+        await user.type(field, "second@kth.se");
+        await user.click(
+          screen.getByRole("button", { name: /send private link/i }),
+        );
+        expect(await screen.findByText(/second@kth.se/)).toBeInTheDocument();
+
+        // The abandoned request lands last and must change nothing.
+        settleFirst({ error: null });
+        await waitFor(() =>
+          expect(screen.getByText(/second@kth.se/)).toBeInTheDocument(),
+        );
+        expect(screen.queryByText(/first@kth.se/)).not.toBeInTheDocument();
+      });
+
       it("sends the private link back to the landing page", async () => {
         const user = userEvent.setup();
         render(<Landing />);

--- a/apps/web/features/landing/components/landing.spec.tsx
+++ b/apps/web/features/landing/components/landing.spec.tsx
@@ -218,6 +218,58 @@ describe("Landing", () => {
         expect(sendMagicLink).not.toHaveBeenCalled();
       });
 
+      // Greptile reproduced this: a rejected request used to leave "Sending…"
+      // standing over a form that could never be submitted again, and closing
+      // the dialog did not clear it either.
+      it("gets its form back when the request never goes through", async () => {
+        sendMagicLink.mockRejectedValue(new Error("offline"));
+        const user = userEvent.setup();
+        render(<Landing />);
+        await openFindYourDot(user);
+        await user.type(
+          await screen.findByLabelText(/email address/i),
+          "elsa@kth.se",
+        );
+        await user.click(
+          screen.getByRole("button", { name: /send private link/i }),
+        );
+
+        expect(
+          await screen.findByText(/could not send the link just now/i),
+        ).toBeInTheDocument();
+        const submit = screen.getByRole("button", {
+          name: /send private link/i,
+        });
+        expect(submit).toBeEnabled();
+
+        sendMagicLink.mockResolvedValue({ error: null });
+        await user.click(submit);
+        expect(
+          await screen.findByText(/check your inbox/i),
+        ).toBeInTheDocument();
+      });
+
+      it("says the send failed, not that the address is wrong", async () => {
+        sendMagicLink.mockResolvedValue({ error: { message: "rate limited" } });
+        const user = userEvent.setup();
+        render(<Landing />);
+        await openFindYourDot(user);
+        await user.type(
+          await screen.findByLabelText(/email address/i),
+          "elsa@kth.se",
+        );
+        await user.click(
+          screen.getByRole("button", { name: /send private link/i }),
+        );
+
+        expect(
+          await screen.findByText(/could not send the link just now/i),
+        ).toBeInTheDocument();
+        expect(
+          screen.queryByText(/enter a valid email address/i),
+        ).not.toBeInTheDocument();
+      });
+
       it("sends the private link back to the landing page", async () => {
         const user = userEvent.setup();
         render(<Landing />);

--- a/apps/web/features/landing/components/landing.spec.tsx
+++ b/apps/web/features/landing/components/landing.spec.tsx
@@ -1,0 +1,395 @@
+import { render, screen, waitFor, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { TRPCClientError } from "@trpc/client";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { Landing } from "./landing";
+
+const push = vi.fn();
+const replace = vi.fn();
+const logout = vi.fn();
+const setTheme = vi.fn();
+const useSessionData = vi.fn();
+const useNeighbourhood = vi.fn();
+const sendMagicLink = vi.fn();
+
+let search = "";
+
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ push, replace }),
+  usePathname: () => "/",
+  useSearchParams: () => new URLSearchParams(search),
+}));
+
+vi.mock("next-themes", () => ({
+  useTheme: () => ({ resolvedTheme: "light", setTheme }),
+}));
+
+vi.mock("@/lib/auth-client", () => ({
+  authClient: {
+    signIn: { magicLink: (...args: unknown[]) => sendMagicLink(...args) },
+  },
+}));
+
+// Only the session hooks are faked; AuthReasonDialog stays real.
+vi.mock("@/features/auth", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("@/features/auth")>()),
+  useSessionData: () => useSessionData(),
+  useLogout: () => logout,
+}));
+
+// `isUnplaced` stays real — how "unplaced" is recognised is the point of the
+// state, so a test that stubbed it would prove nothing.
+vi.mock("../api/queries", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../api/queries")>()),
+  useNeighbourhood: (enabled: boolean) => useNeighbourhood(enabled),
+}));
+
+/** The community graph has nobody in it, which is what a member gets today. */
+function notFound() {
+  return TRPCClientError.from({
+    error: {
+      code: -32004,
+      message: "No community graph node for app user u1",
+      data: { code: "NOT_FOUND" },
+    },
+  });
+}
+
+function graphState(over: Record<string, unknown> = {}) {
+  return {
+    data: undefined,
+    error: null,
+    isSuccess: false,
+    isError: false,
+    refetch: vi.fn(),
+    ...over,
+  };
+}
+
+const NEIGHBOURHOOD = {
+  viewer: { userId: "u1", x: 0, y: 0, effectiveTier: 1 },
+  nodes: [
+    {
+      userId: "u1",
+      x: 0,
+      y: 0,
+      color: "violet",
+      style: "default",
+      signalStyle: "default",
+    },
+    {
+      userId: "u2",
+      x: 240,
+      y: -120,
+      color: "moss",
+      style: "default",
+      signalStyle: "default",
+    },
+  ],
+  edges: [{ nodeUserId: "u1", anchorUserId: "u2" }],
+};
+
+function visitor() {
+  useSessionData.mockReturnValue({ user: null, isPending: false });
+}
+
+function member(name = "Elsa Lindqvist") {
+  useSessionData.mockReturnValue({
+    user: { name, email: "elsa@kth.se" },
+    isPending: false,
+  });
+}
+
+beforeEach(() => {
+  search = "";
+  visitor();
+  useNeighbourhood.mockReturnValue(graphState());
+  sendMagicLink.mockResolvedValue({ error: null });
+  // jsdom has no 2d context. The hero is decoration, so the page must render
+  // without one rather than throw.
+  HTMLCanvasElement.prototype.getContext = vi.fn(() => null) as never;
+});
+
+function openFindYourDot(user: ReturnType<typeof userEvent.setup>) {
+  return user.click(screen.getByRole("button", { name: /find your dot/i }));
+}
+
+/**
+ * The landing's own bar. Its sign-in buttons and the card at the foot of a
+ * narrow page carry the same labels, and only a container query tells them
+ * apart — which jsdom has no layout to answer.
+ */
+function header() {
+  return within(screen.getByRole("banner"));
+}
+
+describe("Landing", () => {
+  describe("a visitor", () => {
+    it("gets the whole page without an account", () => {
+      render(<Landing />);
+      expect(
+        screen.getByRole("heading", {
+          name: /find the course you will be happy you took/i,
+        }),
+      ).toBeInTheDocument();
+      expect(
+        screen.getByLabelText(/search a course, code or subject/i),
+      ).toBeInTheDocument();
+      expect(
+        screen.getByText("Every KTH course, one field"),
+      ).toBeInTheDocument();
+      expect(screen.getByText("Numbers, not vibes")).toBeInTheDocument();
+      expect(screen.getByText("Write first, sign in last")).toBeInTheDocument();
+    });
+
+    // #68 settled that no AI comparison feature exists, so the landing must not
+    // promise one.
+    it("promises nothing the app does not have", () => {
+      render(<Landing />);
+      expect(screen.queryByText(/with ai/i)).not.toBeInTheDocument();
+      expect(screen.queryByText(/compare/i)).not.toBeInTheDocument();
+    });
+
+    it("never asks the community graph anything — it is a protected read", () => {
+      render(<Landing />);
+      expect(useNeighbourhood).toHaveBeenCalledWith(false);
+    });
+
+    it("hands a typed search over to Explore", async () => {
+      const user = userEvent.setup();
+      render(<Landing />);
+      await user.type(
+        screen.getByLabelText(/search a course, code or subject/i),
+        "graph theory{Enter}",
+      );
+      expect(push).toHaveBeenCalledWith("/search?q=graph%20theory");
+    });
+
+    it("hands a suggestion over the same way", async () => {
+      const user = userEvent.setup();
+      render(<Landing />);
+      await user.click(screen.getByRole("button", { name: "DD2380" }));
+      expect(push).toHaveBeenCalledWith("/search?q=DD2380");
+    });
+
+    it("goes nowhere on an empty search", async () => {
+      const user = userEvent.setup();
+      render(<Landing />);
+      await user.type(
+        screen.getByLabelText(/search a course, code or subject/i),
+        "   {Enter}",
+      );
+      expect(push).not.toHaveBeenCalled();
+    });
+
+    it("opens the sign-in dialog from the header", async () => {
+      const user = userEvent.setup();
+      render(<Landing />);
+      await user.click(header().getByRole("button", { name: "Sign up" }));
+      await waitFor(() =>
+        expect(
+          screen.getByRole("heading", { name: /create your account/i }),
+        ).toBeInTheDocument(),
+      );
+    });
+
+    describe("find your dot", () => {
+      it("asks for an account, because a dot belongs to one", async () => {
+        const user = userEvent.setup();
+        render(<Landing />);
+        await openFindYourDot(user);
+        expect(
+          await screen.findByText(/find your place in the community/i),
+        ).toBeInTheDocument();
+        expect(screen.getByLabelText(/email address/i)).toBeInTheDocument();
+      });
+
+      it("refuses an address that cannot be one, and sends nothing", async () => {
+        const user = userEvent.setup();
+        render(<Landing />);
+        await openFindYourDot(user);
+        await user.type(await screen.findByLabelText(/email address/i), "nope");
+        await user.click(
+          screen.getByRole("button", { name: /send private link/i }),
+        );
+        expect(
+          await screen.findByText(/enter a valid email address/i),
+        ).toBeInTheDocument();
+        expect(sendMagicLink).not.toHaveBeenCalled();
+      });
+
+      it("sends the private link back to the landing page", async () => {
+        const user = userEvent.setup();
+        render(<Landing />);
+        await openFindYourDot(user);
+        await user.type(
+          await screen.findByLabelText(/email address/i),
+          "elsa@kth.se",
+        );
+        await user.click(
+          screen.getByRole("button", { name: /send private link/i }),
+        );
+
+        await waitFor(() =>
+          expect(sendMagicLink).toHaveBeenCalledWith({
+            email: "elsa@kth.se",
+            callbackURL: "/?dot=1",
+            errorCallbackURL: "/?dot=expired",
+          }),
+        );
+        expect(
+          await screen.findByText(/check your inbox/i),
+        ).toBeInTheDocument();
+      });
+    });
+  });
+
+  describe("a member whose node exists", () => {
+    beforeEach(() => {
+      member();
+      useNeighbourhood.mockReturnValue(
+        graphState({ data: NEIGHBOURHOOD, isSuccess: true }),
+      );
+    });
+
+    it("names the account and offers a way out of it", async () => {
+      const user = userEvent.setup();
+      render(<Landing />);
+      expect(screen.getByText("Elsa Lindqvist")).toBeInTheDocument();
+      await user.click(header().getByRole("button", { name: /log out/i }));
+      expect(logout).toHaveBeenCalled();
+    });
+
+    it("shows them their own dot once they ask", async () => {
+      const user = userEvent.setup();
+      render(<Landing />);
+      expect(useNeighbourhood).toHaveBeenCalledWith(false);
+
+      await openFindYourDot(user);
+      expect(await screen.findByText(/this one is yours/i)).toBeInTheDocument();
+      expect(useNeighbourhood).toHaveBeenLastCalledWith(true);
+    });
+  });
+
+  describe("a member with no node yet", () => {
+    beforeEach(() => {
+      member();
+      useNeighbourhood.mockReturnValue(
+        graphState({ error: notFound(), isError: true }),
+      );
+    });
+
+    it("says so plainly instead of drawing a dot that is not there", async () => {
+      const user = userEvent.setup();
+      render(<Landing />);
+      await openFindYourDot(user);
+
+      expect(
+        await screen.findByText(/you don’t have a dot yet/i),
+      ).toBeInTheDocument();
+      expect(
+        screen.getByText(/nothing is missing on your side/i),
+      ).toBeInTheDocument();
+      expect(screen.queryByText(/this one is yours/i)).not.toBeInTheDocument();
+    });
+
+    it("blames nobody and reports no failure — this is a normal state", async () => {
+      const user = userEvent.setup();
+      render(<Landing />);
+      await openFindYourDot(user);
+      await screen.findByText(/you don’t have a dot yet/i);
+      expect(screen.queryByRole("alert")).not.toBeInTheDocument();
+      expect(
+        screen.queryByRole("button", { name: /try again/i }),
+      ).not.toBeInTheDocument();
+    });
+
+    it("closes without leaving anything behind", async () => {
+      const user = userEvent.setup();
+      render(<Landing />);
+      await openFindYourDot(user);
+      await user.click(await screen.findByRole("button", { name: "Done" }));
+      await waitFor(() =>
+        expect(screen.queryByRole("dialog")).not.toBeInTheDocument(),
+      );
+    });
+  });
+
+  describe("when the read fails for another reason", () => {
+    it("offers the read again rather than claiming the dot is gone", async () => {
+      const refetch = vi.fn();
+      const user = userEvent.setup();
+      member();
+      useNeighbourhood.mockReturnValue(
+        graphState({ error: new Error("boom"), isError: true, refetch }),
+      );
+      render(<Landing />);
+      await openFindYourDot(user);
+
+      expect(
+        await screen.findByText(/the network did not answer/i),
+      ).toBeInTheDocument();
+      await user.click(screen.getByRole("button", { name: /try again/i }));
+      expect(refetch).toHaveBeenCalled();
+    });
+  });
+
+  describe("coming back through a private link", () => {
+    it("opens straight into the reveal", async () => {
+      search = "dot=1";
+      member();
+      useNeighbourhood.mockReturnValue(
+        graphState({ data: NEIGHBOURHOOD, isSuccess: true }),
+      );
+      render(<Landing />);
+      expect(await screen.findByText(/this one is yours/i)).toBeInTheDocument();
+    });
+
+    it("takes the outcome back out of the URL so a reload does not replay it", () => {
+      search = "dot=1";
+      member();
+      render(<Landing />);
+      expect(replace).toHaveBeenCalledWith("/");
+    });
+
+    it("says a dead link is dead, and does not read the graph on its behalf", async () => {
+      search = "dot=expired";
+      member();
+      render(<Landing />);
+      expect(
+        await screen.findByText(/this link no longer works/i),
+      ).toBeInTheDocument();
+      expect(useNeighbourhood).toHaveBeenCalledWith(false);
+    });
+
+    it("offers a fresh link, and asks a visitor for their address again", async () => {
+      search = "dot=expired";
+      visitor();
+      const user = userEvent.setup();
+      render(<Landing />);
+      await user.click(
+        await screen.findByRole("button", { name: /request a new link/i }),
+      );
+      expect(
+        await screen.findByLabelText(/email address/i),
+      ).toBeInTheDocument();
+    });
+  });
+
+  it("asserts nothing about the session while it is still resolving", () => {
+    useSessionData.mockReturnValue({ user: null, isPending: true });
+    render(<Landing />);
+    expect(
+      header().queryByRole("button", { name: "Sign up" }),
+    ).not.toBeInTheDocument();
+    expect(
+      header().queryByRole("button", { name: /log out/i }),
+    ).not.toBeInTheDocument();
+  });
+
+  it("keeps the network decorative — it is never announced", () => {
+    render(<Landing />);
+    const canvas = screen.getByTestId("hero-network");
+    expect(canvas).toHaveAttribute("aria-hidden", "true");
+  });
+});

--- a/apps/web/features/landing/components/landing.tsx
+++ b/apps/web/features/landing/components/landing.tsx
@@ -1,157 +1,344 @@
 "use client";
 
-import { motion, type Variants } from "framer-motion";
-import { ArrowRight } from "lucide-react";
-import { useRouter } from "next/navigation";
-import { useState } from "react";
-import Topbar from "@/components/Topbar";
-import { Button } from "@/components/ui/button";
-import { useSessionData } from "@/features/auth";
-import { Auth } from "@/features/auth/components/auth";
+import { LogOut, Search } from "lucide-react";
+import Link from "next/link";
+import { useRouter, useSearchParams } from "next/navigation";
+import { useEffect, useState } from "react";
+import {
+  type AuthReason,
+  AuthReasonDialog,
+  useLogout,
+  useSessionData,
+} from "@/features/auth";
+import { ThemeToggle } from "@/features/shell";
+import { isUnplaced, useNeighbourhood } from "../api/queries";
+import { FindYourDot, type FindYourDotStatus } from "./find-your-dot";
+import { HeroNetwork } from "./hero-network";
 
-const containerVariants: Variants = {
-  hidden: { opacity: 0 },
-  visible: {
-    opacity: 1,
-    transition: {
-      staggerChildren: 0.05,
-    },
-  },
-  visibleSub: {
-    opacity: 1,
-    transition: {
-      delayChildren: 1,
-      staggerChildren: 0.05,
-    },
-  },
-};
-const childVariants: Variants = {
-  hidden: {
-    opacity: 0,
-    y: 40,
-  },
-  visible: {
-    opacity: 1,
-    y: 0,
-    transition: {
-      type: "spring",
-      damping: 10,
-      stiffness: 50,
-    },
-  },
-  visibleSub: {
-    opacity: 1,
-    y: 0,
-    transition: {
-      type: "spring",
-      damping: 10,
-      stiffness: 50,
-    },
-  },
-};
+/**
+ * The landing page.
+ *
+ * It owns its own chrome. `/` sits outside the app shell deliberately — the
+ * artboard gives this page a wordmark bar and no rail — so the header here is
+ * the landing's, not a second copy of the shell's.
+ *
+ * Responsive is a container query on the page itself, matching the artboards:
+ * the layout answers to its rendered box, not to the viewport.
+ */
 
-const titleText =
-  "Explore, find and express your thoughts with Course Community!";
-const subTitleText =
-  "What every KTH student has thought of at least once, and it is finally here! A forum for reviewing and exploring all KTH courses! ";
+const TRY = ["deep learning", "machine learning", "DD2380"];
+
+const SECTIONS = [
+  {
+    kicker: "Search",
+    title: "Every KTH course, one field",
+    body: "Filter by school, credits or rating. Open as many courses as you like side by side.",
+  },
+  {
+    kicker: "Read",
+    title: "Numbers, not vibes",
+    body: "Examination mix, theoretical versus applied, workload and learning — aggregated per course.",
+  },
+  {
+    kicker: "Review",
+    title: "Write first, sign in last",
+    body: "Fill in a review as a guest. You only need an account at the moment you post it.",
+  },
+] as const;
 
 export function Landing() {
-  const [isLoggingIn, setIsLoggingIn] = useState(false);
   const router = useRouter();
-  const { isAuthenticated, isPending } = useSessionData();
+  const searchParams = useSearchParams();
+  const { user, isPending: sessionPending } = useSessionData();
+  const logout = useLogout();
 
-  function onSubmit() {
-    if (isPending) return;
-    if (isAuthenticated) {
-      router.push("/search");
-    } else {
-      setIsLoggingIn(true);
-    }
+  const arrivedFromLink = searchParams.get("dot");
+  const [query, setQuery] = useState("");
+  const [authReason, setAuthReason] = useState<AuthReason | null>(null);
+  const [dotOpen, setDotOpen] = useState(arrivedFromLink !== null);
+  const [expired, setExpired] = useState(arrivedFromLink === "expired");
+
+  // The private link lands here with its outcome in the URL. Read once, then
+  // take it back out so a reload does not replay the reveal.
+  useEffect(() => {
+    if (arrivedFromLink !== null) router.replace("/");
+  }, [arrivedFromLink, router]);
+
+  const signedIn = user !== null;
+  const neighbourhood = useNeighbourhood(dotOpen && signedIn && !expired);
+
+  const status = dotStatus({
+    expired,
+    sessionPending,
+    signedIn,
+    isSuccess: neighbourhood.isSuccess,
+    isError: neighbourhood.isError,
+    error: neighbourhood.error,
+  });
+
+  function submitSearch(value: string) {
+    const q = value.trim();
+    if (!q) return;
+    router.push(`/search?q=${encodeURIComponent(q)}`);
   }
-
-  if (isLoggingIn) {
-    return <Auth />;
-  }
-
-  const titleWords = titleText.split(" ");
-  const subTitleWords = subTitleText.split(" ");
 
   return (
-    <div>
-      <Topbar />
-      <motion.div
-        className="flex flex-col w-full justify-left p-40 text-secondary"
-        style={{
-          backgroundImage: 'url("compass-pixabay.png")',
-          backgroundSize: "75%",
-          backgroundPosition: "right center",
-          backgroundRepeat: "no-repeat",
-        }}
-      >
-        <div className="absolute inset-0 bg-gradient-to-r from-background/90 via-background/70 to-transparent" />
-
-        <div className="relative z-10 w-3/4 2xl:w-1/3 break-words">
-          <motion.h1
-            variants={containerVariants}
-            initial="hidden"
-            animate="visible"
-            className="text-7xl font-extrabold tracking-wide leading-snug md:text-6xl"
-          >
-            {titleWords.map((word, id) => {
-              const key = `${word}-${id}`;
-              return (
-                <motion.span
-                  variants={childVariants}
-                  key={key}
-                  style={{ display: "inline-block" }}
-                >
-                  {word}
-                  {"\u00A0"}
-                </motion.span>
-              );
-            })}
-          </motion.h1>
-          <motion.h2
-            variants={containerVariants}
-            initial="hidden"
-            animate="visibleSub"
-            transition={{ delay: 2 }}
-            className="text-xl pt-8 font-serif"
-          >
-            {subTitleWords.map((word, id) => {
-              const key = `${word}-${id}`;
-              return (
-                <motion.span
-                  variants={childVariants}
-                  key={key}
-                  style={{ display: "inline-block" }}
-                >
-                  {word}
-                  {"\u00A0"}
-                </motion.span>
-              );
-            })}
-          </motion.h2>
-        </div>
-        <motion.div
-          initial={{ opacity: 0 }}
-          animate={{ opacity: 1 }}
-          transition={{
-            type: "tween",
-            duration: 0.3,
-            ease: "easeOut",
-            delay: 3.5,
-          }}
-          className="flex relative z-10 w-full pt-8"
+    <div className="@container cc-theme min-h-dvh bg-cc-pg text-cc-ink text-sm">
+      <header className="relative z-10 flex h-[66px] items-center justify-between gap-5 border-cc-rule border-b bg-cc-pg px-4 @lg:px-7">
+        <Link
+          href="/"
+          className="flex items-center gap-2.5 text-cc-ink no-underline"
         >
-          <motion.div whileHover={{ scale: 1.05 }} whileTap={{ scale: 0.95 }}>
-            <Button size="lg" onClick={onSubmit}>
-              Get started
-              <ArrowRight data-icon="inline-end" />
-            </Button>
-          </motion.div>
-        </motion.div>
-      </motion.div>
+          {/* biome-ignore lint/performance/noImgElement: a fixed 34px mark; next/image adds a loader for nothing. */}
+          <img
+            src="/ais-symbol-white.png"
+            alt=""
+            className="size-[22px] shrink-0 rounded-[9px] bg-cc-rail object-contain p-1.5 box-content"
+          />
+          <span aria-hidden className="h-[28px] w-px bg-cc-rule3" />
+          <span className="font-semibold text-[15px] leading-[1.15]">
+            Course
+            <br />
+            Community
+          </span>
+        </Link>
+
+        <div className="flex items-center gap-1.5">
+          <ThemeToggle />
+          {sessionPending ? null : user ? (
+            <div className="flex items-center gap-2">
+              <span className="flex h-[34px] items-center gap-2 rounded-[8px] bg-cc-pill py-0 pr-[11px] pl-[5px]">
+                <span className="flex size-6 items-center justify-center rounded-full bg-cc-btn font-bold text-[10px] text-cc-btn-fg">
+                  {initials(user)}
+                </span>
+                <span className="max-w-[10rem] truncate font-medium text-[13px]">
+                  {displayName(user)}
+                </span>
+              </span>
+              <button
+                type="button"
+                onClick={() => void logout()}
+                aria-label="Log out"
+                className="flex h-[34px] items-center gap-1.5 rounded-[8px] px-[11px] font-medium text-[13px] text-cc-chip-ink hover:bg-cc-pill"
+              >
+                <LogOut size={15} strokeWidth={1.9} aria-hidden />
+                <span className="hidden @lg:inline">Log out</span>
+              </button>
+            </div>
+          ) : (
+            // On a narrow frame the artboard moves these two into a card at the
+            // foot of the page instead of crowding the bar.
+            <div className="hidden items-center gap-2 @lg:flex">
+              <button
+                type="button"
+                onClick={() => setAuthReason("log-in")}
+                className="flex h-[34px] items-center rounded-[8px] px-[13px] font-medium text-[13px] text-cc-brand hover:bg-cc-pill"
+              >
+                Log in
+              </button>
+              <button
+                type="button"
+                onClick={() => setAuthReason("sign-up")}
+                className="flex h-[34px] items-center rounded-[8px] bg-cc-btn px-[15px] font-semibold text-[13px] text-cc-btn-fg hover:opacity-[0.88]"
+              >
+                Sign up
+              </button>
+            </div>
+          )}
+        </div>
+      </header>
+
+      <section
+        data-hero
+        className="relative min-h-[480px] @lg:min-h-[600px] overflow-hidden"
+      >
+        <div aria-hidden className="pointer-events-none absolute inset-0 z-0">
+          <HeroNetwork neighbourhood={neighbourhood.data ?? null} />
+        </div>
+
+        <div className="relative z-[1] flex min-h-[480px] @lg:min-h-[600px] flex-col items-center justify-center px-4 py-14 @lg:px-7">
+          <div className="flex w-full max-w-[720px] flex-col items-center text-center">
+            <p
+              data-hero-clear
+              className="m-0 font-semibold text-[11px] text-cc-dim uppercase tracking-[0.09em]"
+            >
+              Run by students at KTH
+            </p>
+            <h1
+              data-hero-clear
+              className="mt-3.5 text-balance font-semibold text-[30px] @lg:text-[44px] leading-[1.08] tracking-[-0.025em]"
+            >
+              Find the Course You Will Be Happy You Took
+            </h1>
+
+            <form
+              data-hero-clear
+              onSubmit={(event) => {
+                event.preventDefault();
+                submitSearch(query);
+              }}
+              className="mt-4 @lg:mt-[97px] flex h-[42px] w-full @lg:max-w-[560px] items-center gap-2.5 rounded-[10px] border border-cc-rule3 bg-cc-surface px-3.5"
+            >
+              <Search
+                size={16}
+                strokeWidth={2}
+                aria-hidden
+                className="shrink-0 text-cc-muted"
+              />
+              <input
+                value={query}
+                onChange={(event) => setQuery(event.target.value)}
+                placeholder="Search a course, code or subject"
+                aria-label="Search a course, code or subject"
+                className="min-w-0 flex-1 border-none bg-transparent text-[14px] text-cc-ink outline-none"
+              />
+            </form>
+
+            <div
+              data-hero-clear
+              className="mt-4 flex flex-wrap items-center justify-center gap-[7px]"
+            >
+              <span className="text-[12px] text-cc-dim">Try</span>
+              {TRY.map((term) => (
+                <button
+                  key={term}
+                  type="button"
+                  onClick={() => submitSearch(term)}
+                  className="flex h-7 items-center rounded-[14px] border border-cc-rule2 bg-cc-surface px-[11px] text-[12.5px] text-cc-chip-ink hover:border-cc-hov"
+                >
+                  {term}
+                </button>
+              ))}
+            </div>
+
+            <p
+              data-hero-clear
+              className="mt-5 flex items-center gap-1.5 text-[12.5px] text-cc-dim"
+            >
+              <span>Already a member?</span>
+              <button
+                type="button"
+                onClick={() => {
+                  setExpired(false);
+                  setDotOpen(true);
+                }}
+                className="cursor-pointer font-medium text-cc-muted underline underline-offset-2 hover:text-cc-brand"
+              >
+                Find your dot.
+              </button>
+            </p>
+          </div>
+        </div>
+      </section>
+
+      <section className="border-cc-rule border-t bg-cc-surface px-4 py-[34px] @lg:px-7">
+        <div className="mx-auto flex max-w-[960px] flex-col gap-[22px] @lg:grid @lg:grid-cols-3">
+          {SECTIONS.map((section) => (
+            <div key={section.kicker}>
+              <p className="m-0 font-semibold text-[10.5px] text-cc-dim uppercase tracking-[0.09em]">
+                {section.kicker}
+              </p>
+              <p className="mt-[7px] mb-0 font-semibold text-[15px]">
+                {section.title}
+              </p>
+              <p className="mt-[5px] mb-0 text-[13.5px] text-cc-muted leading-[1.5]">
+                {section.body}
+              </p>
+            </div>
+          ))}
+        </div>
+      </section>
+
+      {!sessionPending && !signedIn ? (
+        <section className="px-5 pt-5 pb-9 @lg:hidden">
+          <div className="rounded-[11px] border border-cc-rule2 bg-cc-surface p-5">
+            <p className="m-0 font-semibold text-[11px] text-cc-brand uppercase tracking-[0.06em]">
+              Join
+            </p>
+            <p className="mt-2 mb-0 font-semibold text-[17px] leading-[1.25]">
+              Create your account
+            </p>
+            <p className="mt-1.5 mb-0 text-[13px] text-cc-muted leading-[1.5]">
+              Free for KTH students. You keep everything you were looking at.
+            </p>
+            <button
+              type="button"
+              onClick={() => setAuthReason("sign-up")}
+              className="mt-4 flex h-[42px] w-full items-center justify-center rounded-[9px] bg-cc-btn font-semibold text-[13.5px] text-cc-btn-fg hover:opacity-[0.88]"
+            >
+              Sign up
+            </button>
+            <button
+              type="button"
+              onClick={() => setAuthReason("log-in")}
+              className="mt-2 flex h-[42px] w-full items-center justify-center rounded-[9px] border border-cc-rule3 bg-cc-surface font-medium text-[13.5px] text-cc-ink hover:border-cc-hov"
+            >
+              Log in
+            </button>
+          </div>
+        </section>
+      ) : null}
+
+      <FindYourDot
+        open={dotOpen}
+        status={status}
+        onClose={() => {
+          setDotOpen(false);
+          setExpired(false);
+        }}
+        onRetry={() => {
+          if (expired) {
+            setExpired(false);
+            return;
+          }
+          void neighbourhood.refetch();
+        }}
+      />
+
+      <AuthReasonDialog
+        reason={authReason}
+        onReasonChange={setAuthReason}
+        onClose={() => setAuthReason(null)}
+      />
     </div>
   );
+}
+
+/**
+ * Where the flow has got to.
+ *
+ * Order matters: a dead link is reported before anything else is attempted, and
+ * an unresolved session never shows a member the sign-in form for one frame.
+ */
+function dotStatus(input: {
+  expired: boolean;
+  sessionPending: boolean;
+  signedIn: boolean;
+  isSuccess: boolean;
+  isError: boolean;
+  error: unknown;
+}): FindYourDotStatus {
+  if (input.expired) return "expired";
+  if (input.sessionPending) return "locating";
+  if (!input.signedIn) return "sign-in";
+  if (input.isSuccess) return "placed";
+  if (isUnplaced(input.error)) return "unplaced";
+  if (input.isError) return "unavailable";
+  return "locating";
+}
+
+function displayName(user: { name?: string | null; email?: string | null }) {
+  return user.name?.trim() || (user.email?.trim().split("@")[0] ?? "");
+}
+
+function initials(user: { name?: string | null; email?: string | null }) {
+  const name = user.name?.trim() ?? "";
+  const fromName = name
+    .split(/\s+/)
+    .filter(Boolean)
+    .map((part) => part[0])
+    .join("")
+    .toUpperCase()
+    .slice(0, 2);
+  return fromName || user.email?.trim().charAt(0).toUpperCase() || "?";
 }

--- a/apps/web/features/landing/lib/hero-field.spec.ts
+++ b/apps/web/features/landing/lib/hero-field.spec.ts
@@ -1,0 +1,207 @@
+import { describe, expect, it } from "vitest";
+import {
+  buildField,
+  clearAt,
+  densityAt,
+  distToContent,
+  envelope,
+  FEATHER,
+  halton,
+  hash,
+  INSET,
+  lineClear,
+  quadPoint,
+  type Rect,
+  rgba,
+} from "./hero-field";
+
+const W = 1200;
+const H = 600;
+/** Roughly where the headline, the search field and the chips sit. */
+const COPY: Rect[] = [
+  { x: 300, y: 60, w: 600, h: 180 },
+  { x: 320, y: 300, w: 560, h: 60 },
+];
+
+describe("halton", () => {
+  it("spreads points over the unit interval without repeating", () => {
+    const points = Array.from({ length: 64 }, (_, i) => halton(i, 2));
+    expect(new Set(points).size).toBe(points.length);
+    for (const p of points) {
+      expect(p).toBeGreaterThanOrEqual(0);
+      expect(p).toBeLessThan(1);
+    }
+  });
+
+  it("fills both halves rather than marching up from zero", () => {
+    const points = Array.from({ length: 16 }, (_, i) => halton(i, 2));
+    expect(points.filter((p) => p < 0.5).length).toBeGreaterThan(4);
+    expect(points.filter((p) => p >= 0.5).length).toBeGreaterThan(4);
+  });
+});
+
+describe("hash", () => {
+  it("is deterministic, so a relayout reproduces the same field", () => {
+    expect(hash(7, 3)).toBe(hash(7, 3));
+  });
+
+  it("stays in the unit interval", () => {
+    for (let i = 0; i < 50; i++) {
+      expect(hash(i, 1)).toBeGreaterThanOrEqual(0);
+      expect(hash(i, 1)).toBeLessThan(1);
+    }
+  });
+});
+
+describe("clearAt", () => {
+  it("is 0 inside the copy and 1 well away from it", () => {
+    expect(clearAt(400, 100, COPY)).toBe(0);
+    expect(clearAt(50, 550, COPY)).toBe(1);
+  });
+
+  it("eases rather than steps at the boundary", () => {
+    const justOutside = clearAt(300 - FEATHER / 2, 150, COPY);
+    expect(justOutside).toBeGreaterThan(0);
+    expect(justOutside).toBeLessThan(1);
+  });
+
+  it("judges a dot by its edge, not its centre", () => {
+    const x = 300 - FEATHER - 1;
+    expect(clearAt(x, 150, COPY)).toBe(1);
+    expect(clearAt(x, 150, COPY, 6)).toBeLessThan(1);
+  });
+});
+
+describe("distToContent", () => {
+  it("is 0 inside a rect and grows with distance outside it", () => {
+    expect(distToContent(400, 100, COPY)).toBe(0);
+    expect(distToContent(280, 150, COPY)).toBeCloseTo(20);
+  });
+});
+
+describe("densityAt", () => {
+  it("thins the field out near the copy", () => {
+    expect(densityAt(310, 150, COPY)).toBeLessThan(densityAt(20, 580, COPY));
+  });
+
+  it("never drops to nothing, so the copy is not ringed by a bald patch", () => {
+    expect(densityAt(400, 100, COPY)).toBeGreaterThan(0);
+  });
+});
+
+describe("lineClear", () => {
+  it("rejects a line that crosses the copy", () => {
+    expect(lineClear({ x: 0, y: 150 }, { x: 1200, y: 150 }, COPY)).toBe(false);
+  });
+
+  it("accepts a line that passes well clear of it", () => {
+    expect(lineClear({ x: 0, y: 580 }, { x: 1200, y: 580 }, COPY)).toBe(true);
+  });
+});
+
+describe("envelope", () => {
+  it("is faint at departure and gone on arrival", () => {
+    expect(envelope(0)).toBe(0);
+    expect(envelope(1)).toBe(0);
+    expect(envelope(0.5)).toBeGreaterThan(0.5);
+  });
+});
+
+describe("quadPoint", () => {
+  const seg = { ax: 0, ay: 0, cx: 50, cy: 100, bx: 100, by: 0 };
+
+  it("starts on a and ends on b", () => {
+    expect(quadPoint(seg, 0)).toEqual({ x: 0, y: 0 });
+    expect(quadPoint(seg, 1)).toEqual({ x: 100, y: 0 });
+  });
+
+  it("bows towards the control point in between", () => {
+    expect(quadPoint(seg, 0.5).y).toBeGreaterThan(0);
+  });
+});
+
+describe("rgba", () => {
+  it("rounds the channels and clamps a negative alpha", () => {
+    expect(rgba([23.4, 81.6, 166], 0.5)).toBe("rgba(23,82,166,0.500)");
+    expect(rgba([0, 0, 0], -1)).toBe("rgba(0,0,0,0.000)");
+  });
+});
+
+describe("buildField", () => {
+  const field = buildField({ w: W, h: H, rects: COPY, count: 50 });
+  const drawn = field.nodes.filter((n) => !n.offFrame);
+
+  it("draws no dot on top of the hero copy", () => {
+    for (const node of drawn) {
+      expect(clearAt(node.x, node.y, COPY, node.r)).toBe(1);
+    }
+  });
+
+  it("keeps every drawn dot inside the frame", () => {
+    for (const node of drawn) {
+      expect(node.x).toBeGreaterThanOrEqual(INSET);
+      expect(node.x).toBeLessThanOrEqual(W - INSET);
+      expect(node.y).toBeGreaterThanOrEqual(INSET);
+      expect(node.y).toBeLessThanOrEqual(H - INSET);
+    }
+  });
+
+  it("keeps every off-frame node outside it, so it is never drawn", () => {
+    for (const node of field.nodes.filter((n) => n.offFrame)) {
+      const inside =
+        node.x > INSET &&
+        node.x < W - INSET &&
+        node.y > INSET &&
+        node.y < H - INSET;
+      expect(inside).toBe(false);
+    }
+  });
+
+  it("draws no line across the copy", () => {
+    for (const edge of field.edges) {
+      expect(lineClear(edge.a, edge.b, COPY)).toBe(true);
+    }
+  });
+
+  it("never links two off-frame nodes — neither end would be visible", () => {
+    for (const edge of field.edges) {
+      expect(edge.a.offFrame && edge.b.offFrame).toBe(false);
+    }
+  });
+
+  it("respects every dot's own line quota", () => {
+    for (const [node, edges] of field.byNode) {
+      expect(edges.length).toBeLessThanOrEqual(node.quota);
+    }
+  });
+
+  it("reproduces the same field for the same frame", () => {
+    const again = buildField({ w: W, h: H, rects: COPY, count: 50 });
+    expect(again.nodes.map((n) => [n.x, n.y])).toEqual(
+      field.nodes.map((n) => [n.x, n.y]),
+    );
+  });
+
+  it("picks two well-separated resting dots for reduced motion", () => {
+    expect(field.glows.length).toBeLessThanOrEqual(2);
+    if (field.glows.length === 2) {
+      const [a, b] = field.glows;
+      expect(Math.hypot(a.x - b.x, a.y - b.y)).toBeGreaterThan(200);
+    }
+  });
+
+  it("carries fewer travelling signals on a narrow frame", () => {
+    const narrow = buildField({ w: 400, h: H, rects: [], count: 20 });
+    expect(narrow.maxSignals).toBeLessThan(field.maxSignals);
+  });
+
+  it("survives a frame with no room to place anything", () => {
+    const covered = buildField({
+      w: 300,
+      h: 200,
+      rects: [{ x: -100, y: -100, w: 500, h: 400 }],
+      count: 30,
+    });
+    expect(covered.nodes.filter((n) => !n.offFrame)).toHaveLength(0);
+  });
+});

--- a/apps/web/features/landing/lib/hero-field.ts
+++ b/apps/web/features/landing/lib/hero-field.ts
@@ -1,0 +1,332 @@
+/**
+ * The hero's ambient field: the drifting dots behind the landing copy.
+ *
+ * This is an **illustration of a community, never the community**. Nothing here
+ * reads a world position, and no dot it produces is ever labelled with an
+ * account — the real graph arrives separately, through `graph.neighbourhood`,
+ * and `neighbourhood-view.ts` projects that. Keeping the two apart is the whole
+ * point of the split: a decorative dot must never be mistaken for a Node.
+ *
+ * Nothing here touches the DOM, a canvas or a clock, so every placement
+ * decision can be asserted on directly. `hero-network.tsx` owns the canvas, the
+ * rAF loop and the measuring; it calls in here for *where* things go.
+ *
+ * The one rule the file exists to enforce: no dot and no line between two dots
+ * may sit on top of the hero copy.
+ */
+
+/** A measured content box the field must keep clear of, in canvas pixels. */
+export type Rect = { x: number; y: number; w: number; h: number };
+
+export type FieldNode = {
+  seed: number;
+  /** Live position. */
+  x: number;
+  y: number;
+  /** Home position — drift is clamped to a small box around it. */
+  hx: number;
+  hy: number;
+  r: number;
+  /**
+   * An off-frame node. Lines and signals travel through it so the field reads
+   * as a crop of something larger, and it is never drawn.
+   *
+   * Deliberately not called an anchor: an **Anchor** is an established node a
+   * joining node attaches to in the community graph, and this is a decoration.
+   */
+  offFrame: boolean;
+  /** How many lines this dot will accept. */
+  quota: number;
+  vx: number;
+  vy: number;
+};
+
+export type FieldEdge = {
+  a: FieldNode;
+  b: FieldNode;
+  /** Cached clearance, refreshed on a rolling slice rather than every frame. */
+  clear?: number;
+};
+
+export type Field = {
+  nodes: FieldNode[];
+  edges: FieldEdge[];
+  byNode: Map<FieldNode, FieldEdge[]>;
+  /** Two resting dots, glowing in place when motion is off. */
+  glows: FieldNode[];
+  minGap: number;
+  maxSignals: number;
+  /** How far the virtual canvas extends past the frame, per axis. */
+  marginX: number;
+  marginY: number;
+};
+
+/** Width of the soft margin around the copy, in px. */
+export const FEATHER = 10;
+/** Extra padding added to every measured content rect, in px. */
+export const SAFETY = 25;
+/** Drawn dots stay this far inside the frame; off-frame nodes stay outside it. */
+export const INSET = 20;
+/** How far a dot may drift from its home position, in px. */
+export const DRIFT_BOX = 5;
+
+/** Halton — a low-discrepancy sequence: evenly spread without rows or clumps. */
+export function halton(index: number, base: number) {
+  let f = 1;
+  let r = 0;
+  let n = index + 1;
+  while (n > 0) {
+    f /= base;
+    r += f * (n % base);
+    n = Math.floor(n / base);
+  }
+  return r;
+}
+
+/** Deterministic per-dot jitter, so a relayout reproduces the same field. */
+export function hash(index: number, salt: number) {
+  const x = Math.sin((index + 1) * 12.9898 + salt * 78.233) * 43758.5453;
+  return x - Math.floor(x);
+}
+
+/**
+ * 1 well clear of the hero copy, easing to 0 inside it. `radius` grows the
+ * point into a disc, so a dot is judged by its edge rather than its centre.
+ */
+export function clearAt(x: number, y: number, rects: Rect[], radius = 0) {
+  let m = 1;
+  for (const r of rects) {
+    const dx = Math.max(r.x - x, 0, x - (r.x + r.w)) - radius;
+    const dy = Math.max(r.y - y, 0, y - (r.y + r.h)) - radius;
+    const d = Math.hypot(Math.max(0, dx), Math.max(0, dy));
+    if (d >= FEATHER) continue;
+    const t = d / FEATHER;
+    m = Math.min(m, t * t * (3 - 2 * t)); // smoothstep
+  }
+  return m;
+}
+
+/** Distance from the content keep-out, in px. 0 when inside it. */
+export function distToContent(x: number, y: number, rects: Rect[]) {
+  let m = Number.POSITIVE_INFINITY;
+  for (const r of rects) {
+    const dx = Math.max(r.x - x, 0, x - (r.x + r.w));
+    const dy = Math.max(r.y - y, 0, y - (r.y + r.h));
+    m = Math.min(m, Math.hypot(dx, dy));
+  }
+  return m;
+}
+
+/** Thinner near the copy, full density further out — the field stays legible. */
+export function densityAt(x: number, y: number, rects: Rect[]) {
+  const t = Math.min(1, distToContent(x, y, rects) / 300);
+  return 0.16 + 0.84 * t * t;
+}
+
+/** Sampled clearance along a line — 1 well clear of the copy, 0 crossing it. */
+export function lineClearance(
+  a: { x: number; y: number },
+  b: { x: number; y: number },
+  rects: Rect[],
+) {
+  let m = 1;
+  for (let i = 0; i <= 10; i++) {
+    const t = i / 10;
+    m = Math.min(
+      m,
+      clearAt(a.x + (b.x - a.x) * t, a.y + (b.y - a.y) * t, rects),
+    );
+    if (m <= 0) break;
+  }
+  return m;
+}
+
+export function lineClear(
+  a: { x: number; y: number },
+  b: { x: number; y: number },
+  rects: Rect[],
+) {
+  return lineClearance(a, b, rects) >= 1;
+}
+
+/** Faint on departure, defined mid-flight, gone on arrival. */
+export function envelope(p: number) {
+  const smoothstep = (a: number, b: number, x: number) => {
+    const t = Math.max(0, Math.min(1, (x - a) / (b - a)));
+    return t * t * (3 - 2 * t);
+  };
+  return Math.min(smoothstep(0.03, 0.42, p) ** 1.5, 1 - smoothstep(0.86, 1, p));
+}
+
+/** A point along a signal's quadratic path. */
+export function quadPoint(
+  s: { ax: number; ay: number; cx: number; cy: number; bx: number; by: number },
+  p: number,
+) {
+  const q = 1 - p;
+  return {
+    x: q * q * s.ax + 2 * q * p * s.cx + p * p * s.bx,
+    y: q * q * s.ay + 2 * q * p * s.cy + p * p * s.by,
+  };
+}
+
+/** `rgb(...)` triple plus alpha, for a canvas fill or stroke. */
+export function rgba(colour: readonly number[], alpha: number) {
+  const [r, g, b] = colour;
+  return `rgba(${Math.round(r)},${Math.round(g)},${Math.round(b)},${Math.max(0, alpha).toFixed(3)})`;
+}
+
+/** Keep-out used when the hero's own elements cannot be measured. */
+export function fallbackRects(w: number, h: number): Rect[] {
+  const copy = Math.min(780, w * 0.74);
+  return [
+    { x: w / 2 - copy / 2, y: 10, w: copy, h: h * 0.5 },
+    { x: w / 2 - copy * 0.45, y: h * 0.5, w: copy * 0.9, h: h * 0.3 },
+  ];
+}
+
+export function makeFieldNode(
+  seed: number,
+  x: number,
+  y: number,
+  offFrame: boolean,
+): FieldNode {
+  const dir = hash(seed, 1) * 6.2832;
+  const speed = 1.8 + hash(seed, 2) * 0.4;
+  return {
+    seed,
+    x,
+    y,
+    hx: x,
+    hy: y,
+    r: 4,
+    offFrame,
+    quota: 3 + (hash(seed, 3) < 0.55 ? 1 : 0) + (hash(seed, 4) < 0.28 ? 1 : 0),
+    vx: Math.cos(dir) * speed,
+    vy: Math.sin(dir) * speed,
+  };
+}
+
+export type FieldInput = {
+  w: number;
+  h: number;
+  rects: Rect[];
+  /** How many dots to draw inside the frame. */
+  count: number;
+};
+
+/**
+ * Place the field and wire it up.
+ *
+ * The field lives on a virtual canvas larger than the hero on every side, so
+ * the screen reads as a crop of something bigger: lines cross the frame edges
+ * into off-frame nodes that are never drawn.
+ */
+export function buildField({ w, h, rects, count }: FieldInput): Field {
+  const marginX = Math.max(140, Math.round(w * 0.26));
+  const marginY = Math.max(130, Math.round(h * 0.45));
+  const onArea = Math.max(1, (w - INSET * 2) * (h - INSET * 2));
+  const target = Math.max(1, count);
+  const gap = Math.sqrt(onArea / target) * 0.62;
+  const nodes: FieldNode[] = [];
+
+  let p = 0;
+  for (let seed = 0; seed < target; seed++) {
+    let placed: FieldNode | null = null;
+    for (; p < 30000 && !placed; p++) {
+      const x = INSET + halton(p, 2) * (w - INSET * 2);
+      const y = INSET + halton(p, 3) * (h - INSET * 2);
+      if (clearAt(x, y, rects, 5) < 1) continue;
+      if (hash(p, 7) > densityAt(x, y, rects)) continue; // thin out near the copy
+      if (nodes.some((n) => Math.hypot(n.x - x, n.y - y) < gap)) continue;
+      placed = makeFieldNode(seed, x, y, false);
+    }
+    if (!placed) break; // this frame has no room left
+    nodes.push(placed);
+  }
+
+  const offFrameCount = Math.min(140, Math.round(target * 0.55));
+  for (
+    let i = 0, added = 0;
+    added < offFrameCount && i < offFrameCount * 30;
+    i++
+  ) {
+    const x = -marginX + halton(i + 977, 2) * (w + marginX * 2);
+    const y = -marginY + halton(i + 977, 3) * (h + marginY * 2);
+    if (x > INSET && x < w - INSET && y > INSET && y < h - INSET) continue;
+    if (nodes.some((n) => Math.hypot(n.x - x, n.y - y) < gap * 0.8)) continue;
+    nodes.push(makeFieldNode(i + 977, x, y, true));
+    added++;
+  }
+
+  const edges = buildFieldEdges(nodes, w, h, rects);
+  const byNode = new Map<FieldNode, FieldEdge[]>();
+  for (const n of nodes) byNode.set(n, []);
+  for (const edge of edges) {
+    byNode.get(edge.a)?.push(edge);
+    byNode.get(edge.b)?.push(edge);
+  }
+
+  const still = nodes
+    .filter((n) => !n.offFrame && clearAt(n.x, n.y, rects) > 0.9)
+    .sort((a, b) => b.y - a.y);
+  const glows: FieldNode[] = [];
+  for (const n of still) {
+    if (glows.length >= 2) break;
+    if (glows.every((g) => Math.hypot(g.x - n.x, g.y - n.y) > 200))
+      glows.push(n);
+  }
+
+  return {
+    nodes,
+    edges,
+    byNode,
+    glows,
+    minGap: gap * 0.7,
+    maxSignals: w < 620 ? 3 : w < 1000 ? 5 : 8,
+    marginX,
+    marginY,
+  };
+}
+
+/** Mostly short lines to nearby dots; none of them crosses the copy. */
+export function buildFieldEdges(
+  nodes: FieldNode[],
+  w: number,
+  h: number,
+  rects: Rect[],
+) {
+  const near = Math.max(w, h) * 0.34;
+  const seen = new Set<string>();
+  const edges: FieldEdge[] = [];
+  const degree = new Array(nodes.length).fill(0);
+
+  const add = (i: number, j: number) => {
+    const a = Math.min(i, j);
+    const b = Math.max(i, j);
+    const key = `${a}:${b}`;
+    if (a === b || seen.has(key)) return;
+    if (degree[a] >= nodes[a].quota || degree[b] >= nodes[b].quota) return;
+    if (nodes[a].offFrame && nodes[b].offFrame) return; // both invisible: pointless
+    if (!lineClear(nodes[a], nodes[b], rects)) return; // no line crosses the copy
+    seen.add(key);
+    degree[a]++;
+    degree[b]++;
+    edges.push({ a: nodes[a], b: nodes[b] });
+  };
+
+  for (let i = 0; i < nodes.length; i++) {
+    const candidates: { j: number; len: number }[] = [];
+    for (let j = 0; j < nodes.length; j++) {
+      if (i === j) continue;
+      const len = Math.hypot(nodes[j].x - nodes[i].x, nodes[j].y - nodes[i].y);
+      if (len <= near) candidates.push({ j, len });
+    }
+    candidates.sort((a, b) => a.len - b.len);
+    for (const c of candidates) {
+      if (degree[i] >= nodes[i].quota) break;
+      add(i, c.j);
+    }
+  }
+  return edges;
+}

--- a/apps/web/features/landing/lib/neighbourhood-view.spec.ts
+++ b/apps/web/features/landing/lib/neighbourhood-view.spec.ts
@@ -1,0 +1,213 @@
+import { describe, expect, it } from "vitest";
+import type { Rect } from "./hero-field";
+import {
+  DEFAULT_SCALE,
+  FALLBACK_NODE_COLOR_VAR,
+  fitScale,
+  MAX_SCALE,
+  type NeighbourhoodInput,
+  NODE_COLOR_VARS,
+  nodeColorVar,
+  pickViewportCentre,
+  projectNeighbourhood,
+} from "./neighbourhood-view";
+
+const WIDTH = 1000;
+const HEIGHT = 600;
+
+/** A block of copy across the top half, the way the hero headline sits. */
+const COPY: Rect[] = [{ x: 200, y: 40, w: 600, h: 220 }];
+
+function neighbourhood(
+  nodes: { userId: string; x: number; y: number; color?: string }[],
+  edges: { nodeUserId: string; anchorUserId: string }[] = [],
+): NeighbourhoodInput {
+  const [viewer] = nodes;
+  return {
+    viewer: { userId: viewer.userId, x: viewer.x, y: viewer.y },
+    nodes: nodes.map((n) => ({ ...n, color: n.color ?? "frost" })),
+    edges,
+  };
+}
+
+describe("nodeColorVar", () => {
+  it("maps every colour the server can store onto a token", () => {
+    for (const [name, variable] of Object.entries(NODE_COLOR_VARS)) {
+      expect(nodeColorVar(name)).toBe(variable);
+    }
+  });
+
+  it("draws a name this build has never heard of in the neutral", () => {
+    expect(nodeColorVar("chartreuse")).toBe(FALLBACK_NODE_COLOR_VAR);
+    expect(nodeColorVar("")).toBe(FALLBACK_NODE_COLOR_VAR);
+  });
+
+  // The server stores a name; a hex would mean someone inverted the contract.
+  it("never trusts a hex value as a colour", () => {
+    expect(nodeColorVar("#1751a6")).toBe(FALLBACK_NODE_COLOR_VAR);
+  });
+});
+
+describe("pickViewportCentre", () => {
+  it("keeps the viewer's node out of the hero copy", () => {
+    const centre = pickViewportCentre(WIDTH, HEIGHT, COPY);
+    const insideCopy =
+      centre.x > COPY[0].x &&
+      centre.x < COPY[0].x + COPY[0].w &&
+      centre.y > COPY[0].y &&
+      centre.y < COPY[0].y + COPY[0].h;
+    expect(insideCopy).toBe(false);
+  });
+
+  it("stays inside the frame", () => {
+    const centre = pickViewportCentre(WIDTH, HEIGHT, COPY);
+    expect(centre.x).toBeGreaterThan(0);
+    expect(centre.x).toBeLessThan(WIDTH);
+    expect(centre.y).toBeGreaterThan(0);
+    expect(centre.y).toBeLessThan(HEIGHT);
+  });
+
+  it("takes the middle when nothing is in the way", () => {
+    expect(pickViewportCentre(WIDTH, HEIGHT, [])).toEqual({ x: 500, y: 300 });
+  });
+
+  it("is deterministic — the same frame gives the same centre", () => {
+    expect(pickViewportCentre(WIDTH, HEIGHT, COPY)).toEqual(
+      pickViewportCentre(WIDTH, HEIGHT, COPY),
+    );
+  });
+});
+
+describe("fitScale", () => {
+  const centre = { x: 500, y: 300 };
+
+  it("brings the furthest node inside the frame", () => {
+    const input = neighbourhood([
+      { userId: "me", x: 0, y: 0 },
+      { userId: "far", x: 4000, y: 0 },
+    ]);
+    const scale = fitScale(input, WIDTH, HEIGHT, centre);
+    expect(4000 * scale + centre.x).toBeLessThanOrEqual(WIDTH);
+  });
+
+  it("fits each direction separately, because the centre is rarely central", () => {
+    const input = neighbourhood([
+      { userId: "me", x: 0, y: 0 },
+      { userId: "left", x: -1000, y: 0 },
+    ]);
+    const offCentre = { x: 200, y: 300 };
+    const scale = fitScale(input, WIDTH, HEIGHT, offCentre);
+    expect(offCentre.x - 1000 * scale).toBeGreaterThanOrEqual(0);
+  });
+
+  it("does not magnify a tight neighbourhood past the cap", () => {
+    const input = neighbourhood([
+      { userId: "me", x: 0, y: 0 },
+      { userId: "close", x: 1, y: 1 },
+    ]);
+    expect(fitScale(input, WIDTH, HEIGHT, centre)).toBe(MAX_SCALE);
+  });
+
+  it("has nothing to measure when the viewer is alone", () => {
+    const input = neighbourhood([{ userId: "me", x: 0, y: 0 }]);
+    expect(fitScale(input, WIDTH, HEIGHT, centre)).toBe(DEFAULT_SCALE);
+  });
+});
+
+describe("projectNeighbourhood", () => {
+  const input = neighbourhood(
+    [
+      { userId: "me", x: 100, y: 100, color: "violet" },
+      { userId: "a", x: 400, y: 100, color: "moss" },
+      { userId: "b", x: 100, y: -200, color: "not-a-colour" },
+    ],
+    [
+      { nodeUserId: "a", anchorUserId: "me" },
+      { nodeUserId: "b", anchorUserId: "a" },
+      // An edge to somebody outside the bounded set.
+      { nodeUserId: "a", anchorUserId: "elsewhere" },
+    ],
+  );
+
+  const view = () =>
+    projectNeighbourhood({
+      neighbourhood: input,
+      width: WIDTH,
+      height: HEIGHT,
+      keepOut: COPY,
+    });
+
+  it("puts the viewer's own node exactly on the chosen centre", () => {
+    const projected = view();
+    const me = projected.nodes.find((n) => n.isViewer);
+    expect(me?.screenX).toBeCloseTo(projected.centre.x);
+    expect(me?.screenY).toBeCloseTo(projected.centre.y);
+  });
+
+  it("places everyone else relative to the viewer, in world units times scale", () => {
+    const projected = view();
+    const a = projected.nodes.find((n) => n.userId === "a");
+    expect(a?.screenX).toBeCloseTo(300 * projected.scale + projected.centre.x);
+    expect(a?.screenY).toBeCloseTo(projected.centre.y);
+  });
+
+  it("marks exactly one node as the viewer's", () => {
+    expect(view().nodes.filter((n) => n.isViewer)).toHaveLength(1);
+  });
+
+  it("maps stored colour names onto tokens, falling back for unknown ones", () => {
+    const projected = view();
+    expect(projected.nodes.find((n) => n.userId === "me")?.colorVar).toBe(
+      NODE_COLOR_VARS.violet,
+    );
+    expect(projected.nodes.find((n) => n.userId === "b")?.colorVar).toBe(
+      FALLBACK_NODE_COLOR_VAR,
+    );
+  });
+
+  it("draws only the backbone edges whose two ends are both in the set", () => {
+    const edges = view().edges;
+    expect(edges).toHaveLength(2);
+    for (const [from, to] of edges) {
+      expect(input.nodes.map((n) => n.userId)).toContain(from.userId);
+      expect(input.nodes.map((n) => n.userId)).toContain(to.userId);
+    }
+  });
+
+  it("never fades the node the whole flow exists to reveal", () => {
+    const projected = projectNeighbourhood({
+      neighbourhood: input,
+      width: WIDTH,
+      height: HEIGHT,
+      // Copy covering the entire frame: everyone else is invisible, the viewer
+      // is not.
+      keepOut: [{ x: 0, y: 0, w: WIDTH, h: HEIGHT }],
+    });
+    const me = projected.nodes.find((n) => n.isViewer);
+    expect(me?.clearance).toBe(1);
+    for (const other of projected.nodes.filter((n) => !n.isViewer)) {
+      expect(other.clearance).toBe(0);
+    }
+  });
+
+  // The projection is derived per frame and thrown away. If it ever mutated its
+  // input, a projected pixel could find its way back to the server.
+  it("leaves the world positions it was given untouched", () => {
+    const before = structuredClone(input);
+    view();
+    expect(input).toEqual(before);
+  });
+
+  it("keeps world units out of the result — only screen positions come back", () => {
+    for (const node of view().nodes) {
+      expect(Object.keys(node).sort()).toEqual([
+        "clearance",
+        "colorVar",
+        "isViewer",
+        "screenX",
+        "screenY",
+        "userId",
+      ]);
+    }
+  });
+});

--- a/apps/web/features/landing/lib/neighbourhood-view.ts
+++ b/apps/web/features/landing/lib/neighbourhood-view.ts
@@ -1,0 +1,219 @@
+/**
+ * Turning a bounded neighbourhood of the community graph into something the
+ * hero canvas can draw.
+ *
+ * **World units are not browser pixels.** `graph.neighbourhood` hands back the
+ * persisted world positions untouched; everything in this file is derived at
+ * read time and thrown away on the next resize. Nothing here is ever written
+ * back — the projection, the chosen centre and the fitted scale are all
+ * responsive decisions the client owns, exactly as
+ * `docs/landing_docs/personal-community-viewport.md` requires.
+ *
+ * The projection is the one from that document:
+ *
+ * ```
+ * screenX = (node.x - viewer.x) * scale + centre.x
+ * screenY = (node.y - viewer.y) * scale + centre.y
+ * ```
+ *
+ * The only liberty taken with it is `centre`, which is *not* the middle of the
+ * canvas: the middle of the hero is where the headline is. Picking a centre in
+ * a clear region is the "responsive keep-out adjustment" the document permits,
+ * and it moves the camera, never a node.
+ */
+
+import { distToContent, type Rect } from "./hero-field";
+
+/**
+ * The node colour palette, as the server stores it: **names, never hex**.
+ * `server/graph/placement.ts` owns the list; this is the client half of the
+ * contract, mapping each name onto a `--cc-*` custom property so the palette
+ * can be re-skinned in CSS without a data migration.
+ */
+export const NODE_COLOR_VARS = {
+  aurora: "--cc-node-aurora",
+  ember: "--cc-node-ember",
+  frost: "--cc-node-frost",
+  moss: "--cc-node-moss",
+  slate: "--cc-node-slate",
+  violet: "--cc-node-violet",
+} as const;
+
+export type NodeColorName = keyof typeof NODE_COLOR_VARS;
+
+/**
+ * What an unrecognised colour name draws as. The column is free text in the
+ * database, so a name this build has never heard of is possible; drawing it in
+ * the neutral is better than dropping the node from someone's neighbourhood.
+ */
+export const FALLBACK_NODE_COLOR_VAR = NODE_COLOR_VARS.slate;
+
+export function nodeColorVar(name: string): string {
+  return name in NODE_COLOR_VARS
+    ? NODE_COLOR_VARS[name as NodeColorName]
+    : FALLBACK_NODE_COLOR_VAR;
+}
+
+/** Exactly the shape `graph.neighbourhood` returns, narrowed to what is drawn. */
+export type NeighbourhoodInput = {
+  viewer: { userId: string; x: number; y: number };
+  nodes: { userId: string; x: number; y: number; color: string }[];
+  edges: { nodeUserId: string; anchorUserId: string }[];
+};
+
+/** One node placed on the canvas. Derived, never persisted. */
+export type ScreenNode = {
+  userId: string;
+  screenX: number;
+  screenY: number;
+  /** The custom property this node's stored colour name maps onto. */
+  colorVar: string;
+  isViewer: boolean;
+  /** 1 well clear of the hero copy, 0 underneath it. */
+  clearance: number;
+};
+
+export type NeighbourhoodView = {
+  scale: number;
+  centre: { x: number; y: number };
+  nodes: ScreenNode[];
+  /**
+   * The backbone edges of the set, as pairs of placed nodes.
+   *
+   * A backbone edge records placement history and **is not a friendship**. It
+   * is drawn undirected here for exactly that reason: an arrow would suggest a
+   * direction of feeling that the data does not carry.
+   */
+  edges: [ScreenNode, ScreenNode][];
+};
+
+/** Padding kept between the outermost node and the frame, in px. */
+const FIT_PADDING = 28;
+/** A neighbourhood of one has no extent to fit, so it takes this scale. */
+export const DEFAULT_SCALE = 0.6;
+export const MIN_SCALE = 0.02;
+export const MAX_SCALE = 1.4;
+
+/**
+ * Where the viewer's own node lands on the canvas.
+ *
+ * Sampled rather than solved: a coarse grid, scored on how far each candidate
+ * sits from the hero copy, with a mild pull back towards the middle of the
+ * frame so an empty hero does not shove the graph into a corner.
+ */
+export function pickViewportCentre(
+  width: number,
+  height: number,
+  keepOut: Rect[],
+): { x: number; y: number } {
+  const middle = { x: width / 2, y: height / 2 };
+  if (keepOut.length === 0) return middle;
+
+  const steps = 12;
+  const span = Math.hypot(width, height) || 1;
+  let best = middle;
+  let bestScore = Number.NEGATIVE_INFINITY;
+
+  for (let ix = 1; ix < steps; ix++) {
+    for (let iy = 1; iy < steps; iy++) {
+      const x = (width * ix) / steps;
+      const y = (height * iy) / steps;
+      const clear = distToContent(x, y, keepOut);
+      const pull = Math.hypot(x - middle.x, y - middle.y) / span;
+      const score = clear / span - pull * 0.35;
+      if (score > bestScore) {
+        bestScore = score;
+        best = { x, y };
+      }
+    }
+  }
+  return best;
+}
+
+/**
+ * The largest scale that still fits every node in the neighbourhood inside the
+ * frame, given where the centre ended up. Each direction is fitted separately,
+ * because the centre is rarely in the middle.
+ */
+export function fitScale(
+  input: NeighbourhoodInput,
+  width: number,
+  height: number,
+  centre: { x: number; y: number },
+): number {
+  const room = {
+    left: Math.max(1, centre.x - FIT_PADDING),
+    right: Math.max(1, width - centre.x - FIT_PADDING),
+    up: Math.max(1, centre.y - FIT_PADDING),
+    down: Math.max(1, height - centre.y - FIT_PADDING),
+  };
+
+  let scale = MAX_SCALE;
+  let spread = false;
+  for (const node of input.nodes) {
+    const dx = node.x - input.viewer.x;
+    const dy = node.y - input.viewer.y;
+    if (dx !== 0 || dy !== 0) spread = true;
+    if (dx < 0) scale = Math.min(scale, room.left / -dx);
+    if (dx > 0) scale = Math.min(scale, room.right / dx);
+    if (dy < 0) scale = Math.min(scale, room.up / -dy);
+    if (dy > 0) scale = Math.min(scale, room.down / dy);
+  }
+  // Nobody but the viewer, or everyone stacked on them: there is no extent to
+  // fit, so the scale is a preference rather than a measurement.
+  if (!spread) return DEFAULT_SCALE;
+  return Math.min(MAX_SCALE, Math.max(MIN_SCALE, scale));
+}
+
+/**
+ * Project a neighbourhood onto a canvas of `width` by `height`.
+ *
+ * The result is pure derivation: `input` is not mutated, and nothing computed
+ * here has anywhere to go but the canvas.
+ */
+export function projectNeighbourhood(args: {
+  neighbourhood: NeighbourhoodInput;
+  width: number;
+  height: number;
+  keepOut: Rect[];
+}): NeighbourhoodView {
+  const { neighbourhood, width, height, keepOut } = args;
+  const centre = pickViewportCentre(width, height, keepOut);
+  const scale = fitScale(neighbourhood, width, height, centre);
+
+  const byUser = new Map<string, ScreenNode>();
+  const nodes = neighbourhood.nodes.map((node) => {
+    const screenX = (node.x - neighbourhood.viewer.x) * scale + centre.x;
+    const screenY = (node.y - neighbourhood.viewer.y) * scale + centre.y;
+    const isViewer = node.userId === neighbourhood.viewer.userId;
+    const placed: ScreenNode = {
+      userId: node.userId,
+      screenX,
+      screenY,
+      colorVar: nodeColorVar(node.color),
+      isViewer,
+      // The centre is picked to be clear, so the viewer's own node is already
+      // in the open — and dimming the one dot the flow exists to reveal would
+      // defeat it. Everyone else fades under the copy.
+      clearance: isViewer ? 1 : keepOutClearance(screenX, screenY, keepOut),
+    };
+    byUser.set(node.userId, placed);
+    return placed;
+  });
+
+  const edges: [ScreenNode, ScreenNode][] = [];
+  for (const edge of neighbourhood.edges) {
+    const from = byUser.get(edge.nodeUserId);
+    const to = byUser.get(edge.anchorUserId);
+    if (from && to) edges.push([from, to]);
+  }
+
+  return { scale, centre, nodes, edges };
+}
+
+/** How visible a node is where it landed: 0 under the copy, 1 well clear of it. */
+function keepOutClearance(x: number, y: number, keepOut: Rect[]): number {
+  if (keepOut.length === 0) return 1;
+  const distance = distToContent(x, y, keepOut);
+  return Math.min(1, distance / 24);
+}

--- a/apps/web/features/search/hooks/use-search-page.ts
+++ b/apps/web/features/search/hooks/use-search-page.ts
@@ -20,7 +20,12 @@ export function useSearchPage() {
   const searchParams = useSearchParams();
   const selectedCode = searchParams.get("selected");
 
-  const [localQuery, setLocalQuery] = useState(DEFAULT_QUERY);
+  // The landing page hands its query over in `?q=`, so a search started there
+  // arrives here as the search the visitor actually typed. Read once, as the
+  // initial value: after that the field owns the query.
+  const [localQuery, setLocalQuery] = useState(
+    searchParams.get("q")?.trim() || DEFAULT_QUERY,
+  );
   const [debouncedQuery, setDebouncedQuery] = useDebouncedQuery(localQuery);
   const [filters, setFilters] = useState<Record<string, string | string[]>>({});
 

--- a/apps/web/features/shell/index.ts
+++ b/apps/web/features/shell/index.ts
@@ -1,3 +1,4 @@
 export { AppShell } from "./components/app-shell";
 export { PageColumn } from "./components/page-column";
 export { PageHeader } from "./components/page-header";
+export { ThemeToggle } from "./components/theme-toggle";


### PR DESCRIPTION
Builds `/` fresh from `docs/design/Course Community - Landing.dc.html`. Nothing was cherry-picked from `frontend`; `hero-geometry.ts` there was read as reference only, and its "off-frame" vocabulary is kept.

Closes #95

## What is here

- **The landing's own chrome.** `/` stays outside the app shell, as #85 left it and as the artboard draws it. No rail: `Landing.dc.html` does contain one, but `railShift` is `-236px` unless the artboard is in its embedded `explore` phase, so `/` never shows it. The shell is untouched apart from one barrel export (`ThemeToggle`), so the landing reuses the shipped toggle instead of growing a second one.
- **The hero**, over a canvas network, with the eyebrow, headline, search field, the three "Try" chips and "Already a member? Find your dot."
- **Find your dot**, against the real `graph.neighbourhood`.
- **The three sections** and, on a narrow frame, the designed auth card at the foot of the page.
- Container queries throughout (`@container` / `@lg:`), `--cc-*` tokens throughout.

## Find your dot, and the state that actually happens

`graph.join` is never called — that is #82, unstarted — so `graph.neighbourhood` returns `NOT_FOUND` for **every** member today. That is not an edge case here, it is the normal path, and it gets a designed state rather than a fabricated dot:

> **You don't have a dot yet.** Everyone in the community keeps one place that stays theirs. Yours has not been created yet — nothing is missing on your side, and nothing here is hidden from you. Come back once placement is switched on and this is where your dot appears.

It is drawn as an empty dashed ring inside a dashed panel — deliberately unlabelled, since a label is the one thing we are refusing to invent.

It is **informational, not an error**, and deliberately so now that `--cc-danger` exists: no danger colour, no `role="alert"`, no retry button, and a test asserts all three. A member with no node has not failed at anything and nothing went wrong; dressing an ordinary state as a fault would tell the reader they had done something to deserve it. `--cc-danger` is used on this page only where something genuinely did fail — the sign-in form's invalid address and its "could not send" message.

The rest of the flow:

| artboard state | what it is now |
|---|---|
| email form, `submitting`, `sent` | `authClient.signIn.magicLink` with `callbackURL: "/?dot=1"`, `errorCallbackURL: "/?dot=expired"` |
| `opened` / `locating` | the `graph.neighbourhood` read in flight |
| `found` | the real node, marked "You" on the canvas |
| `expired` | arrived back through a dead link |
| — | **unplaced** (new) |
| — | **unavailable** (new): the read failed for some other reason, offers the read again |

## No projected coordinate goes anywhere

`neighbourhood-view.ts` is pure and has no writer. It takes world units, derives `scale`, `centre` and screen positions for one frame, and they are thrown away on the next resize. `useNeighbourhood` issues a `useQuery` and nothing else — there is no mutation on this page at all, and `graph.join` is not called from it.

The one liberty taken with the documented projection is `centre`, which is **not** the middle of the canvas — the middle of the hero is where the headline is. Choosing a clear centre is exactly the client-side keep-out adjustment `personal-community-viewport.md` permits, and it moves the camera, never a node. `projectNeighbourhood` is asserted not to mutate its input, and its `ScreenNode` deliberately carries no world coordinate at all.

## Contradictions between the design and the schema

Per #68's precedence rule, every one of these resolves the same way: layout, spacing, type, colour and states follow the artboard; what data exists follows the schema; the fix is the smallest one that keeps the design intact.

1. **The private link reveals a dot without an account.** The artboard's whole `dot` machine is mocked, down to two buttons labelled "Prototype — simulate the link". `graph.neighbourhood` is a `protectedProcedure`, and no unauthenticated reveal channel exists or could. **Minimal fix:** the private link *is* the magic link Better Auth already sends — single use, five minutes, already wired to SES. Every designed state survives; the two prototype buttons do not.
2. **The "sent" copy asserts something untrue.** The artboard says *"If an account exists for this email, a private link is on its way."* Our magic link has `disableSignUp` unset, so a link is **always** sent and the account is created on first use. The artboard's conditional wording would tell a new student nothing had been sent. **Minimal fix, in the copy:** "A private link is on its way to {email}. It expires in five minutes, and it only works once." Same class of correction as #97's *students* to *members*.
3. **Node colours: five hexes against six names.** `cc-store.js` has `NODE_COLORS = ["#1751a6","#2f9e8e","#dfa53c","#6a4ea8","#c96a4a"]` — five raw hex values. `server/graph/placement.ts` has six **names**: `aurora, ember, frost, moss, slate, violet`. Schema wins. Six `--cc-node-*` tokens added (light and dark); the client maps name to token and an unknown name falls back to the neutral rather than dropping the node. Five reuse the design's own hues; **`moss` is a new green** for the sixth name the design never assigned — the same situation as `seminars` in the examination palette, and equally changeable. Say the word and it moves.
4. **`node_style` / `node_signal_style`.** `cc-store.js` offers `solid|ring|diamond` and `fade|comet|dashed`. Both Postgres enums declare exactly one value, `default`. Schema wins: one appearance is drawn and the two fields are read but not yet branched on. They come alive when the enums do.
5. **The neighbourhood response shape.** `cc-store.js`'s `graphNeighborhood()` returns `{ origin, me, nodes[].profile (nullable), edges[{from,to}] }`. The real procedure returns `{ viewer: {userId,x,y,effectiveTier}, nodes[] with colour flattened and non-null, edges[{nodeUserId,anchorUserId}] }`. Coded against the real one.
6. **The hero field claims to be the community, and is not.** The artboard's canvas invents ~50 accounts (`kth-1000`…) and `revealYou()` picks one of them as *your* dot from a hash of your email address — a fabricated position and a fabricated identity. Kept strictly as decoration: `hero-field.ts` is a separate module, no dot carries an account, none is ever labelled, and the real neighbourhood cross-fades over it once it arrives. `aria-hidden` throughout.
7. **The landing to Explore shared-element morph.** The artboard hands the search bar's screen box to Explore through `sessionStorage["cc:searchHandoff"]` and mounts Explore underneath a clip-path curtain. That is a two-page animation Explore has to cooperate with, and Explore is #87. Plain `router.push("/search?q=…")` for now — **#87 owns whether the morph comes back.** For the same reason the desktop search bar is rendered in flow inside the 97px gap the hero column leaves rather than `position:absolute; top:400px`; the absolute placement exists only to enable the morph, and the picture is identical without it.
8. **`?q=` was being dropped on the floor.** The artboard's landing hands its query to Explore in `?q=`, and `use-search-page.ts` ignored the param entirely — it hardcoded `DEFAULT_QUERY = "interaction programming"`. Without a fix the landing's primary action visibly does nothing. **This is the one change outside `features/landing/`**: a single expression seeding the initial local query from `?q=`. Deliberately left as one line with no new scaffolding, because #87 owns that file and rewrites it; a `lib/` folder and a spec added to Explore now would be the larger change, not the smaller one.
9. **The narrow-frame header.** The artboard hides the mark, the wordmark and the whole header action cluster below 500px, and `Mobile Preview.dc.html` line 12 shows why — it embeds this page inside a phone frame that supplies its own header (`.cc-landing-mobile [style*="height: 66px"]{display:none}`). On the open web `/` has no such frame, so hiding all of it would leave an empty 66px bar and no way for a member to sign out. **Minimal fix:** brand, theme toggle and the member chip stay at every width; only the guest Log in / Sign up move down into the bottom card, exactly as designed. The ambient field still thins to the 14 dots the Mobile Preview embeds with.
10. **"Open as many courses as you like side by side."** Kept, because the Workspace Pane is #94 — a committed child of this track — not a phantom feature. Flagging it: if it slips, this line goes with it. "Fill in a review as a guest" likewise depends on #88/#89, and matches the promise `AuthReasonDialog`'s `post-review` reason already ships.

## Vocabulary

- The decorative off-frame node is `offFrame`, never `anchor` — an **Anchor** is an established node a joining node attaches to, and stealing the word here would be the exact collision `hero-geometry.ts` avoided on `frontend`.
- Backbone edges are drawn **undirected and silent**: no arrow, and no travelling signal along one. A backbone edge records placement history and **is not a friendship**; animating a recommendation down one would give it a social meaning the data does not carry. Signals stay on the decorative field, where they mean nothing.
- "Dot" appears only in Find-your-dot copy. The type is `Node` / `ScreenNode`.

## Tests

- `ui` — `landing.spec.tsx`: the visitor (whole page without an account, no promise the app cannot keep, never touches the protected read, hands search and chips to Explore, refuses a bad address and sends nothing, sends the link with the right callbacks), the **placed** member, the **unplaced** member (says so plainly, reports no failure, never claims "This one is yours"), the failed read, and all three private-link returns.
- `logic` — `hero-field.spec.ts`: no dot and no line lands on the copy, drawn dots stay in frame, off-frame nodes stay out of it, quotas hold, the field is reproducible. `neighbourhood-view.spec.ts`: the viewer projects exactly onto the centre, everyone else at world-delta times scale, every stored name maps to a token and a hex never does, only edges with both ends in the set are drawn, the viewer's own node is never faded, and **the input world positions come back untouched**.

## Notes on the two things that landed under this branch

- **`PageColumn`** (from #114) is not used here, and should not be. It is the shell's content column: the shared 1216px page cap with the shell topbar above it. The landing sits outside the shell entirely and uses the artboard's own caps for this page — 720px for the hero column, 960px for the three sections. Adopting it would impose a different width and the shell's padding on a page that has no shell.
- **`--cc-success` / `--cc-danger`** (from 13c142e) replaced the substitute-and-flag stopgap: the form's invalid-address border and both error messages were borrowing `--cc-warn-ink` and now take `--cc-danger`. No token was invented. `--cc-node-*` is a separate matter — see contradiction 3; it is the client half of a contract the schema already fixed, not a colour role the palette was missing.

## Gates

`bun run test:web` 300 passed. `npx tsc --noEmit` clean. `bun run lint` clean (pre-existing warnings only, none in touched files).

`/code-review` run on both axes before opening: no must-fix on either; its two should-fix items are in this diff.

**Greptile: 5/5 on round 3.** Two rounds, two genuine P1 races in the magic-link form, both reproduced by T-Rex and both real:

1. **A rejected request stranded the form.** `authClient.signIn.magicLink` rejecting rather than resolving skipped `setSending(false)`, so the button stayed disabled reading "Sending…" with no message — and `close()` did not reset it, so reopening brought the dead form back. Now the request re-enables the button in `finally`, and closing clears what it leaves behind. It was also raising "Enter a valid email address." for our own failure, blaming a good address; those are two separate states now.
2. **A send the visitor walked away from could land.** Closing and reopening did not invalidate an in-flight request: send to one address, close, reopen, send to another, and if the first resolved last it reported "Check your inbox" over the abandoned address. Each submission now carries a token; a stale completion returns without touching state, and `close()` bumps it.

Both are covered in the `ui` project, including sending successfully after a rejection and holding the first request open across a close, a reopen and a second address.

Rebased onto `feat/frontend` at `13c142e`. The one conflict was `globals.css`, where the success/danger tokens and the node tokens are additions to the same three blocks; both are kept. `dev` has not moved under `feat/frontend` since this branch was cut.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01D3d7V2JceJZvtJED18HXFJ
