### PR TITLE
feat(courses): the course card Explore, Saved and Collections share

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -46,8 +46,9 @@ _Avoid_: exam type, assessment method, moment
 **Course prerequisite**:
 A directed edge from a course to one it requires, extracted from the source
 prose. It cannot express AND/OR logic, so it never replaces **Eligibility** —
-extraction narrows, it does not decide.
-_Today_: no table. Closed by `course_prerequisites`.
+extraction narrows, it does not decide. A course with no extracted edges is not
+a course with no prerequisites: nothing in `server/` writes the table yet, so
+absence of edges says nothing either way.
 _Avoid_: requirement, dependency, eligibility
 
 **Eligibility**:

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -46,9 +46,8 @@ _Avoid_: exam type, assessment method, moment
 **Course prerequisite**:
 A directed edge from a course to one it requires, extracted from the source
 prose. It cannot express AND/OR logic, so it never replaces **Eligibility** —
-extraction narrows, it does not decide. A course with no extracted edges is not
-a course with no prerequisites: nothing in `server/` writes the table yet, so
-absence of edges says nothing either way.
+extraction narrows, it does not decide.
+_Today_: no table. Closed by `course_prerequisites`.
 _Avoid_: requirement, dependency, eligibility
 
 **Eligibility**:

--- a/apps/web/data/course-card-sample.ts
+++ b/apps/web/data/course-card-sample.ts
@@ -3,197 +3,48 @@
  *
  * Source: `docs/design/Course Community - Course Card.dc.html` — the
  * `SAMPLE_GEO` / `SAMPLE_COURSE` literals in its trailing
- * `<script type="text/x-dc">` block, and that tag's `data-props` attribute,
- * which names `c: CourseCardModel` and `geo: CardGeometry`.
+ * `<script type="text/x-dc">` block.
  *
- * **Regenerate from the artboard; do not hand-edit.** Values are copied
- * verbatim so a card built against this shape needs no reshaping when the real
- * aggregation lands. Nothing here is invented, renamed or tidied — including
+ * **Regenerate the values from the artboard; do not hand-edit them.** They are
+ * copied verbatim so a card built against this shape needs no reshaping when
+ * the real aggregation lands. Nothing here is invented or tidied — including
  * the things that are plainly wrong (see "Known divergences" below).
  *
+ * The types moved to `@/types/course-card`, which is where the card, the mapper
+ * and every screen read them from; this file is only the artboard's literals.
+ *
  * These are fixtures, not data. The card takes typed props and the *screen*
- * maps tRPC output onto them, so a server change touches one mapping function
- * rather than the card.
+ * maps tRPC output onto them via
+ * `features/courses/lib/course-card-model.ts`, so a server change touches one
+ * mapping function rather than the card.
  *
  * ## Known divergences from the schema — do not "fix" them here
  *
- * - `workload: "3.8"` / `learning: "4.2"` are on the artboard's 1–5 scale.
- *   Scores are **1–10 displayed raw** (issue #68); a 7.6 renders `"7.6"` and
- *   the bar width is `value / 10`, which is the same width the artboard draws.
- * - `comparisons`, `hasComparisons` and `onNewComparison` are the design's word
- *   for **collections**. `CONTEXT.md` bans "comparison" in identifiers and #68
- *   settles the concept as Collection, so the card and everything downstream of
- *   it say `Collection`; these three field names are the one place that word
- *   survives, because #97 requires this file to quote the artboard verbatim.
- *   Every identifier this file coins itself — `CollectionPickerRow` — follows
- *   the glossary instead.
- * - `summary` is `courses.content` in the design's own store, so it does have a
- *   column behind it. `keywords` does not: the store reads a `searchTerms`
- *   field on `course_explore` that the table has no column for, and nothing in
- *   `server/` writes one. Until that is settled the card renders the header
- *   with an empty section (issue #68).
- * - `prereqCourses` entries carry `inCatalog` in the sample but the markup
- *   reads `taken`. Prerequisite ticks are display-only and never cascade.
+ * - `workload: "3.8"` / `learning: "4.2"` are on the artboard's 1-5 scale.
+ *   Scores are **1-10 displayed raw** (#68); a 7.6 renders `"7.6"` and the bar
+ *   width is `value / 10`, which is the same width the artboard draws. The
+ *   mapper does that; these literals predate the scale decision.
+ * - `"1.2k students have taken this course"` is real KTH enrolment in the
+ *   design's mock store. The schema only knows `user_taken_courses` — app users
+ *   who marked the course themselves — so the mapper says **members**, not
+ *   students (#68). The number is real; the artboard's sentence was not.
+ * - `keywords` and `summary` render empty. `course_explore` has no
+ *   `search_terms` column, and the summary maps to `courses.content`, which is
+ *   KOPPS syllabus prose — long, boilerplate-heavy and near-identical across
+ *   courses, so clipping it into a card slot would put the same opening line on
+ *   every card in a grid. #73 generates the real blurb.
+ * - `prereqCourses` entries carry `inCatalog` in the sample but the markup reads
+ *   `taken`. Prerequisite ticks are display-only and never cascade (#68).
+ * - The artboard's `comparisons` / `hasComparisons` / `onNewComparison` are its
+ *   word for **collections**. `CONTEXT.md` bans "comparison" in identifiers and
+ *   #68 settles the concept as Collection, so they are renamed here and
+ *   everywhere downstream. Reader-facing copy still follows the design.
  *
  * `apps/web/data/courseCardMockData.ts` is the older, unrelated mock that
  * existing components still use. This file does not replace it.
  */
 
-/** One prerequisite chip. */
-export interface PrerequisiteCourse {
-  code: string;
-  name: string;
-  /** Whether the prerequisite is itself a course we hold. */
-  inCatalog: boolean;
-  /**
-   * Whether the viewer has separately marked this course taken, which draws
-   * the chip's checkmark. Display-only: marking a course taken never cascades
-   * into its prerequisites (#68).
-   *
-   * The artboard markup reads this; the sample literal does not set it.
-   */
-  taken?: boolean;
-  /**
-   * Per-chip metrics the parent interpolates alongside `geo`, so the chips
-   * shrink with the card. Markup-only, like `taken`.
-   */
-  gap?: string;
-  padding?: string;
-  radius?: string;
-  bg?: string;
-}
-
-/**
- * One row of the collection picker.
- *
- * The artboard's own field is `c.comparisons`, kept verbatim below. This type
- * is not the artboard's, so it takes the glossary's word: `CONTEXT.md` bans
- * "comparison" in identifiers and #68 settles the concept as **Collection**.
- */
-export interface CollectionPickerRow {
-  name: string;
-  /** SVG `fill` for the checkbox glyph. */
-  fill: string;
-  /** SVG `path` `d` for the checkbox tick. */
-  tick: string;
-  onClick?: () => void;
-}
-
-/**
- * The card's `c` prop. `data-props` types it `CourseCardModel`.
- *
- * Presentation is precomputed by the parent: the model carries strings and
- * booleans, not numbers to format or conditions to evaluate. `hasX` / `noX`
- * pairs are the artboard's two `sc-if` branches and are not complements —
- * both may be false while a third state renders.
- */
-export interface CourseCardModel {
-  title: string;
-  /** Credits, department and level, already joined for display. */
-  meta: string;
-  /** Comma-separated; the card chips the first two and counts the rest. */
-  keywords: string;
-  /** Comma-separated prerequisite codes, already joined for display. */
-  prereq: string;
-  prereqCourses: PrerequisiteCourse[];
-  hasPrereq: boolean;
-  noPrereq: boolean;
-  summary: string;
-  /** The summary as the card shows it, clipped to `geo.summaryMax`. */
-  summaryClipped: string;
-  hasStats: boolean;
-  noStats: boolean;
-  /** Top examination contributors, e.g. `"Labs 60% · Exam 40%"`. */
-  examLabel: string;
-  /** Mean workload, preformatted. */
-  workload: string;
-  /** Mean learning, preformatted. */
-  learning: string;
-  /** Workload bar width, as a CSS percentage. */
-  wlW: string;
-  /** Learning bar width, as a CSS percentage. */
-  leW: string;
-  /** Share of reviewers glad they took the course, as a CSS percentage. */
-  happyPct: string;
-  hasReviewStats: boolean;
-  noReviewStats: boolean;
-  /** Taken count, abbreviated for display. */
-  statTaken: string;
-  /** Review count, as a string. */
-  statReviews: string;
-
-  // Per-instance presentation the parent resolves: colours that change with
-  // card state, plus the taken pill's tooltip. Components style against the
-  // `--cc-*` tokens; these fields exist because the artboard has no token for
-  // a value that varies per card. Order is the artboard's, so the tooltip
-  // sits among the colours.
-  borderColor: string;
-  takenTitle: string;
-  takenCountFg: string;
-  takenBg: string;
-  takenFill: string;
-  takenStroke: string;
-  saveLabel: string;
-  saveFg: string;
-  saveBg: string;
-  saveBorder: string;
-  saveFill: string;
-
-  pickerOpen: boolean;
-  creating: boolean;
-  notCreating: boolean;
-  hasComparisons: boolean;
-  comparisons: CollectionPickerRow[];
-
-  // Referenced by the artboard markup but absent from the sample literal.
-  /** Hover fill for the taken pill. */
-  takenHoverBg?: string;
-  /** Whether the guest sign-up prompt over the taken pill is open. */
-  takenPickerOpen?: boolean;
-  /** Accessible name for the picker trigger in the `"add"` action. */
-  addLabel?: string;
-  /** Accessible name and tooltip for the remove button. */
-  removeLabel?: string;
-  onOpen?: () => void;
-  onTaken?: () => void;
-  onReview?: () => void;
-  onSave?: () => void;
-  onPicker?: () => void;
-  onNewComparison?: () => void;
-  onRemove?: () => void;
-  onSignUp?: () => void;
-  onLogIn?: () => void;
-}
-
-/**
- * The card's `geo` prop. `data-props` types it `CardGeometry`.
- *
- * Geometry arrives as one object so the **parent** owns the collapse ramp:
- * Explore interpolates it from the results column width, Saved pins it to the
- * fully collapsed end. Every value is a CSS string the card drops straight
- * into a style, which is why widths and paddings are not numbers.
- */
-export interface CardGeometry {
-  /** CSS `transition` shorthand, or `"none"` while dragging the ramp. */
-  tween: string;
-  titleSize: string;
-  cardGap: string;
-  cardPad: string;
-  factsGap: string;
-  reviewPad: string;
-  labelMax: string;
-  labelOpacity: number;
-  saveW: string;
-  savePad: string;
-  railW: string;
-  railPad: string;
-  summaryMax: string;
-  summaryOpacity: number;
-  reviewFlex: string;
-  saveFlex: string;
-  showLabel: boolean;
-  cardHeight: string;
-}
+import type { CardGeometry, CourseCardModel } from "@/types";
 
 /** The fully expanded end of the collapse ramp. */
 export const SAMPLE_GEO: CardGeometry = {
@@ -262,6 +113,6 @@ export const SAMPLE_COURSE: CourseCardModel = {
   pickerOpen: false,
   creating: false,
   notCreating: true,
-  hasComparisons: false,
-  comparisons: [],
+  hasCollections: false,
+  collections: [],
 };

--- a/apps/web/features/courses/api/mutations.ts
+++ b/apps/web/features/courses/api/mutations.ts
@@ -1,0 +1,81 @@
+"use client";
+
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { useTRPC } from "@/trpc/client";
+
+/**
+ * The viewer's collections, and the writes the card's picker makes against
+ * them.
+ *
+ * All four procedures are `protectedProcedure`, so every hook here takes
+ * `enabled` / is only called once a session exists: a visitor sees the design's
+ * sign-up prompt instead, and never sends a request that would be rejected.
+ */
+export function useCollections(enabled: boolean) {
+  const trpc = useTRPC();
+  return useQuery(trpc.collections.list.queryOptions(undefined, { enabled }));
+}
+
+/**
+ * Creating a collection, and moving one course in or out of it.
+ *
+ * Each write refetches `collections.list`, which is what the picker's ticks are
+ * drawn from — there is no second copy of that state to keep in step.
+ */
+export function useCollectionMutations() {
+  const trpc = useTRPC();
+  const queryClient = useQueryClient();
+  const listKey = trpc.collections.list.queryKey();
+
+  const invalidate = () => queryClient.invalidateQueries({ queryKey: listKey });
+
+  const create = useMutation(
+    trpc.collections.create.mutationOptions({ onSuccess: invalidate }),
+  );
+  const addCourse = useMutation(
+    trpc.collections.addCourse.mutationOptions({ onSuccess: invalidate }),
+  );
+  const removeCourse = useMutation(
+    trpc.collections.removeCourse.mutationOptions({ onSuccess: invalidate }),
+  );
+
+  return { create, addCourse, removeCourse };
+}
+
+/** The viewer's taken courses. Protected, so it waits for a session. */
+export function useTakenCourses(enabled: boolean) {
+  const trpc = useTRPC();
+  return useQuery(trpc.taken.list.queryOptions(undefined, { enabled }));
+}
+
+/**
+ * Marks a course taken.
+ *
+ * `taken.add` upserts on (user, course), so a repeat click cannot duplicate a
+ * row. Grade, credits and periods are left unset: the card asks none of them,
+ * and an omitted field is stored as null rather than as 0.
+ *
+ * Nothing here touches the course's prerequisites. A prerequisite tick means the
+ * viewer separately marked *that* course taken; cascading would fabricate
+ * academic history, which `CONTEXT.md` forbids by holding taken courses to be
+ * self-reported (#68).
+ */
+export function useMarkCourseTaken() {
+  const trpc = useTRPC();
+  const queryClient = useQueryClient();
+  const takenKey = trpc.taken.list.queryKey();
+  // The card's taken count comes from the same table, so it is stale the moment
+  // this succeeds. `queryKey()` with no input matches every batch of stats.
+  const statsKey = trpc.course.stats.queryKey();
+
+  return useMutation(
+    trpc.taken.add.mutationOptions({
+      onSuccess: async () => {
+        await Promise.all([
+          queryClient.invalidateQueries({ queryKey: takenKey }),
+          queryClient.invalidateQueries({ queryKey: statsKey }),
+        ]);
+      },
+    }),
+  );
+}

--- a/apps/web/features/courses/api/mutations.ts
+++ b/apps/web/features/courses/api/mutations.ts
@@ -1,26 +1,14 @@
 "use client";
 
-import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { useTRPC } from "@/trpc/client";
-
-/**
- * The viewer's collections, and the writes the card's picker makes against
- * them.
- *
- * All four procedures are `protectedProcedure`, so every hook here takes
- * `enabled` / is only called once a session exists: a visitor sees the design's
- * sign-up prompt instead, and never sends a request that would be rejected.
- */
-export function useCollections(enabled: boolean) {
-  const trpc = useTRPC();
-  return useQuery(trpc.collections.list.queryOptions(undefined, { enabled }));
-}
 
 /**
  * Creating a collection, and moving one course in or out of it.
  *
  * Each write refetches `collections.list`, which is what the picker's ticks are
- * drawn from — there is no second copy of that state to keep in step.
+ * drawn from — there is no second copy of that state to keep in step. All three
+ * procedures are protected, so the card only reaches them once a session exists.
  */
 export function useCollectionMutations() {
   const trpc = useTRPC();
@@ -40,12 +28,6 @@ export function useCollectionMutations() {
   );
 
   return { create, addCourse, removeCourse };
-}
-
-/** The viewer's taken courses. Protected, so it waits for a session. */
-export function useTakenCourses(enabled: boolean) {
-  const trpc = useTRPC();
-  return useQuery(trpc.taken.list.queryOptions(undefined, { enabled }));
 }
 
 /**

--- a/apps/web/features/courses/api/queries.ts
+++ b/apps/web/features/courses/api/queries.ts
@@ -24,3 +24,21 @@ export function useCourseSummaries(courseCodes: string[], enabled = true) {
     ),
   });
 }
+
+/**
+ * The viewer's collections, which the course card's picker ticks.
+ *
+ * `collections.list` is a `protectedProcedure`, so `enabled` waits for a
+ * session: a visitor sees the design's sign-up prompt rather than sending a
+ * request that would be rejected. Every card on a page shares this one query.
+ */
+export function useCollections(enabled: boolean) {
+  const trpc = useTRPC();
+  return useQuery(trpc.collections.list.queryOptions(undefined, { enabled }));
+}
+
+/** The viewer's taken courses. Protected, so it waits for a session too. */
+export function useTakenCourses(enabled: boolean) {
+  const trpc = useTRPC();
+  return useQuery(trpc.taken.list.queryOptions(undefined, { enabled }));
+}

--- a/apps/web/features/courses/components/course-card-item.spec.tsx
+++ b/apps/web/features/courses/components/course-card-item.spec.tsx
@@ -1,0 +1,114 @@
+import { render, screen, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { EXPANDED_CARD_GEOMETRY } from "../lib/card-geometry";
+import type { CourseCardCourse } from "../lib/course-card-model";
+import { CourseCardItem } from "./course-card-item";
+
+const useMe = vi.fn();
+
+vi.mock("@/features/auth", () => ({ useMe: () => useMe() }));
+vi.mock("@/features/favorites", () => ({
+  useSetCourseSaved: () => ({ setSaved: vi.fn().mockResolvedValue(undefined) }),
+}));
+vi.mock("@/features/courses/api/queries", () => ({
+  useCollections: () => ({ data: [] }),
+  useTakenCourses: () => ({ data: [] }),
+}));
+vi.mock("@/features/courses/api/mutations", () => ({
+  useCollectionMutations: () => ({
+    create: { mutateAsync: vi.fn() },
+    addCourse: { mutateAsync: vi.fn() },
+    removeCourse: { mutateAsync: vi.fn() },
+  }),
+  useMarkCourseTaken: () => ({ mutateAsync: vi.fn() }),
+}));
+vi.mock("sonner", () => ({ toast: { error: vi.fn() } }));
+
+const ALPHA: CourseCardCourse = {
+  courseCode: "AA1000",
+  titleEng: "Alpha",
+  credits: 6,
+  department: "EECS",
+};
+const BETA: CourseCardCourse = {
+  courseCode: "BB2000",
+  titleEng: "Beta",
+  credits: 6,
+  department: "EECS",
+};
+
+function List({ courses }: { courses: CourseCardCourse[] }) {
+  return (
+    <>
+      {courses.map((course) => (
+        <CourseCardItem
+          key={course.courseCode}
+          course={course}
+          stats={{ reviews: null, takenCount: 0 }}
+          geo={EXPANDED_CARD_GEOMETRY}
+          onRequestAuth={vi.fn()}
+        />
+      ))}
+    </>
+  );
+}
+
+/** The picker is open on exactly the card whose "Create new collection" shows. */
+function cardWithOpenPicker(): number {
+  return screen.getAllByRole("article").findIndex(
+    (card) =>
+      within(card).queryByRole("button", {
+        name: "Create new collection",
+      }) !== null,
+  );
+}
+
+beforeEach(() => {
+  useMe.mockReturnValue({ user: { userId: "u1", savedCourseCodes: [] } });
+});
+
+describe("CourseCardItem", () => {
+  it("renders one bound card per course", () => {
+    render(<List courses={[ALPHA, BETA]} />);
+    expect(
+      screen.getByRole("heading", { name: "AA1000 Alpha" }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("heading", { name: "BB2000 Beta" }),
+    ).toBeInTheDocument();
+  });
+
+  // The reason this component exists. Called from a screen's own map callback,
+  // `useCourseCard`'s hooks would bind to a list position: reordering would move
+  // the open picker to another course, and shortening the list would throw
+  // "Rendered fewer hooks than expected". Keyed instances cannot do either.
+  describe("a list that changes under the reader", () => {
+    it("keeps an open picker on the course it was opened for", async () => {
+      const { rerender } = render(<List courses={[ALPHA, BETA]} />);
+
+      await userEvent.click(
+        within(screen.getAllByRole("article")[0] as HTMLElement).getByRole(
+          "button",
+          { name: "Add to collections" },
+        ),
+      );
+      expect(cardWithOpenPicker()).toBe(0);
+
+      rerender(<List courses={[BETA, ALPHA]} />);
+
+      const reordered = screen.getAllByRole("article");
+      expect(
+        within(reordered[0] as HTMLElement).getByText("BB2000 Beta"),
+      ).toBeVisible();
+      // Alpha moved to the end, and the picker went with it.
+      expect(cardWithOpenPicker()).toBe(1);
+    });
+
+    it("survives the list getting shorter", () => {
+      const { rerender } = render(<List courses={[ALPHA, BETA]} />);
+      expect(() => rerender(<List courses={[ALPHA]} />)).not.toThrow();
+      expect(screen.getAllByRole("article")).toHaveLength(1);
+    });
+  });
+});

--- a/apps/web/features/courses/components/course-card-item.tsx
+++ b/apps/web/features/courses/components/course-card-item.tsx
@@ -1,0 +1,64 @@
+"use client";
+
+import { CourseCard } from "@/features/courses/components/course-card";
+import {
+  type UseCourseCardOptions,
+  useCourseCard,
+} from "@/features/courses/hooks/use-course-card";
+import type { CardGeometry } from "@/types";
+
+type Props = UseCourseCardOptions & {
+  /**
+   * The screen's, because the collapse ramp belongs to whatever owns the
+   * column's width: Explore interpolates it, Saved and Collections pin an end.
+   */
+  geo: CardGeometry;
+  /** Opens the picker upwards, for a card near the bottom of a page. */
+  pickerAbove?: boolean;
+  /** Copy for the row that starts a new collection. */
+  newLabel?: string;
+};
+
+/**
+ * One course card in a list, bound to the viewer's own data.
+ *
+ * This is what Explore, Saved and Collections render. It exists to *be* the
+ * component boundary `useCourseCard` needs: the hook holds several hooks of its
+ * own, so calling it inside a screen's `courses.map(...)` would bind a card's
+ * picker and draft to a list *position* — reorder the list and the open picker
+ * jumps to another course; shorten it and React throws "Rendered fewer hooks
+ * than expected". Rendered here, keyed by course code, that cannot happen: each
+ * card's state lives in its own component instance.
+ *
+ * A screen therefore writes the loop and nothing else:
+ *
+ * ```tsx
+ * {courses.map((course) => (
+ *   <CourseCardItem
+ *     key={course.courseCode}
+ *     course={course}
+ *     stats={stats[course.courseCode] ?? NO_STATS}
+ *     geo={geo}
+ *     onOpen={() => open(course.courseCode)}
+ *     onRequestAuth={setAuthReason}
+ *   />
+ * ))}
+ * ```
+ */
+export function CourseCardItem({
+  geo,
+  pickerAbove,
+  newLabel,
+  ...options
+}: Props) {
+  const card = useCourseCard(options);
+
+  return (
+    <CourseCard
+      {...card}
+      geo={geo}
+      pickerAbove={pickerAbove}
+      newLabel={newLabel}
+    />
+  );
+}

--- a/apps/web/features/courses/components/course-card-with-charts.tsx
+++ b/apps/web/features/courses/components/course-card-with-charts.tsx
@@ -60,7 +60,7 @@ export type CourseCardWithChartsProps = {
   onCardClick: () => void;
   onWriteReview: () => void;
   onToggleFavorite: () => void;
-  onAddToComparison: () => void;
+  onAddToCollection: () => void;
   onRecommend?: () => void;
   onMarkAsTaken?: () => void;
 };
@@ -87,7 +87,7 @@ export function CourseCardWithCharts({
   isSelected = false,
   onCardClick,
   onToggleFavorite,
-  onAddToComparison,
+  onAddToCollection,
   onWriteReview,
   onRecommend,
   onMarkAsTaken,
@@ -250,7 +250,7 @@ export function CourseCardWithCharts({
           </span>
         </div>
         <div className="flex shrink-0 justify-center">
-          <Button variant="outline" size="sm" onClick={stop(onAddToComparison)}>
+          <Button variant="outline" size="sm" onClick={stop(onAddToCollection)}>
             <Sparkles data-icon="inline-start" />
             Compare
           </Button>

--- a/apps/web/features/courses/components/course-card.spec.tsx
+++ b/apps/web/features/courses/components/course-card.spec.tsx
@@ -216,6 +216,32 @@ describe("CourseCard", () => {
       expect(onDraftCommit).toHaveBeenCalledOnce();
     });
 
+    // Blur fires before click. Committing on a blur into a collection row would
+    // create a collection and toggle that row from the one click.
+    it("does not commit the draft when focus moves within the picker", async () => {
+      const onDraftCommit = vi.fn();
+      const onClick = vi.fn();
+      render(
+        <CourseCard
+          signedIn
+          c={reviewedCard({
+            pickerOpen: true,
+            creating: true,
+            collections: [
+              { id: "k1", name: "Spring P3", fill: "none", tick: "", onClick },
+            ],
+          })}
+          geo={EXPANDED_CARD_GEOMETRY}
+          draftName="Spring"
+          onDraftCommit={onDraftCommit}
+        />,
+      );
+
+      await userEvent.click(screen.getByRole("button", { name: "Spring P3" }));
+      expect(onClick).toHaveBeenCalledOnce();
+      expect(onDraftCommit).not.toHaveBeenCalled();
+    });
+
     // Unmarking would discard the grade and credits stored beside the row, so
     // the pill stops being a control once the course is marked.
     it("stops offering the taken pill once the course is marked", () => {

--- a/apps/web/features/courses/components/course-card.spec.tsx
+++ b/apps/web/features/courses/components/course-card.spec.tsx
@@ -1,0 +1,338 @@
+import { render, screen, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it, vi } from "vitest";
+import { SAMPLE_COURSE, SAMPLE_GEO } from "@/data/course-card-sample";
+import type { CourseCardModel, CourseReviewStats } from "@/types";
+import {
+  COLLAPSED_CARD_GEOMETRY,
+  EXPANDED_CARD_GEOMETRY,
+} from "../lib/card-geometry";
+import {
+  type CourseCardCourse,
+  toCourseCardModel,
+} from "../lib/course-card-model";
+import { CourseCard } from "./course-card";
+
+const COURSE: CourseCardCourse = {
+  courseCode: "DD2380",
+  titleEng: "Artificial Intelligence",
+  credits: 6,
+  department: "EECS",
+  educationalLevel: "Advanced",
+};
+
+const REVIEWS: CourseReviewStats = {
+  reviewCount: 148,
+  happyCount: 129,
+  happyPercent: 87,
+  workloadMean: 7.6,
+  learningMean: 8.4,
+  approachTheoryPercent: null,
+  approachTheoryAnswerCount: 0,
+  examinationDistribution: null,
+  examinationAnswerCount: 90,
+  examLabel: "Labs 60% · Exam 40%",
+};
+
+function reviewedCard(overrides: Partial<CourseCardModel> = {}) {
+  return {
+    ...toCourseCardModel({
+      course: COURSE,
+      stats: { reviews: REVIEWS, takenCount: 1200 },
+      isSaved: false,
+      isTaken: false,
+    }),
+    ...overrides,
+  };
+}
+
+function unreviewedCard(overrides: Partial<CourseCardModel> = {}) {
+  return {
+    ...toCourseCardModel({
+      course: COURSE,
+      stats: { reviews: null, takenCount: 0 },
+      isSaved: false,
+      isTaken: false,
+    }),
+    ...overrides,
+  };
+}
+
+describe("CourseCard", () => {
+  // The fixture is the artboard's own literal. If the card cannot render it,
+  // the prop shape has drifted from the design it was extracted from.
+  it("renders the artboard's sample with no reshaping", () => {
+    render(<CourseCard c={SAMPLE_COURSE} geo={SAMPLE_GEO} />);
+
+    expect(
+      screen.getByRole("heading", { name: "DD2380 Artificial Intelligence" }),
+    ).toBeInTheDocument();
+    expect(screen.getByText("6.0 credits · EECS · Advanced")).toBeVisible();
+    expect(screen.getByText("Labs 60% · Exam 40%")).toBeVisible();
+    expect(screen.getByText("87%")).toBeVisible();
+  });
+
+  describe("a course nobody has reviewed", () => {
+    // `reviews` is empty today, so this is the common case, not an edge one.
+    it("says so twice and never renders a zero", () => {
+      const { container } = render(
+        <CourseCard c={unreviewedCard()} geo={EXPANDED_CARD_GEOMETRY} />,
+      );
+
+      expect(screen.getAllByText("No reviews yet")).toHaveLength(2);
+      expect(
+        screen.getByText("Be the first to say how it went."),
+      ).toBeVisible();
+      expect(container.textContent).not.toContain("0%");
+      expect(screen.queryByText(/reviewers are happy/)).toBeNull();
+    });
+
+    it("leaves the score bars empty rather than at zero", () => {
+      render(<CourseCard c={unreviewedCard()} geo={EXPANDED_CARD_GEOMETRY} />);
+      expect(screen.getAllByText("—")).toHaveLength(2);
+    });
+  });
+
+  describe("prerequisites", () => {
+    it("says nothing at all when none were ever extracted", () => {
+      render(<CourseCard c={reviewedCard()} geo={EXPANDED_CARD_GEOMETRY} />);
+      expect(screen.getByText("Prerequisites")).toBeVisible();
+      expect(screen.queryByText("None listed")).toBeNull();
+    });
+
+    it("says 'None listed' only when extraction found none", () => {
+      const c = toCourseCardModel({
+        course: COURSE,
+        stats: { reviews: REVIEWS, takenCount: 3 },
+        isSaved: false,
+        isTaken: false,
+        prerequisites: [],
+      });
+      render(<CourseCard c={c} geo={EXPANDED_CARD_GEOMETRY} />);
+      expect(screen.getByText("None listed")).toBeVisible();
+    });
+  });
+
+  describe("a visitor", () => {
+    it("is offered the sign-in prompt instead of a picker", async () => {
+      const onSignUp = vi.fn();
+      const onLogIn = vi.fn();
+      render(
+        <CourseCard
+          c={reviewedCard({ pickerOpen: true, onSignUp, onLogIn })}
+          geo={EXPANDED_CARD_GEOMETRY}
+        />,
+      );
+
+      expect(screen.getByText("Organize your saved courses")).toBeVisible();
+      expect(screen.queryByText("Create new collection")).toBeNull();
+
+      await userEvent.click(screen.getByRole("button", { name: "Sign up" }));
+      expect(onSignUp).toHaveBeenCalledOnce();
+      await userEvent.click(screen.getByRole("button", { name: "Log in" }));
+      expect(onLogIn).toHaveBeenCalledOnce();
+    });
+
+    // The prompt must not advertise a feature that does not exist (#68).
+    it("is not promised an AI comparison", () => {
+      const { container } = render(
+        <CourseCard
+          c={reviewedCard({ pickerOpen: true })}
+          geo={EXPANDED_CARD_GEOMETRY}
+        />,
+      );
+      expect(container.textContent).not.toContain("compare courses with AI");
+    });
+
+    it("gets the same prompt over the taken pill", () => {
+      render(
+        <CourseCard
+          c={reviewedCard({ takenPickerOpen: true })}
+          geo={EXPANDED_CARD_GEOMETRY}
+        />,
+      );
+      expect(screen.getByText("Track courses you've taken")).toBeVisible();
+    });
+  });
+
+  describe("a signed-in viewer", () => {
+    it("gets the picker, its collections and the row that makes one", async () => {
+      const onClick = vi.fn();
+      const onNewCollection = vi.fn();
+      render(
+        <CourseCard
+          signedIn
+          c={reviewedCard({
+            pickerOpen: true,
+            hasCollections: true,
+            onNewCollection,
+            collections: [
+              { id: "k1", name: "Spring P3", fill: "none", tick: "" },
+              {
+                id: "k2",
+                name: "Maybe",
+                fill: "currentColor",
+                tick: "m8.5 12 2.4 2.4 4.6-4.9",
+                onClick,
+              },
+            ],
+          })}
+          geo={EXPANDED_CARD_GEOMETRY}
+        />,
+      );
+
+      expect(screen.queryByText("Organize your saved courses")).toBeNull();
+      await userEvent.click(screen.getByRole("button", { name: "Maybe" }));
+      expect(onClick).toHaveBeenCalledOnce();
+
+      await userEvent.click(
+        screen.getByRole("button", { name: "Create new collection" }),
+      );
+      expect(onNewCollection).toHaveBeenCalledOnce();
+    });
+
+    it("commits a new collection name on Enter and abandons it on Escape", async () => {
+      const onDraftChange = vi.fn();
+      const onDraftCommit = vi.fn();
+      const onDraftCancel = vi.fn();
+      render(
+        <CourseCard
+          signedIn
+          c={reviewedCard({ pickerOpen: true, creating: true })}
+          geo={EXPANDED_CARD_GEOMETRY}
+          draftName="Spring"
+          onDraftChange={onDraftChange}
+          onDraftCommit={onDraftCommit}
+          onDraftCancel={onDraftCancel}
+        />,
+      );
+
+      const field = screen.getByRole("textbox", {
+        name: "New collection name",
+      });
+      await userEvent.type(field, "{Escape}");
+      expect(onDraftCancel).toHaveBeenCalledOnce();
+      await userEvent.type(field, "{Enter}");
+      expect(onDraftCommit).toHaveBeenCalledOnce();
+    });
+
+    // Unmarking would discard the grade and credits stored beside the row, so
+    // the pill stops being a control once the course is marked.
+    it("stops offering the taken pill once the course is marked", () => {
+      render(
+        <CourseCard
+          signedIn
+          c={reviewedCard({ onTaken: undefined })}
+          geo={EXPANDED_CARD_GEOMETRY}
+        />,
+      );
+      expect(screen.queryByRole("button", { name: /have taken/ })).toBeNull();
+      expect(screen.getByTitle(/members have taken this course/)).toBeVisible();
+    });
+  });
+
+  describe("the action control", () => {
+    it("is Explore's split Save button under action='save'", async () => {
+      const onSave = vi.fn();
+      const onPicker = vi.fn();
+      render(
+        <CourseCard
+          c={reviewedCard({ onSave, onPicker })}
+          geo={EXPANDED_CARD_GEOMETRY}
+          action="save"
+        />,
+      );
+
+      await userEvent.click(
+        screen.getByRole("button", { name: "Save course" }),
+      );
+      expect(onSave).toHaveBeenCalledOnce();
+
+      await userEvent.click(
+        screen.getByRole("button", { name: "Add to collections" }),
+      );
+      expect(onPicker).toHaveBeenCalledOnce();
+      expect(screen.queryByText("Add to comparison")).toBeNull();
+    });
+
+    it("is the picker alone under action='add'", async () => {
+      const onPicker = vi.fn();
+      render(
+        <CourseCard
+          c={reviewedCard({ onPicker })}
+          geo={EXPANDED_CARD_GEOMETRY}
+          action="add"
+        />,
+      );
+
+      expect(screen.queryByRole("button", { name: "Save course" })).toBeNull();
+      await userEvent.click(
+        screen.getByRole("button", { name: "Add to collections" }),
+      );
+      expect(onPicker).toHaveBeenCalledOnce();
+    });
+
+    it("only offers removal when the screen names it", () => {
+      const onRemove = vi.fn();
+      const { rerender } = render(
+        <CourseCard c={reviewedCard()} geo={EXPANDED_CARD_GEOMETRY} />,
+      );
+      expect(screen.queryByRole("button", { name: /Remove/ })).toBeNull();
+
+      rerender(
+        <CourseCard
+          c={reviewedCard({ onRemove, removeLabel: "Remove from Saved" })}
+          geo={EXPANDED_CARD_GEOMETRY}
+        />,
+      );
+      expect(
+        screen.getByRole("button", { name: "Remove from Saved" }),
+      ).toBeVisible();
+    });
+  });
+
+  describe("geometry", () => {
+    it("hands the ramp to CSS so a container query can still override it", () => {
+      const { container } = render(
+        <CourseCard c={reviewedCard()} geo={EXPANDED_CARD_GEOMETRY} />,
+      );
+      const frame = container.firstElementChild as HTMLElement;
+      expect(frame.style.getPropertyValue("--card-rail-w")).toBe("224px");
+      expect(frame.style.getPropertyValue("--card-h")).toBe("236px");
+    });
+
+    it("drops the button labels at the collapsed end", () => {
+      const { container } = render(
+        <CourseCard c={reviewedCard()} geo={COLLAPSED_CARD_GEOMETRY} />,
+      );
+
+      expect(screen.queryByText("Write a review")).toBeNull();
+      expect(screen.queryByText("Save course")).toBeNull();
+      // The controls survive as icons, named by their tooltips.
+      expect(
+        screen.getByRole("button", { name: "Write a review" }),
+      ).toBeVisible();
+
+      const frame = container.firstElementChild as HTMLElement;
+      expect(frame.style.getPropertyValue("--card-rail-w")).toBe("134px");
+      expect(frame.style.getPropertyValue("--card-summary-max")).toBe("0px");
+    });
+  });
+
+  it("opens the course from anywhere on the card, through one control", async () => {
+    const onOpen = vi.fn();
+    render(
+      <CourseCard c={reviewedCard({ onOpen })} geo={EXPANDED_CARD_GEOMETRY} />,
+    );
+
+    const heading = screen.getByRole("heading", {
+      name: "DD2380 Artificial Intelligence",
+    });
+    await userEvent.click(
+      within(heading).getByRole("button", {
+        name: "DD2380 Artificial Intelligence",
+      }),
+    );
+    expect(onOpen).toHaveBeenCalledOnce();
+  });
+});

--- a/apps/web/features/courses/components/course-card.spec.tsx
+++ b/apps/web/features/courses/components/course-card.spec.tsx
@@ -133,6 +133,55 @@ describe("CourseCard", () => {
       expect(onLogIn).toHaveBeenCalledOnce();
     });
 
+    // The artboard dismisses its panels from the screen, with one handler that
+    // can see every card. State is per-card here, so the card does it — which
+    // also means pointing at another card's trigger closes this one.
+    it("closes the picker when the reader points somewhere else", async () => {
+      const onPicker = vi.fn();
+      render(
+        <CourseCard
+          signedIn
+          c={reviewedCard({ pickerOpen: true, onPicker })}
+          geo={EXPANDED_CARD_GEOMETRY}
+        />,
+      );
+
+      await userEvent.click(document.body);
+      expect(onPicker).toHaveBeenCalledOnce();
+    });
+
+    it("does not close the picker on a press inside it", async () => {
+      const onPicker = vi.fn();
+      const onNewCollection = vi.fn();
+      render(
+        <CourseCard
+          signedIn
+          c={reviewedCard({ pickerOpen: true, onPicker, onNewCollection })}
+          geo={EXPANDED_CARD_GEOMETRY}
+        />,
+      );
+
+      await userEvent.click(
+        screen.getByRole("button", { name: "Create new collection" }),
+      );
+      expect(onNewCollection).toHaveBeenCalledOnce();
+      expect(onPicker).not.toHaveBeenCalled();
+    });
+
+    it("closes the picker on Escape", async () => {
+      const onPicker = vi.fn();
+      render(
+        <CourseCard
+          signedIn
+          c={reviewedCard({ pickerOpen: true, onPicker })}
+          geo={EXPANDED_CARD_GEOMETRY}
+        />,
+      );
+
+      await userEvent.keyboard("{Escape}");
+      expect(onPicker).toHaveBeenCalledOnce();
+    });
+
     // The prompt must not advertise a feature that does not exist (#68).
     it("is not promised an AI comparison", () => {
       const { container } = render(
@@ -292,9 +341,11 @@ describe("CourseCard", () => {
       );
 
       expect(screen.queryByRole("button", { name: "Save course" })).toBeNull();
-      await userEvent.click(
-        screen.getByRole("button", { name: "Add to collections" }),
-      );
+      // The accessible name is the visible label, not a tidier synonym of it:
+      // voice control cannot reach a control it cannot say (WCAG 2.5.3).
+      const picker = screen.getByRole("button", { name: "Add to comparison" });
+      expect(picker).toHaveTextContent("Add to comparison");
+      await userEvent.click(picker);
       expect(onPicker).toHaveBeenCalledOnce();
     });
 

--- a/apps/web/features/courses/components/course-card.tsx
+++ b/apps/web/features/courses/components/course-card.tsx
@@ -93,6 +93,19 @@ function takenPillStyle(c: CourseCardModel): CSSProperties {
   } as CSSProperties;
 }
 
+/** Shared by the pill's two forms, so they cannot drift apart. */
+function TakenPillBody({ c }: { c: CourseCardModel }) {
+  return (
+    <>
+      <CheckCircleIcon fill={c.takenFill} />
+      <span className="tabular-nums">{c.statTaken}</span>
+    </>
+  );
+}
+
+/** Marks the picker's own subtree, so a blur inside it is not a blur away. */
+const PICKER_MARKER = "data-collection-picker";
+
 export function CourseCard({
   c,
   geo,
@@ -152,8 +165,9 @@ export function CourseCard({
 
             <div className="relative z-10 flex-none">
               {/* Without `onTaken` the pill is a reading, not a control: the
-                  viewer has already marked the course, and unmarking it would
-                  discard the grade and credits recorded beside it. */}
+                  viewer has already marked the course, and unmarking it here
+                  would discard the grade and credits recorded beside the row
+                  without ever showing them. */}
               {c.onTaken ? (
                 <button
                   type="button"
@@ -166,8 +180,7 @@ export function CourseCard({
                   className={`${TAKEN_PILL} cursor-pointer hover:bg-[var(--taken-hover)]`}
                   style={takenPillStyle(c)}
                 >
-                  <CheckCircleIcon fill={c.takenFill} />
-                  <span className="tabular-nums">{c.statTaken}</span>
+                  <TakenPillBody c={c} />
                 </button>
               ) : (
                 <span
@@ -175,8 +188,7 @@ export function CourseCard({
                   className={TAKEN_PILL}
                   style={takenPillStyle(c)}
                 >
-                  <CheckCircleIcon fill={c.takenFill} />
-                  <span className="tabular-nums">{c.statTaken}</span>
+                  <TakenPillBody c={c} />
                 </span>
               )}
 
@@ -226,7 +238,10 @@ export function CourseCard({
                 Prerequisites
               </h4>
               {c.hasPrereq ? (
-                <div className="flex h-5 flex-nowrap gap-[5px] overflow-hidden">
+                <div
+                  title={c.prereq}
+                  className="flex h-5 flex-nowrap gap-[5px] overflow-hidden"
+                >
                   {c.prereqCourses.map((prerequisite) => (
                     <span
                       key={prerequisite.code}
@@ -336,6 +351,7 @@ export function CourseCard({
 
               {c.pickerOpen ? (
                 <div
+                  {...{ [PICKER_MARKER]: "" }}
                   className="absolute left-0 z-30 box-border w-[266px] rounded-[10px] border border-cc-rule2 bg-cc-surface p-[5px] shadow-[0_8px_24px_rgba(20,30,45,0.14)]"
                   style={pickerAbove ? { bottom: "38px" } : { top: "38px" }}
                 >
@@ -459,16 +475,13 @@ export function CourseCard({
                 label="Workload"
                 value={c.workload}
                 width={c.wlW}
-                // The design's amber. `cc-theme.css` carries no palette token
-                // for it — `--warnBtn` is only amber in dark — and the two bars
-                // have to stay distinguishable in both themes.
-                fill="#dfa53c"
+                barClass="bg-cc-score-workload"
               />
               <ScoreBar
                 label="Learning"
                 value={c.learning}
                 width={c.leW}
-                fill="var(--cc-btn)"
+                barClass="bg-cc-btn"
               />
             </div>
           </div>
@@ -492,6 +505,10 @@ export function CourseCard({
  * it takes focus on mount — otherwise the control the reader just activated has
  * vanished and their next keystrokes go nowhere. Focusing once on mount is why
  * this is its own component rather than an `autoFocus` attribute.
+ *
+ * Blur commits the name, as the artboard does — but only a blur that leaves the
+ * picker. Blur fires before click, so committing on a blur *into* a collection
+ * row would create a collection and toggle that row from one click.
  */
 function NewCollectionField({
   value,
@@ -520,7 +537,11 @@ function NewCollectionField({
         value={value}
         aria-label="New collection name"
         onChange={(event) => onChange?.(event.target.value)}
-        onBlur={() => onCommit?.()}
+        onBlur={(event) => {
+          const next = event.relatedTarget as Element | null;
+          if (next?.closest(`[${PICKER_MARKER}]`)) return;
+          onCommit?.();
+        }}
         onKeyDown={(event) => {
           if (event.key === "Enter") onCommit?.();
           if (event.key === "Escape") onCancel?.();
@@ -540,12 +561,13 @@ function ScoreBar({
   label,
   value,
   width,
-  fill,
+  barClass,
 }: {
   label: string;
   value: string;
   width: string;
-  fill: string;
+  /** The bar's fill, as a token utility: the two bars must not share a colour. */
+  barClass: string;
 }) {
   return (
     <div>
@@ -554,7 +576,7 @@ function ScoreBar({
         <span className="font-semibold text-cc-ink">{value}</span>
       </div>
       <div className="h-[5px] overflow-hidden rounded-[3px] bg-cc-pill">
-        <div className="h-full" style={{ width, background: fill }} />
+        <div className={`h-full ${barClass}`} style={{ width }} />
       </div>
     </div>
   );

--- a/apps/web/features/courses/components/course-card.tsx
+++ b/apps/web/features/courses/components/course-card.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import type { CSSProperties, ReactNode } from "react";
+import type { CSSProperties, ReactNode, RefObject } from "react";
 import { useEffect, useRef } from "react";
 import { keywordChips } from "@/features/courses/lib/course-card-model";
 import type { CardGeometry, CourseCardAction, CourseCardModel } from "@/types";
@@ -106,6 +106,44 @@ function TakenPillBody({ c }: { c: CourseCardModel }) {
 /** Marks the picker's own subtree, so a blur inside it is not a blur away. */
 const PICKER_MARKER = "data-collection-picker";
 
+/**
+ * Closes an open popover when the reader points or presses somewhere else.
+ *
+ * The artboard dismisses both panels from the screen, where one `closeAll` can
+ * see every card. Here each card owns its own popover state, so the same
+ * behaviour has to live with the DOM that defines "elsewhere" — which is this
+ * component. It also settles the multi-card case for free: pointing at another
+ * card's trigger is outside this one, so at most one panel is ever open.
+ *
+ * `close` is the trigger's own toggle, and it only runs while the panel is
+ * open, so toggling is closing.
+ */
+function useDismissOnOutside(
+  open: boolean,
+  region: RefObject<HTMLElement | null>,
+  close: (() => void) | undefined,
+) {
+  useEffect(() => {
+    if (!open || !close) return;
+
+    const onPointerDown = (event: PointerEvent) => {
+      const target = event.target;
+      if (target instanceof Node && region.current?.contains(target)) return;
+      close();
+    };
+    const onKeyDown = (event: KeyboardEvent) => {
+      if (event.key === "Escape") close();
+    };
+
+    document.addEventListener("pointerdown", onPointerDown);
+    document.addEventListener("keydown", onKeyDown);
+    return () => {
+      document.removeEventListener("pointerdown", onPointerDown);
+      document.removeEventListener("keydown", onKeyDown);
+    };
+  }, [open, close, region]);
+}
+
 export function CourseCard({
   c,
   geo,
@@ -120,6 +158,13 @@ export function CourseCard({
 }: Props) {
   const tween = { transition: geo.tween };
   const keywords = keywordChips(c.keywords);
+
+  // Each popover's region is its trigger plus its panel: a press inside either
+  // is not a press elsewhere.
+  const takenRegion = useRef<HTMLDivElement>(null);
+  const pickerRegion = useRef<HTMLDivElement>(null);
+  useDismissOnOutside(c.takenPickerOpen ?? false, takenRegion, c.onTaken);
+  useDismissOnOutside(c.pickerOpen, pickerRegion, c.onPicker);
 
   return (
     <div className="@container w-full" style={geometryVars(geo)}>
@@ -163,7 +208,7 @@ export function CourseCard({
               </div>
             </div>
 
-            <div className="relative z-10 flex-none">
+            <div className="relative z-10 flex-none" ref={takenRegion}>
               {/* Without `onTaken` the pill is a reading, not a control: the
                   viewer has already marked the course, and unmarking it here
                   would discard the grade and credits recorded beside the row
@@ -295,7 +340,10 @@ export function CourseCard({
               ) : null}
             </button>
 
-            <div className="relative min-w-[44px] flex-[var(--card-save-flex)]">
+            <div
+              className="relative min-w-[44px] flex-[var(--card-save-flex)]"
+              ref={pickerRegion}
+            >
               {action === "save" ? (
                 <div
                   className="box-border flex h-[34px] max-w-full items-stretch overflow-hidden rounded-[8px] border"
@@ -341,9 +389,14 @@ export function CourseCard({
                   className="box-border flex h-[34px] cursor-pointer items-center gap-[7px] overflow-hidden rounded-[8px] border border-cc-rule3 bg-cc-surface px-[10px] text-[13px] text-cc-ink hover:border-cc-hov hover:bg-cc-info"
                 >
                   <AddToCollectionIcon />
+                  {/* Same string as the accessible name above: a visible label
+                      the accessible name does not contain is unreachable by
+                      voice control (WCAG 2.5.3), and the label is hidden by the
+                      container query on a narrow card, so it cannot be the only
+                      name either. */}
                   {geo.showLabel ? (
                     <span className="min-w-0 overflow-hidden whitespace-nowrap @max-[440px]:hidden">
-                      Add to comparison
+                      {c.addLabel}
                     </span>
                   ) : null}
                 </button>
@@ -549,8 +602,12 @@ function NewCollectionField({
         aria-label="New collection name"
         onChange={(event) => onChange?.(event.target.value)}
         onBlur={(event) => {
-          const next = event.relatedTarget as Element | null;
-          if (next?.closest(`[${PICKER_MARKER}]`)) return;
+          // `relatedTarget` is an EventTarget: it is null when focus leaves the
+          // document, and `.closest` is not on every one of them.
+          const next = event.relatedTarget;
+          if (next instanceof Element && next.closest(`[${PICKER_MARKER}]`)) {
+            return;
+          }
           onCommit?.();
         }}
         onKeyDown={(event) => {

--- a/apps/web/features/courses/components/course-card.tsx
+++ b/apps/web/features/courses/components/course-card.tsx
@@ -419,7 +419,10 @@ export function CourseCard({
                 onClick={c.onRemove}
                 aria-label={c.removeLabel}
                 title={c.removeLabel}
-                className="ml-auto flex size-[34px] flex-none cursor-pointer items-center justify-center rounded-[8px] border border-cc-rule3 bg-cc-surface text-cc-dim hover:border-destructive/50 hover:text-destructive"
+                // The artboard turns this red on hover (#d9a08c border, #a4402a
+                // ink). `--cc-danger` is that colour in the palette now, and the
+                // border is derived from it rather than given a token of its own.
+                className="ml-auto flex size-[34px] flex-none cursor-pointer items-center justify-center rounded-[8px] border border-cc-rule3 bg-cc-surface text-cc-dim hover:border-cc-danger/55 hover:text-cc-danger"
               >
                 <TrashIcon />
               </button>

--- a/apps/web/features/courses/components/course-card.tsx
+++ b/apps/web/features/courses/components/course-card.tsx
@@ -1,0 +1,742 @@
+"use client";
+
+import type { CSSProperties, ReactNode } from "react";
+import { useEffect, useRef } from "react";
+import { keywordChips } from "@/features/courses/lib/course-card-model";
+import type { CardGeometry, CourseCardAction, CourseCardModel } from "@/types";
+
+/**
+ * The course card, shared by Explore, Saved and Collections.
+ *
+ * Straight from `docs/design/Course Community - Course Card.dc.html`. It renders
+ * `c` and measures nothing: geometry arrives as one `geo` object so the parent
+ * owns the collapse ramp, and the only structural difference between the pages
+ * is `action` — Explore's split Save button, or the picker on its own. That is
+ * why this is one component rather than two.
+ *
+ * Everything derived from data is computed before it gets here, by
+ * `toCourseCardModel`. The card decides no truth about a course; it draws the
+ * one it is handed. In particular `hasX` / `noX` are drawn as the two
+ * independent branches they are, so "no reviews yet" and "reviewed, but nobody
+ * remembered the examination split" stay different pictures — and neither ever
+ * becomes 0%.
+ *
+ * `geo` lands in custom properties rather than inline widths, which is what
+ * lets the container query below `@max-[440px]` override the ramp for a card in
+ * a phone-width column without the parent knowing anything about it.
+ */
+
+type Props = {
+  c: CourseCardModel;
+  geo: CardGeometry;
+  /** Explore's split Save button, or Saved's picker-only control. */
+  action?: CourseCardAction;
+  /** Opens the picker upwards, for a card sitting near the bottom of a page. */
+  pickerAbove?: boolean;
+  /** Copy for the row that starts a new collection. */
+  newLabel?: string;
+  /**
+   * Whether the viewer has an account. Defaults to `false`: a visitor sees the
+   * design's sign-up prompt instead of a picker whose writes would be rejected.
+   */
+  signedIn?: boolean;
+  /** The name being typed into the new-collection row. */
+  draftName?: string;
+  onDraftChange?: (name: string) => void;
+  /** Enter, or blur with a name. */
+  onDraftCommit?: () => void;
+  /** Escape. */
+  onDraftCancel?: () => void;
+};
+
+/**
+ * Card metrics as custom properties, so a container query can override them.
+ *
+ * `geo` also carries `saveW`, `savePad`, `reviewPad`, `labelMax` and
+ * `labelOpacity`, which Explore's own chrome interpolates but this card's markup
+ * does not read — the artboard fixes those paddings. They are not emitted rather
+ * than emitted unused.
+ */
+function geometryVars(geo: CardGeometry): CSSProperties {
+  return {
+    "--card-h": geo.cardHeight,
+    "--card-title": geo.titleSize,
+    "--card-gap": geo.cardGap,
+    "--card-pad": geo.cardPad,
+    "--card-facts-gap": geo.factsGap,
+    "--card-rail-w": geo.railW,
+    "--card-rail-pad": geo.railPad,
+    "--card-summary-max": geo.summaryMax,
+    "--card-summary-op": String(geo.summaryOpacity),
+    "--card-review-flex": geo.reviewFlex,
+    "--card-save-flex": geo.saveFlex,
+  } as CSSProperties;
+}
+
+/**
+ * The phone end of the ramp, from
+ * `docs/design/reference/Course Community - Mobile Preview.dc.html`. It is a
+ * container query rather than a viewport one because a card is narrow whenever
+ * its column is, phone or not.
+ */
+const MOBILE_GEOMETRY =
+  "@max-[440px]:[--card-h:168px] @max-[440px]:[--card-title:15px] @max-[440px]:[--card-gap:7px] @max-[440px]:[--card-pad:12px] @max-[440px]:[--card-rail-w:118px] @max-[440px]:[--card-rail-pad:12px_11px] @max-[440px]:[--card-summary-max:0px] @max-[440px]:[--card-summary-op:0] @max-[440px]:[--card-review-flex:0_0_34px] @max-[440px]:[--card-save-flex:0_0_68px]";
+
+const TAKEN_PILL =
+  "flex h-[26px] flex-none items-center gap-1.5 rounded-[7px] py-0 pr-2 pl-[5px] text-[12px]";
+
+function takenPillStyle(c: CourseCardModel): CSSProperties {
+  return {
+    background: c.takenBg,
+    color: c.takenCountFg,
+    "--taken-hover": c.takenHoverBg ?? "var(--cc-pill)",
+  } as CSSProperties;
+}
+
+export function CourseCard({
+  c,
+  geo,
+  action = "save",
+  pickerAbove = false,
+  newLabel = "Create new collection",
+  signedIn = false,
+  draftName = "",
+  onDraftChange,
+  onDraftCommit,
+  onDraftCancel,
+}: Props) {
+  const tween = { transition: geo.tween };
+  const keywords = keywordChips(c.keywords);
+
+  return (
+    <div className="@container w-full" style={geometryVars(geo)}>
+      <article
+        // The resting border is a custom property, not an inline `border-color`:
+        // an inline declaration would outrank the hover class and the card would
+        // never light up under the pointer.
+        className={`relative flex h-[var(--card-h)] rounded-[12px] border border-[color:var(--card-border)] bg-cc-surface shadow-[0_1px_2px_rgba(20,30,45,0.05)] transition-[border-color,box-shadow] hover:border-cc-hov hover:shadow-[0_2px_8px_rgba(20,30,45,0.09)] ${MOBILE_GEOMETRY}`}
+        style={{ "--card-border": c.borderColor } as CSSProperties}
+      >
+        <div
+          className="box-border flex min-w-0 flex-1 flex-col gap-[var(--card-gap)] p-[var(--card-pad)]"
+          style={tween}
+        >
+          <div className="flex flex-none items-start justify-between gap-2.5">
+            <div className="min-w-0 flex-1">
+              <h3
+                className="m-0 font-semibold text-[length:var(--card-title)] text-cc-brand leading-[1.2]"
+                style={tween}
+                title={c.title}
+              >
+                {c.onOpen ? (
+                  // Stretched over the whole card, so clicking anywhere opens
+                  // the course while the only thing focus and a screen reader
+                  // ever meet is this one button. The clipping lives on the
+                  // inner span: `overflow:hidden` on the button would cut the
+                  // overlay off at the title's own box.
+                  <button
+                    type="button"
+                    onClick={c.onOpen}
+                    className="block w-full cursor-pointer text-left after:absolute after:inset-0 after:content-[''] hover:underline"
+                  >
+                    <span className="block truncate">{c.title}</span>
+                  </button>
+                ) : (
+                  <span className="block truncate">{c.title}</span>
+                )}
+              </h3>
+              <div className="mt-[3px] truncate text-[13px] text-cc-muted">
+                {c.meta}
+              </div>
+            </div>
+
+            <div className="relative z-10 flex-none">
+              {/* Without `onTaken` the pill is a reading, not a control: the
+                  viewer has already marked the course, and unmarking it would
+                  discard the grade and credits recorded beside it. */}
+              {c.onTaken ? (
+                <button
+                  type="button"
+                  onClick={c.onTaken}
+                  title={c.takenTitle}
+                  aria-haspopup={signedIn ? undefined : "dialog"}
+                  aria-expanded={
+                    signedIn ? undefined : (c.takenPickerOpen ?? false)
+                  }
+                  className={`${TAKEN_PILL} cursor-pointer hover:bg-[var(--taken-hover)]`}
+                  style={takenPillStyle(c)}
+                >
+                  <CheckCircleIcon fill={c.takenFill} />
+                  <span className="tabular-nums">{c.statTaken}</span>
+                </button>
+              ) : (
+                <span
+                  title={c.takenTitle}
+                  className={TAKEN_PILL}
+                  style={takenPillStyle(c)}
+                >
+                  <CheckCircleIcon fill={c.takenFill} />
+                  <span className="tabular-nums">{c.statTaken}</span>
+                </span>
+              )}
+
+              {c.takenPickerOpen ? (
+                <SignUpPrompt
+                  title="Track courses you've taken"
+                  body="Sign up or log in to mark courses as taken and build your profile."
+                  onSignUp={c.onSignUp}
+                  onLogIn={c.onLogIn}
+                  className="absolute top-[30px] right-0 z-30 w-[250px]"
+                />
+              ) : null}
+            </div>
+          </div>
+
+          {/* Keywords has no writer at all and prerequisites has no writer yet,
+              so both headers stand over an empty row. Reserving the line keeps
+              the card's structure the same for every course, which is what the
+              artboard draws — and is honest in a way "None listed" would not
+              be over a table nothing has ever written to (#68). */}
+          <div
+            className="flex flex-none flex-wrap gap-[var(--card-facts-gap)] py-0.5 @max-[440px]:hidden"
+            style={tween}
+          >
+            <section className="min-w-0 flex-[1_1_150px]">
+              <h4 className="mb-1 font-medium text-[11px] text-cc-muted">
+                Keywords
+              </h4>
+              <div
+                className="flex h-5 flex-nowrap gap-[5px] overflow-hidden"
+                title={c.keywords}
+              >
+                {keywords.map((keyword) => (
+                  <span
+                    key={keyword.label}
+                    className="inline-flex min-w-0 items-center overflow-hidden truncate text-[11.5px] text-cc-muted"
+                    style={{ flex: keyword.flex }}
+                  >
+                    {keyword.label}
+                  </span>
+                ))}
+              </div>
+            </section>
+
+            <section className="min-w-0 flex-[1_1_150px]">
+              <h4 className="mb-1 font-medium text-[11px] text-cc-muted">
+                Prerequisites
+              </h4>
+              {c.hasPrereq ? (
+                <div className="flex h-5 flex-nowrap gap-[5px] overflow-hidden">
+                  {c.prereqCourses.map((prerequisite) => (
+                    <span
+                      key={prerequisite.code}
+                      title={prerequisite.name}
+                      className="inline-flex h-5 flex-none items-center whitespace-nowrap font-medium font-mono text-[11.5px] text-cc-brand"
+                      style={{
+                        gap: prerequisite.gap,
+                        padding: prerequisite.padding,
+                        borderRadius: prerequisite.radius,
+                        background: prerequisite.bg,
+                      }}
+                    >
+                      <PrerequisiteTickIcon taken={prerequisite.taken} />
+                      {prerequisite.code}
+                    </span>
+                  ))}
+                </div>
+              ) : null}
+              {/* Only when prerequisites were actually extracted and there are
+                  none. An empty row instead means nobody has looked. */}
+              {c.noPrereq ? (
+                <p className="m-0 text-[13px] text-cc-dim2 leading-[19px]">
+                  None listed
+                </p>
+              ) : null}
+              {!c.hasPrereq && !c.noPrereq ? <div className="h-5" /> : null}
+            </section>
+          </div>
+
+          <div
+            className="min-h-0 max-h-[var(--card-summary-max)] flex-[1_1_auto] overflow-hidden opacity-[var(--card-summary-op)]"
+            style={tween}
+          >
+            <p className="m-0 overflow-hidden text-[13px] text-cc-muted leading-[19px]">
+              {c.summaryClipped}
+            </p>
+          </div>
+
+          <div className="relative z-10 mt-auto flex min-w-0 flex-none gap-2 pt-0.5">
+            <button
+              type="button"
+              onClick={c.onReview}
+              title="Write a review"
+              className="box-border flex h-[34px] min-w-[40px] flex-[var(--card-review-flex)] cursor-pointer items-center justify-center gap-[7px] overflow-hidden rounded-[8px] bg-cc-warn-btn px-[10px] font-medium text-[13px] text-cc-warn-btn-fg hover:opacity-90"
+            >
+              <ReviewIcon />
+              {geo.showLabel ? (
+                <span className="min-w-0 flex-1 overflow-hidden whitespace-nowrap @max-[440px]:hidden">
+                  Write a review
+                </span>
+              ) : null}
+            </button>
+
+            <div className="relative min-w-[44px] flex-[var(--card-save-flex)]">
+              {action === "save" ? (
+                <div
+                  className="box-border flex h-[34px] max-w-full items-stretch overflow-hidden rounded-[8px] border"
+                  style={{ borderColor: c.saveBorder, background: c.saveBg }}
+                >
+                  <button
+                    type="button"
+                    onClick={c.onSave}
+                    className="flex min-w-0 flex-1 cursor-pointer items-center gap-[7px] overflow-hidden px-[10px] text-[13px] hover:bg-cc-info"
+                    style={{ color: c.saveFg }}
+                  >
+                    <BookmarkIcon fill={c.saveFill} />
+                    {geo.showLabel ? (
+                      <span className="min-w-0 overflow-hidden whitespace-nowrap @max-[440px]:hidden">
+                        {c.saveLabel}
+                      </span>
+                    ) : null}
+                  </button>
+                  <div
+                    className="w-px flex-none"
+                    style={{ background: c.saveBorder }}
+                  />
+                  <button
+                    type="button"
+                    onClick={c.onPicker}
+                    title="Add to collections"
+                    aria-label="Add to collections"
+                    aria-haspopup="menu"
+                    aria-expanded={c.pickerOpen}
+                    className="flex flex-none cursor-pointer items-center px-[9px] text-[10px] hover:bg-cc-info"
+                    style={{ color: c.saveFg }}
+                  >
+                    ▾
+                  </button>
+                </div>
+              ) : (
+                <button
+                  type="button"
+                  onClick={c.onPicker}
+                  aria-haspopup="menu"
+                  aria-expanded={c.pickerOpen}
+                  aria-label={c.addLabel}
+                  className="box-border flex h-[34px] cursor-pointer items-center gap-[7px] overflow-hidden rounded-[8px] border border-cc-rule3 bg-cc-surface px-[10px] text-[13px] text-cc-ink hover:border-cc-hov hover:bg-cc-info"
+                >
+                  <AddToCollectionIcon />
+                  {geo.showLabel ? (
+                    <span className="min-w-0 overflow-hidden whitespace-nowrap @max-[440px]:hidden">
+                      Add to comparison
+                    </span>
+                  ) : null}
+                </button>
+              )}
+
+              {c.pickerOpen ? (
+                <div
+                  className="absolute left-0 z-30 box-border w-[266px] rounded-[10px] border border-cc-rule2 bg-cc-surface p-[5px] shadow-[0_8px_24px_rgba(20,30,45,0.14)]"
+                  style={pickerAbove ? { bottom: "38px" } : { top: "38px" }}
+                >
+                  {signedIn ? (
+                    <div>
+                      <div className="px-[9px] pt-2 pb-1.5 font-semibold text-[10.5px] text-cc-dim uppercase tracking-[0.09em]">
+                        Add to collections
+                      </div>
+                      {c.creating ? (
+                        <NewCollectionField
+                          value={draftName}
+                          onChange={onDraftChange}
+                          onCommit={onDraftCommit}
+                          onCancel={onDraftCancel}
+                        />
+                      ) : (
+                        <button
+                          type="button"
+                          onClick={c.onNewCollection}
+                          className="flex w-full cursor-pointer items-center gap-[9px] rounded-[7px] px-[9px] py-2 text-left font-medium text-[13px] text-cc-brand hover:bg-cc-pill"
+                        >
+                          <span className="flex w-4 flex-none justify-center">
+                            <PlusIcon />
+                          </span>
+                          {newLabel}
+                        </button>
+                      )}
+                      {c.hasCollections ? (
+                        <div className="mx-1.5 my-1 h-px bg-cc-pill" />
+                      ) : null}
+                      {c.collections.map((collection) => (
+                        <button
+                          key={collection.id}
+                          type="button"
+                          onClick={collection.onClick}
+                          className="flex w-full cursor-pointer items-center gap-[9px] rounded-[7px] px-[9px] py-2 text-left text-[13px] text-cc-ink2 hover:bg-cc-pill"
+                        >
+                          <span className="flex w-4 flex-none justify-center">
+                            <CollectionCheckIcon
+                              fill={collection.fill}
+                              tick={collection.tick}
+                            />
+                          </span>
+                          <span className="flex-1 truncate">
+                            {collection.name}
+                          </span>
+                        </button>
+                      ))}
+                    </div>
+                  ) : (
+                    <SignUpPrompt
+                      title="Organize your saved courses"
+                      body="Sign up or log in to create collections and sync across devices."
+                      onSignUp={c.onSignUp}
+                      onLogIn={c.onLogIn}
+                    />
+                  )}
+                </div>
+              ) : null}
+            </div>
+
+            {c.removeLabel && c.onRemove ? (
+              <button
+                type="button"
+                onClick={c.onRemove}
+                aria-label={c.removeLabel}
+                title={c.removeLabel}
+                className="ml-auto flex size-[34px] flex-none cursor-pointer items-center justify-center rounded-[8px] border border-cc-rule3 bg-cc-surface text-cc-dim hover:border-destructive/50 hover:text-destructive"
+              >
+                <TrashIcon />
+              </button>
+            ) : null}
+          </div>
+        </div>
+
+        <div
+          className="box-border flex w-[var(--card-rail-w)] flex-none flex-col justify-between gap-2.5 rounded-r-[11px] border-cc-rule border-l bg-cc-inset p-[var(--card-rail-pad)]"
+          style={tween}
+        >
+          <div className="flex flex-col gap-[11px]">
+            <div className="flex justify-end">
+              {c.hasStats ? (
+                <div className="truncate whitespace-nowrap rounded-[6px] bg-cc-pill px-[9px] py-[3px] text-[11.5px] text-cc-muted">
+                  {c.examLabel}
+                </div>
+              ) : null}
+              {c.noStats ? (
+                <div className="whitespace-nowrap rounded-[6px] bg-cc-pill px-[9px] py-[3px] text-[11.5px] text-cc-dim">
+                  No reviews yet
+                </div>
+              ) : null}
+            </div>
+
+            <div>
+              {c.hasReviewStats ? (
+                <>
+                  <div className="mt-0.5">
+                    <span className="font-semibold text-[26px] text-cc-brand leading-none tracking-[-0.02em] tabular-nums">
+                      {c.happyPct}
+                    </span>
+                  </div>
+                  <div className="mt-[3px] text-[11px] text-cc-muted leading-[1.3]">
+                    of {c.statReviews} reviewers are happy they took the course
+                  </div>
+                </>
+              ) : null}
+              {c.noReviewStats ? (
+                <>
+                  <div className="mt-0.5 font-semibold text-[15px] text-cc-dim">
+                    No reviews yet
+                  </div>
+                  <div className="mt-[3px] text-[11px] text-cc-muted leading-[1.3] @max-[440px]:hidden">
+                    Be the first to say how it went.
+                  </div>
+                </>
+              ) : null}
+            </div>
+
+            <div className="flex flex-col gap-2">
+              <ScoreBar
+                label="Workload"
+                value={c.workload}
+                width={c.wlW}
+                // The design's amber. `cc-theme.css` carries no palette token
+                // for it — `--warnBtn` is only amber in dark — and the two bars
+                // have to stay distinguishable in both themes.
+                fill="#dfa53c"
+              />
+              <ScoreBar
+                label="Learning"
+                value={c.learning}
+                width={c.leW}
+                fill="var(--cc-btn)"
+              />
+            </div>
+          </div>
+
+          <div className="flex justify-end gap-2 text-[12px] text-cc-muted @max-[440px]:hidden">
+            <span className="flex items-center gap-1" title="Number of reviews">
+              <ReviewCountIcon />
+              {c.statReviews}
+            </span>
+          </div>
+        </div>
+      </article>
+    </div>
+  );
+}
+
+/**
+ * The row that names a new collection.
+ *
+ * It replaces the "Create new collection" row the moment that row is clicked, so
+ * it takes focus on mount — otherwise the control the reader just activated has
+ * vanished and their next keystrokes go nowhere. Focusing once on mount is why
+ * this is its own component rather than an `autoFocus` attribute.
+ */
+function NewCollectionField({
+  value,
+  onChange,
+  onCommit,
+  onCancel,
+}: {
+  value: string;
+  onChange?: (name: string) => void;
+  onCommit?: () => void;
+  onCancel?: () => void;
+}) {
+  const field = useRef<HTMLInputElement>(null);
+
+  useEffect(() => {
+    field.current?.focus();
+  }, []);
+
+  return (
+    <div className="flex items-center gap-[9px] px-[9px] pt-0.5 pb-1.5">
+      <span className="flex w-4 flex-none justify-center">
+        <PlusIcon />
+      </span>
+      <input
+        ref={field}
+        value={value}
+        aria-label="New collection name"
+        onChange={(event) => onChange?.(event.target.value)}
+        onBlur={() => onCommit?.()}
+        onKeyDown={(event) => {
+          if (event.key === "Enter") onCommit?.();
+          if (event.key === "Escape") onCancel?.();
+        }}
+        className="box-border h-7 min-w-0 flex-1 rounded-[6px] border border-cc-brand px-2 text-[13px] text-cc-ink outline-none"
+      />
+    </div>
+  );
+}
+
+/**
+ * One 1-10 mean. The number is shown raw and the bar is that number over ten,
+ * which is the same width the artboard draws for the five-point scale it
+ * predates (#68). Nothing here converts between scales.
+ */
+function ScoreBar({
+  label,
+  value,
+  width,
+  fill,
+}: {
+  label: string;
+  value: string;
+  width: string;
+  fill: string;
+}) {
+  return (
+    <div>
+      <div className="mb-[3px] flex justify-between text-[11.5px] text-cc-muted">
+        <span>{label}</span>
+        <span className="font-semibold text-cc-ink">{value}</span>
+      </div>
+      <div className="h-[5px] overflow-hidden rounded-[3px] bg-cc-pill">
+        <div className="h-full" style={{ width, background: fill }} />
+      </div>
+    </div>
+  );
+}
+
+/**
+ * The design's inline prompt over a control a visitor cannot use. Its two
+ * buttons hand off to `AuthReasonDialog`, which is the app's one sign-in
+ * surface — this panel only names the reason.
+ */
+function SignUpPrompt({
+  title,
+  body,
+  onSignUp,
+  onLogIn,
+  className,
+}: {
+  title: string;
+  body: string;
+  onSignUp?: () => void;
+  onLogIn?: () => void;
+  className?: string;
+}) {
+  const panel = (
+    <div className="px-[11px] pt-[11px] pb-2.5">
+      <div className="flex items-center gap-2">
+        <LockIcon />
+        <div className="font-semibold text-[13.5px]">{title}</div>
+      </div>
+      <div className="mt-1.5 text-[12.5px] text-cc-muted leading-[1.5]">
+        {body}
+      </div>
+      <div className="mt-[11px] flex gap-[7px]">
+        <button
+          type="button"
+          onClick={onSignUp}
+          className="flex h-8 flex-1 cursor-pointer items-center justify-center rounded-[8px] bg-cc-btn font-semibold text-[12.5px] text-cc-btn-fg hover:opacity-90"
+        >
+          Sign up
+        </button>
+        <button
+          type="button"
+          onClick={onLogIn}
+          className="flex h-8 flex-1 cursor-pointer items-center justify-center rounded-[8px] border border-cc-rule3 bg-cc-surface font-medium text-[12.5px] text-cc-brand hover:border-cc-hov"
+        >
+          Log in
+        </button>
+      </div>
+    </div>
+  );
+
+  if (!className) return panel;
+  return (
+    <div
+      className={`box-border rounded-[10px] border border-cc-rule2 bg-cc-surface shadow-[0_8px_24px_rgba(20,30,45,0.14)] ${className}`}
+    >
+      {panel}
+    </div>
+  );
+}
+
+// The artboard's own glyphs, kept verbatim so the card does not drift from the
+// design when an icon package renames or redraws one.
+
+function Svg({
+  size = 15,
+  fill = "none",
+  strokeWidth = 1.8,
+  className,
+  children,
+}: {
+  size?: number;
+  fill?: string;
+  strokeWidth?: number;
+  className?: string;
+  children: ReactNode;
+}) {
+  return (
+    <svg
+      width={size}
+      height={size}
+      viewBox="0 0 24 24"
+      fill={fill}
+      stroke="currentColor"
+      strokeWidth={strokeWidth}
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      className={className}
+      aria-hidden="true"
+      focusable="false"
+    >
+      {children}
+    </svg>
+  );
+}
+
+function CheckCircleIcon({ fill }: { fill: string }) {
+  return (
+    <Svg size={16} fill={fill} className="flex-none">
+      <circle cx="12" cy="12" r="10" />
+      <path d="m9 12 2 2 4-4" />
+    </Svg>
+  );
+}
+
+function PrerequisiteTickIcon({ taken }: { taken?: boolean }) {
+  return (
+    <Svg size={11} strokeWidth={2.2} className="flex-none">
+      <circle cx="12" cy="12" r="10" />
+      {taken ? <path d="m9 12 2 2 4-4" /> : null}
+    </Svg>
+  );
+}
+
+function LockIcon() {
+  return (
+    <Svg className="flex-none text-cc-dim">
+      <rect x="4" y="10.5" width="16" height="10.5" rx="2.5" />
+      <path d="M8 10.5V7.5a4 4 0 0 1 8 0v3" />
+    </Svg>
+  );
+}
+
+function ReviewIcon() {
+  return (
+    <Svg strokeWidth={2} className="flex-none">
+      <path d="M21 12a8 8 0 0 1-8 8H4l2-3.2A8 8 0 1 1 21 12z" />
+    </Svg>
+  );
+}
+
+function BookmarkIcon({ fill }: { fill: string }) {
+  return (
+    <Svg fill={fill} className="flex-none">
+      <path d="m19 21-7-4-7 4V5a2 2 0 0 1 2-2h10a2 2 0 0 1 2 2z" />
+    </Svg>
+  );
+}
+
+function AddToCollectionIcon() {
+  return (
+    <Svg className="flex-none">
+      <rect x="3" y="5" width="14" height="14" rx="2.5" />
+      <path d="M8.5 12h5M11 9.5v5" />
+    </Svg>
+  );
+}
+
+function PlusIcon() {
+  return (
+    <Svg size={16} strokeWidth={2} className="text-cc-brand">
+      <path d="M5 12h14" />
+      <path d="M12 5v14" />
+    </Svg>
+  );
+}
+
+function CollectionCheckIcon({ fill, tick }: { fill: string; tick: string }) {
+  return (
+    <Svg size={16} fill={fill}>
+      <rect x="3" y="5" width="14" height="14" rx="2.5" />
+      {tick ? <path d={tick} /> : null}
+    </Svg>
+  );
+}
+
+function TrashIcon() {
+  return (
+    <Svg strokeWidth={1.9} className="flex-none">
+      <path d="M4 7h16" />
+      <path d="M6 7V5a2 2 0 0 1 2-2h8a2 2 0 0 1 2 2v2" />
+      <path d="M6 7l1 13a2 2 0 0 0 2 2h6a2 2 0 0 0 2-2l1-13" />
+      <path d="M10 11v6" />
+      <path d="M14 11v6" />
+    </Svg>
+  );
+}
+
+function ReviewCountIcon() {
+  return (
+    <Svg size={14} className="flex-none">
+      <path d="M22 17a2 2 0 0 1-2 2H6l-4 4V4a2 2 0 0 1 2-2h16a2 2 0 0 1 2 2z" />
+    </Svg>
+  );
+}

--- a/apps/web/features/courses/components/course-card.tsx
+++ b/apps/web/features/courses/components/course-card.tsx
@@ -471,11 +471,19 @@ export function CourseCard({
             </div>
 
             <div className="flex flex-col gap-2">
+              {/* The artboard fills this bar with a fixed amber (#dfa53c) that
+                  no `--cc-*` token carries: the palette has no accent family,
+                  and `--cc-warn-btn` is amber only in dark, blue in light —
+                  which would make both score bars one colour here. `--cc-warn-ink`
+                  is the palette's amber-family value in both themes, so it is
+                  substituted rather than a new token invented. In dark it sits
+                  closer to `--cc-btn` than the design intends; the gap is real
+                  and belongs in the palette, not in this file. */}
               <ScoreBar
                 label="Workload"
                 value={c.workload}
                 width={c.wlW}
-                barClass="bg-cc-score-workload"
+                barClass="bg-cc-warn-ink"
               />
               <ScoreBar
                 label="Learning"

--- a/apps/web/features/courses/hooks/use-collection-picker.ts
+++ b/apps/web/features/courses/hooks/use-collection-picker.ts
@@ -1,0 +1,213 @@
+"use client";
+
+import { useCallback, useMemo, useState } from "react";
+import { toast } from "sonner";
+import { useCollectionMutations } from "@/features/courses/api/mutations";
+import { useCollections } from "@/features/courses/api/queries";
+import type { CollectionPickerRow } from "@/types";
+
+/**
+ * The course card's collection picker: which collections hold this course, and
+ * every write that changes that.
+ *
+ * It is its own hook because putting a course in a collection is not one write.
+ * A course may only join a collection its owner has also saved, so the picker
+ * has to save first — and then two writes can fail independently, in ways that
+ * need different words and different recovery advice. That consistency problem
+ * belongs together, and it belongs away from the card's save and taken
+ * controls, which are each a single idempotent call.
+ *
+ * The open/closed and draft state is local to one course, which is why a list
+ * can have many cards without a screen tracking which picker is open.
+ */
+
+/** The tick the picker draws on a collection that already holds the course. */
+const PICKER_TICK = "m8.5 12 2.4 2.4 4.6-4.9";
+
+/**
+ * A picker write that failed, carrying which of its steps did.
+ *
+ * The recovery advice differs by step: a failed *add* can be retried from the
+ * collection's row, but a failed *save* blocks that row too, so pointing at it
+ * would be sending the reader somewhere that cannot succeed. The message is
+ * written where the failure happens; `step` is what lets a caller add context
+ * without replacing it.
+ */
+export class CollectionWriteError extends Error {
+  constructor(
+    readonly step: "save" | "add" | "remove",
+    message: string,
+  ) {
+    super(message);
+    this.name = "CollectionWriteError";
+  }
+}
+
+/** Surfaces a failed write in the words of the step that actually failed. */
+function reportWriteFailure(error: unknown) {
+  toast.error(
+    error instanceof Error ? error.message : "That did not go through.",
+  );
+}
+
+type Options = {
+  courseCode: string;
+  /** Whether the viewer has saved this course; a collection requires it. */
+  isSaved: boolean;
+  /** Gates the protected query: a visitor is shown the sign-up prompt instead. */
+  signedIn: boolean;
+  /** From `useSetCourseSaved`, so the picker and the Save button share one path. */
+  setSaved: (courseCode: string, saved: boolean) => Promise<void>;
+};
+
+export type CollectionPicker = {
+  rows: CollectionPickerRow[];
+  isOpen: boolean;
+  creating: boolean;
+  draftName: string;
+  /** Opens or closes the panel, abandoning any half-typed name. */
+  toggle: () => void;
+  close: () => void;
+  /** Swaps the "Create new collection" row for the name field. */
+  startNew: () => void;
+  onDraftChange: (name: string) => void;
+  onDraftCommit: () => void;
+  onDraftCancel: () => void;
+};
+
+export function useCollectionPicker({
+  courseCode,
+  isSaved,
+  signedIn,
+  setSaved,
+}: Options): CollectionPicker {
+  const { data: collections } = useCollections(signedIn);
+  const { create, addCourse, removeCourse } = useCollectionMutations();
+
+  const [isOpen, setIsOpen] = useState(false);
+  const [creating, setCreating] = useState(false);
+  const [draftName, setDraftName] = useState("");
+
+  /**
+   * Saves the course when it is not saved yet, then adds it.
+   *
+   * Each step throws a message naming itself, so a caller never blames one for
+   * the other. A save that succeeded before a failed add is said out loud
+   * rather than left as a Save button that appears to have flipped on its own.
+   */
+  const addToCollection = useCallback(
+    async (collectionId: string, collectionName: string) => {
+      if (!isSaved) {
+        try {
+          await setSaved(courseCode, true);
+        } catch {
+          throw new CollectionWriteError(
+            "save",
+            `Could not save ${courseCode}, so it was not added to "${collectionName}".`,
+          );
+        }
+      }
+      try {
+        await addCourse.mutateAsync({ collectionId, courseCode });
+      } catch {
+        throw new CollectionWriteError(
+          "add",
+          isSaved
+            ? `Could not add ${courseCode} to "${collectionName}".`
+            : `Saved ${courseCode}, but could not add it to "${collectionName}".`,
+        );
+      }
+    },
+    [addCourse, courseCode, isSaved, setSaved],
+  );
+
+  const rows: CollectionPickerRow[] = useMemo(
+    () =>
+      (collections ?? []).map((collection) => {
+        const holdsCourse = collection.courseCodes.includes(courseCode);
+        return {
+          id: collection.id,
+          name: collection.name,
+          fill: holdsCourse ? "currentColor" : "none",
+          tick: holdsCourse ? PICKER_TICK : "",
+          onClick: () => {
+            const write = holdsCourse
+              ? removeCourse
+                  .mutateAsync({ collectionId: collection.id, courseCode })
+                  .catch(() => {
+                    throw new CollectionWriteError(
+                      "remove",
+                      `Could not remove ${courseCode} from "${collection.name}".`,
+                    );
+                  })
+              : addToCollection(collection.id, collection.name);
+            write.catch(reportWriteFailure);
+          },
+        };
+      }),
+    [addToCollection, collections, courseCode, removeCourse],
+  );
+
+  /** Abandons the draft: the name typed into a picker that is being closed. */
+  const clearDraft = useCallback(() => {
+    setCreating(false);
+    setDraftName("");
+  }, []);
+
+  /**
+   * Creates a collection and puts the course in it — two writes, reported
+   * apart.
+   *
+   * If a later step fails, saying "could not create" would send the reader back
+   * to the name field, and typing the same name again makes a *second* empty
+   * collection: `collections.create` has no uniqueness on name. So the failure
+   * says the collection was made, and then says which step actually failed,
+   * because that decides whether the recovery on screen can even work.
+   */
+  const onDraftCommit = useCallback(async () => {
+    const name = draftName.trim();
+    clearDraft();
+    if (!name) return;
+
+    let collection: { id: string };
+    try {
+      collection = await create.mutateAsync({ name });
+    } catch {
+      toast.error(`Could not create the collection "${name}".`);
+      return;
+    }
+
+    try {
+      await addToCollection(collection.id, name);
+    } catch (error) {
+      const failedToSave =
+        error instanceof CollectionWriteError && error.step === "save";
+      toast.error(
+        failedToSave
+          ? `Created "${name}", but could not save ${courseCode}, so it is not in the collection yet. Save the course, then pick "${name}" from the list.`
+          : `Created "${name}", but could not add ${courseCode} to it. Pick it from the list to try again.`,
+      );
+    }
+  }, [addToCollection, clearDraft, courseCode, create, draftName]);
+
+  return {
+    rows,
+    isOpen,
+    creating,
+    draftName,
+    toggle: () => {
+      setIsOpen((open) => !open);
+      // Both the name and the row it belongs to go, so reopening the picker
+      // does not offer a half-typed name from the last time it was open.
+      clearDraft();
+    },
+    close: () => {
+      setIsOpen(false);
+      clearDraft();
+    },
+    startNew: () => setCreating(true),
+    onDraftChange: setDraftName,
+    onDraftCommit,
+    onDraftCancel: clearDraft,
+  };
+}

--- a/apps/web/features/courses/hooks/use-course-card.spec.tsx
+++ b/apps/web/features/courses/hooks/use-course-card.spec.tsx
@@ -224,15 +224,77 @@ describe("useCourseCard", () => {
         expect(result.current.c.creating).toBe(false);
       });
 
-      it("says so when a write fails instead of showing a tick that is not there", async () => {
+      // Each write can fail on its own, so the message has to name the step that
+      // actually failed rather than blame the whole gesture.
+      describe("when a write fails", () => {
+        it("does not blame the add for a save that failed", async () => {
+          setSaved.mockRejectedValue(new Error("nope"));
+          const { result } = card();
+          await act(async () => result.current.c.collections[0]?.onClick?.());
+          await waitFor(() =>
+            expect(toastError).toHaveBeenCalledWith(
+              'Could not save DD2380, so it was not added to "Spring P3".',
+            ),
+          );
+          expect(addCourse).not.toHaveBeenCalled();
+        });
+
+        // The save is a real, visible outcome; leaving it unsaid would make the
+        // Save button look like it flipped on its own.
+        it("says the course was saved even though the add failed", async () => {
+          addCourse.mockRejectedValue(new Error("nope"));
+          const { result } = card();
+          await act(async () => result.current.c.collections[0]?.onClick?.());
+          await waitFor(() =>
+            expect(toastError).toHaveBeenCalledWith(
+              'Saved DD2380, but could not add it to "Spring P3".',
+            ),
+          );
+        });
+
+        it("names the collection a removal failed on", async () => {
+          removeCourse.mockRejectedValue(new Error("nope"));
+          const { result } = card();
+          await act(async () => result.current.c.collections[1]?.onClick?.());
+          await waitFor(() =>
+            expect(toastError).toHaveBeenCalledWith(
+              'Could not remove DD2380 from "Maybe".',
+            ),
+          );
+        });
+      });
+
+      // `collections.create` has no uniqueness on name, so sending the reader
+      // back to the name field would make a second empty collection. The
+      // recovery is the row the picker now lists.
+      it("does not call a made collection a failed one when only the add failed", async () => {
         addCourse.mockRejectedValue(new Error("nope"));
         const { result } = card();
-        await act(async () => result.current.c.collections[0]?.onClick?.());
+        act(() => result.current.c.onNewCollection?.());
+        act(() => result.current.onDraftChange("Spring"));
+        await act(async () => result.current.onDraftCommit());
+
+        expect(create).toHaveBeenCalledWith({ name: "Spring" });
         await waitFor(() =>
           expect(toastError).toHaveBeenCalledWith(
-            "Could not add DD2380 to Spring P3.",
+            'Created "Spring", but could not add DD2380 to it. Pick it from the list to try again.',
           ),
         );
+      });
+
+      it("reports a creation that genuinely failed as one", async () => {
+        create.mockRejectedValue(new Error("nope"));
+        const { result } = card();
+        act(() => result.current.c.onNewCollection?.());
+        act(() => result.current.onDraftChange("Spring"));
+        await act(async () => result.current.onDraftCommit());
+
+        await waitFor(() =>
+          expect(toastError).toHaveBeenCalledWith(
+            'Could not create the collection "Spring".',
+          ),
+        );
+        expect(addCourse).not.toHaveBeenCalled();
       });
     });
   });

--- a/apps/web/features/courses/hooks/use-course-card.spec.tsx
+++ b/apps/web/features/courses/hooks/use-course-card.spec.tsx
@@ -103,6 +103,19 @@ describe("useCourseCard", () => {
       expect(onRequestAuth).toHaveBeenCalledWith("sign-up");
       expect(onRequestAuth).toHaveBeenCalledWith("log-in");
     });
+
+    // Otherwise the panel sits behind the dialog and is still open when the
+    // reader dismisses it.
+    it("puts away the panel that asked before the dialog opens", async () => {
+      const { result } = card();
+      await act(async () => result.current.c.onTaken?.());
+      expect(result.current.c.takenPickerOpen).toBe(true);
+
+      await act(async () => result.current.c.onSignUp?.());
+      expect(result.current.c.takenPickerOpen).toBe(false);
+      expect(result.current.c.pickerOpen).toBe(false);
+      expect(onRequestAuth).toHaveBeenCalledWith("sign-up");
+    });
   });
 
   describe("a signed-in viewer", () => {

--- a/apps/web/features/courses/hooks/use-course-card.spec.tsx
+++ b/apps/web/features/courses/hooks/use-course-card.spec.tsx
@@ -267,6 +267,25 @@ describe("useCourseCard", () => {
       // `collections.create` has no uniqueness on name, so sending the reader
       // back to the name field would make a second empty collection. The
       // recovery is the row the picker now lists.
+      // Pointing at the collection's row is only useful if clicking it could
+      // work. A failed save blocks that row too — the service will not let an
+      // unsaved course join a collection — so the advice has to change with it.
+      it("names the save as the blocker when creating, and does not send the reader to a row that cannot work", async () => {
+        setSaved.mockRejectedValue(new Error("nope"));
+        const { result } = card();
+        act(() => result.current.c.onNewCollection?.());
+        act(() => result.current.onDraftChange("Spring"));
+        await act(async () => result.current.onDraftCommit());
+
+        expect(create).toHaveBeenCalledWith({ name: "Spring" });
+        await waitFor(() =>
+          expect(toastError).toHaveBeenCalledWith(
+            'Created "Spring", but could not save DD2380, so it is not in the collection yet. Save the course, then pick "Spring" from the list.',
+          ),
+        );
+        expect(addCourse).not.toHaveBeenCalled();
+      });
+
       it("does not call a made collection a failed one when only the add failed", async () => {
         addCourse.mockRejectedValue(new Error("nope"));
         const { result } = card();

--- a/apps/web/features/courses/hooks/use-course-card.spec.tsx
+++ b/apps/web/features/courses/hooks/use-course-card.spec.tsx
@@ -1,0 +1,239 @@
+import { act, renderHook, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { CourseStats } from "@/types";
+import { useCourseCard } from "./use-course-card";
+
+const useMe = vi.fn();
+const setSaved = vi.fn();
+const takenList = vi.fn();
+const collectionsList = vi.fn();
+const create = vi.fn();
+const addCourse = vi.fn();
+const removeCourse = vi.fn();
+const markTaken = vi.fn();
+const onRequestAuth = vi.fn();
+const toastError = vi.fn();
+
+vi.mock("@/features/auth", () => ({ useMe: () => useMe() }));
+vi.mock("@/features/favorites", () => ({
+  useSetCourseSaved: () => ({ setSaved }),
+}));
+vi.mock("@/features/courses/api/queries", () => ({
+  useCollections: (enabled: boolean) => collectionsList(enabled),
+  useTakenCourses: (enabled: boolean) => takenList(enabled),
+}));
+vi.mock("@/features/courses/api/mutations", () => ({
+  useCollectionMutations: () => ({
+    create: { mutateAsync: create },
+    addCourse: { mutateAsync: addCourse },
+    removeCourse: { mutateAsync: removeCourse },
+  }),
+  useMarkCourseTaken: () => ({ mutateAsync: markTaken }),
+}));
+vi.mock("sonner", () => ({ toast: { error: (m: string) => toastError(m) } }));
+
+const COURSE = {
+  courseCode: "DD2380",
+  titleEng: "Artificial Intelligence",
+  credits: 6,
+  department: "EECS",
+};
+
+const NO_REVIEWS: CourseStats = { reviews: null, takenCount: 0 };
+
+function signedOut() {
+  useMe.mockReturnValue({ user: null });
+}
+
+function signedIn(savedCourseCodes: string[] = []) {
+  useMe.mockReturnValue({ user: { userId: "u1", savedCourseCodes } });
+}
+
+function card(overrides: Record<string, unknown> = {}) {
+  return renderHook(() =>
+    useCourseCard({
+      course: COURSE,
+      stats: NO_REVIEWS,
+      onRequestAuth,
+      ...overrides,
+    }),
+  );
+}
+
+beforeEach(() => {
+  signedOut();
+  takenList.mockReturnValue({ data: undefined });
+  collectionsList.mockReturnValue({ data: undefined });
+  setSaved.mockResolvedValue(undefined);
+  create.mockResolvedValue({ id: "k-new", name: "Spring", courseCodes: [] });
+  addCourse.mockResolvedValue(undefined);
+  removeCourse.mockResolvedValue(undefined);
+  markTaken.mockResolvedValue(undefined);
+});
+
+describe("useCourseCard", () => {
+  describe("a visitor", () => {
+    // Every one of these procedures is protected, so a request would only be
+    // rejected. The prompts hand off to AuthReasonDialog instead.
+    it("asks none of the protected queries", () => {
+      card();
+      expect(takenList).toHaveBeenCalledWith(false);
+      expect(collectionsList).toHaveBeenCalledWith(false);
+    });
+
+    it("is asked to sign in rather than silently failing to save", async () => {
+      const { result } = card();
+      await act(async () => result.current.c.onSave?.());
+      expect(setSaved).not.toHaveBeenCalled();
+      expect(onRequestAuth).toHaveBeenCalledWith("save-course");
+    });
+
+    it("gets the design's inline prompt over the taken pill", async () => {
+      const { result } = card();
+      await act(async () => result.current.c.onTaken?.());
+      expect(markTaken).not.toHaveBeenCalled();
+      expect(result.current.c.takenPickerOpen).toBe(true);
+    });
+
+    // The prompt names the reason; the dialog does the signing in.
+    it("routes both prompt buttons to the one sign-in surface", async () => {
+      const { result } = card();
+      await act(async () => result.current.c.onSignUp?.());
+      await act(async () => result.current.c.onLogIn?.());
+      expect(onRequestAuth).toHaveBeenCalledWith("sign-up");
+      expect(onRequestAuth).toHaveBeenCalledWith("log-in");
+    });
+  });
+
+  describe("a signed-in viewer", () => {
+    beforeEach(() => signedIn());
+
+    it("saves and unsaves through the same course code", async () => {
+      const { result } = card();
+      await act(async () => result.current.c.onSave?.());
+      expect(setSaved).toHaveBeenCalledWith("DD2380", true);
+
+      signedIn(["DD2380"]);
+      const saved = card();
+      await act(async () => saved.result.current.c.onSave?.());
+      expect(setSaved).toHaveBeenLastCalledWith("DD2380", false);
+    });
+
+    it("marks the course taken, and nothing else", async () => {
+      const { result } = card({
+        prerequisites: [
+          { code: "DD1337", name: "Programming", inCatalog: true },
+        ],
+      });
+      await act(async () => result.current.c.onTaken?.());
+      // One write, for this course. A prerequisite is never marked with it.
+      expect(markTaken).toHaveBeenCalledTimes(1);
+      expect(markTaken).toHaveBeenCalledWith({ courseCode: "DD2380" });
+    });
+
+    it("stops offering the pill once the course is marked", () => {
+      takenList.mockReturnValue({ data: [{ courseCode: "DD2380" }] });
+      const { result } = card();
+      expect(result.current.c.onTaken).toBeUndefined();
+    });
+
+    describe("the collections picker", () => {
+      beforeEach(() => {
+        collectionsList.mockReturnValue({
+          data: [
+            { id: "k1", name: "Spring P3", courseCodes: [] },
+            { id: "k2", name: "Maybe", courseCodes: ["DD2380"] },
+          ],
+        });
+      });
+
+      it("ticks only the collections the course is already in", () => {
+        const { result } = card();
+        expect(result.current.c.collections.map((row) => row.tick)).toEqual([
+          "",
+          "m8.5 12 2.4 2.4 4.6-4.9",
+        ]);
+        expect(result.current.c.hasCollections).toBe(true);
+      });
+
+      // A course may only join a collection its owner has also saved, so the
+      // picker saves first rather than letting the service reject the write.
+      it("saves an unsaved course before adding it", async () => {
+        const { result } = card();
+        await act(async () => result.current.c.collections[0]?.onClick?.());
+        expect(setSaved).toHaveBeenCalledWith("DD2380", true);
+        expect(addCourse).toHaveBeenCalledWith({
+          collectionId: "k1",
+          courseCode: "DD2380",
+        });
+      });
+
+      it("does not re-save a course it already holds", async () => {
+        signedIn(["DD2380"]);
+        const { result } = card();
+        await act(async () => result.current.c.collections[0]?.onClick?.());
+        expect(setSaved).not.toHaveBeenCalled();
+        expect(addCourse).toHaveBeenCalledOnce();
+      });
+
+      it("removes the course from a collection that holds it", async () => {
+        const { result } = card();
+        await act(async () => result.current.c.collections[1]?.onClick?.());
+        expect(removeCourse).toHaveBeenCalledWith({
+          collectionId: "k2",
+          courseCode: "DD2380",
+        });
+        expect(addCourse).not.toHaveBeenCalled();
+      });
+
+      it("creates a collection and puts the course straight into it", async () => {
+        const { result } = card();
+        act(() => result.current.c.onPicker?.());
+        act(() => result.current.c.onNewCollection?.());
+        act(() => result.current.onDraftChange("Spring"));
+        expect(result.current.c.creating).toBe(true);
+
+        await act(async () => result.current.onDraftCommit());
+        expect(create).toHaveBeenCalledWith({ name: "Spring" });
+        await waitFor(() =>
+          expect(addCourse).toHaveBeenCalledWith({
+            collectionId: "k-new",
+            courseCode: "DD2380",
+          }),
+        );
+        expect(result.current.c.creating).toBe(false);
+      });
+
+      it("writes nothing for a blank name", async () => {
+        const { result } = card();
+        act(() => result.current.c.onNewCollection?.());
+        act(() => result.current.onDraftChange("   "));
+        await act(async () => result.current.onDraftCommit());
+        expect(create).not.toHaveBeenCalled();
+      });
+
+      // Reopening the picker must not offer a name abandoned last time.
+      it("abandons the draft when the picker closes", () => {
+        const { result } = card();
+        act(() => result.current.c.onPicker?.());
+        act(() => result.current.c.onNewCollection?.());
+        act(() => result.current.onDraftChange("Half typed"));
+        act(() => result.current.c.onPicker?.());
+
+        expect(result.current.draftName).toBe("");
+        expect(result.current.c.creating).toBe(false);
+      });
+
+      it("says so when a write fails instead of showing a tick that is not there", async () => {
+        addCourse.mockRejectedValue(new Error("nope"));
+        const { result } = card();
+        await act(async () => result.current.c.collections[0]?.onClick?.());
+        await waitFor(() =>
+          expect(toastError).toHaveBeenCalledWith(
+            "Could not add DD2380 to Spring P3.",
+          ),
+        );
+      });
+    });
+  });
+});

--- a/apps/web/features/courses/hooks/use-course-card.ts
+++ b/apps/web/features/courses/hooks/use-course-card.ts
@@ -1,0 +1,225 @@
+"use client";
+
+import { useCallback, useMemo, useState } from "react";
+import { toast } from "sonner";
+import { type AuthReason, useMe } from "@/features/auth";
+import {
+  useCollectionMutations,
+  useCollections,
+  useMarkCourseTaken,
+  useTakenCourses,
+} from "@/features/courses/api/mutations";
+import {
+  type CourseCardCourse,
+  type CourseCardView,
+  toCourseCardModel,
+} from "@/features/courses/lib/course-card-model";
+import { useSetCourseSaved } from "@/features/favorites";
+import type {
+  CollectionPickerRow,
+  CourseCardAction,
+  CourseCardModel,
+  CourseStats,
+  PrerequisiteCourse,
+} from "@/types";
+
+/** The checkbox tick the picker draws for a collection the course is already in. */
+const PICKER_TICK = "m8.5 12 2.4 2.4 4.6-4.9";
+
+export type UseCourseCardOptions = {
+  course: CourseCardCourse;
+  /** From `course.stats`, batched for the whole page. `reviews: null` is absent. */
+  stats: CourseStats;
+  action?: CourseCardAction;
+  /** `null` — the only value today — means nobody ever extracted them. */
+  prerequisites?: PrerequisiteCourse[] | null;
+  /** Explore rings the card whose workspace pane is open. */
+  isActive?: boolean;
+  /** Names and enables the remove button. Saved and Collections pass one. */
+  removeLabel?: string;
+  onOpen?: () => void;
+  onReview?: () => void;
+  onRemove?: () => void;
+  /**
+   * Opens the app's one sign-in surface. The card's inline prompts name the
+   * reason; `AuthReasonDialog` does the signing in, and the screen renders a
+   * single one for its whole list.
+   */
+  onRequestAuth: (reason: AuthReason) => void;
+};
+
+/** Exactly the props `CourseCard` needs beyond `geo`. */
+export type CourseCardProps = {
+  c: CourseCardModel;
+  action: CourseCardAction;
+  signedIn: boolean;
+  draftName: string;
+  onDraftChange: (name: string) => void;
+  onDraftCommit: () => void;
+  onDraftCancel: () => void;
+};
+
+/**
+ * Binds one course card to the real procedures.
+ *
+ * This is the seam the pages sit on: a screen fetches its courses and their
+ * stats, calls this per card, and spreads the result. Everything that decides
+ * what the card *says* is in `toCourseCardModel`, which is pure; everything that
+ * decides what a click *does* is here. The card itself does neither.
+ *
+ * The picker's open/closed and draft state is local to one card, so a list can
+ * have many cards without a screen tracking which one is open.
+ */
+export function useCourseCard({
+  course,
+  stats,
+  action = "save",
+  prerequisites = null,
+  isActive,
+  removeLabel,
+  onOpen,
+  onReview,
+  onRemove,
+  onRequestAuth,
+}: UseCourseCardOptions): CourseCardProps {
+  const { user } = useMe();
+  const signedIn = user !== null;
+  const courseCode = course.courseCode;
+
+  const { setSaved } = useSetCourseSaved();
+  const { data: takenCourses } = useTakenCourses(signedIn);
+  const { data: collections } = useCollections(signedIn);
+  const { create, addCourse, removeCourse } = useCollectionMutations();
+  const markTaken = useMarkCourseTaken();
+
+  const [pickerOpen, setPickerOpen] = useState(false);
+  const [takenPickerOpen, setTakenPickerOpen] = useState(false);
+  const [creating, setCreating] = useState(false);
+  const [draftName, setDraftName] = useState("");
+
+  const isSaved = user?.savedCourseCodes.includes(courseCode) ?? false;
+  const isTaken =
+    takenCourses?.some((taken) => taken.courseCode === courseCode) ?? false;
+
+  /**
+   * A course may only join a collection its owner has also saved — the service
+   * rejects it otherwise, and the composite foreign key would too. The artboard
+   * treats the picker as independent of Save, so the minimal fit is for the
+   * picker to save first rather than to fail or to hide itself.
+   */
+  const addToCollection = useCallback(
+    async (collectionId: string) => {
+      if (!isSaved) await setSaved(courseCode, true);
+      await addCourse.mutateAsync({ collectionId, courseCode });
+    },
+    [addCourse, courseCode, isSaved, setSaved],
+  );
+
+  const pickerRows: CollectionPickerRow[] = useMemo(
+    () =>
+      (collections ?? []).map((collection) => {
+        const holdsCourse = collection.courseCodes.includes(courseCode);
+        return {
+          id: collection.id,
+          name: collection.name,
+          fill: holdsCourse ? "currentColor" : "none",
+          tick: holdsCourse ? PICKER_TICK : "",
+          onClick: () => {
+            const write = holdsCourse
+              ? removeCourse.mutateAsync({
+                  collectionId: collection.id,
+                  courseCode,
+                })
+              : addToCollection(collection.id);
+            write.catch(() =>
+              toast.error(
+                holdsCourse
+                  ? `Could not remove ${courseCode} from ${collection.name}.`
+                  : `Could not add ${courseCode} to ${collection.name}.`,
+              ),
+            );
+          },
+        };
+      }),
+    [addToCollection, collections, courseCode, removeCourse],
+  );
+
+  function onSave() {
+    if (!signedIn) {
+      onRequestAuth("save-course");
+      return;
+    }
+    setSaved(courseCode, !isSaved).catch(() =>
+      toast.error(`Could not ${isSaved ? "unsave" : "save"} ${courseCode}.`),
+    );
+  }
+
+  function onTaken() {
+    if (!signedIn) {
+      setPickerOpen(false);
+      setTakenPickerOpen((open) => !open);
+      return;
+    }
+    markTaken
+      .mutateAsync({ courseCode })
+      .catch(() => toast.error(`Could not mark ${courseCode} as taken.`));
+  }
+
+  function onPicker() {
+    setTakenPickerOpen(false);
+    setPickerOpen((open) => !open);
+    setCreating(false);
+  }
+
+  function onDraftCommit() {
+    const name = draftName.trim();
+    setCreating(false);
+    setDraftName("");
+    if (!name) return;
+    create
+      .mutateAsync({ name })
+      .then((collection) => addToCollection(collection.id))
+      .catch(() => toast.error(`Could not create the collection "${name}".`));
+  }
+
+  const view: CourseCardView = {
+    course,
+    stats,
+    isSaved,
+    isTaken,
+    prerequisites,
+    collections: pickerRows,
+    isActive,
+    pickerOpen,
+    creating,
+    takenPickerOpen,
+    removeLabel: onRemove ? (removeLabel ?? `Remove ${courseCode}`) : undefined,
+  };
+
+  return {
+    c: {
+      ...toCourseCardModel(view),
+      onOpen,
+      onReview,
+      onRemove,
+      onSave,
+      // Once a course is marked taken the pill stops being a control: unmarking
+      // would delete the self-reported grade, credits and periods stored beside
+      // it, and that belongs on Taken courses where those values are visible.
+      onTaken: signedIn && isTaken ? undefined : onTaken,
+      onPicker,
+      onNewCollection: () => setCreating(true),
+      onSignUp: () => onRequestAuth("sign-up"),
+      onLogIn: () => onRequestAuth("log-in"),
+    },
+    action,
+    signedIn,
+    draftName,
+    onDraftChange: setDraftName,
+    onDraftCommit,
+    onDraftCancel: () => {
+      setCreating(false);
+      setDraftName("");
+    },
+  };
+}

--- a/apps/web/features/courses/hooks/use-course-card.ts
+++ b/apps/web/features/courses/hooks/use-course-card.ts
@@ -28,6 +28,18 @@ import type {
 /** The checkbox tick the picker draws for a collection the course is already in. */
 const PICKER_TICK = "m8.5 12 2.4 2.4 4.6-4.9";
 
+/**
+ * Surfaces a failed write in the words of the step that failed.
+ *
+ * The picker's writes throw messages rather than codes, because there is
+ * nothing for the card to do with a failure except say what did not happen.
+ */
+function reportWriteFailure(error: unknown) {
+  toast.error(
+    error instanceof Error ? error.message : "That did not go through.",
+  );
+}
+
 export type UseCourseCardOptions = {
   course: CourseCardCourse;
   /** From `course.stats`, batched for the whole page. `reviews: null` is absent. */
@@ -64,13 +76,20 @@ export type CourseCardProps = {
 /**
  * Binds one course card to the real procedures.
  *
- * This is the seam the pages sit on: a screen fetches its courses and their
- * stats, calls this per card, and spreads the result. Everything that decides
- * what the card *says* is in `toCourseCardModel`, which is pure; everything that
- * decides what a click *does* is here. The card itself does neither.
+ * Everything that decides what the card *says* is in `toCourseCardModel`, which
+ * is pure; everything that decides what a click *does* is here. The card itself
+ * does neither.
  *
- * The picker's open/closed and draft state is local to one card, so a list can
- * have many cards without a screen tracking which one is open.
+ * **Call this from a component that renders exactly one card, keyed by course
+ * code — never from a `courses.map(...)` callback in the screen.** It holds
+ * several hooks, so a parent that calls it once per list item binds that state
+ * to a list *position*: reorder the list and the open picker moves to another
+ * course, shorten it and React throws "Rendered fewer hooks than expected".
+ * `CourseCardItem` is that component, and it is what the barrel exports —
+ * screens should render it rather than reach for this hook.
+ *
+ * The picker's open/closed and draft state is local to one card, which is why a
+ * list can have many cards without a screen tracking which one is open.
  */
 export function useCourseCard({
   course,
@@ -108,11 +127,32 @@ export function useCourseCard({
    * rejects it otherwise, and the composite foreign key would too. The artboard
    * treats the picker as independent of Save, so the minimal fit is for the
    * picker to save first rather than to fail or to hide itself.
+   *
+   * These are two writes and either can fail on its own, so each throws a
+   * message naming the step that actually failed. A save that succeeded before
+   * a failed add is said out loud rather than left as a Save button that
+   * silently flipped.
    */
   const addToCollection = useCallback(
-    async (collectionId: string) => {
-      if (!isSaved) await setSaved(courseCode, true);
-      await addCourse.mutateAsync({ collectionId, courseCode });
+    async (collectionId: string, collectionName: string) => {
+      if (!isSaved) {
+        try {
+          await setSaved(courseCode, true);
+        } catch {
+          throw new Error(
+            `Could not save ${courseCode}, so it was not added to "${collectionName}".`,
+          );
+        }
+      }
+      try {
+        await addCourse.mutateAsync({ collectionId, courseCode });
+      } catch {
+        throw new Error(
+          isSaved
+            ? `Could not add ${courseCode} to "${collectionName}".`
+            : `Saved ${courseCode}, but could not add it to "${collectionName}".`,
+        );
+      }
     },
     [addCourse, courseCode, isSaved, setSaved],
   );
@@ -128,18 +168,15 @@ export function useCourseCard({
           tick: holdsCourse ? PICKER_TICK : "",
           onClick: () => {
             const write = holdsCourse
-              ? removeCourse.mutateAsync({
-                  collectionId: collection.id,
-                  courseCode,
-                })
-              : addToCollection(collection.id);
-            write.catch(() =>
-              toast.error(
-                holdsCourse
-                  ? `Could not remove ${courseCode} from ${collection.name}.`
-                  : `Could not add ${courseCode} to ${collection.name}.`,
-              ),
-            );
+              ? removeCourse
+                  .mutateAsync({ collectionId: collection.id, courseCode })
+                  .catch(() => {
+                    throw new Error(
+                      `Could not remove ${courseCode} from "${collection.name}".`,
+                    );
+                  })
+              : addToCollection(collection.id, collection.name);
+            write.catch(reportWriteFailure);
           },
         };
       }),
@@ -181,14 +218,37 @@ export function useCourseCard({
     clearDraft();
   }
 
-  function onDraftCommit() {
+  /**
+   * Creates a collection and puts the course in it — two writes, reported
+   * apart.
+   *
+   * If the add fails after the collection was made, saying "could not create"
+   * would send the reader back to the name field, and typing the same name
+   * again makes a *second* empty collection: `collections.create` has no
+   * uniqueness on name. So the failure names what really happened and points at
+   * the recovery already on screen — the collection now exists, the picker has
+   * refetched, and its row is one click away.
+   */
+  async function onDraftCommit() {
     const name = draftName.trim();
     clearDraft();
     if (!name) return;
-    create
-      .mutateAsync({ name })
-      .then((collection) => addToCollection(collection.id))
-      .catch(() => toast.error(`Could not create the collection "${name}".`));
+
+    let collection: { id: string };
+    try {
+      collection = await create.mutateAsync({ name });
+    } catch {
+      toast.error(`Could not create the collection "${name}".`);
+      return;
+    }
+
+    try {
+      await addToCollection(collection.id, name);
+    } catch {
+      toast.error(
+        `Created "${name}", but could not add ${courseCode} to it. Pick it from the list to try again.`,
+      );
+    }
   }
 
   const view: CourseCardView = {

--- a/apps/web/features/courses/hooks/use-course-card.ts
+++ b/apps/web/features/courses/hooks/use-course-card.ts
@@ -108,7 +108,7 @@ export function useCourseCard({
 
   function onSave() {
     if (!signedIn) {
-      onRequestAuth("save-course");
+      requestAuthFrom("save-course");
       return;
     }
     setSaved(courseCode, !isSaved).catch(() =>
@@ -131,6 +131,13 @@ export function useCourseCard({
   function onPicker() {
     setTakenPickerOpen(false);
     picker.toggle();
+  }
+
+  /** Hands off to the app's one sign-in surface, closing whatever asked. */
+  function requestAuthFrom(reason: AuthReason) {
+    picker.close();
+    setTakenPickerOpen(false);
+    onRequestAuth(reason);
   }
 
   const view: CourseCardView = {
@@ -160,8 +167,11 @@ export function useCourseCard({
       onTaken: signedIn && isTaken ? undefined : onTaken,
       onPicker,
       onNewCollection: picker.startNew,
-      onSignUp: () => onRequestAuth("sign-up"),
-      onLogIn: () => onRequestAuth("log-in"),
+      // The panel that named the reason gets out of the way first, as the
+      // artboard's own `closeAll({ authOpen: true })` does — otherwise it sits
+      // behind the dialog and is still open when the reader dismisses it.
+      onSignUp: () => requestAuthFrom("sign-up"),
+      onLogIn: () => requestAuthFrom("log-in"),
     },
     action,
     signedIn,

--- a/apps/web/features/courses/hooks/use-course-card.ts
+++ b/apps/web/features/courses/hooks/use-course-card.ts
@@ -29,11 +29,26 @@ import type {
 const PICKER_TICK = "m8.5 12 2.4 2.4 4.6-4.9";
 
 /**
- * Surfaces a failed write in the words of the step that failed.
+ * A picker write that failed, carrying which of its steps did.
  *
- * The picker's writes throw messages rather than codes, because there is
- * nothing for the card to do with a failure except say what did not happen.
+ * Putting a course in a collection is up to two writes, and the caller's
+ * recovery advice differs by which one failed: an add that failed can be
+ * retried from the collection's row, but a *save* that failed blocks that row
+ * too, because a course may only join a collection its owner has saved. The
+ * message is written where the failure happens; `step` is what lets a caller
+ * add context without replacing it.
  */
+class CollectionWriteError extends Error {
+  constructor(
+    readonly step: "save" | "add" | "remove",
+    message: string,
+  ) {
+    super(message);
+    this.name = "CollectionWriteError";
+  }
+}
+
+/** Surfaces a failed write in the words of the step that actually failed. */
 function reportWriteFailure(error: unknown) {
   toast.error(
     error instanceof Error ? error.message : "That did not go through.",
@@ -139,7 +154,8 @@ export function useCourseCard({
         try {
           await setSaved(courseCode, true);
         } catch {
-          throw new Error(
+          throw new CollectionWriteError(
+            "save",
             `Could not save ${courseCode}, so it was not added to "${collectionName}".`,
           );
         }
@@ -147,7 +163,8 @@ export function useCourseCard({
       try {
         await addCourse.mutateAsync({ collectionId, courseCode });
       } catch {
-        throw new Error(
+        throw new CollectionWriteError(
+          "add",
           isSaved
             ? `Could not add ${courseCode} to "${collectionName}".`
             : `Saved ${courseCode}, but could not add it to "${collectionName}".`,
@@ -171,7 +188,8 @@ export function useCourseCard({
               ? removeCourse
                   .mutateAsync({ collectionId: collection.id, courseCode })
                   .catch(() => {
-                    throw new Error(
+                    throw new CollectionWriteError(
+                      "remove",
                       `Could not remove ${courseCode} from "${collection.name}".`,
                     );
                   })
@@ -222,12 +240,14 @@ export function useCourseCard({
    * Creates a collection and puts the course in it — two writes, reported
    * apart.
    *
-   * If the add fails after the collection was made, saying "could not create"
-   * would send the reader back to the name field, and typing the same name
-   * again makes a *second* empty collection: `collections.create` has no
-   * uniqueness on name. So the failure names what really happened and points at
-   * the recovery already on screen — the collection now exists, the picker has
-   * refetched, and its row is one click away.
+   * If a later step fails, saying "could not create" would send the reader back
+   * to the name field, and typing the same name again makes a *second* empty
+   * collection: `collections.create` has no uniqueness on name. So the failure
+   * says the collection was made, and then says which step actually failed —
+   * which decides whether the recovery on screen can even work. A failed *add*
+   * retries from the collection's row. A failed *save* blocks that row too,
+   * because a course may only join a collection its owner has saved, so
+   * pointing at it would be sending the reader somewhere that cannot succeed.
    */
   async function onDraftCommit() {
     const name = draftName.trim();
@@ -244,9 +264,13 @@ export function useCourseCard({
 
     try {
       await addToCollection(collection.id, name);
-    } catch {
+    } catch (error) {
+      const failedToSave =
+        error instanceof CollectionWriteError && error.step === "save";
       toast.error(
-        `Created "${name}", but could not add ${courseCode} to it. Pick it from the list to try again.`,
+        failedToSave
+          ? `Created "${name}", but could not save ${courseCode}, so it is not in the collection yet. Save the course, then pick "${name}" from the list.`
+          : `Created "${name}", but could not add ${courseCode} to it. Pick it from the list to try again.`,
       );
     }
   }

--- a/apps/web/features/courses/hooks/use-course-card.ts
+++ b/apps/web/features/courses/hooks/use-course-card.ts
@@ -5,10 +5,12 @@ import { toast } from "sonner";
 import { type AuthReason, useMe } from "@/features/auth";
 import {
   useCollectionMutations,
-  useCollections,
   useMarkCourseTaken,
-  useTakenCourses,
 } from "@/features/courses/api/mutations";
+import {
+  useCollections,
+  useTakenCourses,
+} from "@/features/courses/api/queries";
 import {
   type CourseCardCourse,
   type CourseCardView,
@@ -165,16 +167,23 @@ export function useCourseCard({
       .catch(() => toast.error(`Could not mark ${courseCode} as taken.`));
   }
 
+  /** Abandons the draft: the name typed into a picker that is being closed. */
+  function clearDraft() {
+    setCreating(false);
+    setDraftName("");
+  }
+
   function onPicker() {
     setTakenPickerOpen(false);
     setPickerOpen((open) => !open);
-    setCreating(false);
+    // Both the name and the row it belongs to go, so reopening the picker does
+    // not offer a half-typed name from the last time it was open.
+    clearDraft();
   }
 
   function onDraftCommit() {
     const name = draftName.trim();
-    setCreating(false);
-    setDraftName("");
+    clearDraft();
     if (!name) return;
     create
       .mutateAsync({ name })
@@ -217,9 +226,6 @@ export function useCourseCard({
     draftName,
     onDraftChange: setDraftName,
     onDraftCommit,
-    onDraftCancel: () => {
-      setCreating(false);
-      setDraftName("");
-    },
+    onDraftCancel: clearDraft,
   };
 }

--- a/apps/web/features/courses/hooks/use-course-card.ts
+++ b/apps/web/features/courses/hooks/use-course-card.ts
@@ -1,16 +1,11 @@
 "use client";
 
-import { useCallback, useMemo, useState } from "react";
+import { useState } from "react";
 import { toast } from "sonner";
 import { type AuthReason, useMe } from "@/features/auth";
-import {
-  useCollectionMutations,
-  useMarkCourseTaken,
-} from "@/features/courses/api/mutations";
-import {
-  useCollections,
-  useTakenCourses,
-} from "@/features/courses/api/queries";
+import { useMarkCourseTaken } from "@/features/courses/api/mutations";
+import { useTakenCourses } from "@/features/courses/api/queries";
+import { useCollectionPicker } from "@/features/courses/hooks/use-collection-picker";
 import {
   type CourseCardCourse,
   type CourseCardView,
@@ -18,42 +13,11 @@ import {
 } from "@/features/courses/lib/course-card-model";
 import { useSetCourseSaved } from "@/features/favorites";
 import type {
-  CollectionPickerRow,
   CourseCardAction,
   CourseCardModel,
   CourseStats,
   PrerequisiteCourse,
 } from "@/types";
-
-/** The checkbox tick the picker draws for a collection the course is already in. */
-const PICKER_TICK = "m8.5 12 2.4 2.4 4.6-4.9";
-
-/**
- * A picker write that failed, carrying which of its steps did.
- *
- * Putting a course in a collection is up to two writes, and the caller's
- * recovery advice differs by which one failed: an add that failed can be
- * retried from the collection's row, but a *save* that failed blocks that row
- * too, because a course may only join a collection its owner has saved. The
- * message is written where the failure happens; `step` is what lets a caller
- * add context without replacing it.
- */
-class CollectionWriteError extends Error {
-  constructor(
-    readonly step: "save" | "add" | "remove",
-    message: string,
-  ) {
-    super(message);
-    this.name = "CollectionWriteError";
-  }
-}
-
-/** Surfaces a failed write in the words of the step that actually failed. */
-function reportWriteFailure(error: unknown) {
-  toast.error(
-    error instanceof Error ? error.message : "That did not go through.",
-  );
-}
 
 export type UseCourseCardOptions = {
   course: CourseCardCourse;
@@ -124,82 +88,23 @@ export function useCourseCard({
 
   const { setSaved } = useSetCourseSaved();
   const { data: takenCourses } = useTakenCourses(signedIn);
-  const { data: collections } = useCollections(signedIn);
-  const { create, addCourse, removeCourse } = useCollectionMutations();
   const markTaken = useMarkCourseTaken();
 
-  const [pickerOpen, setPickerOpen] = useState(false);
   const [takenPickerOpen, setTakenPickerOpen] = useState(false);
-  const [creating, setCreating] = useState(false);
-  const [draftName, setDraftName] = useState("");
 
   const isSaved = user?.savedCourseCodes.includes(courseCode) ?? false;
   const isTaken =
     takenCourses?.some((taken) => taken.courseCode === courseCode) ?? false;
 
-  /**
-   * A course may only join a collection its owner has also saved — the service
-   * rejects it otherwise, and the composite foreign key would too. The artboard
-   * treats the picker as independent of Save, so the minimal fit is for the
-   * picker to save first rather than to fail or to hide itself.
-   *
-   * These are two writes and either can fail on its own, so each throws a
-   * message naming the step that actually failed. A save that succeeded before
-   * a failed add is said out loud rather than left as a Save button that
-   * silently flipped.
-   */
-  const addToCollection = useCallback(
-    async (collectionId: string, collectionName: string) => {
-      if (!isSaved) {
-        try {
-          await setSaved(courseCode, true);
-        } catch {
-          throw new CollectionWriteError(
-            "save",
-            `Could not save ${courseCode}, so it was not added to "${collectionName}".`,
-          );
-        }
-      }
-      try {
-        await addCourse.mutateAsync({ collectionId, courseCode });
-      } catch {
-        throw new CollectionWriteError(
-          "add",
-          isSaved
-            ? `Could not add ${courseCode} to "${collectionName}".`
-            : `Saved ${courseCode}, but could not add it to "${collectionName}".`,
-        );
-      }
-    },
-    [addCourse, courseCode, isSaved, setSaved],
-  );
-
-  const pickerRows: CollectionPickerRow[] = useMemo(
-    () =>
-      (collections ?? []).map((collection) => {
-        const holdsCourse = collection.courseCodes.includes(courseCode);
-        return {
-          id: collection.id,
-          name: collection.name,
-          fill: holdsCourse ? "currentColor" : "none",
-          tick: holdsCourse ? PICKER_TICK : "",
-          onClick: () => {
-            const write = holdsCourse
-              ? removeCourse
-                  .mutateAsync({ collectionId: collection.id, courseCode })
-                  .catch(() => {
-                    throw new CollectionWriteError(
-                      "remove",
-                      `Could not remove ${courseCode} from "${collection.name}".`,
-                    );
-                  })
-              : addToCollection(collection.id, collection.name);
-            write.catch(reportWriteFailure);
-          },
-        };
-      }),
-    [addToCollection, collections, courseCode, removeCourse],
-  );
+  // Putting a course in a collection is two writes that can fail apart, and the
+  // panel carries its own open/draft state; that whole concern lives in its own
+  // hook rather than in among the card's two single-call controls.
+  const picker = useCollectionPicker({
+    courseCode,
+    isSaved,
+    signedIn,
+    setSaved,
+  });
 
   function onSave() {
     if (!signedIn) {
@@ -213,7 +118,8 @@ export function useCourseCard({
 
   function onTaken() {
     if (!signedIn) {
-      setPickerOpen(false);
+      // The two panels are mutually exclusive: one card, one popover.
+      picker.close();
       setTakenPickerOpen((open) => !open);
       return;
     }
@@ -222,57 +128,9 @@ export function useCourseCard({
       .catch(() => toast.error(`Could not mark ${courseCode} as taken.`));
   }
 
-  /** Abandons the draft: the name typed into a picker that is being closed. */
-  function clearDraft() {
-    setCreating(false);
-    setDraftName("");
-  }
-
   function onPicker() {
     setTakenPickerOpen(false);
-    setPickerOpen((open) => !open);
-    // Both the name and the row it belongs to go, so reopening the picker does
-    // not offer a half-typed name from the last time it was open.
-    clearDraft();
-  }
-
-  /**
-   * Creates a collection and puts the course in it — two writes, reported
-   * apart.
-   *
-   * If a later step fails, saying "could not create" would send the reader back
-   * to the name field, and typing the same name again makes a *second* empty
-   * collection: `collections.create` has no uniqueness on name. So the failure
-   * says the collection was made, and then says which step actually failed —
-   * which decides whether the recovery on screen can even work. A failed *add*
-   * retries from the collection's row. A failed *save* blocks that row too,
-   * because a course may only join a collection its owner has saved, so
-   * pointing at it would be sending the reader somewhere that cannot succeed.
-   */
-  async function onDraftCommit() {
-    const name = draftName.trim();
-    clearDraft();
-    if (!name) return;
-
-    let collection: { id: string };
-    try {
-      collection = await create.mutateAsync({ name });
-    } catch {
-      toast.error(`Could not create the collection "${name}".`);
-      return;
-    }
-
-    try {
-      await addToCollection(collection.id, name);
-    } catch (error) {
-      const failedToSave =
-        error instanceof CollectionWriteError && error.step === "save";
-      toast.error(
-        failedToSave
-          ? `Created "${name}", but could not save ${courseCode}, so it is not in the collection yet. Save the course, then pick "${name}" from the list.`
-          : `Created "${name}", but could not add ${courseCode} to it. Pick it from the list to try again.`,
-      );
-    }
+    picker.toggle();
   }
 
   const view: CourseCardView = {
@@ -281,10 +139,10 @@ export function useCourseCard({
     isSaved,
     isTaken,
     prerequisites,
-    collections: pickerRows,
+    collections: picker.rows,
     isActive,
-    pickerOpen,
-    creating,
+    pickerOpen: picker.isOpen,
+    creating: picker.creating,
     takenPickerOpen,
     removeLabel: onRemove ? (removeLabel ?? `Remove ${courseCode}`) : undefined,
   };
@@ -301,15 +159,15 @@ export function useCourseCard({
       // it, and that belongs on Taken courses where those values are visible.
       onTaken: signedIn && isTaken ? undefined : onTaken,
       onPicker,
-      onNewCollection: () => setCreating(true),
+      onNewCollection: picker.startNew,
       onSignUp: () => onRequestAuth("sign-up"),
       onLogIn: () => onRequestAuth("log-in"),
     },
     action,
     signedIn,
-    draftName,
-    onDraftChange: setDraftName,
-    onDraftCommit,
-    onDraftCancel: clearDraft,
+    draftName: picker.draftName,
+    onDraftChange: picker.onDraftChange,
+    onDraftCommit: picker.onDraftCommit,
+    onDraftCancel: picker.onDraftCancel,
   };
 }

--- a/apps/web/features/courses/index.ts
+++ b/apps/web/features/courses/index.ts
@@ -1,23 +1,33 @@
-export { useCollectionMutations, useMarkCourseTaken } from "./api/mutations";
-export {
-  useCollections,
-  useCourseDetails,
-  useCourseSummaries,
-  useTakenCourses,
-} from "./api/queries";
+/**
+ * The cross-feature API of the courses feature.
+ *
+ * What Explore (#89), Saved (#90) and Collections (#91) need in order to render
+ * a course card, and nothing else. The card's mapper, its formatting helpers
+ * and the tRPC hooks behind the picker are all reachable through
+ * `CourseCardItem`, so they stay inside the feature — a barrel that exports its
+ * own internals turns each of them into a promise to three other pages.
+ */
+
+export { useCourseDetails, useCourseSummaries } from "./api/queries";
+/** The presentational card: takes a model, and measures nothing. */
 export { CourseCard } from "./components/course-card";
-// The binding a screen should render. `useCourseCard` is deliberately not
-// exported: it holds several hooks, so it has to be called from a component
-// that renders one card, and this is that component.
+/**
+ * What a screen renders, keyed by course code.
+ *
+ * `useCourseCard` is deliberately not exported. It holds several hooks, so it
+ * has to be called from a component that renders exactly one card, and this is
+ * that component.
+ */
 export { CourseCardItem } from "./components/course-card-item";
 export { CourseCardWithCharts } from "./components/course-card-with-charts";
 export { CourseDetailsSidebar } from "./components/course-details-sidebar";
 export { CourseItemSkeleton } from "./components/course-item-skeleton";
 export { CoursePageSkeleton } from "./components/course-page-skeleton";
-export type {
-  CourseCardProps,
-  UseCourseCardOptions,
-} from "./hooks/use-course-card";
+export type { UseCourseCardOptions } from "./hooks/use-course-card";
+/**
+ * The collapse ramp. The parent owns it: Explore interpolates from its results
+ * column, Saved and Collections pin an end.
+ */
 export {
   CARD_RAMP_CEILING,
   CARD_RAMP_FLOOR,
@@ -25,11 +35,4 @@ export {
   courseCardGeometry,
   EXPANDED_CARD_GEOMETRY,
 } from "./lib/card-geometry";
-export {
-  type CourseCardCourse,
-  type CourseCardView,
-  formatCount,
-  formatCourseMeta,
-  keywordChips,
-  toCourseCardModel,
-} from "./lib/course-card-model";
+export type { CourseCardCourse } from "./lib/course-card-model";

--- a/apps/web/features/courses/index.ts
+++ b/apps/web/features/courses/index.ts
@@ -6,14 +6,17 @@ export {
   useTakenCourses,
 } from "./api/queries";
 export { CourseCard } from "./components/course-card";
+// The binding a screen should render. `useCourseCard` is deliberately not
+// exported: it holds several hooks, so it has to be called from a component
+// that renders one card, and this is that component.
+export { CourseCardItem } from "./components/course-card-item";
 export { CourseCardWithCharts } from "./components/course-card-with-charts";
 export { CourseDetailsSidebar } from "./components/course-details-sidebar";
 export { CourseItemSkeleton } from "./components/course-item-skeleton";
 export { CoursePageSkeleton } from "./components/course-page-skeleton";
-export {
-  type CourseCardProps,
-  type UseCourseCardOptions,
-  useCourseCard,
+export type {
+  CourseCardProps,
+  UseCourseCardOptions,
 } from "./hooks/use-course-card";
 export {
   CARD_RAMP_CEILING,

--- a/apps/web/features/courses/index.ts
+++ b/apps/web/features/courses/index.ts
@@ -1,5 +1,32 @@
+export {
+  useCollectionMutations,
+  useCollections,
+  useMarkCourseTaken,
+  useTakenCourses,
+} from "./api/mutations";
 export { useCourseDetails, useCourseSummaries } from "./api/queries";
+export { CourseCard } from "./components/course-card";
 export { CourseCardWithCharts } from "./components/course-card-with-charts";
 export { CourseDetailsSidebar } from "./components/course-details-sidebar";
 export { CourseItemSkeleton } from "./components/course-item-skeleton";
 export { CoursePageSkeleton } from "./components/course-page-skeleton";
+export {
+  type CourseCardProps,
+  type UseCourseCardOptions,
+  useCourseCard,
+} from "./hooks/use-course-card";
+export {
+  CARD_RAMP_CEILING,
+  CARD_RAMP_FLOOR,
+  COLLAPSED_CARD_GEOMETRY,
+  courseCardGeometry,
+  EXPANDED_CARD_GEOMETRY,
+} from "./lib/card-geometry";
+export {
+  type CourseCardCourse,
+  type CourseCardView,
+  formatCount,
+  formatCourseMeta,
+  keywordChips,
+  toCourseCardModel,
+} from "./lib/course-card-model";

--- a/apps/web/features/courses/index.ts
+++ b/apps/web/features/courses/index.ts
@@ -1,10 +1,10 @@
+export { useCollectionMutations, useMarkCourseTaken } from "./api/mutations";
 export {
-  useCollectionMutations,
   useCollections,
-  useMarkCourseTaken,
+  useCourseDetails,
+  useCourseSummaries,
   useTakenCourses,
-} from "./api/mutations";
-export { useCourseDetails, useCourseSummaries } from "./api/queries";
+} from "./api/queries";
 export { CourseCard } from "./components/course-card";
 export { CourseCardWithCharts } from "./components/course-card-with-charts";
 export { CourseDetailsSidebar } from "./components/course-details-sidebar";

--- a/apps/web/features/courses/lib/card-geometry.spec.ts
+++ b/apps/web/features/courses/lib/card-geometry.spec.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it } from "vitest";
+import { SAMPLE_GEO } from "@/data/course-card-sample";
+import {
+  CARD_RAMP_CEILING,
+  CARD_RAMP_FLOOR,
+  COLLAPSED_CARD_GEOMETRY,
+  courseCardGeometry,
+  EXPANDED_CARD_GEOMETRY,
+} from "./card-geometry";
+
+describe("courseCardGeometry", () => {
+  // The whole point of the ramp is that its top end is the artboard. If this
+  // drifts, every card in the app is drawn to a geometry the design never had.
+  it("lands on the artboard's own geometry at full width", () => {
+    expect(
+      courseCardGeometry(Number.POSITIVE_INFINITY, { animated: false }),
+    ).toEqual(SAMPLE_GEO);
+  });
+
+  it("is fully expanded once the column reaches the ceiling", () => {
+    expect(courseCardGeometry(CARD_RAMP_CEILING)).toEqual(
+      EXPANDED_CARD_GEOMETRY,
+    );
+  });
+
+  it("crops to the same floor for any width below it", () => {
+    expect(courseCardGeometry(120)).toEqual(COLLAPSED_CARD_GEOMETRY);
+    expect(courseCardGeometry(CARD_RAMP_FLOOR)).toEqual(
+      COLLAPSED_CARD_GEOMETRY,
+    );
+  });
+
+  it("drops the labels and the summary at the floor", () => {
+    expect(COLLAPSED_CARD_GEOMETRY.showLabel).toBe(false);
+    expect(COLLAPSED_CARD_GEOMETRY.summaryMax).toBe("0px");
+    expect(COLLAPSED_CARD_GEOMETRY.summaryOpacity).toBe(0);
+    // Icon-only buttons, so the row still fits what is left of the column.
+    expect(COLLAPSED_CARD_GEOMETRY.reviewFlex).toBe("0 0 34px");
+    expect(COLLAPSED_CARD_GEOMETRY.saveFlex).toBe("0 0 68px");
+  });
+
+  it("narrows the rail as the column does, without ever jumping", () => {
+    const midway = courseCardGeometry(CARD_RAMP_FLOOR + 85);
+    expect(midway.railW).toBe("179px");
+    expect(Number.parseFloat(midway.titleSize)).toBeGreaterThan(15.5);
+    expect(Number.parseFloat(midway.titleSize)).toBeLessThan(17);
+  });
+
+  // Whole 19px line boxes only: half a line of text sliced across its x-height
+  // reads as a rendering bug rather than as a clipped summary.
+  it("gives the summary whole lines or none", () => {
+    expect(courseCardGeometry(CARD_RAMP_FLOOR + 40).summaryMax).toBe("0px");
+    expect(courseCardGeometry(CARD_RAMP_FLOOR + 80).summaryMax).toBe("19px");
+    expect(courseCardGeometry(CARD_RAMP_FLOOR + 120).summaryMax).toBe("38px");
+  });
+
+  it("stops transitions while the ramp is being dragged", () => {
+    expect(courseCardGeometry(600, { animated: false }).tween).toBe("none");
+    expect(courseCardGeometry(600).tween).toContain("ease-out");
+  });
+});

--- a/apps/web/features/courses/lib/card-geometry.ts
+++ b/apps/web/features/courses/lib/card-geometry.ts
@@ -1,0 +1,122 @@
+/**
+ * The course card's collapse ramp.
+ *
+ * The card never measures anything. Its parent hands it one `geo` object, which
+ * is what lets Explore interpolate the whole card from its results column as a
+ * workspace pane is dragged open, while Saved and Collections simply pin an end
+ * of the ramp. That split is the reason the card is one component and not two.
+ *
+ * Every number here is the artboard's:
+ * `docs/design/Course Community - Explore.dc.html` computes exactly this ramp,
+ * and at full width it lands on the `SAMPLE_GEO` literal in
+ * `docs/design/Course Community - Course Card.dc.html`, which the fixture
+ * mirrors — `card-geometry.spec.ts` holds those two together.
+ */
+
+import type { CardGeometry } from "@/types";
+
+/** Below this the results column has stopped giving; the card is fully cropped. */
+export const CARD_RAMP_FLOOR = 470;
+
+/** The span over which the card grows back to full size. */
+const CARD_RAMP_SPAN = 170;
+
+/** At and above this width nothing is collapsed. */
+export const CARD_RAMP_CEILING = CARD_RAMP_FLOOR + CARD_RAMP_SPAN;
+
+/**
+ * The action buttons hold their labels until the column is genuinely tight, so
+ * they give way over the last stretch of the ramp rather than all the way down
+ * it.
+ */
+const LATE_RAMP_END = 0.22;
+
+/** One 19px line box of summary. Partial lines are never sliced. */
+const SUMMARY_LINE_HEIGHT = 19;
+
+/** Two lines of summary need this much of the ramp; one line needs the lower. */
+const TWO_SUMMARY_LINES_FROM = 0.62;
+const ONE_SUMMARY_LINE_FROM = 0.38;
+
+/**
+ * Below this the label is clipped rather than shortened, so the button drops it
+ * and shows its icon alone.
+ */
+const LABEL_SURVIVES_ABOVE = 0.02;
+
+/** What every geometry-driven property animates over as the ramp moves. */
+export const CARD_TWEEN =
+  "padding .18s ease-out, width .18s ease-out, gap .18s ease-out, max-height .18s ease-out, max-width .18s ease-out, opacity .14s ease-out, font-size .18s ease-out";
+
+function clamp01(value: number): number {
+  if (Number.isNaN(value)) return 0;
+  return Math.min(1, Math.max(0, value));
+}
+
+/** Interpolates one pixel metric, rounded to a tenth so styles stay stable. */
+function px(from: number, to: number, k: number): string {
+  return `${Math.round((from + (to - from) * k) * 10) / 10}px`;
+}
+
+export type CardGeometryOptions = {
+  /**
+   * `false` while the reader is dragging the ramp: transitions chasing a value
+   * that changes every frame lag behind the pointer instead of smoothing it.
+   */
+  animated?: boolean;
+};
+
+/**
+ * The card's geometry at a given available width.
+ *
+ * `Infinity` — a column with nothing competing for it — is the fully expanded
+ * end, and any width at or below {@link CARD_RAMP_FLOOR} is the fully collapsed
+ * one. Everything between lerps, so no property of the card is ever binary
+ * except the two that cannot be: whether a button keeps its label, and how many
+ * whole lines of summary fit.
+ */
+export function courseCardGeometry(
+  availableWidth: number,
+  options: CardGeometryOptions = {},
+): CardGeometry {
+  const t = Number.isFinite(availableWidth)
+    ? clamp01((availableWidth - CARD_RAMP_FLOOR) / CARD_RAMP_SPAN)
+    : 1;
+  const late = clamp01(t / LATE_RAMP_END);
+
+  const summaryLines =
+    t >= TWO_SUMMARY_LINES_FROM ? 2 : t >= ONE_SUMMARY_LINE_FROM ? 1 : 0;
+  const showLabel = t > LABEL_SURVIVES_ABOVE;
+
+  return {
+    tween: options.animated === false ? "none" : CARD_TWEEN,
+    titleSize: px(15.5, 17, t),
+    cardGap: px(8, 10, t),
+    cardPad: px(14, 18, t),
+    factsGap: px(10, 14, t),
+    reviewPad: `0 ${px(10, 12, late)}`,
+    labelMax: px(0, 120, late),
+    labelOpacity: late,
+    saveW: px(96, 126, late),
+    savePad: px(10, 12, late),
+    railW: px(134, 224, t),
+    railPad: `${px(14, 18, t)} ${px(12, 16, t)}`,
+    summaryMax: `${summaryLines * SUMMARY_LINE_HEIGHT}px`,
+    summaryOpacity: summaryLines === 0 ? 0 : 1,
+    reviewFlex: showLabel ? "0 1 132px" : "0 0 34px",
+    saveFlex: showLabel ? "0 1 158px" : "0 0 68px",
+    showLabel,
+    cardHeight: "236px",
+  };
+}
+
+/**
+ * The card at full width. What Saved and Collections render, since their lists
+ * have no pane to yield to.
+ */
+export const EXPANDED_CARD_GEOMETRY = courseCardGeometry(
+  Number.POSITIVE_INFINITY,
+);
+
+/** The card at its floor: no labels, no summary, the narrowest rail. */
+export const COLLAPSED_CARD_GEOMETRY = courseCardGeometry(CARD_RAMP_FLOOR);

--- a/apps/web/features/courses/lib/card-geometry.ts
+++ b/apps/web/features/courses/lib/card-geometry.ts
@@ -94,6 +94,10 @@ export function courseCardGeometry(
     cardGap: px(8, 10, t),
     cardPad: px(14, 18, t),
     factsGap: px(10, 14, t),
+    // The Explore artboard interpolates this to 13px, its own `SAMPLE_GEO` to
+    // 12px. The Course Card artboard is the authority for the card's own
+    // geometry, so the ramp lands where its fixture does — and the card's markup
+    // fixes this padding anyway, so nothing reads it.
     reviewPad: `0 ${px(10, 12, late)}`,
     labelMax: px(0, 120, late),
     labelOpacity: late,
@@ -111,8 +115,14 @@ export function courseCardGeometry(
 }
 
 /**
- * The card at full width. What Saved and Collections render, since their lists
- * have no pane to yield to.
+ * The card at full width: the top of the ramp, and what a list with no pane to
+ * yield to starts from.
+ *
+ * Saved's own artboard passes a fully expanded geometry with a taller
+ * `summaryMax` (57px, three lines) than this ramp ever reaches, which #68's body
+ * — saying Saved pins the *collapsed* end — also disagrees with. Both ends are
+ * exported so #90 can settle that against its own artboard; nothing here
+ * forecloses either.
  */
 export const EXPANDED_CARD_GEOMETRY = courseCardGeometry(
   Number.POSITIVE_INFINITY,

--- a/apps/web/features/courses/lib/course-card-model.spec.ts
+++ b/apps/web/features/courses/lib/course-card-model.spec.ts
@@ -1,0 +1,240 @@
+import { describe, expect, it } from "vitest";
+import type { CourseReviewStats, CourseStats } from "@/types";
+import {
+  type CourseCardCourse,
+  type CourseCardView,
+  formatCount,
+  formatCourseMeta,
+  keywordChips,
+  toCourseCardModel,
+} from "./course-card-model";
+
+const COURSE: CourseCardCourse = {
+  courseCode: "DD2380",
+  titleEng: "Artificial Intelligence",
+  credits: 6,
+  department: "EECS",
+  educationalLevel: "Advanced",
+};
+
+const REVIEWS: CourseReviewStats = {
+  reviewCount: 148,
+  happyCount: 129,
+  happyPercent: 87,
+  workloadMean: 7.6,
+  learningMean: 8.4,
+  approachTheoryPercent: 60,
+  approachTheoryAnswerCount: 100,
+  examinationDistribution: null,
+  examinationAnswerCount: 90,
+  examLabel: "Labs 60% · Exam 40%",
+};
+
+function view(overrides: Partial<CourseCardView> = {}): CourseCardView {
+  return {
+    course: COURSE,
+    stats: { reviews: REVIEWS, takenCount: 1200 },
+    isSaved: false,
+    isTaken: false,
+    ...overrides,
+  };
+}
+
+const NO_REVIEWS: CourseStats = { reviews: null, takenCount: 0 };
+
+describe("toCourseCardModel", () => {
+  it("names the course the way the artboard does", () => {
+    const c = toCourseCardModel(view());
+    expect(c.title).toBe("DD2380 Artificial Intelligence");
+    expect(c.meta).toBe("6.0 credits · EECS · Advanced");
+  });
+
+  // Scores are stored 1-10 and shown raw: 7.6 is 7.6, never 3.8. The bar is
+  // that number over ten, which is the width the artboard already drew.
+  it("shows 1-10 scores raw and fills the bar with value over ten", () => {
+    const c = toCourseCardModel(view());
+    expect(c.workload).toBe("7.6");
+    expect(c.learning).toBe("8.4");
+    expect(c.wlW).toBe("76%");
+    expect(c.leW).toBe("84%");
+  });
+
+  describe("a course nobody has reviewed", () => {
+    // `reviews` is empty today, so this is the state the app actually renders.
+    it("is absent rather than zero everywhere it shows", () => {
+      const c = toCourseCardModel(view({ stats: NO_REVIEWS }));
+
+      expect(c.noReviewStats).toBe(true);
+      expect(c.hasReviewStats).toBe(false);
+      expect(c.noStats).toBe(true);
+      expect(c.hasStats).toBe(false);
+
+      // The three places a zero would have been a lie.
+      expect(c.happyPct).not.toBe("0%");
+      expect(c.workload).toBe("—");
+      expect(c.learning).toBe("—");
+    });
+
+    it("still reports a genuine taken count of zero", () => {
+      const c = toCourseCardModel(view({ stats: NO_REVIEWS }));
+      expect(c.statTaken).toBe("0");
+      expect(c.statReviews).toBe("0");
+    });
+  });
+
+  // Reviewed, but nobody remembered how the course was examined. Saying "No
+  // reviews yet" there would be as wrong as saying 0% happy for an unreviewed
+  // one, so both flags are false and the pill simply does not render.
+  it("keeps a missing examination split distinct from having no reviews", () => {
+    const c = toCourseCardModel(
+      view({
+        stats: {
+          reviews: { ...REVIEWS, examLabel: null },
+          takenCount: 12,
+        },
+      }),
+    );
+    expect(c.hasStats).toBe(false);
+    expect(c.noStats).toBe(false);
+    expect(c.examLabel).toBe("");
+    expect(c.hasReviewStats).toBe(true);
+  });
+
+  describe("prerequisites", () => {
+    // `course_prerequisites` is a real table that nothing writes, so "None
+    // listed" would assert a fact we never established.
+    it("renders neither chips nor 'None listed' when none were extracted", () => {
+      const c = toCourseCardModel(view({ prerequisites: null }));
+      expect(c.hasPrereq).toBe(false);
+      expect(c.noPrereq).toBe(false);
+      expect(c.prereqCourses).toEqual([]);
+    });
+
+    it("says 'None listed' only when extraction found none", () => {
+      const c = toCourseCardModel(view({ prerequisites: [] }));
+      expect(c.noPrereq).toBe(true);
+      expect(c.hasPrereq).toBe(false);
+    });
+
+    it("pills a prerequisite the viewer has separately marked taken", () => {
+      const c = toCourseCardModel(
+        view({
+          prerequisites: [
+            {
+              code: "DD1337",
+              name: "Programming",
+              inCatalog: true,
+              taken: true,
+            },
+            { code: "SF1918", name: "Statistics", inCatalog: true },
+          ],
+        }),
+      );
+      expect(c.prereq).toBe("DD1337, SF1918");
+      expect(c.prereqCourses[0]?.radius).toBe("999px");
+      expect(c.prereqCourses[1]?.radius).toBe("6px");
+      // The tick is display-only; nothing here marks the prerequisite taken.
+      expect(c.prereqCourses[1]?.taken).toBeUndefined();
+    });
+  });
+
+  // The artboard's "students" came from real KTH enrolment in the design's mock
+  // store. `user_taken_courses` counts app users who marked it themselves.
+  describe("the taken pill's tooltip", () => {
+    it("says members, never students", () => {
+      const c = toCourseCardModel(view());
+      expect(c.takenTitle).toContain("1.2k members have taken this course");
+      expect(c.takenTitle).not.toContain("students");
+    });
+
+    it("does not claim a count when there is none", () => {
+      const c = toCourseCardModel(view({ stats: NO_REVIEWS }));
+      expect(c.takenTitle).toBe(
+        "No members have marked this course as taken · click to mark as taken",
+      );
+    });
+
+    it("agrees with itself for a single member", () => {
+      const c = toCourseCardModel(
+        view({ stats: { reviews: null, takenCount: 1 } }),
+      );
+      expect(c.takenTitle).toContain("1 member has taken this course");
+    });
+  });
+
+  it("reflects the viewer's own saved and taken state", () => {
+    const c = toCourseCardModel(view({ isSaved: true, isTaken: true }));
+    expect(c.saveLabel).toBe("Saved");
+    expect(c.saveBorder).toBe("var(--cc-brand)");
+    expect(c.takenCountFg).toBe("var(--cc-brand)");
+  });
+
+  // Styling goes through the palette so light and dark both work; the model
+  // carries the per-card values the tokens cannot express as one class.
+  it("carries tokens rather than raw colours", () => {
+    const c = toCourseCardModel(view());
+    for (const colour of [
+      c.borderColor,
+      c.takenCountFg,
+      c.saveFg,
+      c.saveBorder,
+    ]) {
+      expect(colour).toMatch(/^var\(--cc-|^transparent$|^currentColor$|^none$/);
+    }
+  });
+
+  // Both have their header drawn over an empty section: keywords have no column
+  // at all, and the summary would otherwise repeat KOPPS boilerplate on every
+  // card in a grid. #73 fills them.
+  it("leaves keywords and the summary empty", () => {
+    const c = toCourseCardModel(view());
+    expect(c.keywords).toBe("");
+    expect(c.summary).toBe("");
+    expect(c.summaryClipped).toBe("");
+  });
+
+  it("only enables the remove button when a screen names it", () => {
+    expect(toCourseCardModel(view()).removeLabel).toBeUndefined();
+    expect(
+      toCourseCardModel(view({ removeLabel: "Remove from Saved" })).removeLabel,
+    ).toBe("Remove from Saved");
+  });
+});
+
+describe("formatCourseMeta", () => {
+  it("drops what the course does not have rather than leaving separators", () => {
+    expect(
+      formatCourseMeta({
+        courseCode: "SF1918",
+        titleEng: "Statistics",
+        credits: null,
+        department: "SCI",
+      }),
+    ).toBe("SCI");
+  });
+});
+
+describe("formatCount", () => {
+  it("abbreviates only once the pill would overflow", () => {
+    expect(formatCount(0)).toBe("0");
+    expect(formatCount(940)).toBe("940");
+    expect(formatCount(1000)).toBe("1k");
+    expect(formatCount(1200)).toBe("1.2k");
+    expect(formatCount(2450)).toBe("2.5k");
+    expect(formatCount(24_000)).toBe("24k");
+  });
+});
+
+describe("keywordChips", () => {
+  it("counts what will not fit on the single row", () => {
+    expect(keywordChips("search, planning, agents, logic")).toEqual([
+      { label: "search", flex: "0 1 auto" },
+      { label: "planning", flex: "0 1 auto" },
+      { label: "+2", flex: "none" },
+    ]);
+  });
+
+  it("has nothing to draw while keywords are unbacked", () => {
+    expect(keywordChips("")).toEqual([]);
+  });
+});

--- a/apps/web/features/courses/lib/course-card-model.ts
+++ b/apps/web/features/courses/lib/course-card-model.ts
@@ -237,7 +237,11 @@ export function toCourseCardModel(view: CourseCardView): CourseCardModel {
     collections,
 
     takenPickerOpen: view.takenPickerOpen ?? false,
-    addLabel: "Add to collections",
+    // Reader-facing copy follows the design, which calls this "Add to
+    // comparison"; the identifier behind it is a collection either way
+    // (`CONTEXT.md`, "How to read it"). The card renders this string *and* uses
+    // it as the accessible name, so the two cannot drift apart.
+    addLabel: "Add to comparison",
     removeLabel: view.removeLabel,
   };
 }

--- a/apps/web/features/courses/lib/course-card-model.ts
+++ b/apps/web/features/courses/lib/course-card-model.ts
@@ -1,0 +1,243 @@
+/**
+ * The one place tRPC output becomes what the course card renders.
+ *
+ * Every screen that shows a card — Explore, Saved, Collections — maps through
+ * here, so when the aggregation behind `course.stats` changes, one function
+ * changes and no card does. Nothing in this file touches React or the network:
+ * it is pure, which is why it is tested in the `logic` project rather than
+ * through a render.
+ *
+ * ## The rules it exists to keep
+ *
+ * - **Absent is not zero.** `stats.reviews === null` means nobody has reviewed
+ *   the course. It renders "No reviews yet", never 0% happy. `reviews` is empty
+ *   today, so this is the common case rather than an edge one.
+ * - **Scores are 1-10, shown raw.** A 7.6 mean renders `"7.6"` and fills 76% of
+ *   its bar. Nothing converts to a five-point scale (#68).
+ * - **`hasX` / `noX` are not complements.** Both false is a real third state:
+ *   prerequisites nobody ever extracted, or a reviewed course whose reviewers
+ *   did not remember the examination split.
+ */
+
+import type {
+  CollectionPickerRow,
+  CourseCardModel,
+  CourseStats,
+  PrerequisiteCourse,
+} from "@/types";
+
+/** Chips shown before the row overflows into a `+n` counter. */
+const KEYWORD_CHIPS_SHOWN = 2;
+
+/** Counts at or above this are abbreviated to thousands. */
+const ABBREVIATE_FROM = 1000;
+
+/** Above this many thousands the decimal stops earning its place. */
+const DECIMAL_K_BELOW = 10_000;
+
+/** The course facts the card names in its title and its meta line. */
+export type CourseCardCourse = {
+  courseCode: string;
+  titleEng: string;
+  credits: number | null;
+  department: string | null;
+  /** KOPPS's level word, e.g. `"Advanced"`. Only `course.details` carries it. */
+  educationalLevel?: string | null;
+};
+
+/** Everything the card's display half is derived from. */
+export type CourseCardView = {
+  course: CourseCardCourse;
+  stats: CourseStats;
+  /** Whether the viewer has saved this course. */
+  isSaved: boolean;
+  /** Whether the viewer has marked this course taken. */
+  isTaken: boolean;
+  /**
+   * `null` means prerequisites were never extracted, which is every course
+   * today: `course_prerequisites` is a real table that nothing in `server/`
+   * writes. `[]` means they were extracted and the course genuinely has none.
+   * The two render differently, because "None listed" over an empty table
+   * asserts something false (#68).
+   */
+  prerequisites?: PrerequisiteCourse[] | null;
+  /** The picker's rows, already bound to their collections. */
+  collections?: CollectionPickerRow[];
+  /** Explore rings the card whose workspace pane is open. */
+  isActive?: boolean;
+  pickerOpen?: boolean;
+  creating?: boolean;
+  takenPickerOpen?: boolean;
+  /** Enables the remove button, and names it. Collections and Saved pass one. */
+  removeLabel?: string;
+};
+
+/**
+ * The keyword row is exactly one 20px line, so a second row would be clipped
+ * through the middle of its glyphs. Two chips fit; whatever else there is gets
+ * counted instead of half-drawn.
+ */
+export function keywordChips(
+  raw: string,
+): Array<{ label: string; flex: string }> {
+  const all = raw
+    .split(",")
+    .map((term) => term.trim())
+    .filter(Boolean);
+
+  const shown = all
+    .slice(0, KEYWORD_CHIPS_SHOWN)
+    .map((label) => ({ label, flex: "0 1 auto" }));
+
+  if (all.length > KEYWORD_CHIPS_SHOWN) {
+    shown.push({
+      label: `+${all.length - KEYWORD_CHIPS_SHOWN}`,
+      flex: "none",
+    });
+  }
+  return shown;
+}
+
+/**
+ * Counts as the 26px taken pill can hold them: `"940"`, `"1.2k"`, `"24k"`.
+ */
+export function formatCount(count: number): string {
+  if (count < ABBREVIATE_FROM) return String(count);
+  if (count < DECIMAL_K_BELOW) {
+    return `${(Math.round(count / 100) / 10).toFixed(1).replace(/\.0$/, "")}k`;
+  }
+  return `${Math.round(count / 1000)}k`;
+}
+
+/** `"6.0 credits · EECS · Advanced"`, minus whatever the course does not have. */
+export function formatCourseMeta(course: CourseCardCourse): string {
+  return [
+    course.credits === null ? null : `${course.credits.toFixed(1)} credits`,
+    course.department,
+    course.educationalLevel,
+  ]
+    .filter((part): part is string => Boolean(part))
+    .join(" · ");
+}
+
+/**
+ * A 1-10 mean as a bar width. 7.6 fills 76%, which is the width the artboard
+ * draws for the same bar — the scale changed, the geometry did not.
+ */
+function barWidth(mean: number): string {
+  const percent = Math.min(100, Math.max(0, Math.round(mean * 100) / 10));
+  return `${percent}%`;
+}
+
+/**
+ * The taken pill's tooltip.
+ *
+ * The artboard says "students", sourced from real KTH enrolment in the design's
+ * mock store. The schema has no such figure: `user_taken_courses` counts app
+ * users who marked the course themselves, a smaller and different population.
+ * The number is real, the sentence was not, so the copy is what changed (#68).
+ */
+function takenTitle(takenCount: number, isTaken: boolean): string {
+  const suffix = isTaken ? "you marked it as taken" : "click to mark as taken";
+
+  if (takenCount === 0) {
+    return `No members have marked this course as taken · ${suffix}`;
+  }
+  const members =
+    takenCount === 1
+      ? "1 member has taken this course"
+      : `${formatCount(takenCount)} members have taken this course`;
+  return `${members} · ${suffix}`;
+}
+
+/**
+ * Chip metrics for one prerequisite. A course the viewer has taken gets the
+ * pill treatment; the tick itself is drawn by the card from `taken`.
+ */
+function toPrerequisiteChip(
+  prerequisite: PrerequisiteCourse,
+): PrerequisiteCourse {
+  return {
+    ...prerequisite,
+    bg: prerequisite.taken ? "var(--cc-info)" : "transparent",
+    radius: prerequisite.taken ? "999px" : "6px",
+    padding: "0 8px 0 5px",
+    gap: "5px",
+  };
+}
+
+/**
+ * Maps one course, its aggregates and the viewer's relationship to it onto the
+ * card's display fields.
+ *
+ * Handlers and the picker's transient state are the caller's to add — see
+ * `useCourseCard`, which spreads them over this result. Splitting it that way
+ * keeps everything derived from data testable without a DOM.
+ */
+export function toCourseCardModel(view: CourseCardView): CourseCardModel {
+  const { course, stats } = view;
+  const reviews = stats.reviews;
+  const prerequisites = view.prerequisites ?? null;
+  const collections = view.collections ?? [];
+  const creating = view.creating ?? false;
+
+  return {
+    title: `${course.courseCode} ${course.titleEng}`,
+    meta: formatCourseMeta(course),
+
+    // `course_explore` has no `search_terms` column and nothing writes one, so
+    // the header renders over an empty row until #73 seeds keywords.
+    keywords: "",
+
+    prereq: prerequisites ? prerequisites.map((p) => p.code).join(", ") : "",
+    prereqCourses: prerequisites ? prerequisites.map(toPrerequisiteChip) : [],
+    hasPrereq: prerequisites !== null && prerequisites.length > 0,
+    noPrereq: prerequisites !== null && prerequisites.length === 0,
+
+    // `courses.content` exists, but it is KOPPS syllabus prose: long,
+    // boilerplate-heavy and near-identical across courses, so clipping it here
+    // would print the same opening line on every card in a grid. #73 writes the
+    // blurb that belongs in this slot.
+    summary: "",
+    summaryClipped: "",
+
+    hasStats: reviews !== null && reviews.examLabel !== null,
+    noStats: reviews === null,
+    examLabel: reviews?.examLabel ?? "",
+
+    workload: reviews ? reviews.workloadMean.toFixed(1) : "—",
+    learning: reviews ? reviews.learningMean.toFixed(1) : "—",
+    wlW: reviews ? barWidth(reviews.workloadMean) : "0%",
+    leW: reviews ? barWidth(reviews.learningMean) : "0%",
+    happyPct: reviews ? `${reviews.happyPercent}%` : "—",
+    hasReviewStats: reviews !== null,
+    noReviewStats: reviews === null,
+
+    statTaken: formatCount(stats.takenCount),
+    statReviews: String(reviews?.reviewCount ?? 0),
+
+    borderColor: view.isActive ? "var(--cc-brand)" : "var(--cc-rule2)",
+    takenTitle: takenTitle(stats.takenCount, view.isTaken),
+    takenCountFg: view.isTaken ? "var(--cc-brand)" : "var(--cc-muted)",
+    takenBg: view.isTaken ? "var(--cc-info)" : "transparent",
+    takenHoverBg: "var(--cc-pill)",
+    takenFill: "none",
+    takenStroke: "currentColor",
+
+    saveLabel: view.isSaved ? "Saved" : "Save course",
+    saveFg: view.isSaved ? "var(--cc-brand)" : "var(--cc-chip-ink)",
+    saveBg: view.isSaved ? "var(--cc-info)" : "transparent",
+    saveBorder: view.isSaved ? "var(--cc-brand)" : "var(--cc-rule3)",
+    saveFill: "none",
+
+    pickerOpen: view.pickerOpen ?? false,
+    creating,
+    notCreating: !creating,
+    hasCollections: collections.length > 0,
+    collections,
+
+    takenPickerOpen: view.takenPickerOpen ?? false,
+    addLabel: "Add to collections",
+    removeLabel: view.removeLabel,
+  };
+}

--- a/apps/web/features/favorites/components/favorites.tsx
+++ b/apps/web/features/favorites/components/favorites.tsx
@@ -58,7 +58,7 @@ export function Favorites() {
     [router],
   );
 
-  const onAddToComparison = useCallback((_courseCode: string) => {}, []);
+  const onAddToCollection = useCallback((_courseCode: string) => {}, []);
 
   // Every course on this screen is saved, so the only move here is unsaving.
   async function onToggleFavorite(courseCode: string) {
@@ -104,7 +104,7 @@ export function Favorites() {
                   onCardClick={() => onCardClick(course.courseCode)}
                   onWriteReview={() => onWriteReview(course.courseCode)}
                   onToggleFavorite={() => onToggleFavorite(course.courseCode)}
-                  onAddToComparison={() => onAddToComparison(course.courseCode)}
+                  onAddToCollection={() => onAddToCollection(course.courseCode)}
                 />
               </li>
             ))}

--- a/apps/web/features/search/components/search.tsx
+++ b/apps/web/features/search/components/search.tsx
@@ -180,7 +180,7 @@ export function Search() {
     onCardClick,
     onWriteReview,
     onToggleFavorite,
-    onAddToComparison,
+    onAddToCollection,
     selectedCode,
     courseDetails,
     courseDetailsLoading,
@@ -365,8 +365,8 @@ export function Search() {
                     onCardClick={() => onCardClick(course.courseCode)}
                     onWriteReview={() => onWriteReview(course.courseCode)}
                     onToggleFavorite={() => onToggleFavorite(course.courseCode)}
-                    onAddToComparison={() =>
-                      onAddToComparison(course.courseCode)
+                    onAddToCollection={() =>
+                      onAddToCollection(course.courseCode)
                     }
                   />
                 </li>

--- a/apps/web/features/search/hooks/use-search-page.ts
+++ b/apps/web/features/search/hooks/use-search-page.ts
@@ -110,7 +110,7 @@ export function useSearchPage() {
     [router],
   );
 
-  const onAddToComparison = useCallback((_courseCode: string) => {}, []);
+  const onAddToCollection = useCallback((_courseCode: string) => {}, []);
 
   // `toggleSaved` reads the cache at call time. Deriving the target state from
   // `savedCourseCodes` here would reuse this render's value, so two fast clicks
@@ -135,7 +135,7 @@ export function useSearchPage() {
     onCardClick,
     onWriteReview,
     onToggleFavorite,
-    onAddToComparison,
+    onAddToCollection,
     selectedCode,
     courseDetails: selectedCourseDetails,
     courseDetailsLoading,

--- a/apps/web/types/course-card.ts
+++ b/apps/web/types/course-card.ts
@@ -1,0 +1,186 @@
+/**
+ * The course card's prop shape.
+ *
+ * Extracted from `docs/design/Course Community - Course Card.dc.html` — the
+ * `data-props` attribute on its trailing `<script type="text/x-dc">` block names
+ * `c: CourseCardModel` and `geo: CardGeometry`, and the markup below it is what
+ * reads each field. `apps/web/data/course-card-sample.ts` carries the artboard's
+ * own literals against these types.
+ *
+ * The card takes these props and the *screen* maps tRPC output onto them
+ * (`features/courses/lib/course-card-model.ts`), so a server change touches one
+ * mapping function rather than the card.
+ *
+ * ## Where these names differ from the artboard
+ *
+ * The artboard says `comparisons`, `hasComparisons` and `onNewComparison`.
+ * `CONTEXT.md` bans "comparison" in identifiers and #68 settles the concept as
+ * **Collection**, so every identifier here says `Collection`. Reader-facing copy
+ * still follows the design, which is why the artboard's button may read "Add to
+ * comparison" while the field behind it is `collections`.
+ */
+
+/**
+ * One prerequisite chip.
+ *
+ * Ticks are display-only: a chip shows a checkmark when the viewer has
+ * separately marked *that* course taken. Marking a course taken never cascades
+ * into its prerequisites — that would fabricate academic history, and
+ * `CONTEXT.md` holds taken courses to be self-reported (#68).
+ */
+export interface PrerequisiteCourse {
+  code: string;
+  name: string;
+  /** Whether the prerequisite is itself a course we hold. */
+  inCatalog: boolean;
+  /** Whether the viewer has marked this course taken, which draws the tick. */
+  taken?: boolean;
+  /**
+   * Per-chip metrics the parent interpolates alongside `geo`, so the chips
+   * shrink with the card.
+   */
+  gap?: string;
+  padding?: string;
+  radius?: string;
+  bg?: string;
+}
+
+/** One row of the collection picker. */
+export interface CollectionPickerRow {
+  /** Identifies the collection this row writes to. */
+  id: string;
+  name: string;
+  /** SVG `fill` for the checkbox glyph. */
+  fill: string;
+  /** SVG `path` `d` for the checkbox tick; empty when the course is not in it. */
+  tick: string;
+  onClick?: () => void;
+}
+
+/** Which action control the card shows: Explore's split Save, or Saved's picker. */
+export type CourseCardAction = "save" | "add";
+
+/**
+ * The card's `c` prop.
+ *
+ * Presentation is precomputed by the parent: the model carries strings and
+ * booleans, not numbers to format or conditions to evaluate. `hasX` / `noX`
+ * pairs are the artboard's two `sc-if` branches and are **not complements** —
+ * both may be false while a third state renders. That is how a course whose
+ * prerequisites were never extracted stays distinct from one that genuinely has
+ * none, and how a reviewed course with no remembered examination split stays
+ * distinct from an unreviewed one (#68).
+ */
+export interface CourseCardModel {
+  title: string;
+  /** Credits, department and level, already joined for display. */
+  meta: string;
+  /** Comma-separated; the card chips the first two and counts the rest. */
+  keywords: string;
+  /** Comma-separated prerequisite codes, already joined for display. */
+  prereq: string;
+  prereqCourses: PrerequisiteCourse[];
+  /** Prerequisites were extracted and there is at least one. */
+  hasPrereq: boolean;
+  /** Prerequisites were extracted and there are none. */
+  noPrereq: boolean;
+  summary: string;
+  /** The summary as the card shows it, clipped to `geo.summaryMax`. */
+  summaryClipped: string;
+  /** There are reviews and they remembered an examination split. */
+  hasStats: boolean;
+  /** There are no reviews at all. */
+  noStats: boolean;
+  /** Top examination contributors, e.g. `"Labs 60% · Exam 40%"`. */
+  examLabel: string;
+  /** Mean workload on the stored 1-10 scale, preformatted and unconverted. */
+  workload: string;
+  /** Mean learning on the stored 1-10 scale, preformatted and unconverted. */
+  learning: string;
+  /** Workload bar width, as a CSS percentage: the mean over 10. */
+  wlW: string;
+  /** Learning bar width, as a CSS percentage: the mean over 10. */
+  leW: string;
+  /** Share of reviewers glad they took the course, as a CSS percentage. */
+  happyPct: string;
+  hasReviewStats: boolean;
+  noReviewStats: boolean;
+  /** Taken count, abbreviated for display. */
+  statTaken: string;
+  /** Review count, as a string. */
+  statReviews: string;
+
+  // Per-instance presentation the parent resolves: colours that change with
+  // card state, plus the taken pill's tooltip. Components style against the
+  // `--cc-*` tokens; these fields exist because the artboard has no token for a
+  // value that varies per card, and the mapper fills them with `var(--cc-*)`.
+  borderColor: string;
+  takenTitle: string;
+  takenCountFg: string;
+  takenBg: string;
+  takenFill: string;
+  takenStroke: string;
+  saveLabel: string;
+  saveFg: string;
+  saveBg: string;
+  saveBorder: string;
+  saveFill: string;
+
+  pickerOpen: boolean;
+  creating: boolean;
+  notCreating: boolean;
+  hasCollections: boolean;
+  collections: CollectionPickerRow[];
+
+  /** Hover fill for the taken pill. */
+  takenHoverBg?: string;
+  /** Whether the sign-up prompt over the taken pill is open. */
+  takenPickerOpen?: boolean;
+  /** Accessible name for the picker trigger in the `"add"` action. */
+  addLabel?: string;
+  /** Accessible name and tooltip for the remove button, which it also enables. */
+  removeLabel?: string;
+  onOpen?: () => void;
+  onTaken?: () => void;
+  onReview?: () => void;
+  onSave?: () => void;
+  onPicker?: () => void;
+  onNewCollection?: () => void;
+  onRemove?: () => void;
+  onSignUp?: () => void;
+  onLogIn?: () => void;
+}
+
+/**
+ * The card's `geo` prop.
+ *
+ * Geometry arrives as one object so the **parent** owns the collapse ramp:
+ * Explore interpolates it from the results column width, Saved pins it to one
+ * end. Every value is a CSS string the card drops straight into a custom
+ * property, which is why widths and paddings are not numbers — and why a
+ * container query can still override one on a narrow card.
+ *
+ * `features/courses/lib/card-geometry.ts` builds these; nothing should write one
+ * by hand.
+ */
+export interface CardGeometry {
+  /** CSS `transition` shorthand, or `"none"` while dragging the ramp. */
+  tween: string;
+  titleSize: string;
+  cardGap: string;
+  cardPad: string;
+  factsGap: string;
+  reviewPad: string;
+  labelMax: string;
+  labelOpacity: number;
+  saveW: string;
+  savePad: string;
+  railW: string;
+  railPad: string;
+  summaryMax: string;
+  summaryOpacity: number;
+  reviewFlex: string;
+  saveFlex: string;
+  showLabel: boolean;
+  cardHeight: string;
+}

--- a/apps/web/types/index.ts
+++ b/apps/web/types/index.ts
@@ -1,3 +1,4 @@
 export * from "./auth.types";
 export * from "./course";
+export * from "./course-card";
 export * from "./review";


### PR DESCRIPTION
Builds the course card from `docs/design/Course Community - Course Card.dc.html` against `apps/web/data/course-card-sample.ts`, the fixture extracted from it. Explore (#89), Saved (#90) and Collections (#91) all render this, so the work here is mostly the seam.

Closes #86

## The seam

Three pieces, each with one job:

| | |
|---|---|
| `CourseCard` | Draws a `CourseCardModel`. Measures nothing, fetches nothing, decides nothing. |
| `toCourseCardModel` | The one place tRPC output becomes that model. Pure, so it is tested without a DOM. |
| `useCourseCard` | Binds one card to the real procedures and owns the picker's transient state. |
| `CourseCardItem` | **What a screen renders.** The keyed boundary the hook needs, and the only one of these the barrel exports. |

A screen writes the loop and nothing else:

```tsx
{courses.map((course) => (
  <CourseCardItem
    key={course.courseCode}
    course={course}
    stats={stats[course.courseCode] ?? NO_STATS}
    geo={geo}
    onOpen={() => open(course.courseCode)}
    onRequestAuth={setAuthReason}
  />
))}
```

`CourseCardItem` is not ceremony. `useCourseCard` holds several hooks, so calling it inside a screen's own `map` callback binds a card's picker and draft to a list *position*: reorder and the open picker jumps to another course, shorten and React throws "Rendered fewer hooks than expected". Greptile reproduced both. Keyed instances make it impossible, which is why the hook is deliberately **not** exported from the barrel.

When #67's aggregation changes, the mapper changes and no card does.

`action: "save" | "add"` is the only structural difference between the pages, so the card is one component rather than two — as #68 required.

## Geometry

`courseCardGeometry(width)` is the artboard's own ramp, lifted from the Explore artboard's interpolation. At full width it lands exactly on `SAMPLE_GEO`, and a test holds those two together — if the ramp drifts, the card is no longer the one the design drew.

The parent still owns it: Explore interpolates from its results column, Saved and Collections use `EXPANDED_CARD_GEOMETRY`. `COLLAPSED_CARD_GEOMETRY` is the other end.

Geometry reaches the card as CSS custom properties rather than inline widths. That is what lets the container query at `@max-[440px]` pin the phone end of the ramp (from the Mobile Preview reference) without the parent knowing a card is narrow — an inline `width` would have outranked it. Mobile is this issue's own, per #68 decision 6.

## Design vs schema — what I hit, and the minimal change made

Per #68's precedence rule, the schema won each of these and the smallest edit that keeps the design intact was made.

| The design assumed | The schema has | Minimal change |
|---|---|---|
| `workload: "3.8"` on a 1-5 scale, bar at 76% | `workload_score BETWEEN 1 AND 10` | Render the mean raw (`"7.6"`); bar width is the mean over ten, which is the *same* 76% the artboard drew. Nothing converts. |
| `"1.2k students have taken this course"`, from KTH enrolment in `cc-store.js` | `user_taken_courses` — app users who marked it themselves | Copy changed to **members**. The number stayed; the sentence was what was wrong. Zero and one are worded so they cannot imply a population that is not there. |
| `hasPrereq` / `noPrereq`, `noPrereq` rendering "None listed" | `course_prerequisites` exists; nothing in `server/` writes it | Third state: both flags false renders an empty row. "None listed" is now reserved for extraction that genuinely found none. |
| `keywords` from a `searchTerms` field | `course_explore` has no such column, on this branch or on `dev` | Header renders over an empty row (#68 decision 3; #73 seeds it). |
| `summary` from `courses.content` | The column exists, but holds KOPPS syllabus prose | Left empty. Rendering it would open every card in a grid with the same boilerplate line. #73 writes the real blurb. |
| The picker adds to a collection independently of Save | `addCourseToCollection` rejects a course the user has not saved | Adding to a collection saves the course first. Flagged here because it is a behaviour change, not just a rendering one. |
| Guest copy promising "compare courses with AI" | No such feature | Deleted, per #68 decision 1. |
| `c.comparisons`, `hasComparisons`, `onNewComparison` | `CONTEXT.md` bans "comparison" in identifiers | Renamed to `collections` / `hasCollections` / `onNewCollection` in the fixture, its types and every use. The button still *reads* "Add to comparison": reader-facing copy follows the design. |
| A fixed amber (`#dfa53c`) for the workload bar | No `--cc-*` carries it; `--cc-warn-btn` is amber only in dark and blue in light, which would make both score bars one colour | Substituted **`--cc-warn-ink`**, the palette's amber-family value in both themes. I briefly added a `--cc-score-workload` token and withdrew it: the palette gap is being settled once at source, not four times by four pages. In dark it sits closer to `--cc-btn` than the artboard intends — **that is the gap, and it is the one thing here still worth fixing in the palette.** |

Two more worth naming:

- **`CONTEXT.md` bans "member" for an app user** while #68's correction mandates "members" in this sentence. `CONTEXT.md`'s own reading rule resolves it — that ban governs identifiers, and this is reader-facing copy — but it is the one place the two documents point in opposite directions.
- **#68 says Saved "pins the ramp to the fully collapsed end"; the Saved artboard does the opposite**, passing a fully expanded geo with a 3-line summary. Both ends are exported, so #90 can take the artboard's. Nothing here forecloses either.

## Other decisions worth a look

- **Prerequisite ticks never cascade.** Marking a course taken writes exactly one row; the tick on a chip means the viewer separately marked *that* course. Covered by a test.
- **The taken pill stops being a control once the course is marked**, rendering as a reading rather than a dead button. The artboard toggles it, but its store holds a boolean flag; ours holds a row with a self-reported grade, credits and periods, and `taken.remove` deletes all of it. Neither the Explore nor the Saved tooltip invites unmarking ("you marked it as taken", "You have taken this course"), so the toggle looks like a mock convenience rather than an intent. Unmarking belongs on Taken courses (#93), where the values at risk are on screen. **Flagging this one specifically** — it is the place I most expect the design owner to overrule me.
- **The whole card opens the course through one control.** The title button carries a stretched `::after` overlay, so a click anywhere opens it while focus and a screen reader meet exactly one affordance — rather than a `role="button"` div wrapping other buttons.
- **Guest prompts are the artboard's inline panels**, but their two buttons hand off to `AuthReasonDialog` from #61. No new sign-in surface, and the screen renders one dialog for its whole list.

## Tests

`ui` project (`features/**/*.spec.tsx`): the card covers no reviews, visitor, signed-in, both `action` values and the collapsed geometry; `useCourseCard` covers what a visitor is asked rather than sent, that marking a course taken writes exactly one row and never a prerequisite's, that the picker saves before it adds, and that a failed write says so instead of drawing a tick that is not there.

The mapper and the ramp are pure, so they go in the `logic` project — including the assertion that the ramp's top end equals `SAMPLE_GEO`, which is what stops the card drifting off the artboard.

`bun run test:web` 297 passed · `npx tsc --noEmit` clean · `bun run lint` clean.

## Greptile

Four rounds. Every in-scope finding is fixed and every inline thread resolved:

- **Partial collection creation left inconsistent state.** Creation and membership are two writes; a failed add was reported as a failed create, which sends the reader back to the name field — and `collections.create` has no uniqueness on name, so retrying made a second empty collection. They now fail apart.
- **The stage-specific error was then lost.** A failed *save* was still being reported as a failed add, pointing at a collection row that cannot work until the course is saved. Writes now throw a `CollectionWriteError` carrying `step`, and the advice follows it.
- **The hook could be called in a list map.** Fixed by construction with `CourseCardItem` rather than by documentation.

The score sits at 4/5 on one objection I have declined: that Explore and Saved still render the legacy card. That is #89 and #90, both `blocked_by` this issue — holding this PR for them is a cycle — and #68 sets the bar as "the app still works", with the shell rollout as explicit precedent for a shared piece landing a round before its consumers. Nothing here changes what those pages render today.

## One documentation fix

`CONTEXT.md`'s **Course prerequisite** entry still carried `_Today_: no table`, but `course_prerequisites` landed in #62/#71, and ADR 0003 has those receipts deleted by the migration that closes them. It is replaced with the fact this card actually depends on: no extracted edges says nothing either way. Without that, the glossary and this diff's comments assert opposite things.

## Notes for the integration branch

`dev` is one commit ahead of `feat/frontend` (`48bb338`, #99 — server-side search state moved to `course_explore`). It touches only `server/**` and does not conflict with this diff. Whether to move `feat/frontend` onto it is the product owner's call, since it changes the base under every open child PR.

Not renamed here: the pre-existing `onAddToComparison` no-op handlers in `course-card-with-charts.tsx`, `search.tsx` and `favorites.tsx`. They are dead callbacks on the components #89 and #90 replace wholesale, and editing them now would only collide with those branches.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01D3d7V2JceJZvtJED18HXFJ
