### PR TITLE
feat(reviews): the unreviewed card (#88)

### DIFF
--- a/apps/web/features/reviews/api/queries.ts
+++ b/apps/web/features/reviews/api/queries.ts
@@ -3,7 +3,10 @@
 import { useQueries, useQuery } from "@tanstack/react-query";
 import { useMe } from "@/features/auth";
 import { type RouterOutputs, useTRPC } from "@/trpc/client";
-import { selectUnreviewedCourses } from "../lib/unreviewed";
+import {
+  reviewsWhenEveryListLoaded,
+  selectUnreviewedCourses,
+} from "../lib/unreviewed";
 
 export type ReviewList = RouterOutputs["reviews"]["list"];
 
@@ -32,14 +35,21 @@ export function useReviewList(courseCode: string | undefined) {
  * filter, so it would ship every review in the database, with its author id,
  * to a browser in order to keep a handful.
  *
- * Rows stay hidden until every query has answered. A course whose reviews have
- * not loaded yet is not "unreviewed", it is unknown, and prompting someone to
- * review a course they already reviewed is the one mistake this card must not
- * make.
+ * Rows stay hidden until every list has actually arrived. A course whose
+ * reviews did not load is not "unreviewed", it is unknown — and that holds
+ * whether the request is still in flight or has failed outright, which is why
+ * `isLoading` alone does not gate the difference. Prompting someone to review a
+ * course they already reviewed is the one mistake this card must not make, so
+ * a list that failed leaves the set unavailable rather than empty.
  */
 export function useUnreviewedTakenCourses(): {
   courses: TakenCourse[];
   isLoading: boolean;
+  /**
+   * A list did not load, so the difference cannot be told. Distinct from an
+   * empty `courses`, which means everything taken has been reviewed.
+   */
+  isUnavailable: boolean;
 } {
   const trpc = useTRPC();
   const { userId, isAuthenticated, isLoading: isSessionLoading } = useMe();
@@ -61,14 +71,16 @@ export function useUnreviewedTakenCourses(): {
     (isAuthenticated && takenQuery.isPending) ||
     reviewQueries.some((query) => query.isPending);
 
+  const reviews = reviewsWhenEveryListLoaded(
+    reviewQueries.map((query) => query.data),
+  );
+  const isKnown = !isLoading && !takenQuery.isError && reviews !== null;
+
   return {
-    courses: isLoading
-      ? []
-      : selectUnreviewedCourses(
-          takenCourses,
-          reviewQueries.flatMap((query) => query.data ?? []),
-          userId,
-        ),
+    courses: isKnown
+      ? selectUnreviewedCourses(takenCourses, reviews, userId)
+      : [],
     isLoading,
+    isUnavailable: !isLoading && !isKnown,
   };
 }

--- a/apps/web/features/reviews/api/queries.ts
+++ b/apps/web/features/reviews/api/queries.ts
@@ -1,9 +1,14 @@
 "use client";
 
-import { useQuery } from "@tanstack/react-query";
+import { useQueries, useQuery } from "@tanstack/react-query";
+import { useMe } from "@/features/auth";
 import { type RouterOutputs, useTRPC } from "@/trpc/client";
+import { selectUnreviewedCourses } from "../lib/unreviewed";
 
 export type ReviewList = RouterOutputs["reviews"]["list"];
+
+/** One taken course as `taken.list` returns it: a code and self-reported facts. */
+export type TakenCourse = RouterOutputs["taken"]["list"][number];
 
 export function useReviewList(courseCode: string | undefined) {
   const trpc = useTRPC();
@@ -13,4 +18,57 @@ export function useReviewList(courseCode: string | undefined) {
       { enabled: Boolean(courseCode) },
     ),
   );
+}
+
+/**
+ * The viewer's taken courses that they have not reviewed — the list
+ * `UnreviewedCard` renders, shared by Taken courses and My Page.
+ *
+ * The difference is worked out here, in the client, deliberately: it is a
+ * per-user set of at most a few dozen rows and #88 rules out a server procedure
+ * for it. That costs one `reviews.list` per taken course, in the same shape
+ * Saved already uses for `course.summary`. The cheaper-looking alternative —
+ * one unfiltered `reviews.list` — was rejected: `reviews.list` has no author
+ * filter, so it would ship every review in the database, with its author id,
+ * to a browser in order to keep a handful.
+ *
+ * Rows stay hidden until every query has answered. A course whose reviews have
+ * not loaded yet is not "unreviewed", it is unknown, and prompting someone to
+ * review a course they already reviewed is the one mistake this card must not
+ * make.
+ */
+export function useUnreviewedTakenCourses(): {
+  courses: TakenCourse[];
+  isLoading: boolean;
+} {
+  const trpc = useTRPC();
+  const { userId, isAuthenticated, isLoading: isSessionLoading } = useMe();
+
+  const takenQuery = useQuery({
+    ...trpc.taken.list.queryOptions(),
+    enabled: isAuthenticated,
+  });
+  const takenCourses = takenQuery.data ?? [];
+
+  const reviewQueries = useQueries({
+    queries: takenCourses.map((course) =>
+      trpc.reviews.list.queryOptions({ courseCode: course.courseCode }),
+    ),
+  });
+
+  const isLoading =
+    isSessionLoading ||
+    (isAuthenticated && takenQuery.isPending) ||
+    reviewQueries.some((query) => query.isPending);
+
+  return {
+    courses: isLoading
+      ? []
+      : selectUnreviewedCourses(
+          takenCourses,
+          reviewQueries.flatMap((query) => query.data ?? []),
+          userId,
+        ),
+    isLoading,
+  };
 }

--- a/apps/web/features/reviews/components/unreviewed-card.spec.tsx
+++ b/apps/web/features/reviews/components/unreviewed-card.spec.tsx
@@ -29,7 +29,9 @@ function renderScreen(
     VIEWER,
   ).map((course) => ({ code: course.courseCode, name: course.name }));
 
-  return render(<UnreviewedCard courses={courses} {...over} />);
+  return render(
+    <UnreviewedCard courses={courses} onStart={() => {}} {...over} />,
+  );
 }
 
 describe("UnreviewedCard", () => {
@@ -73,13 +75,14 @@ describe("UnreviewedCard", () => {
     expect(container).toBeEmptyDOMElement();
   });
 
-  it("offers the fast track only when a screen can open one", async () => {
+  it("counts the fast track's label and opens the reviewer with it", async () => {
     const onStart = vi.fn();
-    const { rerender } = renderScreen([]);
+    const { rerender } = renderScreen([], { onStart });
 
-    expect(
-      screen.queryByRole("button", { name: /Fast track/ }),
-    ).not.toBeInTheDocument();
+    await userEvent.click(
+      screen.getByRole("button", { name: "Fast track all 2" }),
+    );
+    expect(onStart).toHaveBeenCalledOnce();
 
     rerender(
       <UnreviewedCard
@@ -87,11 +90,9 @@ describe("UnreviewedCard", () => {
         onStart={onStart}
       />,
     );
-
-    await userEvent.click(
+    expect(
       screen.getByRole("button", { name: "Fast track it" }),
-    );
-    expect(onStart).toHaveBeenCalledOnce();
+    ).toBeInTheDocument();
   });
 
   it("hands a row to onSelect instead of navigating when a screen supplies one", async () => {
@@ -111,6 +112,7 @@ describe("UnreviewedCard", () => {
         courses={["DD2424", "SF1918", "AK2030"].map((code) => ({ code }))}
         line="You have 3 unreviewed courses."
         max={2}
+        onStart={() => {}}
       />,
     );
 

--- a/apps/web/features/reviews/components/unreviewed-card.spec.tsx
+++ b/apps/web/features/reviews/components/unreviewed-card.spec.tsx
@@ -1,0 +1,123 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it, vi } from "vitest";
+import { selectUnreviewedCourses } from "../lib/unreviewed";
+import { UnreviewedCard, type UnreviewedCourse } from "./unreviewed-card";
+
+const VIEWER = "u1";
+
+/** `taken.list` carries a code and self-reported facts; the name is the screen's. */
+const TAKEN = [
+  { courseCode: "DD2424", name: "Deep Learning in Data Science" },
+  { courseCode: "SF1918", name: "Probability and Statistics" },
+];
+
+type ReviewedBy = { courseCode: string; userId: string };
+
+/**
+ * Exactly what a screen does — difference the two lists, then map the result
+ * onto card props — so these cover the seam Taken courses and My Page use, not
+ * a hand-written list that could drift from it.
+ */
+function renderScreen(
+  reviews: ReviewedBy[],
+  over: Partial<Parameters<typeof UnreviewedCard>[0]> = {},
+) {
+  const courses: UnreviewedCourse[] = selectUnreviewedCourses(
+    TAKEN,
+    reviews,
+    VIEWER,
+  ).map((course) => ({ code: course.courseCode, name: course.name }));
+
+  return render(<UnreviewedCard courses={courses} {...over} />);
+}
+
+describe("UnreviewedCard", () => {
+  it("prompts for taken courses with no review and routes each into the review flow", () => {
+    renderScreen([]);
+
+    expect(
+      screen.getByText("2 courses have no review yet"),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText("Your review is what the next student reads."),
+    ).toBeInTheDocument();
+
+    expect(
+      screen.getByRole("link", { name: /Deep Learning in Data Science/ }),
+    ).toHaveAttribute("href", "/course/DD2424?writeReview=1");
+    expect(
+      screen.getByRole("link", { name: /Probability and Statistics/ }),
+    ).toHaveAttribute("href", "/course/SF1918?writeReview=1");
+  });
+
+  it("leaves out a taken course the viewer has already reviewed", () => {
+    renderScreen([{ courseCode: "SF1918", userId: VIEWER }]);
+
+    expect(screen.getByText("1 course has no review yet")).toBeInTheDocument();
+    expect(screen.getByText("DD2424")).toBeInTheDocument();
+    expect(screen.queryByText("SF1918")).not.toBeInTheDocument();
+    expect(
+      screen.queryByText("Probability and Statistics"),
+    ).not.toBeInTheDocument();
+  });
+
+  // The prompt is the whole card, so with nothing to prompt for there is no
+  // empty state to draw — the screens rely on this instead of each guarding.
+  it("renders nothing once everything taken has been reviewed", () => {
+    const { container } = renderScreen([
+      { courseCode: "DD2424", userId: VIEWER },
+      { courseCode: "SF1918", userId: VIEWER },
+    ]);
+
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it("offers the fast track only when a screen can open one", async () => {
+    const onStart = vi.fn();
+    const { rerender } = renderScreen([]);
+
+    expect(
+      screen.queryByRole("button", { name: /Fast track/ }),
+    ).not.toBeInTheDocument();
+
+    rerender(
+      <UnreviewedCard
+        courses={[{ code: "DD2424", name: "Deep Learning in Data Science" }]}
+        onStart={onStart}
+      />,
+    );
+
+    await userEvent.click(
+      screen.getByRole("button", { name: "Fast track it" }),
+    );
+    expect(onStart).toHaveBeenCalledOnce();
+  });
+
+  it("hands a row to onSelect instead of navigating when a screen supplies one", async () => {
+    const onSelect = vi.fn();
+    renderScreen([{ courseCode: "SF1918", userId: VIEWER }], { onSelect });
+
+    expect(screen.queryByRole("link")).not.toBeInTheDocument();
+    await userEvent.click(
+      screen.getByRole("button", { name: /Deep Learning in Data Science/ }),
+    );
+    expect(onSelect).toHaveBeenCalledWith("DD2424");
+  });
+
+  it("collapses the tail of a long list and takes a headline of the screen's own", () => {
+    render(
+      <UnreviewedCard
+        courses={["DD2424", "SF1918", "AK2030"].map((code) => ({ code }))}
+        line="You have 3 unreviewed courses."
+        max={2}
+      />,
+    );
+
+    expect(
+      screen.getByText("You have 3 unreviewed courses."),
+    ).toBeInTheDocument();
+    expect(screen.getByText("+1 more")).toBeInTheDocument();
+    expect(screen.queryByText("AK2030")).not.toBeInTheDocument();
+  });
+});

--- a/apps/web/features/reviews/components/unreviewed-card.tsx
+++ b/apps/web/features/reviews/components/unreviewed-card.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import { MessageCircle } from "lucide-react";
 import Link from "next/link";
 import type { ReactNode } from "react";
@@ -26,14 +28,15 @@ type Props = {
   /** How many rows to list before collapsing the rest into "+N more". */
   max?: number;
   /**
-   * Opens the run-them-back-to-back reviewer. Optional, and the button is left
-   * out when it is missing — a call to action that goes nowhere is worse than
-   * no call to action. The rows still route on their own.
+   * Opens the run-them-back-to-back reviewer. Required, because the artboard
+   * never draws this card without its call to action — a screen that cannot
+   * offer one has no business rendering the prompt.
    */
-  onStart?: () => void;
+  onStart: () => void;
   /**
-   * Handles a row instead of the default link into the review flow. Taken
-   * courses opens its reviewer in place rather than navigating away.
+   * Handles a row instead of the default link into the review flow. This is the
+   * artboard's own per-course `c.onClick`, which Taken courses uses to open its
+   * reviewer in place rather than navigating away; My Page passes one too.
    */
   onSelect?: (courseCode: string) => void;
 };
@@ -111,16 +114,14 @@ export function UnreviewedCard({
             Your review is what the next student reads.
           </p>
         </div>
-        {onStart ? (
-          <button
-            type="button"
-            onClick={onStart}
-            className="flex h-10 flex-none items-center justify-center gap-2 rounded-[9px] bg-cc-btn px-[18px] font-semibold text-[13.5px] text-cc-btn-fg hover:opacity-[.88] @max-md:w-full"
-          >
-            <MessageCircle size={15} aria-hidden />
-            {fastTrackLabelFor(courses.length)}
-          </button>
-        ) : null}
+        <button
+          type="button"
+          onClick={onStart}
+          className="flex h-10 flex-none items-center justify-center gap-2 rounded-[9px] bg-cc-btn px-[18px] font-semibold text-[13.5px] text-cc-btn-fg hover:opacity-[.88] @max-[440px]:w-full"
+        >
+          <MessageCircle size={15} aria-hidden />
+          {fastTrackLabelFor(courses.length)}
+        </button>
       </div>
 
       <ul className="mt-3 flex list-none flex-col gap-[7px] border-cc-rule border-t pt-3 pl-0">

--- a/apps/web/features/reviews/components/unreviewed-card.tsx
+++ b/apps/web/features/reviews/components/unreviewed-card.tsx
@@ -1,0 +1,169 @@
+import { MessageCircle } from "lucide-react";
+import Link from "next/link";
+import type { ReactNode } from "react";
+
+/**
+ * One row of the prompt: a course the viewer took and has not reviewed.
+ *
+ * `name` is optional because `user_taken_courses` stores only a course code —
+ * the title lives on `courses` and is the screen's to look up. The artboard
+ * falls back to the code when it has no name and so does this.
+ */
+export type UnreviewedCourse = {
+  code: string;
+  name?: string | null;
+};
+
+type Props = {
+  /**
+   * The unreviewed courses, already differenced against the viewer's reviews.
+   * The card renders what it is given; `selectUnreviewedCourses` is what works
+   * the set out.
+   */
+  courses: UnreviewedCourse[];
+  /** Replaces the generated headline. Taken courses passes its own wording. */
+  line?: string;
+  /** How many rows to list before collapsing the rest into "+N more". */
+  max?: number;
+  /**
+   * Opens the run-them-back-to-back reviewer. Optional, and the button is left
+   * out when it is missing — a call to action that goes nowhere is worse than
+   * no call to action. The rows still route on their own.
+   */
+  onStart?: () => void;
+  /**
+   * Handles a row instead of the default link into the review flow. Taken
+   * courses opens its reviewer in place rather than navigating away.
+   */
+  onSelect?: (courseCode: string) => void;
+};
+
+/** Where a course's review gets written. Same entry point Saved and Explore use. */
+function reviewFlowHref(courseCode: string): string {
+  return `/course/${courseCode}?writeReview=1`;
+}
+
+const ROW_CLASS =
+  "flex w-full items-baseline gap-[9px] text-left transition-opacity hover:opacity-80";
+
+function headlineFor(count: number): string {
+  return count === 1
+    ? "1 course has no review yet"
+    : `${count} courses have no review yet`;
+}
+
+function fastTrackLabelFor(count: number): string {
+  return count === 1 ? "Fast track it" : `Fast track all ${count}`;
+}
+
+function CourseRowContent({ course }: { course: UnreviewedCourse }) {
+  return (
+    <>
+      <span
+        aria-hidden
+        className="mt-[5px] size-1 flex-none rounded-full bg-cc-brand opacity-50"
+      />
+      <span className="flex-none font-medium font-mono text-[12px] text-cc-brand">
+        {course.code}
+      </span>
+      <span className="min-w-0 flex-1 truncate text-[13px] text-cc-ink2">
+        {course.name || course.code}
+      </span>
+    </>
+  );
+}
+
+/**
+ * The prompt shown for courses the viewer marked taken but never reviewed —
+ * `docs/design/Course Community - Unreviewed Card.dc.html`.
+ *
+ * It is an invitation, not a warning, which is why it wears the ordinary card
+ * surface and the brand button rather than the `--cc-warn-*` nudge palette; the
+ * artboard makes the same choice.
+ *
+ * The card is deliberately incurious about the set. It takes a list and renders
+ * it, so Taken courses (#92) and My Page (#93) can each hand it a differently
+ * derived list — and so nothing here is tempted to show a satisfaction state
+ * for a course that has no review to carry one.
+ */
+export function UnreviewedCard({
+  courses,
+  line,
+  max = 6,
+  onStart,
+  onSelect,
+}: Props) {
+  // Nothing taken is unreviewed: there is nothing to invite. Guarded here so
+  // neither screen has to remember to guard it.
+  if (courses.length === 0) return null;
+
+  const shown = courses.slice(0, max);
+  const remaining = courses.length - shown.length;
+
+  return (
+    <div className="@container box-border w-full rounded-[12px] border border-cc-rule2 bg-cc-surface px-[18px] pt-4 pb-3.5 shadow-[0_1px_2px_rgba(20,30,45,.05)]">
+      <div className="flex flex-wrap items-center justify-between gap-x-4 gap-y-3">
+        <div className="min-w-[180px]">
+          <p className="m-0 font-semibold text-[15.5px]">
+            {line ?? headlineFor(courses.length)}
+          </p>
+          <p className="m-0 mt-[3px] text-[12.5px] text-cc-muted">
+            Your review is what the next student reads.
+          </p>
+        </div>
+        {onStart ? (
+          <button
+            type="button"
+            onClick={onStart}
+            className="flex h-10 flex-none items-center justify-center gap-2 rounded-[9px] bg-cc-btn px-[18px] font-semibold text-[13.5px] text-cc-btn-fg hover:opacity-[.88] @max-md:w-full"
+          >
+            <MessageCircle size={15} aria-hidden />
+            {fastTrackLabelFor(courses.length)}
+          </button>
+        ) : null}
+      </div>
+
+      <ul className="mt-3 flex list-none flex-col gap-[7px] border-cc-rule border-t pt-3 pl-0">
+        {shown.map((course) => (
+          <li key={course.code} className="m-0">
+            <CourseRow course={course} onSelect={onSelect} />
+          </li>
+        ))}
+        {remaining > 0 ? (
+          <li className="m-0 text-[12px] text-cc-dim2">+{remaining} more</li>
+        ) : null}
+      </ul>
+    </div>
+  );
+}
+
+/**
+ * A row navigates into the review flow by default, so the card is useful with
+ * nothing but a list. `onSelect` swaps the link for a button when the screen
+ * would rather open a reviewer in place than leave the page.
+ */
+function CourseRow({
+  course,
+  onSelect,
+}: {
+  course: UnreviewedCourse;
+  onSelect?: (courseCode: string) => void;
+}): ReactNode {
+  if (onSelect) {
+    return (
+      <button
+        type="button"
+        className={ROW_CLASS}
+        onClick={() => onSelect(course.code)}
+      >
+        <CourseRowContent course={course} />
+      </button>
+    );
+  }
+
+  return (
+    <Link href={reviewFlowHref(course.code)} className={ROW_CLASS}>
+      <CourseRowContent course={course} />
+    </Link>
+  );
+}

--- a/apps/web/features/reviews/index.ts
+++ b/apps/web/features/reviews/index.ts
@@ -1,4 +1,13 @@
-export { useReviewList } from "./api/queries";
+export {
+  type TakenCourse,
+  useReviewList,
+  useUnreviewedTakenCourses,
+} from "./api/queries";
 export { Post, type PostProps } from "./components/post";
 export { Review, type ReviewFormData } from "./components/review";
+export {
+  UnreviewedCard,
+  type UnreviewedCourse,
+} from "./components/unreviewed-card";
 export { useAddReview } from "./hooks/use-add-review";
+export { selectUnreviewedCourses } from "./lib/unreviewed";

--- a/apps/web/features/reviews/index.ts
+++ b/apps/web/features/reviews/index.ts
@@ -1,3 +1,11 @@
+/**
+ * The cross-feature API of the reviews feature.
+ *
+ * `selectUnreviewedCourses` is deliberately absent: it is what
+ * `useUnreviewedTakenCourses` is made of, and a screen that reached for it
+ * directly would be re-deriving the set the hook already derives.
+ */
+
 export {
   type TakenCourse,
   useReviewList,
@@ -5,9 +13,9 @@ export {
 } from "./api/queries";
 export { Post, type PostProps } from "./components/post";
 export { Review, type ReviewFormData } from "./components/review";
+/** The prompt for taken courses with no review — Taken courses and My Page. */
 export {
   UnreviewedCard,
   type UnreviewedCourse,
 } from "./components/unreviewed-card";
 export { useAddReview } from "./hooks/use-add-review";
-export { selectUnreviewedCourses } from "./lib/unreviewed";

--- a/apps/web/features/reviews/lib/unreviewed.spec.ts
+++ b/apps/web/features/reviews/lib/unreviewed.spec.ts
@@ -1,5 +1,8 @@
 import { describe, expect, it } from "vitest";
-import { selectUnreviewedCourses } from "./unreviewed";
+import {
+  reviewsWhenEveryListLoaded,
+  selectUnreviewedCourses,
+} from "./unreviewed";
 
 const TAKEN = [{ courseCode: "DD2424" }, { courseCode: "SF1918" }];
 
@@ -47,5 +50,26 @@ describe("selectUnreviewedCourses", () => {
   // all would be prompting the wrong person.
   it("prompts nobody when there is no viewer", () => {
     expect(selectUnreviewedCourses(TAKEN, [], "")).toEqual([]);
+  });
+});
+
+describe("reviewsWhenEveryListLoaded", () => {
+  it("flattens the lists once they have all arrived", () => {
+    expect(
+      reviewsWhenEveryListLoaded([[{ id: "r1" }], [], [{ id: "r2" }]]),
+    ).toEqual([{ id: "r1" }, { id: "r2" }]);
+  });
+
+  // The failure Greptile proved: a request that has exhausted its retries is
+  // no longer pending and still has no data. Reading that as "no reviews"
+  // would put a prompt in front of somebody who already wrote theirs.
+  it("gives up rather than reading a list that never arrived as empty", () => {
+    expect(
+      reviewsWhenEveryListLoaded([[{ id: "r1" }], undefined, [{ id: "r2" }]]),
+    ).toBeNull();
+  });
+
+  it("has nothing to withhold when there are no lists at all", () => {
+    expect(reviewsWhenEveryListLoaded([])).toEqual([]);
   });
 });

--- a/apps/web/features/reviews/lib/unreviewed.spec.ts
+++ b/apps/web/features/reviews/lib/unreviewed.spec.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from "vitest";
+import { selectUnreviewedCourses } from "./unreviewed";
+
+const TAKEN = [{ courseCode: "DD2424" }, { courseCode: "SF1918" }];
+
+function codes(taken: { courseCode: string }[]): string[] {
+  return taken.map((course) => course.courseCode);
+}
+
+describe("selectUnreviewedCourses", () => {
+  it("keeps the taken courses the viewer has not reviewed", () => {
+    const kept = selectUnreviewedCourses(
+      TAKEN,
+      [{ courseCode: "SF1918", userId: "u1" }],
+      "u1",
+    );
+
+    expect(codes(kept)).toEqual(["DD2424"]);
+  });
+
+  // Reviews are public, so a course's list is everybody's reviews of it. Only
+  // the viewer's own answers the question this card asks.
+  it("ignores reviews written by other students", () => {
+    const kept = selectUnreviewedCourses(
+      TAKEN,
+      [
+        { courseCode: "DD2424", userId: "u2" },
+        { courseCode: "SF1918", userId: "u3" },
+      ],
+      "u1",
+    );
+
+    expect(codes(kept)).toEqual(["DD2424", "SF1918"]);
+  });
+
+  it("keeps a reviewed course that is not among the taken ones out of the way", () => {
+    const kept = selectUnreviewedCourses(
+      TAKEN,
+      [{ courseCode: "AK2030", userId: "u1" }],
+      "u1",
+    );
+
+    expect(codes(kept)).toEqual(["DD2424", "SF1918"]);
+  });
+
+  // Nobody signed in means no author to compare against; prompting anyone at
+  // all would be prompting the wrong person.
+  it("prompts nobody when there is no viewer", () => {
+    expect(selectUnreviewedCourses(TAKEN, [], "")).toEqual([]);
+  });
+});

--- a/apps/web/features/reviews/lib/unreviewed.ts
+++ b/apps/web/features/reviews/lib/unreviewed.ts
@@ -1,0 +1,36 @@
+import type { Review } from "@/types";
+
+/**
+ * The taken courses this viewer has not reviewed yet.
+ *
+ * The set arithmetic lives here rather than inside `UnreviewedCard` so the card
+ * renders whatever list it is handed and knows nothing about how that list was
+ * derived — and so Taken courses and My Page derive it the same way instead of
+ * each writing their own filter.
+ *
+ * `reviews` is every review the caller loaded for the courses in `taken`, not
+ * only the viewer's: `reviews.list` takes a course code and has no author
+ * filter, so the personal half of the question is answered here. Another
+ * student's review of a course leaves that course unreviewed *by you*.
+ *
+ * Note what is deliberately absent: nothing here reads a satisfaction state.
+ * `happyTook` belongs to a published review and does not exist until one is
+ * written, so a course in this list has no verdict to render.
+ */
+export function selectUnreviewedCourses<T extends { courseCode: string }>(
+  taken: readonly T[],
+  reviews: readonly Pick<Review, "courseCode" | "userId">[],
+  viewerUserId: string,
+): T[] {
+  // With nobody signed in there is no author to compare against, and treating
+  // every taken course as unreviewed would prompt the wrong person.
+  if (!viewerUserId) return [];
+
+  const reviewedCourseCodes = new Set(
+    reviews
+      .filter((review) => review.userId === viewerUserId)
+      .map((review) => review.courseCode),
+  );
+
+  return taken.filter((course) => !reviewedCourseCodes.has(course.courseCode));
+}

--- a/apps/web/features/reviews/lib/unreviewed.ts
+++ b/apps/web/features/reviews/lib/unreviewed.ts
@@ -1,6 +1,28 @@
 import type { Review } from "@/types";
 
 /**
+ * Every review across a set of per-course lists, or `null` if any one of them
+ * is missing.
+ *
+ * A list is missing while its request is in flight *and* after that request has
+ * failed, and the two are indistinguishable from the data. Both mean the same
+ * thing here: we do not know what this course's reviews are. Substituting an
+ * empty list would answer "nobody has reviewed it", which is a different claim
+ * and the one that puts a review prompt in front of somebody who already wrote
+ * theirs.
+ */
+export function reviewsWhenEveryListLoaded<T>(
+  lists: readonly (readonly T[] | undefined)[],
+): T[] | null {
+  const reviews: T[] = [];
+  for (const list of lists) {
+    if (list === undefined) return null;
+    reviews.push(...list);
+  }
+  return reviews;
+}
+
+/**
  * The taken courses this viewer has not reviewed yet.
  *
  * The set arithmetic lives here rather than inside `UnreviewedCard` so the card


### PR DESCRIPTION
Implements **F4: Unreviewed Card** — the prompt shown for courses the viewer marked taken but never reviewed, and the entry point into writing a review. Taken Courses (#92) and My Page (#93) are both blocked on it.

Artboard: `docs/design/Course Community - Unreviewed Card.dc.html`. Nothing under `docs/design/` was touched.

## The seam #92 and #93 consume

Three pieces, so nothing that changes for one reason changes for another:

| | |
|---|---|
| `features/reviews/lib/unreviewed.ts` | `selectUnreviewedCourses(taken, reviews, viewerUserId)` — the set arithmetic, and nothing else |
| `features/reviews/api/queries.ts` | `useUnreviewedTakenCourses()` — wires the selector to `taken.list` and `reviews.list` |
| `features/reviews/components/unreviewed-card.tsx` | `UnreviewedCard` — renders a list it is handed, and knows nothing about how the list was derived |

A screen writes four lines:

```tsx
const { courses } = useUnreviewedTakenCourses();
<UnreviewedCard
  courses={courses.map((c) => ({ code: c.courseCode, name: names[c.courseCode] }))}
  onStart={openReviewer}
/>
```

`UnreviewedCard`, `UnreviewedCourse` and `useUnreviewedTakenCourses` are exported from `features/reviews/index.ts`. `selectUnreviewedCourses` deliberately is not — it is what the hook is made of, and a screen reaching for it directly would be re-deriving a set the hook already derives.

Row behaviour is the artboard's `c.onClick` with a useful default: a row links to `/course/<code>?writeReview=1` — the same review-flow entry Saved and Explore already use — unless the screen passes `onSelect`, which #92 needs to open its reviewer in place instead of navigating away.

## No server procedure, as instructed

The difference is computed in the client. That costs one `reviews.list` per taken course through `useQueries`, in the same shape Saved already uses for `course.summary`. It is a per-user set of at most a few dozen rows.

**The cheaper-looking alternative was rejected.** `reviews.list` has no author filter, so one unfiltered call would ship every review in the database — each with its author's user id — to a browser in order to keep a handful. That is both an unbounded payload and the widest possible surface for de-anonymising reviews that the Review Card renders anonymously. If the fan-out ever matters, the fix is a `reviewedCourseCodes` field on `user.me` alongside `savedCourseCodes`, not a new procedure; it is not needed at this size.

Rows stay hidden until every query has answered. A course whose reviews have not loaded is not "unreviewed", it is unknown, and prompting someone to review a course they already reviewed is the one mistake this card must not make.

## Design vs schema

Per #68's precedence rule, each of these is the minimal change that keeps the design intact.

1. **A taken course has no title.** The artboard renders `c.name`, sourced in `cc-store.js` from `takenView`. `user_taken_courses` stores only `course_code`; the title lives on `courses`. Minimal fix: `UnreviewedCourse.name` is optional and falls back to the code, which is exactly what the artboard's own `c.name || c.code` does. Looking the title up is the screen's job — #92 is already fetching course summaries for its list.

2. **No satisfaction state, and none was tempting.** `happyTook` belongs to a published review and does not exist until one is written. Nothing in the card, the selector or `UnreviewedCourse` carries one. Flagged because the sibling surfaces do render it and it would be an easy thing to copy across.

3. **`total` is a dead prop.** The artboard declares it and My Page passes `takenTotal`, but `renderVals` never reads it. Dropped rather than carried forward. `line` and `max` are both live and are both kept.

4. **The empty case has no artboard.** The component's own logic would produce "0 courses have no review yet" and "Fast track all 0". The card returns `null` for an empty list instead, so neither screen has to remember to guard it.

5. **This is an invitation, not a warning.** The artboard dresses it in `--btn` on the ordinary `--surface`, not the amber nudge, so it uses `--cc-btn` / `--cc-surface` / `--cc-rule2` and never touches `--cc-warn-*`. Noting it because the token comment in `globals.css` describes `--cc-warn-*` as "the nudge to write a review", which points the other way — the artboard wins, and the warn palette belongs to whichever surface actually nags.

No token was invented and no raw hex was added; the one `rgba()` is the artboard's shadow, matching existing practice. Responsive is a container query (`@container` + `@max-[440px]`), aligned with the course card's breakpoint.

## Tests

`features/reviews/components/unreviewed-card.spec.tsx` (`ui` project) drives the card through the real selector, which is what a screen does, so the two cannot drift:

- a taken-but-unreviewed course renders the prompt and routes into the review flow (asserts the `href`)
- a taken course the viewer already reviewed does not appear
- everything taken reviewed → the card renders nothing
- the fast track's count and its callback; `onSelect` replacing the link; `+N more` and a screen-supplied headline

`features/reviews/lib/unreviewed.spec.ts` (`logic` project) covers the selector directly, including the case that matters most: another student's review of a course leaves it unreviewed *by you*.

## Gates

`bun run test:web` 381/381 · `npx tsc --noEmit` clean · `bun run lint` clean (10 pre-existing warnings, none in these files). Rebased onto `feat/frontend` at `d3d5b2c`.

## Note

The card and hook have no consumer on this branch by design — #92 and #93 are the consumers and are blocked on this issue. `dev` is unaffected either way: nothing existing changed behaviour.

Closes #88

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01D3d7V2JceJZvtJED18HXFJ
