### PR TITLE
feat(graph): place every account in the community graph (#82)

### DIFF
--- a/apps/web/server/auth.ts
+++ b/apps/web/server/auth.ts
@@ -4,6 +4,7 @@ import { magicLink } from "better-auth/plugins/magic-link";
 import { db } from "./db";
 import * as schema from "./db/schema";
 import { sendMagicLinkEmail } from "./email/send";
+import { joinCommunityGraphOnSignUp } from "./graph/service";
 
 function createAuth() {
   return betterAuth({
@@ -13,6 +14,18 @@ function createAuth() {
       usePlural: true,
     }),
     emailAndPassword: { enabled: false },
+    databaseHooks: {
+      user: {
+        create: {
+          // Every account gets its place in the community graph from its first
+          // request. The graph service swallows its own failures, so this hook
+          // cannot fail sign-up.
+          after: async (user) => {
+            await joinCommunityGraphOnSignUp(user.id);
+          },
+        },
+      },
+    },
     socialProviders: {
       google: {
         clientId: process.env.GOOGLE_CLIENT_ID ?? "",

--- a/apps/web/server/graph/service.spec.ts
+++ b/apps/web/server/graph/service.spec.ts
@@ -7,6 +7,7 @@ import {
   getEffectiveTier,
   getNeighbourhood,
   joinCommunityGraph,
+  joinCommunityGraphOnSignUp,
   MAX_NEIGHBOURHOOD_NODES,
 } from "./service";
 
@@ -220,6 +221,32 @@ describe("joinCommunityGraph", () => {
   });
 });
 
+describe("joinCommunityGraphOnSignUp", () => {
+  it("gives the new account a node", async () => {
+    const { nodes } = inMemoryCommunity();
+    for (const established of community(6)) {
+      await joinCommunityGraph(established.userId);
+    }
+
+    await joinCommunityGraphOnSignUp("newcomer");
+
+    expect(nodes.map((node) => node.userId)).toContain("newcomer");
+  });
+
+  it("swallows a placement failure, so it can never fail sign-up", async () => {
+    const failure = new Error("graph unreachable");
+    vi.mocked(graphRepo.findNode).mockRejectedValue(failure);
+    const logged = vi.spyOn(console, "error").mockImplementation(() => {});
+
+    await expect(
+      joinCommunityGraphOnSignUp("newcomer"),
+    ).resolves.toBeUndefined();
+
+    expect(logged).toHaveBeenCalledWith(expect.any(String), failure);
+    logged.mockRestore();
+  });
+});
+
 describe("getNeighbourhood", () => {
   const viewer = neighbour("viewer", 100, 100);
 
@@ -306,12 +333,19 @@ describe("getNeighbourhood", () => {
     expect(neighbourhood.nodes).toEqual([viewer]);
   });
 
-  it("rejects an app user who has no node yet", async () => {
-    vi.mocked(graphRepo.findNode).mockResolvedValue(undefined);
+  it("places an app user who has no node yet, rather than turning them away", async () => {
+    const { nodes } = inMemoryCommunity();
+    for (const established of community(6)) {
+      await joinCommunityGraph(established.userId);
+    }
 
-    await expect(getNeighbourhood("stranger")).rejects.toBeInstanceOf(
-      NotFoundError,
+    const neighbourhood = await getNeighbourhood("latecomer");
+
+    expect(neighbourhood.viewer.userId).toBe("latecomer");
+    expect(neighbourhood.nodes.map((node) => node.userId)).toContain(
+      "latecomer",
     );
+    expect(nodes.map((node) => node.userId)).toContain("latecomer");
   });
 });
 

--- a/apps/web/server/graph/service.ts
+++ b/apps/web/server/graph/service.ts
@@ -73,6 +73,27 @@ export async function joinCommunityGraph(userId: string): Promise<GraphNode> {
 }
 
 /**
+ * Place a freshly created account in the community graph.
+ *
+ * Sign-up is the wrong moment to be strict: a member who cannot sign in
+ * because the graph is unavailable has lost their account, while a member
+ * without a node has lost nothing they can see yet — `getNeighbourhood` places
+ * them on their first read. So a failure here is logged and swallowed.
+ */
+export async function joinCommunityGraphOnSignUp(
+  userId: string,
+): Promise<void> {
+  try {
+    await joinCommunityGraph(userId);
+  } catch (error) {
+    console.error(
+      `Could not place app user ${userId} in the community graph at sign-up:`,
+      error,
+    );
+  }
+}
+
+/**
  * The bounded neighbourhood around an app user's own node: the nearby nodes,
  * the backbone edges spanning exactly that set, and the app user's effective
  * personalization tier.
@@ -84,15 +105,19 @@ export async function joinCommunityGraph(userId: string): Promise<GraphNode> {
  *
  * World units come back untouched. Projecting them into screen pixels, and any
  * responsive keep-out adjustment, happens on the client and never returns here.
+ *
+ * An app user without a node is placed rather than refused, so this read can
+ * write on its first call for them.
  */
 export async function getNeighbourhood(
   userId: string,
   now: Date = new Date(),
 ): Promise<Neighbourhood> {
-  const node = await graphRepo.findNode(userId);
-  if (!node) {
-    throw new NotFoundError(`No community graph node for app user ${userId}`);
-  }
+  // Sign-up placement is the primary pathway, but it cannot cover everyone:
+  // it is deliberately fallible, and accounts created before the community
+  // graph existed never saw it. Joining here repairs both, and because joining
+  // is idempotent an app user who already has a node just gets it back.
+  const node = await joinCommunityGraph(userId);
 
   const nodes = await graphRepo.findNearestNodes(
     { x: node.x, y: node.y },


### PR DESCRIPTION
Closes nothing on its own — see #82, which stays open until this is merged.

`graph.join` had no caller, so no `users_graph_nodes` row was ever written and `graph.neighbourhood` answered `NOT_FOUND` for everybody. This implements the issue's recommended fork: **A** as the primary mechanism, **B** as the backstop.

## Changes

**A — placement at account creation.** `apps/web/server/auth.ts` gains `databaseHooks.user.create.after`, which calls the new `joinCommunityGraphOnSignUp`. Verified against better-auth 1.7.2's `getWithHooks` plumbing that this hook shape actually fires, on both the magic-link (`createUser`) and OAuth (`createOAuthUser`) paths. The user id comes from the adapter-created row, never from client input.

**Placement can't cost anyone their account.** `joinCommunityGraphOnSignUp` catches, logs via `console.error` (the convention already used in `ingest/` and `search/`), and swallows. better-auth awaits the after-hook — inside `runWithTransaction`'s pending-hooks loop when a transaction is active, synchronously otherwise — so an escaping rejection *would* fail sign-up. Nothing escapes.

**B — repair on read.** `getNeighbourhood` now calls the idempotent `joinCommunityGraph` instead of throwing `NOT_FOUND`. An app user who already has a node pays exactly one read, the same one the old code did. This is the stated pathway for accounts that predate the graph, and it also catches any sign-up whose hook failed.

## Acceptance criteria

- [x] New app users receive `users_graph_nodes`, `users_node_profiles` and 3–5 backbone edges — the hook calls the placement path that issue #65 already tests for anchor count and profile rows
- [x] Placement failures cannot block sign-up — covered by `swallows a placement failure, so it can never fail sign-up`
- [x] Existing users acquire nodes through a stated, tested pathway — lazy repair in `getNeighbourhood`, covered by `places an app user who has no node yet, rather than turning them away`
- [x] Tests and linting pass — 180 tests, `tsc --noEmit` clean, `bun run lint` exit 0

## Notes for the reviewer

`getNeighbourhood` is now a read that can write on its first call for a given app user. That is deliberate and is the issue's option B; concurrent placement was already made safe in #65, which returns the winning node rather than coordinates that were never stored.

`graph.join` on the router is left in place. It is no longer the only way to get a node, but it is still a valid explicit endpoint and is covered by `router.spec.ts`.