### PR TITLE
feat(transcript): bound PDF parsing CPU for transcript upload

### DIFF
--- a/apps/web/app/api/user/transcript/route.ts
+++ b/apps/web/app/api/user/transcript/route.ts
@@ -1,6 +1,9 @@
 import { getAuth } from "@/server/auth";
 import { TranscriptParseError } from "@/server/ingest/transcript/parse";
-import { extractTranscriptText } from "@/server/ingest/transcript/pdf-text";
+import {
+  extractTranscriptText,
+  TranscriptBusyError,
+} from "@/server/ingest/transcript/pdf-text";
 import { buildTranscriptProposal } from "@/server/ingest/transcript/service";
 import {
   capRequestBody,
@@ -68,6 +71,17 @@ export async function POST(request: Request) {
   } catch (error) {
     if (error instanceof TranscriptParseError) {
       return Response.json({ message: error.message }, { status: 422 });
+    }
+    // Parsing is capacity-bound, so a burst is a "come back", not a bad file.
+    // Saying so keeps the user from re-editing a transcript that was fine.
+    if (error instanceof TranscriptBusyError) {
+      return Response.json(
+        {
+          message:
+            "Too many transcripts are being read right now. Try again in a moment.",
+        },
+        { status: 503, headers: { "Retry-After": "10" } },
+      );
     }
     throw error;
   }

--- a/apps/web/next.config.ts
+++ b/apps/web/next.config.ts
@@ -4,6 +4,16 @@ import type { NextConfig } from "next";
 
 const nextConfig: NextConfig = {
   output: "standalone",
+  // `unpdf` bundles pdf.js and is loaded by path from a worker thread, not by
+  // an import the bundler can follow. Keeping it external leaves it a real
+  // package in node_modules for that worker to resolve at runtime.
+  serverExternalPackages: ["unpdf"],
+  // That same indirection hides it from file tracing, which only follows
+  // static imports — without this the standalone build ships a transcript
+  // route whose worker has nothing to load.
+  outputFileTracingIncludes: {
+    "/api/user/transcript": ["../../node_modules/unpdf/**/*"],
+  },
   outputFileTracingRoot: path.join(
     path.dirname(fileURLToPath(import.meta.url)),
     "../..",

--- a/apps/web/server/ingest/transcript/pdf-text-setup.spec.ts
+++ b/apps/web/server/ingest/transcript/pdf-text-setup.spec.ts
@@ -1,0 +1,36 @@
+import { beforeAll, describe, expect, it, vi } from "vitest";
+
+// Worker construction is made to fail for every call in this file, which is why
+// it is a file of its own: the point is what the capacity gate does when a
+// parse never gets as far as running.
+vi.mock("node:worker_threads", () => ({
+  Worker: class {
+    constructor() {
+      throw new Error("worker could not be started");
+    }
+  },
+}));
+
+describe("extractTranscriptText when the parser cannot be started", () => {
+  let extractTranscriptText: typeof import("./pdf-text").extractTranscriptText;
+  let TranscriptBusyError: typeof import("./pdf-text").TranscriptBusyError;
+
+  beforeAll(async () => {
+    ({ extractTranscriptText, TranscriptBusyError } = await import(
+      "./pdf-text"
+    ));
+  });
+
+  it("hands the slot back so a failure does not cost capacity", async () => {
+    const pdf = new TextEncoder().encode("%PDF-1.7\n");
+
+    // Far more attempts than the two slots and eight queue places. If a failed
+    // setup kept its slot, the gate would be exhausted after two and the rest
+    // would come back as "busy" — which is the bug this pins.
+    for (let attempt = 0; attempt < 25; attempt++) {
+      await expect(extractTranscriptText(pdf)).rejects.not.toBeInstanceOf(
+        TranscriptBusyError,
+      );
+    }
+  }, 30_000);
+});

--- a/apps/web/server/ingest/transcript/pdf-text.spec.ts
+++ b/apps/web/server/ingest/transcript/pdf-text.spec.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 import { TranscriptParseError } from "./parse";
-import { extractTranscriptText } from "./pdf-text";
+import { extractTranscriptText, TranscriptBusyError } from "./pdf-text";
 
 /**
  * A syntactically valid PDF of `pages` text pages.
@@ -85,6 +85,21 @@ describe("extractTranscriptText", () => {
       extractTranscriptText(heavy, { budgetMs: 1000 }),
     ).rejects.toBeInstanceOf(TranscriptParseError);
   }, 30_000);
+
+  it("refuses a new parse once the queue behind the cap is full", async () => {
+    // Two run, eight wait, and anything beyond that is turned away rather than
+    // being allowed to start a thread of its own.
+    const heavy = textPdf(3000);
+    const inFlight = Array.from({ length: 10 }, () =>
+      extractTranscriptText(heavy, { budgetMs: 2_000 }).catch(() => undefined),
+    );
+
+    await expect(extractTranscriptText(textPdf(2))).rejects.toBeInstanceOf(
+      TranscriptBusyError,
+    );
+
+    await Promise.all(inFlight);
+  }, 60_000);
 
   it("gives up at the budget instead of finishing the parse", async () => {
     const heavy = textPdf(3000);

--- a/apps/web/server/ingest/transcript/pdf-text.spec.ts
+++ b/apps/web/server/ingest/transcript/pdf-text.spec.ts
@@ -2,6 +2,54 @@ import { describe, expect, it } from "vitest";
 import { TranscriptParseError } from "./parse";
 import { extractTranscriptText } from "./pdf-text";
 
+/**
+ * A syntactically valid PDF of `pages` text pages.
+ *
+ * Real transcripts cannot be committed — they are academic records carrying a
+ * personal identity number — so the tests that need real PDF bytes build their
+ * own. Page count is the dial: it buys parsing work without needing a
+ * maliciously crafted file.
+ */
+function textPdf(pages: number, linesPerPage = 45): Uint8Array {
+  const objects: string[] = [
+    "<</Type/Catalog/Pages 2 0 R>>",
+    `<</Type/Pages/Kids[${Array.from(
+      { length: pages },
+      (_, p) => `${4 + p * 2} 0 R`,
+    ).join(" ")}]/Count ${pages}>>`,
+    "<</Type/Font/Subtype/Type1/BaseFont/Helvetica>>",
+  ];
+
+  for (let p = 0; p < pages; p++) {
+    let content = "BT /F1 9 Tf 40 750 Td 11 TL\n";
+    for (let line = 0; line < linesPerPage; line++) {
+      content += `(DD${1000 + line} Kursnamn ${p}-${line} 7,5 hp A 2024-01-15) Tj T*\n`;
+    }
+    content += "ET";
+    objects.push(
+      "<</Type/Page/Parent 2 0 R/MediaBox[0 0 595 842]" +
+        `/Resources<</Font<</F1 3 0 R>>>>/Contents ${5 + p * 2} 0 R>>`,
+      `<</Length ${content.length}>>\nstream\n${content}\nendstream`,
+    );
+  }
+
+  let pdf = "%PDF-1.7\n";
+  const offsets: number[] = [];
+  for (const [index, body] of objects.entries()) {
+    offsets.push(pdf.length);
+    pdf += `${index + 1} 0 obj\n${body}\nendobj\n`;
+  }
+  const xref = pdf.length;
+  pdf += `xref\n0 ${objects.length + 1}\n0000000000 65535 f \n`;
+  for (const offset of offsets) {
+    pdf += `${String(offset).padStart(10, "0")} 00000 n \n`;
+  }
+  pdf += `trailer\n<</Size ${objects.length + 1}/Root 1 0 R>>\n`;
+  pdf += `startxref\n${xref}\n%%EOF\n`;
+
+  return new TextEncoder().encode(pdf);
+}
+
 describe("extractTranscriptText", () => {
   it("rejects bytes that are not a PDF", async () => {
     const notAPdf = new TextEncoder().encode("just some text, not a PDF");
@@ -18,4 +66,38 @@ describe("extractTranscriptText", () => {
       (error: Error) => !error.message.includes("Sec"),
     );
   });
+
+  it("reads the text of a PDF it can parse", async () => {
+    const text = await extractTranscriptText(textPdf(2));
+
+    expect(text).toContain("DD1000 Kursnamn 0-0 7,5 hp A 2024-01-15");
+    expect(text).toContain("DD1000 Kursnamn 1-0 7,5 hp A 2024-01-15");
+  });
+
+  it("rejects a document that runs past the CPU budget", async () => {
+    // Deliberately heavier than the 4MB the route admits: the size cap is a
+    // separate, earlier layer, and what is under test here is the budget. The
+    // page count buys enough parsing work that the outcome cannot turn on how
+    // fast the machine running the test is.
+    const heavy = textPdf(3000);
+
+    await expect(
+      extractTranscriptText(heavy, { budgetMs: 1000 }),
+    ).rejects.toBeInstanceOf(TranscriptParseError);
+  }, 30_000);
+
+  it("gives up at the budget instead of finishing the parse", async () => {
+    const heavy = textPdf(3000);
+
+    const startedAt = performance.now();
+    await expect(
+      extractTranscriptText(heavy, { budgetMs: 1000 }),
+    ).rejects.toThrow();
+    const elapsed = performance.now() - startedAt;
+
+    // Parsing this document to completion takes ~3.5s on the development
+    // machine. Returning inside 2.5s is only possible if the parse was cut
+    // short rather than waited out.
+    expect(elapsed).toBeLessThan(2_500);
+  }, 30_000);
 });

--- a/apps/web/server/ingest/transcript/pdf-text.ts
+++ b/apps/web/server/ingest/transcript/pdf-text.ts
@@ -1,5 +1,76 @@
-import { extractText } from "unpdf";
+import { createRequire } from "node:module";
+import { join } from "node:path";
+import { pathToFileURL } from "node:url";
+import { Worker } from "node:worker_threads";
 import { TranscriptParseError } from "./parse";
+
+/**
+ * Wall-clock ceiling on one extraction, in milliseconds.
+ *
+ * Measured, not guessed. On the development machine a cold worker — thread
+ * start, pdf.js load and parse — costs 82-126ms for the two real Ladok
+ * transcripts, and ~1150ms for a synthetic 1000-page, 3.5MB document, which is
+ * about the largest text PDF that fits under the route's 4MB cap. The budget
+ * sits above that worst legitimate case with room for slower hardware: ~4x the
+ * heaviest admissible document and ~40x a real transcript.
+ */
+const DEFAULT_BUDGET_MS = 5_000;
+
+/**
+ * Runs inside the worker. Kept to one job so there is little to go wrong in a
+ * context that cannot be debugged from a request.
+ *
+ * It posts back the text or a bare failure flag. The library's own error never
+ * crosses the thread boundary: a PDF parser's message can quote bytes from the
+ * document, and nothing from inside a transcript may reach a log or a response.
+ */
+const WORKER_SOURCE = `
+import { workerData, parentPort } from "node:worker_threads";
+
+try {
+  const { extractText } = await import(workerData.unpdfUrl);
+  const { text } = await extractText(workerData.bytes, { mergePages: true });
+  parentPort.postMessage({ ok: true, text });
+} catch {
+  parentPort.postMessage({ ok: false });
+}
+`;
+
+let cachedUnpdfUrl: string | undefined;
+
+/**
+ * Where the worker should import `unpdf` from.
+ *
+ * Resolved in the parent and handed over as a file URL, because an `eval`
+ * worker resolves a bare specifier against the working directory rather than
+ * against this module. `import.meta.url` is not usable as the resolution base:
+ * Turbopack rewrites it to a numeric module id at build time, so anchoring on
+ * it fails while Next collects page data. The application root is the base that
+ * survives dev, Vitest and the standalone build alike — `unpdf` is a
+ * `serverExternalPackage`, so it is a real directory under `node_modules` in
+ * all three, and Node walks up from here to find it.
+ *
+ * Resolved on first use rather than at module scope: this module is evaluated
+ * during `next build`, where throwing would fail the build rather than one
+ * upload.
+ */
+function resolveUnpdfUrl(): string {
+  if (!cachedUnpdfUrl) {
+    const from = createRequire(join(process.cwd(), "noop.js"));
+    cachedUnpdfUrl = pathToFileURL(from.resolve("unpdf")).href;
+  }
+  return cachedUnpdfUrl;
+}
+
+/** What the worker is allowed to send back. */
+type WorkerReply = { ok: true; text: string } | { ok: false };
+
+function unreadable(): TranscriptParseError {
+  return new TranscriptParseError(
+    "This file could not be read. Upload the PDF that Ladok generates, " +
+      "not a scan or a screenshot of it.",
+  );
+}
 
 /**
  * Pulls the text layer out of a transcript PDF.
@@ -9,20 +80,54 @@ import { TranscriptParseError } from "./parse";
  * length of one request — a transcript is a student's academic record and is
  * never written to disk, to blob storage, or to a log.
  *
- * The underlying error is deliberately dropped rather than chained: a PDF
- * library's failure message can quote bytes from the document, and nothing from
- * inside the file may reach a log line or an API response.
+ * The parse runs on a worker thread under a wall-clock budget. The size cap on
+ * the route bounds how many bytes arrive, not how long they take to parse: a
+ * small, deliberately pathological document can hold a parser far longer than
+ * any real transcript, and on Node that is time the whole process spends not
+ * serving anyone else. `terminate()` is what makes the budget real — it stops a
+ * thread that is spinning in native code, which a cancelled promise cannot do.
+ *
+ * A document that runs past the budget fails exactly as an unreadable one does.
+ * Distinguishing the two would only tell an attacker where the ceiling sits,
+ * and the caller does the same thing either way: reject the upload, store
+ * nothing.
  */
 export async function extractTranscriptText(
   bytes: Uint8Array,
+  { budgetMs = DEFAULT_BUDGET_MS }: { budgetMs?: number } = {},
 ): Promise<string> {
+  const worker = new Worker(WORKER_SOURCE, {
+    eval: true,
+    workerData: { unpdfUrl: resolveUnpdfUrl(), bytes },
+  });
+
   try {
-    const { text } = await extractText(bytes, { mergePages: true });
-    return text;
-  } catch {
-    throw new TranscriptParseError(
-      "This file could not be read. Upload the PDF that Ladok generates, " +
-        "not a scan or a screenshot of it.",
-    );
+    return await new Promise<string>((resolve, reject) => {
+      // Whichever outcome lands first wins, and the timer is cleared in every
+      // case: an early result would otherwise hold the event loop open until
+      // the whole budget had elapsed.
+      let settled = false;
+      let budget: ReturnType<typeof setTimeout>;
+      const settle = (outcome: () => void) => {
+        if (settled) return;
+        settled = true;
+        clearTimeout(budget);
+        outcome();
+      };
+
+      budget = setTimeout(() => settle(() => reject(unreadable())), budgetMs);
+
+      worker.on("message", (reply: WorkerReply) => {
+        settle(() => (reply.ok ? resolve(reply.text) : reject(unreadable())));
+      });
+      // A worker that dies outright — an OOM kill, a failure to boot — is
+      // reported the same way as a file the parser rejected.
+      worker.on("error", () => settle(() => reject(unreadable())));
+      worker.on("exit", () => settle(() => reject(unreadable())));
+    });
+  } finally {
+    // Unconditional: on the timeout path this is what actually reclaims the
+    // CPU, and on every other path the thread is done and must not be leaked.
+    await worker.terminate();
   }
 }

--- a/apps/web/server/ingest/transcript/pdf-text.ts
+++ b/apps/web/server/ingest/transcript/pdf-text.ts
@@ -17,6 +17,56 @@ import { TranscriptParseError } from "./parse";
 const DEFAULT_BUDGET_MS = 5_000;
 
 /**
+ * How many transcripts may be parsed at once, and how many may wait.
+ *
+ * A worker bounds the CPU one upload can spend; it does nothing about how many
+ * uploads spend it at the same time. Left ungated, each concurrent request
+ * starts its own parser thread, so a signed-in user can hold a core per
+ * request for a whole budget each — the request thread is no longer the thing
+ * that serialises them. Two at a time keeps the heaviest admissible document
+ * (~1150ms) well inside the budget while leaving the box able to serve
+ * everything else; the queue absorbs an ordinary burst without turning it into
+ * an error.
+ */
+const MAX_CONCURRENT_EXTRACTIONS = 2;
+const MAX_QUEUED_EXTRACTIONS = 8;
+
+/** Raised when too many transcripts are already being parsed. */
+export class TranscriptBusyError extends Error {
+  readonly code = "TRANSCRIPT_BUSY" as const;
+  constructor() {
+    super("Transcript parsing is at capacity");
+    this.name = "TranscriptBusyError";
+  }
+}
+
+let running = 0;
+const queued: Array<() => void> = [];
+
+/**
+ * Takes a parsing slot, waiting for one if the queue has room.
+ *
+ * Rejecting past the queue is deliberate: making a caller wait an unbounded
+ * time is the same denial of service by a slower route, and the client would
+ * rather be told to come back than hold a connection open.
+ */
+async function acquireSlot(): Promise<void> {
+  if (running < MAX_CONCURRENT_EXTRACTIONS) {
+    running++;
+    return;
+  }
+  if (queued.length >= MAX_QUEUED_EXTRACTIONS) throw new TranscriptBusyError();
+  await new Promise<void>((resume) => queued.push(resume));
+  running++;
+}
+
+/** Hands the slot to whoever is next in line. */
+function releaseSlot(): void {
+  running--;
+  queued.shift()?.();
+}
+
+/**
  * Runs inside the worker. Kept to one job so there is little to go wrong in a
  * context that cannot be debugged from a request.
  *
@@ -98,6 +148,9 @@ export async function extractTranscriptText(
   bytes: Uint8Array,
   { budgetMs = DEFAULT_BUDGET_MS }: { budgetMs?: number } = {},
 ): Promise<string> {
+  // Before the thread exists: the point is to not create it under load.
+  await acquireSlot();
+
   const worker = new Worker(WORKER_SOURCE, {
     eval: true,
     workerData: { unpdfUrl: resolveUnpdfUrl(), bytes },
@@ -135,6 +188,9 @@ export async function extractTranscriptText(
   } finally {
     // Unconditional: on the timeout path this is what actually reclaims the
     // CPU, and on every other path the thread is done and must not be leaked.
+    // The slot is handed on only once the thread is genuinely gone, or the cap
+    // would let the next parse start alongside one still winding down.
     await worker.terminate();
+    releaseSlot();
   }
 }

--- a/apps/web/server/ingest/transcript/pdf-text.ts
+++ b/apps/web/server/ingest/transcript/pdf-text.ts
@@ -151,12 +151,18 @@ export async function extractTranscriptText(
   // Before the thread exists: the point is to not create it under load.
   await acquireSlot();
 
-  const worker = new Worker(WORKER_SOURCE, {
-    eval: true,
-    workerData: { unpdfUrl: resolveUnpdfUrl(), bytes },
-  });
-
+  // Setup sits inside the block that releases the slot. Resolving `unpdf` or
+  // starting the thread can throw, and a slot lost that way is lost for the
+  // life of the process: enough of them and the cap turns into a permanent
+  // outage for a route that is otherwise healthy.
+  let worker: Worker | undefined;
   try {
+    worker = new Worker(WORKER_SOURCE, {
+      eval: true,
+      workerData: { unpdfUrl: resolveUnpdfUrl(), bytes },
+    });
+    const started = worker;
+
     return await new Promise<string>((resolve, reject) => {
       // Whichever outcome lands first wins, and the timer is cleared in every
       // case: an early result would otherwise hold the event loop open until
@@ -174,7 +180,7 @@ export async function extractTranscriptText(
 
       budget = setTimeout(fail, budgetMs);
 
-      worker.on("message", (reply: WorkerReply) => {
+      started.on("message", (reply: WorkerReply) => {
         settle(() => (reply.ok ? resolve(reply.text) : reject(unreadable())));
       });
       // A worker that dies outright — an OOM kill, a failure to boot — is
@@ -182,15 +188,17 @@ export async function extractTranscriptText(
       // on the way out of a successful parse, after `terminate()` below; that
       // is a no-op because the promise has already settled, and it stays one
       // because Node delivers a worker's `message` before its `exit`.
-      worker.on("error", fail);
-      worker.on("exit", fail);
+      started.on("error", fail);
+      started.on("exit", fail);
     });
   } finally {
-    // Unconditional: on the timeout path this is what actually reclaims the
-    // CPU, and on every other path the thread is done and must not be leaked.
-    // The slot is handed on only once the thread is genuinely gone, or the cap
-    // would let the next parse start alongside one still winding down.
-    await worker.terminate();
+    // Terminating is unconditional where a thread exists: on the timeout path
+    // it is what actually reclaims the CPU, and on every other path the thread
+    // is done and must not be leaked. The slot is handed on only once that
+    // thread is genuinely gone, or the cap would let the next parse start
+    // alongside one still winding down — and it is handed on even when there
+    // was never a thread at all.
+    await worker?.terminate();
     releaseSlot();
   }
 }

--- a/apps/web/server/ingest/transcript/pdf-text.ts
+++ b/apps/web/server/ingest/transcript/pdf-text.ts
@@ -56,6 +56,8 @@ let cachedUnpdfUrl: string | undefined;
  */
 function resolveUnpdfUrl(): string {
   if (!cachedUnpdfUrl) {
+    // `createRequire` wants a file to resolve *from*, not a real file: only
+    // the directory part is used, so `noop.js` never has to exist.
     const from = createRequire(join(process.cwd(), "noop.js"));
     cachedUnpdfUrl = pathToFileURL(from.resolve("unpdf")).href;
   }
@@ -115,15 +117,20 @@ export async function extractTranscriptText(
         outcome();
       };
 
-      budget = setTimeout(() => settle(() => reject(unreadable())), budgetMs);
+      const fail = () => settle(() => reject(unreadable()));
+
+      budget = setTimeout(fail, budgetMs);
 
       worker.on("message", (reply: WorkerReply) => {
         settle(() => (reply.ok ? resolve(reply.text) : reject(unreadable())));
       });
       // A worker that dies outright — an OOM kill, a failure to boot — is
-      // reported the same way as a file the parser rejected.
-      worker.on("error", () => settle(() => reject(unreadable())));
-      worker.on("exit", () => settle(() => reject(unreadable())));
+      // reported the same way as a file the parser rejected. `exit` also fires
+      // on the way out of a successful parse, after `terminate()` below; that
+      // is a no-op because the promise has already settled, and it stays one
+      // because Node delivers a worker's `message` before its `exit`.
+      worker.on("error", fail);
+      worker.on("exit", fail);
     });
   } finally {
     // Unconditional: on the timeout path this is what actually reclaims the


### PR DESCRIPTION
Closes nothing — `Refs #83`.

## The gap

`POST /api/user/transcript` ran `unpdf` (pdf.js) in-process on a user-supplied
PDF. The upload caps bound the *size* of the file, not the CPU the parser
spends on it, so a small, deliberately pathological document could hold the
request thread for an unbounded time — on Node, time the whole process spends
serving nobody.

## The change

Extraction moves to a worker thread under a hard wall-clock budget.
`worker.terminate()` is what makes the budget real: it stops a thread spinning
in native code, which a cancelled promise cannot do. I verified that
separately — a worker running `while(true){}` is killed by `terminate()` while
the main thread keeps ticking every 100ms throughout.

A document over the budget fails exactly as an unreadable one does
(`TranscriptParseError` → 422) and still writes nothing. The two are
deliberately indistinguishable: separating them would only tell an attacker
where the ceiling sits, and the caller does the same thing either way.

## The measurement

The budget is measured, not guessed. Cold worker = thread start + pdf.js load +
parse, which is what a request actually pays.

| Document | Size | Cold worker |
| --- | --- | --- |
| Swedish.pdf (real transcript) | 157 KB | 82–116 ms |
| English.pdf (real transcript) | 159 KB | 99–126 ms |
| synthetic 200-page | 0.69 MB | ~300 ms |
| synthetic 1000-page | 3.48 MB | ~1150 ms |

The 1000-page document is roughly the largest text PDF that fits under the
route's existing 4 MB cap, so ~1150 ms — not the 126 ms real transcript — is
the worst *legitimate* case the budget must admit. **5 s** leaves ~4x headroom
over it and ~40x over a real transcript.

The real transcripts are not committed: they are academic records carrying a
personal identity number. Tests that need PDF bytes build their own.

## Why the two next.config lines

Loading `unpdf` by path from a worker takes it off the bundler's static graph,
which breaks two things that a passing test suite does not catch:

- `serverExternalPackages` — without it Turbopack inlines pdf.js.
- `outputFileTracingIncludes` — without it `unpdf` is **not copied into the
  standalone output at all** (I confirmed: 12 packages, no `unpdf`), so the
  Docker image would ship a transcript route whose worker has nothing to load.

Verified by copying `.next/standalone` to a directory with no parent
`node_modules` and running an extraction there — the shape the Docker image
ships.

Note: `import.meta.url` is unusable as a resolution base here — Turbopack
rewrites it to a numeric module id, which fails the build during page-data
collection. Resolution is anchored at the app root and done on first use, not
at module scope, so a misconfigured deployment fails one upload rather than the
build.

## Bounding concurrency too

A worker bounds the CPU *one* upload spends; it says nothing about how many
spend it at once. Moving the parse off the request thread removed the thing
that used to serialise uploads, so this PR briefly made aggregate CPU *worse*:
twelve concurrent uploads took the process from 10 threads to 34 (caught by
Greptile on this PR).

Two transcripts parse at a time, eight may queue, and anything past that is
refused before a thread exists. That refusal is a distinct `TranscriptBusyError`
→ `503` with `Retry-After`, kept separate from the `422` for an unreadable
file: a burst means "come back", and calling it a bad file would send the user
off to re-edit a transcript that was fine.

After the change, twelve concurrent uploads complete in strict pairs —
`1,1,48,48,94,94,140,140,186,186,230,230` ms: two immediate rejections, then
six sequential batches of two.

Gating also introduced a leak, caught on re-review: the slot was taken before
`unpdf` was resolved and the thread started, but released by a `finally` that
began after both, so a setup failure cost a slot permanently. Setup now sits
inside the releasing block. The regression test pins the symptom rather than
the shape — with the leak it doesn't merely fail, it hangs to the 30s timeout
as uploads queue behind slots that never come back.

## Gates

- `bun run test:web` — 185 passed
- `npx tsc --noEmit` — clean
- `bun run lint` — clean
- `next build` — succeeds

Refs #83

🤖 Generated with [Claude Code](https://claude.com/claude-code)
