### PR TITLE
feat(collections): the Collections page (#91)

### DIFF
--- a/apps/web/app/(service)/collections/page.tsx
+++ b/apps/web/app/(service)/collections/page.tsx
@@ -1,0 +1,16 @@
+import { Collections } from "@/features/collections/components/collections";
+
+/**
+ * `?collection=<id>` names the open collection, so a refresh or a shared link
+ * lands back on it. An id that is not one of the viewer's own reads as
+ * not-found: ownership is scoped in the query, so a stranger's collection is
+ * simply absent rather than refused.
+ */
+export default async function Page({
+  searchParams,
+}: {
+  searchParams: Promise<{ collection?: string }>;
+}) {
+  const { collection } = await searchParams;
+  return <Collections openCollectionId={collection ?? null} />;
+}

--- a/apps/web/features/collections/components/collection-detail.tsx
+++ b/apps/web/features/collections/components/collection-detail.tsx
@@ -1,8 +1,10 @@
 "use client";
 
 import { ArrowLeft, ChevronDown, ChevronUp } from "lucide-react";
-import { useEffect, useRef, useState } from "react";
+import { useEffect } from "react";
 import type { AuthReason } from "@/features/auth";
+import { usePopover } from "@/features/collections/hooks/use-popover";
+import { useRenameDraft } from "@/features/collections/hooks/use-rename-draft";
 import { courseCountLabel } from "@/features/collections/lib/collection-model";
 import {
   type Collection,
@@ -12,6 +14,7 @@ import {
   EXPANDED_CARD_GEOMETRY,
 } from "@/features/courses";
 import type { CourseStats } from "@/types";
+import { EmptyPanel } from "./empty-panel";
 
 /** A course the viewer has saved, with everything a card needs to draw it. */
 export type SavedCourse = {
@@ -75,32 +78,17 @@ export function CollectionDetail({
   onOpenCourse,
   onRequestAuth,
 }: Props) {
-  const [draft, setDraft] = useState<string | null>(null);
-  const [addOpen, setAddOpen] = useState(false);
-  const addRef = useRef<HTMLDivElement>(null);
-
-  useEffect(() => {
-    if (!addOpen) return;
-    function onPointerDown(event: PointerEvent) {
-      if (!addRef.current?.contains(event.target as Node)) setAddOpen(false);
-    }
-    document.addEventListener("pointerdown", onPointerDown, true);
-    return () =>
-      document.removeEventListener("pointerdown", onPointerDown, true);
-  }, [addOpen]);
+  const renaming = useRenameDraft(collection.name, onRename);
+  const addMenu = usePopover();
 
   // The collection under the reader can change: another tab removes a course,
   // or unsaving one cascades its membership away. Nothing addable means nothing
-  // to open.
+  // to open, and the trigger itself goes with it.
+  const nothingAddable = addableCourseCodes.length === 0;
+  const closeAddMenu = addMenu.close;
   useEffect(() => {
-    if (addableCourseCodes.length === 0) setAddOpen(false);
-  }, [addableCourseCodes.length]);
-
-  function commitRename() {
-    const name = draft?.trim() ?? "";
-    setDraft(null);
-    if (name && name !== collection.name) onRename(name);
-  }
+    if (nothingAddable) closeAddMenu();
+  }, [nothingAddable, closeAddMenu]);
 
   const { courseCodes } = collection;
 
@@ -117,24 +105,21 @@ export function CollectionDetail({
 
       <div className="flex flex-wrap items-start justify-between gap-4">
         <div className="min-w-0">
-          {draft === null ? (
-            <h2 className="m-0 font-semibold text-[21px] tracking-[-0.015em]">
-              {collection.name}
-            </h2>
-          ) : (
+          {renaming.isRenaming ? (
             <input
               // biome-ignore lint/a11y/noAutofocus: Rename put the caret here, as the artboard's own autoFocus does.
               autoFocus
               aria-label="Collection name"
-              value={draft}
-              onChange={(event) => setDraft(event.target.value)}
-              onBlur={commitRename}
-              onKeyDown={(event) => {
-                if (event.key === "Enter") event.currentTarget.blur();
-                if (event.key === "Escape") setDraft(null);
-              }}
+              value={renaming.draft}
+              onChange={(event) => renaming.change(event.target.value)}
+              onBlur={renaming.commit}
+              onKeyDown={renaming.onKeyDown}
               className="box-border h-[34px] rounded-[8px] border border-cc-brand bg-cc-surface px-2.5 font-semibold text-[20px] text-cc-ink outline-none"
             />
+          ) : (
+            <h2 className="m-0 font-semibold text-[21px] tracking-[-0.015em]">
+              {collection.name}
+            </h2>
           )}
           <div className="mt-[5px] text-[12.5px] text-cc-muted">
             {courseCountLabel(courseCodes.length)}
@@ -144,25 +129,27 @@ export function CollectionDetail({
         <div className="flex items-center gap-[7px]">
           <button
             type="button"
-            onClick={() => setDraft(collection.name)}
+            onClick={renaming.start}
             className={ACTION_BUTTON}
           >
             Rename
           </button>
 
-          {addableCourseCodes.length > 0 ? (
-            <div className="relative" ref={addRef}>
+          {nothingAddable ? null : (
+            <div className="relative">
               <button
+                ref={addMenu.triggerRef}
                 type="button"
-                onClick={() => setAddOpen((open) => !open)}
+                onClick={addMenu.toggle}
                 aria-haspopup="menu"
-                aria-expanded={addOpen}
+                aria-expanded={addMenu.isOpen}
                 className={ACTION_BUTTON}
               >
                 Add course
               </button>
-              {addOpen ? (
+              {addMenu.isOpen ? (
                 <div
+                  ref={addMenu.panelRef}
                   role="menu"
                   aria-label="Add a saved course"
                   className="absolute top-9 right-0 z-20 box-border max-h-[260px] w-[250px] overflow-auto rounded-[10px] border border-cc-rule2 bg-cc-surface p-[5px] shadow-[0_8px_24px_rgba(20,30,45,.14)]"
@@ -173,7 +160,7 @@ export function CollectionDetail({
                       type="button"
                       role="menuitem"
                       onClick={() => {
-                        setAddOpen(false);
+                        addMenu.close();
                         onAddCourse(courseCode);
                       }}
                       className="flex w-full cursor-pointer items-baseline gap-2 rounded-[7px] px-[9px] py-2 text-left text-[12.5px] text-cc-ink2 hover:bg-cc-pill"
@@ -189,7 +176,7 @@ export function CollectionDetail({
                 </div>
               ) : null}
             </div>
-          ) : null}
+          )}
 
           <button
             type="button"
@@ -202,16 +189,14 @@ export function CollectionDetail({
       </div>
 
       {courseCodes.length === 0 ? (
-        <div className="rounded-[11px] border border-cc-rule bg-cc-surface p-6 text-center">
-          <div className="font-semibold text-[14.5px]">
-            No courses in this collection
-          </div>
-          <div className="mt-[5px] text-[12.5px] text-cc-muted">
-            {hasSavedCourses
+        <EmptyPanel
+          title="No courses in this collection"
+          body={
+            hasSavedCourses
               ? "Add one of your saved courses to it — a collection can only hold courses you have saved."
-              : "A collection can only hold courses you have saved. Save some from Explore, then add them here."}
-          </div>
-        </div>
+              : "A collection can only hold courses you have saved. Save some from Explore, then add them here."
+          }
+        />
       ) : (
         <ol className="flex list-none flex-col gap-3 p-0">
           {courseCodes.map((courseCode, index) => {

--- a/apps/web/features/collections/components/collection-detail.tsx
+++ b/apps/web/features/collections/components/collection-detail.tsx
@@ -1,0 +1,265 @@
+"use client";
+
+import { ArrowLeft, ChevronDown, ChevronUp } from "lucide-react";
+import { useEffect, useRef, useState } from "react";
+import type { AuthReason } from "@/features/auth";
+import { courseCountLabel } from "@/features/collections/lib/collection-model";
+import {
+  type Collection,
+  type CourseCardCourse,
+  CourseCardItem,
+  CourseItemSkeleton,
+  EXPANDED_CARD_GEOMETRY,
+} from "@/features/courses";
+import type { CourseStats } from "@/types";
+
+/** A course the viewer has saved, with everything a card needs to draw it. */
+export type SavedCourse = {
+  course: CourseCardCourse;
+  stats: CourseStats;
+};
+
+type Props = {
+  collection: Collection;
+  /** `undefined` while the course's summary is still in flight. */
+  courseFor: (courseCode: string) => SavedCourse | undefined;
+  /** Saved courses this collection does not already hold. Saved-only, always. */
+  addableCourseCodes: string[];
+  /** Whether the viewer has saved anything at all, which changes the empty copy. */
+  hasSavedCourses: boolean;
+  onBack: () => void;
+  onRename: (name: string) => void;
+  onDelete: () => void;
+  onAddCourse: (courseCode: string) => void;
+  onRemoveCourse: (courseCode: string) => void;
+  onMoveCourse: (courseCode: string, direction: "up" | "down") => void;
+  onOpenCourse: (courseCode: string) => void;
+  onRequestAuth: (reason: AuthReason) => void;
+};
+
+const ACTION_BUTTON =
+  "flex h-8 cursor-pointer items-center rounded-[8px] border border-cc-rule3 bg-cc-surface px-[11px] font-medium text-[12.5px] text-cc-ink hover:border-cc-hov";
+
+const MOVE_BUTTON =
+  "flex size-[26px] cursor-pointer items-center justify-center rounded-[7px] border border-cc-rule3 bg-cc-surface text-cc-dim hover:border-cc-hov hover:text-cc-brand disabled:cursor-default disabled:opacity-35 disabled:hover:border-cc-rule3 disabled:hover:text-cc-dim";
+
+/**
+ * One open collection: its name, its courses in stored order, and everything
+ * that changes either.
+ *
+ * The courses are `CourseCardItem`s rather than the artboard's one-line rows.
+ * The artboard's row shows a code, a title and a `hp · period · school` meta
+ * string assembled from its mock store; `period` and `school` are not fields the
+ * schema has, and the card renders the same course from data that does exist —
+ * so the codebase wins, as #68 has it, and the design's remove affordance
+ * survives as the card's own `removeLabel` button, which #86 built for this page.
+ * The geometry is pinned to the expanded end: the page column has nothing
+ * competing for its width, so there is no ramp to interpolate along.
+ *
+ * Reordering is a pair of move buttons per course. The artboard designs no
+ * reorder control at all, and `collections.reorder` is the only ordering the
+ * schema carries, so this is the smallest control that reaches it — and one a
+ * keyboard can drive, which a drag handle is not.
+ */
+export function CollectionDetail({
+  collection,
+  courseFor,
+  addableCourseCodes,
+  hasSavedCourses,
+  onBack,
+  onRename,
+  onDelete,
+  onAddCourse,
+  onRemoveCourse,
+  onMoveCourse,
+  onOpenCourse,
+  onRequestAuth,
+}: Props) {
+  const [draft, setDraft] = useState<string | null>(null);
+  const [addOpen, setAddOpen] = useState(false);
+  const addRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    if (!addOpen) return;
+    function onPointerDown(event: PointerEvent) {
+      if (!addRef.current?.contains(event.target as Node)) setAddOpen(false);
+    }
+    document.addEventListener("pointerdown", onPointerDown, true);
+    return () =>
+      document.removeEventListener("pointerdown", onPointerDown, true);
+  }, [addOpen]);
+
+  // The collection under the reader can change: another tab removes a course,
+  // or unsaving one cascades its membership away. Nothing addable means nothing
+  // to open.
+  useEffect(() => {
+    if (addableCourseCodes.length === 0) setAddOpen(false);
+  }, [addableCourseCodes.length]);
+
+  function commitRename() {
+    const name = draft?.trim() ?? "";
+    setDraft(null);
+    if (name && name !== collection.name) onRename(name);
+  }
+
+  const { courseCodes } = collection;
+
+  return (
+    <div className="flex flex-col gap-4">
+      <button
+        type="button"
+        onClick={onBack}
+        className="flex cursor-pointer items-center gap-1.5 self-start font-medium text-[12.5px] text-cc-brand hover:underline"
+      >
+        <ArrowLeft size={14} aria-hidden />
+        All collections
+      </button>
+
+      <div className="flex flex-wrap items-start justify-between gap-4">
+        <div className="min-w-0">
+          {draft === null ? (
+            <h2 className="m-0 font-semibold text-[21px] tracking-[-0.015em]">
+              {collection.name}
+            </h2>
+          ) : (
+            <input
+              // biome-ignore lint/a11y/noAutofocus: Rename put the caret here, as the artboard's own autoFocus does.
+              autoFocus
+              aria-label="Collection name"
+              value={draft}
+              onChange={(event) => setDraft(event.target.value)}
+              onBlur={commitRename}
+              onKeyDown={(event) => {
+                if (event.key === "Enter") event.currentTarget.blur();
+                if (event.key === "Escape") setDraft(null);
+              }}
+              className="box-border h-[34px] rounded-[8px] border border-cc-brand bg-cc-surface px-2.5 font-semibold text-[20px] text-cc-ink outline-none"
+            />
+          )}
+          <div className="mt-[5px] text-[12.5px] text-cc-muted">
+            {courseCountLabel(courseCodes.length)}
+          </div>
+        </div>
+
+        <div className="flex items-center gap-[7px]">
+          <button
+            type="button"
+            onClick={() => setDraft(collection.name)}
+            className={ACTION_BUTTON}
+          >
+            Rename
+          </button>
+
+          {addableCourseCodes.length > 0 ? (
+            <div className="relative" ref={addRef}>
+              <button
+                type="button"
+                onClick={() => setAddOpen((open) => !open)}
+                aria-haspopup="menu"
+                aria-expanded={addOpen}
+                className={ACTION_BUTTON}
+              >
+                Add course
+              </button>
+              {addOpen ? (
+                <div
+                  role="menu"
+                  aria-label="Add a saved course"
+                  className="absolute top-9 right-0 z-20 box-border max-h-[260px] w-[250px] overflow-auto rounded-[10px] border border-cc-rule2 bg-cc-surface p-[5px] shadow-[0_8px_24px_rgba(20,30,45,.14)]"
+                >
+                  {addableCourseCodes.map((courseCode) => (
+                    <button
+                      key={courseCode}
+                      type="button"
+                      role="menuitem"
+                      onClick={() => {
+                        setAddOpen(false);
+                        onAddCourse(courseCode);
+                      }}
+                      className="flex w-full cursor-pointer items-baseline gap-2 rounded-[7px] px-[9px] py-2 text-left text-[12.5px] text-cc-ink2 hover:bg-cc-pill"
+                    >
+                      <span className="font-mono text-[11.5px] text-cc-dim">
+                        {courseCode}
+                      </span>
+                      <span className="min-w-0 flex-1 truncate">
+                        {courseFor(courseCode)?.course.titleEng ?? ""}
+                      </span>
+                    </button>
+                  ))}
+                </div>
+              ) : null}
+            </div>
+          ) : null}
+
+          <button
+            type="button"
+            onClick={onDelete}
+            className="flex h-8 cursor-pointer items-center rounded-[8px] border border-cc-danger/35 bg-cc-surface px-[11px] font-medium text-[12.5px] text-cc-danger hover:border-cc-danger/60"
+          >
+            Delete
+          </button>
+        </div>
+      </div>
+
+      {courseCodes.length === 0 ? (
+        <div className="rounded-[11px] border border-cc-rule bg-cc-surface p-6 text-center">
+          <div className="font-semibold text-[14.5px]">
+            No courses in this collection
+          </div>
+          <div className="mt-[5px] text-[12.5px] text-cc-muted">
+            {hasSavedCourses
+              ? "Add one of your saved courses to it — a collection can only hold courses you have saved."
+              : "A collection can only hold courses you have saved. Save some from Explore, then add them here."}
+          </div>
+        </div>
+      ) : (
+        <ol className="flex list-none flex-col gap-3 p-0">
+          {courseCodes.map((courseCode, index) => {
+            const saved = courseFor(courseCode);
+            return (
+              <li key={courseCode} className="flex items-center gap-2.5">
+                <div className="flex flex-none flex-col gap-1">
+                  <button
+                    type="button"
+                    onClick={() => onMoveCourse(courseCode, "up")}
+                    disabled={index === 0}
+                    aria-label={`Move ${courseCode} up`}
+                    className={MOVE_BUTTON}
+                  >
+                    <ChevronUp size={15} aria-hidden />
+                  </button>
+                  <button
+                    type="button"
+                    onClick={() => onMoveCourse(courseCode, "down")}
+                    disabled={index === courseCodes.length - 1}
+                    aria-label={`Move ${courseCode} down`}
+                    className={MOVE_BUTTON}
+                  >
+                    <ChevronDown size={15} aria-hidden />
+                  </button>
+                </div>
+
+                <div className="min-w-0 flex-1">
+                  {saved ? (
+                    <CourseCardItem
+                      course={saved.course}
+                      stats={saved.stats}
+                      geo={EXPANDED_CARD_GEOMETRY}
+                      action="add"
+                      removeLabel={`Remove ${courseCode} from ${collection.name}`}
+                      onRemove={() => onRemoveCourse(courseCode)}
+                      onOpen={() => onOpenCourse(courseCode)}
+                      onRequestAuth={onRequestAuth}
+                    />
+                  ) : (
+                    <CourseItemSkeleton />
+                  )}
+                </div>
+              </li>
+            );
+          })}
+        </ol>
+      )}
+    </div>
+  );
+}

--- a/apps/web/features/collections/components/collection-tile.tsx
+++ b/apps/web/features/collections/components/collection-tile.tsx
@@ -1,7 +1,8 @@
 "use client";
 
 import { MoreHorizontal } from "lucide-react";
-import { useEffect, useRef, useState } from "react";
+import { usePopover } from "@/features/collections/hooks/use-popover";
+import { useRenameDraft } from "@/features/collections/hooks/use-rename-draft";
 import {
   courseCountLabel,
   overflowLabel,
@@ -43,36 +44,15 @@ export function CollectionTile({
   onRename,
   onDelete,
 }: Props) {
-  const [menuOpen, setMenuOpen] = useState(false);
-  const [draft, setDraft] = useState<string | null>(null);
-  const menuRef = useRef<HTMLDivElement>(null);
-
-  // A menu left open behind a click elsewhere on the page would sit over the
-  // next tile the reader reaches for; the artboard closes it on any pointer
-  // down outside itself, and so does this.
-  useEffect(() => {
-    if (!menuOpen) return;
-    function onPointerDown(event: PointerEvent) {
-      if (!menuRef.current?.contains(event.target as Node)) setMenuOpen(false);
-    }
-    document.addEventListener("pointerdown", onPointerDown, true);
-    return () =>
-      document.removeEventListener("pointerdown", onPointerDown, true);
-  }, [menuOpen]);
-
-  function commitRename() {
-    const name = draft?.trim() ?? "";
-    setDraft(null);
-    if (name && name !== collection.name) onRename(name);
-  }
+  const menu = usePopover();
+  const renaming = useRenameDraft(collection.name, onRename);
 
   const previews = collection.courseCodes.slice(0, TILE_PREVIEW_LIMIT);
   const overflow = overflowLabel(collection.courseCodes.length);
-  const renaming = draft !== null;
 
   return (
     <div className="relative box-border flex min-h-[150px] flex-col gap-[9px] rounded-[11px] border border-cc-rule bg-cc-surface p-[14px_15px] hover:border-cc-hov">
-      {renaming ? null : (
+      {renaming.isRenaming ? null : (
         <button
           type="button"
           onClick={onOpen}
@@ -83,18 +63,15 @@ export function CollectionTile({
 
       <div className="flex items-start justify-between gap-2">
         <div className="pointer-events-none min-w-0 flex-1">
-          {renaming ? (
+          {renaming.isRenaming ? (
             <input
-              // biome-ignore lint/a11y/noAutofocus: the menu's Rename put the caret here, as the artboard's own autoFocus does.
+              // biome-ignore lint/a11y/noAutofocus: Rename put the caret here, as the artboard's own autoFocus does.
               autoFocus
               aria-label="Collection name"
-              value={draft ?? ""}
-              onChange={(event) => setDraft(event.target.value)}
-              onBlur={commitRename}
-              onKeyDown={(event) => {
-                if (event.key === "Enter") event.currentTarget.blur();
-                if (event.key === "Escape") setDraft(null);
-              }}
+              value={renaming.draft}
+              onChange={(event) => renaming.change(event.target.value)}
+              onBlur={renaming.commit}
+              onKeyDown={renaming.onKeyDown}
               className="pointer-events-auto box-border h-7 w-full rounded-[6px] border border-cc-brand bg-cc-surface px-2 font-semibold text-[13.5px] text-cc-ink outline-none"
             />
           ) : (
@@ -104,25 +81,33 @@ export function CollectionTile({
           )}
         </div>
 
-        <div className="relative flex-none" ref={menuRef}>
+        <div className="relative flex-none">
           <button
+            ref={menu.triggerRef}
             type="button"
-            onClick={() => setMenuOpen((open) => !open)}
+            onClick={menu.toggle}
             aria-label={`More actions for ${collection.name}`}
-            aria-expanded={menuOpen}
+            aria-haspopup="menu"
+            aria-expanded={menu.isOpen}
             title={`More actions for ${collection.name}`}
             className="flex size-[26px] cursor-pointer items-center justify-center rounded-[7px] text-cc-dim hover:bg-cc-pill"
           >
             <MoreHorizontal size={16} aria-hidden />
           </button>
 
-          {menuOpen ? (
-            <div className="absolute top-[30px] right-0 z-20 w-[150px] rounded-[9px] border border-cc-rule2 bg-cc-surface p-1 shadow-[0_8px_24px_rgba(20,30,45,.14)]">
+          {menu.isOpen ? (
+            <div
+              ref={menu.panelRef}
+              role="menu"
+              aria-label={`Actions for ${collection.name}`}
+              className="absolute top-[30px] right-0 z-20 w-[150px] rounded-[9px] border border-cc-rule2 bg-cc-surface p-1 shadow-[0_8px_24px_rgba(20,30,45,.14)]"
+            >
               <button
                 type="button"
+                role="menuitem"
                 onClick={() => {
-                  setMenuOpen(false);
-                  setDraft(collection.name);
+                  menu.close();
+                  renaming.start();
                 }}
                 className="block w-full cursor-pointer rounded-[6px] px-[9px] py-2 text-left text-[12.5px] text-cc-ink2 hover:bg-cc-pill"
               >
@@ -130,8 +115,9 @@ export function CollectionTile({
               </button>
               <button
                 type="button"
+                role="menuitem"
                 onClick={() => {
-                  setMenuOpen(false);
+                  menu.close();
                   onDelete();
                 }}
                 className="block w-full cursor-pointer rounded-[6px] px-[9px] py-2 text-left text-[12.5px] text-cc-danger hover:bg-[color-mix(in_srgb,var(--cc-danger)_12%,var(--cc-surface))]"

--- a/apps/web/features/collections/components/collection-tile.tsx
+++ b/apps/web/features/collections/components/collection-tile.tsx
@@ -1,0 +1,172 @@
+"use client";
+
+import { MoreHorizontal } from "lucide-react";
+import { useEffect, useRef, useState } from "react";
+import {
+  courseCountLabel,
+  overflowLabel,
+  TILE_PREVIEW_LIMIT,
+} from "@/features/collections/lib/collection-model";
+import type { Collection, CourseCardCourse } from "@/features/courses";
+
+type Props = {
+  collection: Collection;
+  /** The catalogue entry behind a course code, once its summary has loaded. */
+  courseFor: (courseCode: string) => CourseCardCourse | undefined;
+  onOpen: () => void;
+  onRename: (name: string) => void;
+  onDelete: () => void;
+};
+
+/**
+ * One collection in the grid: its name, the first few courses in it, and the
+ * menu that renames or deletes it.
+ *
+ * The menu and the rename draft are the tile's own state rather than the page's,
+ * for the reason `CourseCardItem` carries its picker: state held by the page and
+ * keyed by collection id has to be cleaned up when a collection is deleted, and
+ * a keyed component instance does that by unmounting.
+ *
+ * The whole tile opens the collection, as the artboard's does, so the click
+ * target is a button covering it rather than the name alone — the previews and
+ * the count are text, and text inside a button is what a nested `role="button"`
+ * would have made unreadable to a screen reader. The menu sits above it.
+ *
+ * The artboard's tile also has a "last updated" line in its footer. `collections`
+ * has `created_at` and no `updated_at`, and nothing in `server/` would write one,
+ * so the footer carries only the count (#68).
+ */
+export function CollectionTile({
+  collection,
+  courseFor,
+  onOpen,
+  onRename,
+  onDelete,
+}: Props) {
+  const [menuOpen, setMenuOpen] = useState(false);
+  const [draft, setDraft] = useState<string | null>(null);
+  const menuRef = useRef<HTMLDivElement>(null);
+
+  // A menu left open behind a click elsewhere on the page would sit over the
+  // next tile the reader reaches for; the artboard closes it on any pointer
+  // down outside itself, and so does this.
+  useEffect(() => {
+    if (!menuOpen) return;
+    function onPointerDown(event: PointerEvent) {
+      if (!menuRef.current?.contains(event.target as Node)) setMenuOpen(false);
+    }
+    document.addEventListener("pointerdown", onPointerDown, true);
+    return () =>
+      document.removeEventListener("pointerdown", onPointerDown, true);
+  }, [menuOpen]);
+
+  function commitRename() {
+    const name = draft?.trim() ?? "";
+    setDraft(null);
+    if (name && name !== collection.name) onRename(name);
+  }
+
+  const previews = collection.courseCodes.slice(0, TILE_PREVIEW_LIMIT);
+  const overflow = overflowLabel(collection.courseCodes.length);
+  const renaming = draft !== null;
+
+  return (
+    <div className="relative box-border flex min-h-[150px] flex-col gap-[9px] rounded-[11px] border border-cc-rule bg-cc-surface p-[14px_15px] hover:border-cc-hov">
+      {renaming ? null : (
+        <button
+          type="button"
+          onClick={onOpen}
+          aria-label={`Open collection ${collection.name}`}
+          className="absolute inset-0 cursor-pointer rounded-[11px]"
+        />
+      )}
+
+      <div className="flex items-start justify-between gap-2">
+        <div className="pointer-events-none min-w-0 flex-1">
+          {renaming ? (
+            <input
+              // biome-ignore lint/a11y/noAutofocus: the menu's Rename put the caret here, as the artboard's own autoFocus does.
+              autoFocus
+              aria-label="Collection name"
+              value={draft ?? ""}
+              onChange={(event) => setDraft(event.target.value)}
+              onBlur={commitRename}
+              onKeyDown={(event) => {
+                if (event.key === "Enter") event.currentTarget.blur();
+                if (event.key === "Escape") setDraft(null);
+              }}
+              className="pointer-events-auto box-border h-7 w-full rounded-[6px] border border-cc-brand bg-cc-surface px-2 font-semibold text-[13.5px] text-cc-ink outline-none"
+            />
+          ) : (
+            <div className="truncate font-semibold text-[14px] leading-[1.3]">
+              {collection.name}
+            </div>
+          )}
+        </div>
+
+        <div className="relative flex-none" ref={menuRef}>
+          <button
+            type="button"
+            onClick={() => setMenuOpen((open) => !open)}
+            aria-label={`More actions for ${collection.name}`}
+            aria-expanded={menuOpen}
+            title={`More actions for ${collection.name}`}
+            className="flex size-[26px] cursor-pointer items-center justify-center rounded-[7px] text-cc-dim hover:bg-cc-pill"
+          >
+            <MoreHorizontal size={16} aria-hidden />
+          </button>
+
+          {menuOpen ? (
+            <div className="absolute top-[30px] right-0 z-20 w-[150px] rounded-[9px] border border-cc-rule2 bg-cc-surface p-1 shadow-[0_8px_24px_rgba(20,30,45,.14)]">
+              <button
+                type="button"
+                onClick={() => {
+                  setMenuOpen(false);
+                  setDraft(collection.name);
+                }}
+                className="block w-full cursor-pointer rounded-[6px] px-[9px] py-2 text-left text-[12.5px] text-cc-ink2 hover:bg-cc-pill"
+              >
+                Rename
+              </button>
+              <button
+                type="button"
+                onClick={() => {
+                  setMenuOpen(false);
+                  onDelete();
+                }}
+                className="block w-full cursor-pointer rounded-[6px] px-[9px] py-2 text-left text-[12.5px] text-cc-danger hover:bg-[color-mix(in_srgb,var(--cc-danger)_12%,var(--cc-surface))]"
+              >
+                Delete
+              </button>
+            </div>
+          ) : null}
+        </div>
+      </div>
+
+      <div className="pointer-events-none flex flex-col gap-[3px]">
+        {previews.map((courseCode) => (
+          <div
+            key={courseCode}
+            className="flex items-baseline gap-[7px] text-[11.5px] text-cc-ink2"
+          >
+            <span className="font-mono text-[11px] text-cc-dim">
+              {courseCode}
+            </span>
+            <span className="min-w-0 flex-1 truncate">
+              {courseFor(courseCode)?.titleEng ?? ""}
+            </span>
+          </div>
+        ))}
+        {overflow ? (
+          <div className="font-medium text-[11.5px] text-cc-brand">
+            {overflow}
+          </div>
+        ) : null}
+      </div>
+
+      <div className="pointer-events-none mt-auto flex items-baseline justify-end gap-2.5 text-[11px] text-cc-dim2">
+        <span>{courseCountLabel(collection.courseCodes.length)}</span>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/features/collections/components/collections.spec.tsx
+++ b/apps/web/features/collections/components/collections.spec.tsx
@@ -1,0 +1,361 @@
+import { render, screen, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { Collections } from "./collections";
+
+/**
+ * The Collections page against mocked procedures.
+ *
+ * The api modules are mocked rather than the barrel, so the real
+ * `CourseCardItem` renders — the detail's rows are cards, and a stub would hide
+ * whether the remove button the page asks for is the one the card draws.
+ */
+
+const useMe = vi.fn();
+const useCollections = vi.fn();
+const useCourseSummaries = vi.fn();
+
+const create = vi.fn();
+const rename = vi.fn();
+const deleteCollection = vi.fn();
+const reorder = vi.fn();
+const addCourse = vi.fn();
+const removeCourse = vi.fn();
+
+const replace = vi.fn();
+const push = vi.fn();
+
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ replace, push }),
+  usePathname: () => "/collections",
+}));
+vi.mock("@/features/auth", () => ({
+  useMe: () => useMe(),
+  AuthReasonDialog: () => null,
+}));
+vi.mock("@/features/favorites", () => ({
+  useSetCourseSaved: () => ({ setSaved: vi.fn().mockResolvedValue(undefined) }),
+}));
+vi.mock("@/features/courses/api/queries", () => ({
+  useCollections: (enabled: boolean) => useCollections(enabled),
+  useCourseSummaries: (codes: string[], enabled?: boolean) =>
+    useCourseSummaries(codes, enabled),
+  useTakenCourses: () => ({ data: [] }),
+  useCourseDetails: () => ({ data: undefined }),
+}));
+vi.mock("@/features/courses/api/mutations", () => ({
+  useCollectionMutations: () => ({
+    create: { mutateAsync: create },
+    rename: { mutateAsync: rename },
+    deleteCollection: { mutateAsync: deleteCollection },
+    reorder: { mutateAsync: reorder },
+    addCourse: { mutateAsync: addCourse },
+    removeCourse: { mutateAsync: removeCourse },
+  }),
+  useMarkCourseTaken: () => ({ mutateAsync: vi.fn() }),
+}));
+vi.mock("sonner", () => ({ toast: { error: vi.fn(), success: vi.fn() } }));
+
+const TITLES: Record<string, string> = {
+  AA1000: "Alpha",
+  BB2000: "Beta",
+  CC3000: "Gamma",
+  DD4000: "Delta",
+};
+
+/** `course.summary` as the page reads it: catalogue fields plus card numbers. */
+function summaryOf(courseCode: string) {
+  return {
+    data: {
+      courseCode,
+      titleEng: TITLES[courseCode] ?? courseCode,
+      credits: 6,
+      department: "EECS",
+      stats: { reviews: null, takenCount: 0 },
+    },
+  };
+}
+
+type Setup = {
+  savedCourseCodes?: string[];
+  collections?: Array<{ id: string; name: string; courseCodes: string[] }>;
+  signedIn?: boolean;
+};
+
+function setup({
+  savedCourseCodes = [],
+  collections = [],
+  signedIn = true,
+}: Setup = {}) {
+  useMe.mockReturnValue({
+    user: signedIn ? { userId: "u1", savedCourseCodes } : null,
+    isLoading: false,
+  });
+  useCollections.mockReturnValue({
+    data: signedIn ? collections : undefined,
+    isPending: !signedIn,
+  });
+  useCourseSummaries.mockImplementation((codes: string[]) =>
+    codes.map(summaryOf),
+  );
+}
+
+beforeEach(() => {
+  create.mockResolvedValue({ id: "new", name: "New", courseCodes: [] });
+  rename.mockResolvedValue(undefined);
+  deleteCollection.mockResolvedValue({ id: "c1" });
+  reorder.mockResolvedValue(undefined);
+  addCourse.mockResolvedValue(undefined);
+  removeCourse.mockResolvedValue(undefined);
+  setup();
+});
+
+describe("no collections yet", () => {
+  it("says so, and offers the one thing there is to do", async () => {
+    setup({ savedCourseCodes: ["AA1000"] });
+    render(<Collections />);
+
+    expect(screen.getByText("No collections yet")).toBeVisible();
+    expect(
+      screen.getByRole("button", { name: "Create collection" }),
+    ).toBeVisible();
+    // Nothing to list, so the grid and its "New collection" tile stay away.
+    expect(
+      screen.queryByRole("button", { name: /^New collection/ }),
+    ).not.toBeInTheDocument();
+  });
+
+  it("opens the new-collection dialog from it", async () => {
+    setup({ savedCourseCodes: ["AA1000"] });
+    render(<Collections />);
+
+    await userEvent.click(
+      screen.getByRole("button", { name: "Create collection" }),
+    );
+    expect(screen.getByLabelText("Collection name")).toBeVisible();
+  });
+});
+
+describe("an empty collection", () => {
+  it("says it is empty rather than showing an empty list", () => {
+    setup({
+      savedCourseCodes: ["AA1000"],
+      collections: [{ id: "c1", name: "Spring", courseCodes: [] }],
+    });
+    render(<Collections openCollectionId="c1" />);
+
+    expect(screen.getByText("No courses in this collection")).toBeVisible();
+    expect(screen.queryAllByRole("article")).toHaveLength(0);
+  });
+
+  it("sends a viewer with nothing saved to Explore first", () => {
+    setup({
+      savedCourseCodes: [],
+      collections: [{ id: "c1", name: "Spring", courseCodes: [] }],
+    });
+    render(<Collections openCollectionId="c1" />);
+
+    expect(
+      screen.getByText(/A collection can only hold courses you have saved/),
+    ).toBeVisible();
+    // Nothing is addable, so the control that would offer nothing is not drawn.
+    expect(
+      screen.queryByRole("button", { name: "Add course" }),
+    ).not.toBeInTheDocument();
+  });
+});
+
+describe("the saved-only rule", () => {
+  // A course may only join a collection its owner has also saved. The picker is
+  // built from the saved codes, so an unsaved course is never offered and the
+  // server is never asked to refuse one.
+  it("offers only saved courses the collection does not already hold", async () => {
+    setup({
+      savedCourseCodes: ["AA1000", "BB2000", "CC3000"],
+      collections: [{ id: "c1", name: "Spring", courseCodes: ["AA1000"] }],
+    });
+    render(<Collections openCollectionId="c1" />);
+
+    await userEvent.click(screen.getByRole("button", { name: "Add course" }));
+
+    const offered = within(screen.getByRole("menu")).getAllByRole("menuitem");
+    // Every saved course except the one the collection already holds, and
+    // nothing from the catalogue that this viewer has not saved.
+    expect(offered.map((item) => item.textContent)).toEqual([
+      "BB2000Beta",
+      "CC3000Gamma",
+    ]);
+    expect(screen.queryByText("DD4000")).not.toBeInTheDocument();
+  });
+
+  it("adds the course the reader picked", async () => {
+    setup({
+      savedCourseCodes: ["AA1000", "BB2000"],
+      collections: [{ id: "c1", name: "Spring", courseCodes: ["AA1000"] }],
+    });
+    render(<Collections openCollectionId="c1" />);
+
+    await userEvent.click(screen.getByRole("button", { name: "Add course" }));
+    await userEvent.click(screen.getByRole("menuitem", { name: /BB2000/ }));
+
+    expect(addCourse).toHaveBeenCalledWith({
+      collectionId: "c1",
+      courseCode: "BB2000",
+    });
+  });
+
+  it("offers only saved courses in the new-collection dialog too", async () => {
+    setup({ savedCourseCodes: ["AA1000"] });
+    render(<Collections />);
+
+    await userEvent.click(
+      screen.getByRole("button", { name: "Create collection" }),
+    );
+
+    const boxes = screen.getAllByRole("checkbox");
+    expect(boxes).toHaveLength(1);
+    expect(boxes[0]).toHaveAccessibleName(/AA1000/);
+    expect(screen.queryByText("DD4000")).not.toBeInTheDocument();
+  });
+});
+
+describe("reordering within a collection", () => {
+  const COLLECTION = {
+    id: "c1",
+    name: "Spring",
+    courseCodes: ["AA1000", "BB2000", "CC3000"],
+  };
+
+  it("sends the whole new order when a course moves up", async () => {
+    setup({
+      savedCourseCodes: COLLECTION.courseCodes,
+      collections: [COLLECTION],
+    });
+    render(<Collections openCollectionId="c1" />);
+
+    await userEvent.click(
+      screen.getByRole("button", { name: "Move BB2000 up" }),
+    );
+
+    expect(reorder).toHaveBeenCalledWith({
+      collectionId: "c1",
+      courseCodes: ["BB2000", "AA1000", "CC3000"],
+    });
+  });
+
+  it("sends the whole new order when a course moves down", async () => {
+    setup({
+      savedCourseCodes: COLLECTION.courseCodes,
+      collections: [COLLECTION],
+    });
+    render(<Collections openCollectionId="c1" />);
+
+    await userEvent.click(
+      screen.getByRole("button", { name: "Move BB2000 down" }),
+    );
+
+    expect(reorder).toHaveBeenCalledWith({
+      collectionId: "c1",
+      courseCodes: ["AA1000", "CC3000", "BB2000"],
+    });
+  });
+
+  it("cannot move the ends off the list", () => {
+    setup({
+      savedCourseCodes: COLLECTION.courseCodes,
+      collections: [COLLECTION],
+    });
+    render(<Collections openCollectionId="c1" />);
+
+    expect(
+      screen.getByRole("button", { name: "Move AA1000 up" }),
+    ).toBeDisabled();
+    expect(
+      screen.getByRole("button", { name: "Move CC3000 down" }),
+    ).toBeDisabled();
+    expect(
+      screen.getByRole("button", { name: "Move AA1000 down" }),
+    ).toBeEnabled();
+  });
+});
+
+describe("a collection that is not the viewer's", () => {
+  // Ownership is scoped in the query, so a stranger's collection is absent
+  // rather than refused, and the page says exactly what the server says.
+  it("reads as not found, never as someone else's", () => {
+    setup({
+      collections: [{ id: "c1", name: "Spring", courseCodes: [] }],
+    });
+    render(<Collections openCollectionId="someone-elses" />);
+
+    expect(screen.getByText("Collection not found")).toBeVisible();
+    expect(screen.queryByText(/belongs to/i)).not.toBeInTheDocument();
+    expect(screen.queryByText(/permission/i)).not.toBeInTheDocument();
+  });
+});
+
+describe("the grid", () => {
+  it("lists a collection with its courses and its count", () => {
+    setup({
+      savedCourseCodes: ["AA1000", "BB2000"],
+      collections: [
+        { id: "c1", name: "Spring", courseCodes: ["AA1000", "BB2000"] },
+      ],
+    });
+    render(<Collections />);
+
+    const tile = screen.getByRole("button", {
+      name: "Open collection Spring",
+    }).parentElement as HTMLElement;
+    expect(within(tile).getByText("Spring")).toBeVisible();
+    expect(within(tile).getByText("Alpha")).toBeVisible();
+    expect(within(tile).getByText("2 courses")).toBeVisible();
+  });
+
+  it("renames a collection from its menu", async () => {
+    setup({
+      collections: [{ id: "c1", name: "Spring", courseCodes: [] }],
+    });
+    render(<Collections />);
+
+    await userEvent.click(
+      screen.getByRole("button", { name: "More actions for Spring" }),
+    );
+    await userEvent.click(screen.getByRole("button", { name: "Rename" }));
+
+    const field = screen.getByLabelText("Collection name");
+    await userEvent.clear(field);
+    await userEvent.type(field, "Autumn{Enter}");
+
+    expect(rename).toHaveBeenCalledWith({
+      collectionId: "c1",
+      name: "Autumn",
+    });
+  });
+
+  it("deletes a collection from its menu", async () => {
+    setup({
+      collections: [{ id: "c1", name: "Spring", courseCodes: [] }],
+    });
+    render(<Collections />);
+
+    await userEvent.click(
+      screen.getByRole("button", { name: "More actions for Spring" }),
+    );
+    await userEvent.click(screen.getByRole("button", { name: "Delete" }));
+
+    expect(deleteCollection).toHaveBeenCalledWith({ collectionId: "c1" });
+  });
+});
+
+describe("a visitor", () => {
+  it("is told what an account adds, and is promised nothing else", () => {
+    setup({ signedIn: false });
+    render(<Collections />);
+
+    expect(screen.getByText("Organize your saved courses")).toBeVisible();
+    expect(screen.getByRole("button", { name: "Sign up" })).toBeVisible();
+    // There is no comparison feature to promise (#68).
+    expect(screen.queryByText(/AI/)).not.toBeInTheDocument();
+  });
+});

--- a/apps/web/features/collections/components/collections.spec.tsx
+++ b/apps/web/features/collections/components/collections.spec.tsx
@@ -94,6 +94,7 @@ function setup({
   useCollections.mockReturnValue({
     data: signedIn ? collections : undefined,
     isPending: !signedIn,
+    isFetching: false,
   });
   useCourseSummaries.mockImplementation((codes: string[]) =>
     codes.map(summaryOf),
@@ -279,6 +280,25 @@ describe("reordering within a collection", () => {
   });
 });
 
+describe("the add-course menu", () => {
+  it("closes on Escape and gives focus back to the trigger", async () => {
+    setup({
+      savedCourseCodes: ["AA1000", "BB2000"],
+      collections: [{ id: "c1", name: "Spring", courseCodes: ["AA1000"] }],
+    });
+    render(<Collections openCollectionId="c1" />);
+
+    const trigger = screen.getByRole("button", { name: "Add course" });
+    await userEvent.click(trigger);
+    expect(screen.getByRole("menu")).toBeVisible();
+
+    await userEvent.keyboard("{Escape}");
+
+    expect(screen.queryByRole("menu")).not.toBeInTheDocument();
+    expect(trigger).toHaveFocus();
+  });
+});
+
 describe("a collection that is not the viewer's", () => {
   // Ownership is scoped in the query, so a stranger's collection is absent
   // rather than refused, and the page says exactly what the server says.
@@ -291,6 +311,20 @@ describe("a collection that is not the viewer's", () => {
     expect(screen.getByText("Collection not found")).toBeVisible();
     expect(screen.queryByText(/belongs to/i)).not.toBeInTheDocument();
     expect(screen.queryByText(/permission/i)).not.toBeInTheDocument();
+  });
+
+  // Creating a collection opens it before its refetch lands. Calling that frame
+  // "not found" would accuse the app of losing what it had just made.
+  it("waits rather than saying not found while the list is still arriving", () => {
+    setup({ collections: [] });
+    useCollections.mockReturnValue({
+      data: [],
+      isPending: false,
+      isFetching: true,
+    });
+    render(<Collections openCollectionId="brand-new" />);
+
+    expect(screen.queryByText("Collection not found")).not.toBeInTheDocument();
   });
 });
 
@@ -321,7 +355,7 @@ describe("the grid", () => {
     await userEvent.click(
       screen.getByRole("button", { name: "More actions for Spring" }),
     );
-    await userEvent.click(screen.getByRole("button", { name: "Rename" }));
+    await userEvent.click(screen.getByRole("menuitem", { name: "Rename" }));
 
     const field = screen.getByLabelText("Collection name");
     await userEvent.clear(field);
@@ -342,7 +376,7 @@ describe("the grid", () => {
     await userEvent.click(
       screen.getByRole("button", { name: "More actions for Spring" }),
     );
-    await userEvent.click(screen.getByRole("button", { name: "Delete" }));
+    await userEvent.click(screen.getByRole("menuitem", { name: "Delete" }));
 
     expect(deleteCollection).toHaveBeenCalledWith({ collectionId: "c1" });
   });

--- a/apps/web/features/collections/components/collections.tsx
+++ b/apps/web/features/collections/components/collections.tsx
@@ -1,0 +1,394 @@
+"use client";
+
+import { Check, Lock, Plus } from "lucide-react";
+import { useRouter } from "next/navigation";
+import { useCallback, useEffect, useState } from "react";
+import { toast } from "sonner";
+import { type AuthReason, AuthReasonDialog, useMe } from "@/features/auth";
+import {
+  addableCourseCodes,
+  moveCourse,
+} from "@/features/collections/lib/collection-model";
+import {
+  type Collection,
+  CourseItemSkeleton,
+  useCollectionMutations,
+  useCollections,
+  useCourseSummaries,
+} from "@/features/courses";
+import { PageColumn, PageHeader } from "@/features/shell";
+import { CollectionDetail, type SavedCourse } from "./collection-detail";
+import { CollectionTile } from "./collection-tile";
+import { NewCollectionDialog } from "./new-collection-dialog";
+
+/** How long the artboard's confirmation strip stays up, in milliseconds. */
+const NOTE_LIFETIME = 4000;
+
+const SKELETON_KEYS = ["c0", "c1", "c2"] as const;
+
+type Props = {
+  /**
+   * The collection named by `?collection=` on the route, if any.
+   *
+   * Deep links are why the not-found state is reachable at all. Another user's
+   * collection is absent from `collections.list` — ownership is scoped in the
+   * query, so the server never learns whether a stranger's id exists — and this
+   * page says the same thing the server does: not found, never "not yours".
+   */
+  openCollectionId?: string | null;
+};
+
+/**
+ * Collections: the viewer's named groups of saved courses, and the whole of
+ * what they can do to them.
+ *
+ * ## The rule this page is built around
+ *
+ * A course may only join a collection its owner has also saved. Composite
+ * foreign keys enforce it and `addCourseToCollection` refuses before they have
+ * to, so every list of courses this page offers — the new-collection dialog and
+ * the detail's "Add course" — is derived from `savedCourseCodes` rather than
+ * filtered down to it. There is no path here that offers an unsaved course and
+ * lets the server say no.
+ *
+ * The same foreign key runs the other way with `on delete cascade`: unsaving a
+ * course removes it from every collection it was in. That is the schema's
+ * decision, not this page's, and it is why `collections.list` is the only place
+ * membership is read from.
+ *
+ * ## Where it sits
+ *
+ * `Course Community - Saved.dc.html` imports the Collections artboard as a
+ * section of the Saved page, in its `compact` variant. That embedding is Saved's
+ * to build (#90); this is the same component as a page of its own, so the
+ * feature is reachable and usable before Saved exists. The `compact` chip
+ * variant is deliberately not built — it has no caller yet, and building an
+ * untested second layout for one is worse than leaving it to whoever embeds it.
+ *
+ * ## What the writes do about failure
+ *
+ * Creating a collection with courses in it is `collections.create` and then one
+ * `collections.addCourse` per course, in order, because position is appended in
+ * call order and a parallel batch would file them arbitrarily. Each step can
+ * fail on its own, so the message names the step that did: saying "could not
+ * create" after a failed *add* would send the reader back to the name field,
+ * and `collections.create` has no uniqueness on name, so typing it again makes a
+ * second empty collection.
+ */
+export function Collections({ openCollectionId = null }: Props) {
+  const router = useRouter();
+  const { user, isLoading: sessionLoading } = useMe();
+  const signedIn = user !== null;
+  const savedCourseCodes = user?.savedCourseCodes ?? [];
+
+  const { data: collections, isPending: collectionsPending } =
+    useCollections(signedIn);
+  const summaries = useCourseSummaries(savedCourseCodes, signedIn);
+  const { create, rename, deleteCollection, reorder, addCourse, removeCourse } =
+    useCollectionMutations();
+
+  const [openId, setOpenId] = useState<string | null>(openCollectionId);
+  const [dialogOpen, setDialogOpen] = useState(false);
+  const [note, setNote] = useState<{ key: number; text: string } | null>(null);
+  const [authReason, setAuthReason] = useState<AuthReason | null>(null);
+
+  const showNote = useCallback(
+    (text: string) => setNote({ key: Date.now(), text }),
+    [],
+  );
+
+  useEffect(() => {
+    if (!note) return;
+    const timer = setTimeout(() => setNote(null), NOTE_LIFETIME);
+    return () => clearTimeout(timer);
+  }, [note]);
+
+  /** Keeps the route in step with what is open, so a refresh lands back here. */
+  const openCollection = useCallback(
+    (collectionId: string | null) => {
+      setOpenId(collectionId);
+      router.replace(
+        collectionId
+          ? `/collections?collection=${encodeURIComponent(collectionId)}`
+          : "/collections",
+        { scroll: false },
+      );
+    },
+    [router],
+  );
+
+  // Every course this page can show is a saved course: a collection cannot hold
+  // one that is not, so `savedCourseCodes` is the whole set of summaries needed
+  // for the tiles' previews, the detail's cards and both pickers.
+  const savedByCode = new Map<string, SavedCourse>();
+  for (const summary of summaries) {
+    const course = summary.data;
+    if (!course) continue;
+    savedByCode.set(course.courseCode, {
+      course: {
+        courseCode: course.courseCode,
+        titleEng: course.titleEng,
+        credits: course.credits,
+        department: course.department,
+      },
+      stats: course.stats,
+    });
+  }
+  const savedCourses = savedCourseCodes.flatMap(
+    (courseCode) => savedByCode.get(courseCode)?.course ?? [],
+  );
+
+  const openCollectionRecord =
+    collections?.find((collection) => collection.id === openId) ?? null;
+
+  async function onCreate(name: string, courseCodes: string[]) {
+    let created: { id: string };
+    try {
+      created = await create.mutateAsync({ name });
+    } catch {
+      toast.error(`Could not create the collection "${name}".`);
+      return;
+    }
+
+    const failed: string[] = [];
+    for (const courseCode of courseCodes) {
+      try {
+        await addCourse.mutateAsync({ collectionId: created.id, courseCode });
+      } catch {
+        failed.push(courseCode);
+      }
+    }
+
+    openCollection(created.id);
+    if (failed.length === 0) {
+      showNote(`Collection "${name}" created`);
+    } else {
+      toast.error(
+        `Created "${name}", but could not add ${failed.join(", ")}. Add them from the collection.`,
+      );
+    }
+  }
+
+  function onRename(collection: Collection, name: string) {
+    rename
+      .mutateAsync({ collectionId: collection.id, name })
+      .catch(() =>
+        toast.error(`Could not rename "${collection.name}" to "${name}".`),
+      );
+  }
+
+  function onDelete(collection: Collection) {
+    deleteCollection
+      .mutateAsync({ collectionId: collection.id })
+      .then(() => {
+        if (openId === collection.id) openCollection(null);
+        showNote(`Collection "${collection.name}" deleted`);
+      })
+      .catch(() => toast.error(`Could not delete "${collection.name}".`));
+  }
+
+  function onAddCourse(collection: Collection, courseCode: string) {
+    addCourse
+      .mutateAsync({ collectionId: collection.id, courseCode })
+      .catch(() =>
+        toast.error(`Could not add ${courseCode} to "${collection.name}".`),
+      );
+  }
+
+  function onRemoveCourse(collection: Collection, courseCode: string) {
+    removeCourse
+      .mutateAsync({ collectionId: collection.id, courseCode })
+      .catch(() =>
+        toast.error(
+          `Could not remove ${courseCode} from "${collection.name}".`,
+        ),
+      );
+  }
+
+  function onMoveCourse(
+    collection: Collection,
+    courseCode: string,
+    direction: "up" | "down",
+  ) {
+    const courseCodes = moveCourse(
+      collection.courseCodes,
+      courseCode,
+      direction,
+    );
+    reorder
+      .mutateAsync({ collectionId: collection.id, courseCodes })
+      .catch(() => toast.error(`Could not reorder "${collection.name}".`));
+  }
+
+  const isLoading = sessionLoading || (signedIn && collectionsPending);
+
+  return (
+    <PageColumn>
+      <PageHeader
+        title="Collections"
+        subtitle="Group courses you want to compare."
+      />
+
+      <div className="flex flex-col gap-3.5 px-7 pt-[18px]">
+        {note ? (
+          <div
+            aria-live="polite"
+            className="flex items-center gap-2 rounded-[9px] border border-cc-rule2 bg-cc-pill px-[13px] py-[9px] text-[12.5px] text-cc-brand"
+          >
+            <Check size={14} aria-hidden />
+            {note.text}
+          </div>
+        ) : null}
+
+        {isLoading ? (
+          <ul className="flex list-none flex-col gap-3 p-0">
+            {SKELETON_KEYS.map((key) => (
+              <li key={key}>
+                <CourseItemSkeleton />
+              </li>
+            ))}
+          </ul>
+        ) : null}
+
+        {!isLoading && !signedIn ? (
+          <div className="max-w-[520px] rounded-[11px] border border-cc-rule2 bg-cc-surface p-[16px_17px]">
+            <div className="flex items-center gap-2">
+              <Lock size={15} className="text-cc-dim" aria-hidden />
+              <div className="font-semibold text-[13.5px]">
+                Organize your saved courses
+              </div>
+            </div>
+            <div className="mt-1.5 text-[12.5px] text-cc-muted leading-[1.5]">
+              Sign up or log in to create collections and sync across devices.
+            </div>
+            <div className="mt-[11px] flex gap-[7px]">
+              <button
+                type="button"
+                onClick={() => setAuthReason("sign-up")}
+                className="flex h-8 cursor-pointer items-center rounded-[8px] bg-cc-btn px-3.5 font-semibold text-[12.5px] text-cc-btn-fg hover:opacity-[0.88]"
+              >
+                Sign up
+              </button>
+              <button
+                type="button"
+                onClick={() => setAuthReason("log-in")}
+                className="flex h-8 cursor-pointer items-center rounded-[8px] border border-cc-rule3 bg-cc-surface px-3.5 font-medium text-[12.5px] text-cc-brand hover:border-cc-hov"
+              >
+                Log in
+              </button>
+            </div>
+          </div>
+        ) : null}
+
+        {!isLoading && signedIn && openId !== null && !openCollectionRecord ? (
+          <div className="rounded-[11px] border border-cc-rule bg-cc-surface p-6 text-center">
+            <div className="font-semibold text-[14.5px]">
+              Collection not found
+            </div>
+            <div className="mt-[5px] text-[12.5px] text-cc-muted">
+              There is no such collection. It may have been deleted.
+            </div>
+            <button
+              type="button"
+              onClick={() => openCollection(null)}
+              className="mx-auto mt-[13px] flex h-[34px] w-max cursor-pointer items-center rounded-[9px] bg-cc-btn px-3.5 font-semibold text-[13px] text-cc-btn-fg hover:opacity-[0.88]"
+            >
+              All collections
+            </button>
+          </div>
+        ) : null}
+
+        {!isLoading && signedIn && openCollectionRecord ? (
+          <CollectionDetail
+            collection={openCollectionRecord}
+            courseFor={(courseCode) => savedByCode.get(courseCode)}
+            addableCourseCodes={addableCourseCodes(
+              savedCourseCodes,
+              openCollectionRecord.courseCodes,
+            )}
+            hasSavedCourses={savedCourseCodes.length > 0}
+            onBack={() => openCollection(null)}
+            onRename={(name) => onRename(openCollectionRecord, name)}
+            onDelete={() => onDelete(openCollectionRecord)}
+            onAddCourse={(courseCode) =>
+              onAddCourse(openCollectionRecord, courseCode)
+            }
+            onRemoveCourse={(courseCode) =>
+              onRemoveCourse(openCollectionRecord, courseCode)
+            }
+            onMoveCourse={(courseCode, direction) =>
+              onMoveCourse(openCollectionRecord, courseCode, direction)
+            }
+            onOpenCourse={(courseCode) =>
+              router.push(`/course/${courseCode}?from=collections`)
+            }
+            onRequestAuth={setAuthReason}
+          />
+        ) : null}
+
+        {!isLoading && signedIn && openId === null && collections ? (
+          collections.length === 0 ? (
+            <div className="rounded-[11px] border border-cc-rule bg-cc-surface p-6 text-center">
+              <div className="font-semibold text-[14.5px]">
+                No collections yet
+              </div>
+              <div className="mt-[5px] text-[12.5px] text-cc-muted">
+                Create a collection to organize courses you are considering
+                together.
+              </div>
+              <button
+                type="button"
+                onClick={() => setDialogOpen(true)}
+                className="mx-auto mt-[13px] flex h-[34px] w-max cursor-pointer items-center rounded-[9px] bg-cc-btn px-3.5 font-semibold text-[13px] text-cc-btn-fg hover:opacity-[0.88]"
+              >
+                Create collection
+              </button>
+            </div>
+          ) : (
+            <div className="grid grid-cols-[repeat(auto-fill,minmax(240px,1fr))] gap-3">
+              <button
+                type="button"
+                onClick={() => setDialogOpen(true)}
+                className="box-border flex min-h-[150px] cursor-pointer flex-col items-center justify-center gap-[7px] rounded-[11px] border border-cc-hov border-dashed bg-cc-info p-[15px_16px] hover:border-cc-brand"
+              >
+                <span className="flex items-center gap-2 font-semibold text-[16px] text-cc-brand">
+                  <Plus size={18} aria-hidden />
+                  New collection
+                </span>
+                <span className="max-w-[190px] text-center text-[12px] text-cc-muted leading-[1.5]">
+                  Group specific courses you are considering together.
+                </span>
+              </button>
+
+              {collections.map((collection) => (
+                <CollectionTile
+                  key={collection.id}
+                  collection={collection}
+                  courseFor={(courseCode) =>
+                    savedByCode.get(courseCode)?.course
+                  }
+                  onOpen={() => openCollection(collection.id)}
+                  onRename={(name) => onRename(collection, name)}
+                  onDelete={() => onDelete(collection)}
+                />
+              ))}
+            </div>
+          )
+        ) : null}
+      </div>
+
+      <NewCollectionDialog
+        open={dialogOpen}
+        savedCourses={savedCourses}
+        onClose={() => setDialogOpen(false)}
+        onCreate={onCreate}
+      />
+
+      <AuthReasonDialog
+        reason={authReason}
+        onReasonChange={setAuthReason}
+        onClose={() => setAuthReason(null)}
+      />
+    </PageColumn>
+  );
+}

--- a/apps/web/features/collections/components/collections.tsx
+++ b/apps/web/features/collections/components/collections.tsx
@@ -19,10 +19,11 @@ import {
 import { PageColumn, PageHeader } from "@/features/shell";
 import { CollectionDetail, type SavedCourse } from "./collection-detail";
 import { CollectionTile } from "./collection-tile";
+import { EmptyPanel } from "./empty-panel";
 import { NewCollectionDialog } from "./new-collection-dialog";
 
 /** How long the artboard's confirmation strip stays up, in milliseconds. */
-const NOTE_LIFETIME = 4000;
+const NOTE_LIFETIME = 3000;
 
 const SKELETON_KEYS = ["c0", "c1", "c2"] as const;
 
@@ -81,27 +82,37 @@ export function Collections({ openCollectionId = null }: Props) {
   const signedIn = user !== null;
   const savedCourseCodes = user?.savedCourseCodes ?? [];
 
-  const { data: collections, isPending: collectionsPending } =
-    useCollections(signedIn);
+  const {
+    data: collections,
+    isPending: collectionsPending,
+    isFetching: collectionsFetching,
+  } = useCollections(signedIn);
   const summaries = useCourseSummaries(savedCourseCodes, signedIn);
   const { create, rename, deleteCollection, reorder, addCourse, removeCourse } =
     useCollectionMutations();
 
   const [openId, setOpenId] = useState<string | null>(openCollectionId);
   const [dialogOpen, setDialogOpen] = useState(false);
-  const [note, setNote] = useState<{ key: number; text: string } | null>(null);
+  /**
+   * The confirmation strip. A fresh object every time, so that saying the same
+   * thing twice is a state change React does not skip — and the timer under it
+   * restarts rather than expiring on the first message's clock.
+   */
+  const [note, setNote] = useState<{ text: string } | null>(null);
   const [authReason, setAuthReason] = useState<AuthReason | null>(null);
 
-  const showNote = useCallback(
-    (text: string) => setNote({ key: Date.now(), text }),
-    [],
-  );
+  const showNote = useCallback((text: string) => setNote({ text }), []);
 
   useEffect(() => {
     if (!note) return;
     const timer = setTimeout(() => setNote(null), NOTE_LIFETIME);
     return () => clearTimeout(timer);
   }, [note]);
+
+  // The route is the authority on what is open: a link to `/collections` from
+  // the rail while a collection is open has to close it, and only the prop
+  // knows that happened.
+  useEffect(() => setOpenId(openCollectionId), [openCollectionId]);
 
   /** Keeps the route in step with what is open, so a refresh lands back here. */
   const openCollection = useCallback(
@@ -134,12 +145,29 @@ export function Collections({ openCollectionId = null }: Props) {
       stats: course.stats,
     });
   }
-  const savedCourses = savedCourseCodes.flatMap(
-    (courseCode) => savedByCode.get(courseCode)?.course ?? [],
+  // Keyed on the saved codes, not on the summaries that have arrived: a course
+  // whose title is still in flight is still addable, and dropping it would make
+  // the dialog and the detail's "Add course" disagree about what can be added.
+  const savedCourses = savedCourseCodes.map(
+    (courseCode) =>
+      savedByCode.get(courseCode)?.course ?? {
+        courseCode,
+        titleEng: "",
+        credits: null,
+        department: null,
+      },
   );
 
   const openCollectionRecord =
     collections?.find((collection) => collection.id === openId) ?? null;
+
+  /**
+   * A collection that is open but not in the list yet is still arriving, not
+   * missing. Creating one opens it before its refetch lands, and saying "not
+   * found" for that frame would accuse the app of losing what it just made.
+   */
+  const resolvingOpen =
+    openId !== null && !openCollectionRecord && collectionsFetching;
 
   async function onCreate(name: string, courseCodes: string[]) {
     let created: { id: string };
@@ -220,7 +248,8 @@ export function Collections({ openCollectionId = null }: Props) {
       .catch(() => toast.error(`Could not reorder "${collection.name}".`));
   }
 
-  const isLoading = sessionLoading || (signedIn && collectionsPending);
+  const isLoading =
+    sessionLoading || (signedIn && collectionsPending) || resolvingOpen;
 
   return (
     <PageColumn>
@@ -230,12 +259,19 @@ export function Collections({ openCollectionId = null }: Props) {
       />
 
       <div className="flex flex-col gap-3.5 px-7 pt-[18px]">
+        {/* The live region is always in the tree and out of the flow: a region
+            that appears already carrying its text announces nothing, because
+            there was no change for a screen reader to notice. The strip below
+            is the same words, drawn. */}
+        <div aria-live="polite" className="sr-only">
+          {note?.text ?? ""}
+        </div>
         {note ? (
           <div
-            aria-live="polite"
+            aria-hidden
             className="flex items-center gap-2 rounded-[9px] border border-cc-rule2 bg-cc-pill px-[13px] py-[9px] text-[12.5px] text-cc-brand"
           >
-            <Check size={14} aria-hidden />
+            <Check size={14} />
             {note.text}
           </div>
         ) : null}
@@ -281,21 +317,14 @@ export function Collections({ openCollectionId = null }: Props) {
         ) : null}
 
         {!isLoading && signedIn && openId !== null && !openCollectionRecord ? (
-          <div className="rounded-[11px] border border-cc-rule bg-cc-surface p-6 text-center">
-            <div className="font-semibold text-[14.5px]">
-              Collection not found
-            </div>
-            <div className="mt-[5px] text-[12.5px] text-cc-muted">
-              There is no such collection. It may have been deleted.
-            </div>
-            <button
-              type="button"
-              onClick={() => openCollection(null)}
-              className="mx-auto mt-[13px] flex h-[34px] w-max cursor-pointer items-center rounded-[9px] bg-cc-btn px-3.5 font-semibold text-[13px] text-cc-btn-fg hover:opacity-[0.88]"
-            >
-              All collections
-            </button>
-          </div>
+          <EmptyPanel
+            title="Collection not found"
+            body="There is no such collection. It may have been deleted."
+            action={{
+              label: "All collections",
+              onClick: () => openCollection(null),
+            }}
+          />
         ) : null}
 
         {!isLoading && signedIn && openCollectionRecord ? (
@@ -328,22 +357,14 @@ export function Collections({ openCollectionId = null }: Props) {
 
         {!isLoading && signedIn && openId === null && collections ? (
           collections.length === 0 ? (
-            <div className="rounded-[11px] border border-cc-rule bg-cc-surface p-6 text-center">
-              <div className="font-semibold text-[14.5px]">
-                No collections yet
-              </div>
-              <div className="mt-[5px] text-[12.5px] text-cc-muted">
-                Create a collection to organize courses you are considering
-                together.
-              </div>
-              <button
-                type="button"
-                onClick={() => setDialogOpen(true)}
-                className="mx-auto mt-[13px] flex h-[34px] w-max cursor-pointer items-center rounded-[9px] bg-cc-btn px-3.5 font-semibold text-[13px] text-cc-btn-fg hover:opacity-[0.88]"
-              >
-                Create collection
-              </button>
-            </div>
+            <EmptyPanel
+              title="No collections yet"
+              body="Create a collection to organize courses you are considering together."
+              action={{
+                label: "Create collection",
+                onClick: () => setDialogOpen(true),
+              }}
+            />
           ) : (
             <div className="grid grid-cols-[repeat(auto-fill,minmax(240px,1fr))] gap-3">
               <button

--- a/apps/web/features/collections/components/empty-panel.tsx
+++ b/apps/web/features/collections/components/empty-panel.tsx
@@ -1,0 +1,35 @@
+import type { ReactNode } from "react";
+
+type Props = {
+  title: string;
+  body: ReactNode;
+  /** The one thing there is to do here, when there is one. */
+  action?: { label: string; onClick: () => void };
+};
+
+/**
+ * The centred panel this page shows when there is nothing to list: no
+ * collections, a collection with no courses in it, and a collection that is not
+ * there at all.
+ *
+ * One component because the artboard draws one panel — `noCollections` in
+ * `Course Community - Collections.dc.html` is the shape all three take, and
+ * three copies of it would drift apart at the first change to its border.
+ */
+export function EmptyPanel({ title, body, action }: Props) {
+  return (
+    <div className="rounded-[11px] border border-cc-rule bg-cc-surface p-6 text-center">
+      <div className="font-semibold text-[14.5px]">{title}</div>
+      <div className="mt-[5px] text-[12.5px] text-cc-muted">{body}</div>
+      {action ? (
+        <button
+          type="button"
+          onClick={action.onClick}
+          className="mx-auto mt-[13px] flex h-[34px] w-max cursor-pointer items-center rounded-[9px] bg-cc-btn px-3.5 font-semibold text-[13px] text-cc-btn-fg hover:opacity-[0.88]"
+        >
+          {action.label}
+        </button>
+      ) : null}
+    </div>
+  );
+}

--- a/apps/web/features/collections/components/new-collection-dialog.tsx
+++ b/apps/web/features/collections/components/new-collection-dialog.tsx
@@ -1,0 +1,208 @@
+"use client";
+
+import { Check } from "lucide-react";
+import { useState } from "react";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import type { CourseCardCourse } from "@/features/courses";
+
+type Props = {
+  open: boolean;
+  /**
+   * The only courses the dialog may offer.
+   *
+   * A course may only join a collection its owner has also saved, so the list is
+   * built from the saved codes rather than filtered for them — nothing here can
+   * offer an unsaved course and leave the server to refuse it.
+   */
+  savedCourses: readonly CourseCardCourse[];
+  onClose: () => void;
+  onCreate: (name: string, courseCodes: string[]) => void;
+};
+
+/**
+ * Naming a new collection and choosing which saved courses start in it.
+ *
+ * The draft lives here and dies with the dialog, so a cancelled name is never
+ * offered back the next time it opens.
+ */
+export function NewCollectionDialog({
+  open,
+  savedCourses,
+  onClose,
+  onCreate,
+}: Props) {
+  const [name, setName] = useState("");
+  const [query, setQuery] = useState("");
+  const [picked, setPicked] = useState<string[]>([]);
+  const [error, setError] = useState("");
+
+  function reset() {
+    setName("");
+    setQuery("");
+    setPicked([]);
+    setError("");
+  }
+
+  function close() {
+    reset();
+    onClose();
+  }
+
+  function submit() {
+    const trimmed = name.trim();
+    if (!trimmed) {
+      setError("Give this collection a name");
+      return;
+    }
+    const courseCodes = picked;
+    reset();
+    onClose();
+    onCreate(trimmed, courseCodes);
+  }
+
+  const needle = query.trim().toLowerCase();
+  const matches = savedCourses.filter(
+    (course) =>
+      !needle ||
+      `${course.courseCode} ${course.titleEng}`.toLowerCase().includes(needle),
+  );
+
+  return (
+    <Dialog open={open} onOpenChange={(next) => !next && close()}>
+      <DialogContent
+        showCloseButton={false}
+        overlayClassName="bg-[rgba(14,26,44,0.34)] supports-backdrop-filter:backdrop-blur-none"
+        className="cc-theme w-[440px] max-w-[calc(100vw-2rem)] gap-0 rounded-[14px] border-cc-rule2 bg-cc-surface p-[22px] text-cc-ink shadow-[0_18px_48px_rgba(20,30,45,0.26)]"
+      >
+        <div className="flex items-center justify-between gap-3">
+          <DialogTitle className="font-semibold text-[18px]">
+            New collection
+          </DialogTitle>
+          <button
+            type="button"
+            onClick={close}
+            aria-label="Cancel"
+            className="flex size-[26px] cursor-pointer items-center justify-center rounded-[7px] text-[17px] text-cc-dim leading-none hover:bg-cc-pill"
+          >
+            ×
+          </button>
+        </div>
+        <DialogDescription className="sr-only">
+          Name a collection and pick which of your saved courses start in it.
+        </DialogDescription>
+
+        <input
+          autoFocus
+          value={name}
+          onChange={(event) => {
+            setName(event.target.value);
+            setError("");
+          }}
+          placeholder="Collection name"
+          aria-label="Collection name"
+          className="mt-3.5 box-border h-[38px] w-full rounded-[9px] border border-cc-rule3 bg-cc-surface px-3 text-[13.5px] text-cc-ink outline-none focus:border-cc-brand"
+        />
+
+        {savedCourses.length > 0 ? (
+          <>
+            <input
+              value={query}
+              onChange={(event) => setQuery(event.target.value)}
+              placeholder="Filter saved courses"
+              aria-label="Filter saved courses"
+              className="mt-2 box-border h-[34px] w-full rounded-[9px] border border-cc-rule bg-cc-inset px-3 text-[12.5px] text-cc-ink outline-none focus:border-cc-brand"
+            />
+            <div className="mt-2.5 max-h-[210px] overflow-auto rounded-[9px] border border-cc-rule">
+              {matches.map((course) => {
+                const checked = picked.includes(course.courseCode);
+                return (
+                  <label
+                    key={course.courseCode}
+                    className="flex w-full cursor-pointer items-center gap-2.5 border-cc-rule border-b px-[11px] py-[9px] text-left last:border-b-0 hover:bg-cc-inset"
+                  >
+                    <input
+                      type="checkbox"
+                      checked={checked}
+                      onChange={() =>
+                        setPicked((current) =>
+                          checked
+                            ? current.filter(
+                                (code) => code !== course.courseCode,
+                              )
+                            : [...current, course.courseCode],
+                        )
+                      }
+                      className="sr-only"
+                    />
+                    <span
+                      aria-hidden
+                      className={`flex size-4 flex-none items-center justify-center rounded-[4px] border ${
+                        checked
+                          ? "border-cc-brand bg-cc-brand text-cc-btn-fg"
+                          : "border-cc-rule3"
+                      }`}
+                    >
+                      {checked ? <Check size={11} /> : null}
+                    </span>
+                    <span className="font-mono text-[11.5px] text-cc-dim">
+                      {course.courseCode}
+                    </span>
+                    <span className="min-w-0 flex-1 truncate text-[13px]">
+                      {course.titleEng}
+                    </span>
+                  </label>
+                );
+              })}
+            </div>
+            <div className="mt-2.5 flex items-center justify-between gap-3">
+              <div className="text-[12px] text-cc-muted">
+                {picked.length} selected
+              </div>
+              {error ? (
+                <div
+                  role="alert"
+                  className="font-medium text-[12px] text-cc-danger"
+                >
+                  {error}
+                </div>
+              ) : null}
+            </div>
+          </>
+        ) : (
+          <div className="mt-2.5 rounded-[9px] border border-cc-rule bg-cc-inset px-[13px] py-[11px] text-[12.5px] text-cc-muted">
+            You have no saved courses yet. Name the collection now and add
+            courses to it once you have saved some — a collection can only hold
+            courses you have saved.
+            {error ? (
+              <div role="alert" className="mt-2 font-medium text-cc-danger">
+                {error}
+              </div>
+            ) : null}
+          </div>
+        )}
+
+        <div className="mt-3.5 flex gap-2">
+          <button
+            type="button"
+            onClick={submit}
+            className="flex h-10 flex-1 cursor-pointer items-center justify-center rounded-[9px] bg-cc-btn font-semibold text-[13.5px] text-cc-btn-fg hover:opacity-[0.88]"
+          >
+            Create collection
+          </button>
+          <button
+            type="button"
+            onClick={close}
+            className="flex h-10 cursor-pointer items-center justify-center rounded-[9px] border border-cc-rule3 bg-cc-surface px-4 font-medium text-[13.5px] text-cc-ink hover:border-cc-hov"
+          >
+            Cancel
+          </button>
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/apps/web/features/collections/hooks/use-popover.ts
+++ b/apps/web/features/collections/hooks/use-popover.ts
@@ -1,0 +1,50 @@
+"use client";
+
+import { useCallback, useEffect, useRef, useState } from "react";
+
+/**
+ * A small panel anchored to a button: the tile's ⋯ menu, and the detail's "Add
+ * course" list.
+ *
+ * Both artboards close their popovers on a pointer down anywhere outside, and
+ * this adds the two things a keyboard needs and markup alone cannot give:
+ * Escape closes, and closing puts focus back on the trigger it came from —
+ * without that, dismissing a menu drops the caret at the top of the document.
+ *
+ * The trigger is excluded from "outside" so a click on it toggles once rather
+ * than closing on pointer down and reopening on click.
+ */
+export function usePopover<Panel extends HTMLElement = HTMLDivElement>() {
+  const [isOpen, setIsOpen] = useState(false);
+  const panelRef = useRef<Panel>(null);
+  const triggerRef = useRef<HTMLButtonElement>(null);
+
+  const toggle = useCallback(() => setIsOpen((open) => !open), []);
+  const close = useCallback(() => setIsOpen(false), []);
+
+  useEffect(() => {
+    if (!isOpen) return;
+
+    function onPointerDown(event: PointerEvent) {
+      const target = event.target as Node;
+      if (panelRef.current?.contains(target)) return;
+      if (triggerRef.current?.contains(target)) return;
+      setIsOpen(false);
+    }
+
+    function onKeyDown(event: KeyboardEvent) {
+      if (event.key !== "Escape") return;
+      setIsOpen(false);
+      triggerRef.current?.focus();
+    }
+
+    document.addEventListener("pointerdown", onPointerDown, true);
+    document.addEventListener("keydown", onKeyDown, true);
+    return () => {
+      document.removeEventListener("pointerdown", onPointerDown, true);
+      document.removeEventListener("keydown", onKeyDown, true);
+    };
+  }, [isOpen]);
+
+  return { isOpen, toggle, close, panelRef, triggerRef };
+}

--- a/apps/web/features/collections/hooks/use-rename-draft.ts
+++ b/apps/web/features/collections/hooks/use-rename-draft.ts
@@ -1,0 +1,46 @@
+"use client";
+
+import type { KeyboardEvent } from "react";
+import { useCallback, useState } from "react";
+
+/**
+ * Renaming a collection in place, as both the tile and the detail header do it.
+ *
+ * The draft is `null` until Rename opens it, which is what separates "not
+ * renaming" from "renaming to the empty string" — the second is a name the
+ * server would reject, so it commits nothing rather than sending it.
+ *
+ * Escape clears the draft before the field can blur, so the blur that follows
+ * commits nothing. Enter blurs, and the blur commits: one path, whichever way
+ * the reader leaves the field.
+ */
+export function useRenameDraft(
+  currentName: string,
+  onRename: (name: string) => void,
+) {
+  const [draft, setDraft] = useState<string | null>(null);
+
+  const cancel = useCallback(() => setDraft(null), []);
+
+  const commit = useCallback(() => {
+    const name = draft?.trim() ?? "";
+    setDraft(null);
+    if (name && name !== currentName) onRename(name);
+  }, [draft, currentName, onRename]);
+
+  const onKeyDown = useCallback((event: KeyboardEvent<HTMLInputElement>) => {
+    if (event.key === "Enter") event.currentTarget.blur();
+    if (event.key === "Escape") setDraft(null);
+  }, []);
+
+  return {
+    /** The text in the field. Meaningless while `isRenaming` is false. */
+    draft: draft ?? "",
+    isRenaming: draft !== null,
+    start: () => setDraft(currentName),
+    change: (name: string) => setDraft(name),
+    commit,
+    cancel,
+    onKeyDown,
+  };
+}

--- a/apps/web/features/collections/index.ts
+++ b/apps/web/features/collections/index.ts
@@ -1,0 +1,14 @@
+/**
+ * The cross-feature API of the collections feature.
+ *
+ * `Collections` is exported because it is not only a page: the Saved artboard
+ * imports the Collections artboard as a section of itself, so whoever builds
+ * Saved (#90) renders this component rather than a second copy of it. The route
+ * at `app/(service)/collections` renders it too — pages import from
+ * `features/<name>/components`, so that import does not come through here.
+ *
+ * The writes live in `useCollectionMutations` (`@/features/courses`), which the
+ * course card's picker shares, so nothing collection-shaped is exported twice.
+ */
+
+export { Collections } from "./components/collections";

--- a/apps/web/features/collections/lib/collection-model.spec.ts
+++ b/apps/web/features/collections/lib/collection-model.spec.ts
@@ -1,0 +1,87 @@
+import { describe, expect, it } from "vitest";
+import {
+  addableCourseCodes,
+  courseCountLabel,
+  moveCourse,
+  overflowLabel,
+} from "./collection-model";
+
+describe("courseCountLabel", () => {
+  it("counts one course in the singular", () => {
+    expect(courseCountLabel(1)).toBe("1 course");
+  });
+
+  it("counts anything else in the plural, an empty collection included", () => {
+    expect(courseCountLabel(0)).toBe("0 courses");
+    expect(courseCountLabel(4)).toBe("4 courses");
+  });
+});
+
+describe("overflowLabel", () => {
+  it("says nothing while the tile still lists every course", () => {
+    expect(overflowLabel(0)).toBeNull();
+    expect(overflowLabel(3)).toBeNull();
+  });
+
+  it("counts the courses the tile had no room for", () => {
+    expect(overflowLabel(4)).toBe("+1 more");
+    expect(overflowLabel(9)).toBe("+6 more");
+  });
+});
+
+describe("addableCourseCodes", () => {
+  // The rule the database enforces: a course may only join a collection its
+  // owner has also saved. The list is built from the saved codes, so an unsaved
+  // course has no way into it.
+  it("offers only saved courses", () => {
+    expect(addableCourseCodes(["AA1000", "BB2000"], [])).toEqual([
+      "AA1000",
+      "BB2000",
+    ]);
+  });
+
+  it("leaves out the courses the collection already holds", () => {
+    expect(
+      addableCourseCodes(["AA1000", "BB2000", "CC3000"], ["BB2000"]),
+    ).toEqual(["AA1000", "CC3000"]);
+  });
+
+  it("offers nothing when every saved course is already in", () => {
+    expect(addableCourseCodes(["AA1000"], ["AA1000"])).toEqual([]);
+  });
+});
+
+describe("moveCourse", () => {
+  const ORDER = ["AA1000", "BB2000", "CC3000"];
+
+  it("swaps a course with the one above it", () => {
+    expect(moveCourse(ORDER, "BB2000", "up")).toEqual([
+      "BB2000",
+      "AA1000",
+      "CC3000",
+    ]);
+  });
+
+  it("swaps a course with the one below it", () => {
+    expect(moveCourse(ORDER, "BB2000", "down")).toEqual([
+      "AA1000",
+      "CC3000",
+      "BB2000",
+    ]);
+  });
+
+  it("leaves the order alone at either end", () => {
+    expect(moveCourse(ORDER, "AA1000", "up")).toEqual(ORDER);
+    expect(moveCourse(ORDER, "CC3000", "down")).toEqual(ORDER);
+  });
+
+  it("leaves the order alone for a course that is not in it", () => {
+    expect(moveCourse(ORDER, "ZZ9000", "up")).toEqual(ORDER);
+  });
+
+  it("never mutates the order it was given", () => {
+    const original = [...ORDER];
+    moveCourse(ORDER, "BB2000", "up");
+    expect(ORDER).toEqual(original);
+  });
+});

--- a/apps/web/features/collections/lib/collection-model.ts
+++ b/apps/web/features/collections/lib/collection-model.ts
@@ -1,0 +1,66 @@
+/**
+ * What the Collections page counts, offers and orders — everything it decides
+ * without rendering anything, so it is tested in the `logic` project rather than
+ * through a render.
+ *
+ * The artboard's tile also carries a "last updated" line, sourced from an
+ * `updated` string on its mock store. `collections` has `created_at` and no
+ * `updated_at`, and nothing writes one, so there is no such label here: a
+ * relative time with nothing behind it is worse than the missing line (#68).
+ */
+
+/** `"1 course"` / `"3 courses"`, as the artboard writes the tile's count. */
+export function courseCountLabel(count: number): string {
+  return `${count} ${count === 1 ? "course" : "courses"}`;
+}
+
+/** How many course lines a tile shows before it counts the rest instead. */
+export const TILE_PREVIEW_LIMIT = 3;
+
+/** `"+2 more"`, or `null` when the tile already lists every course. */
+export function overflowLabel(count: number): string | null {
+  const hidden = count - TILE_PREVIEW_LIMIT;
+  return hidden > 0 ? `+${hidden} more` : null;
+}
+
+/**
+ * The saved courses a collection can still take.
+ *
+ * A course may only join a collection its owner has also saved — composite
+ * foreign keys enforce it, and `addCourseToCollection` refuses before they have
+ * to. So the picker is built *from* the saved codes rather than filtered for
+ * them afterwards: there is no path here that offers an unsaved course and
+ * lets the server say no.
+ */
+export function addableCourseCodes(
+  savedCourseCodes: readonly string[],
+  collectionCourseCodes: readonly string[],
+): string[] {
+  const held = new Set(collectionCourseCodes);
+  return savedCourseCodes.filter((courseCode) => !held.has(courseCode));
+}
+
+/**
+ * The collection's order with one course moved one place towards `direction`.
+ *
+ * `collection_courses.position` is the only ordering the schema carries, and
+ * `collections.reorder` rewrites it wholesale, so a move is computed here and
+ * sent as the whole new order.
+ *
+ * A move that would leave the list returns the order unchanged, so a caller can
+ * compare against what it passed in to decide whether there is anything to send.
+ */
+export function moveCourse(
+  courseCodes: readonly string[],
+  courseCode: string,
+  direction: "up" | "down",
+): string[] {
+  const from = courseCodes.indexOf(courseCode);
+  const to = direction === "up" ? from - 1 : from + 1;
+  if (from < 0 || to < 0 || to >= courseCodes.length) return [...courseCodes];
+
+  const moved = [...courseCodes];
+  moved[from] = courseCodes[to] as string;
+  moved[to] = courseCode;
+  return moved;
+}

--- a/apps/web/features/courses/api/collection-mutations.spec.tsx
+++ b/apps/web/features/courses/api/collection-mutations.spec.tsx
@@ -1,0 +1,150 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { renderHook, waitFor } from "@testing-library/react";
+import type { ReactNode } from "react";
+import { describe, expect, it, vi } from "vitest";
+import { useCollectionMutations } from "./mutations";
+
+/**
+ * Two reorders in flight at once.
+ *
+ * A reader nudging a course twice quickly sends the second request before the
+ * first has answered, and the two write the same cache entry. What the second
+ * move shows must survive the first one failing: the server takes the whole
+ * order from whichever request reaches it last, so an earlier failure says
+ * nothing about the later move.
+ */
+
+const LIST_KEY = ["collections", "list"];
+
+type Deferred = {
+  resolve: (value: unknown) => void;
+  reject: (reason: unknown) => void;
+};
+
+const pending: Deferred[] = [];
+
+/** Hands back a promise per call, so a test decides which settles and how. */
+function nextRequest() {
+  return new Promise((resolve, reject) => {
+    pending.push({ resolve, reject });
+  });
+}
+
+vi.mock("@/trpc/client", () => {
+  const mutation = { mutationOptions: (options: object) => options };
+  return {
+    useTRPC: () => ({
+      collections: {
+        list: { queryKey: () => LIST_KEY },
+        create: mutation,
+        rename: mutation,
+        delete: mutation,
+        addCourse: mutation,
+        removeCourse: mutation,
+        reorder: {
+          mutationOptions: (options: object) => ({
+            ...options,
+            mutationFn: () => nextRequest(),
+          }),
+        },
+      },
+    }),
+  };
+});
+
+const COLLECTION = {
+  id: "c1",
+  name: "Spring",
+  createdAt: "2026-01-01T00:00:00.000Z",
+  courseCodes: ["AA1000", "BB2000", "CC3000"],
+};
+
+function setup() {
+  pending.length = 0;
+  const queryClient = new QueryClient({
+    defaultOptions: {
+      queries: { retry: false },
+      mutations: { retry: false },
+    },
+  });
+  queryClient.setQueryData(LIST_KEY, [COLLECTION]);
+
+  function Wrapper({ children }: { children: ReactNode }) {
+    return (
+      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    );
+  }
+
+  const { result } = renderHook(() => useCollectionMutations(), {
+    wrapper: Wrapper,
+  });
+
+  const order = () =>
+    queryClient.getQueryData<Array<typeof COLLECTION>>(LIST_KEY)?.[0]
+      ?.courseCodes;
+
+  return { result, order };
+}
+
+describe("overlapping reorders", () => {
+  it("keeps the newer move when the older request fails", async () => {
+    const { result, order } = setup();
+
+    // Nudge BB2000 up, then nudge it up again before the first answers.
+    const first = result.current.reorder
+      .mutateAsync({
+        collectionId: "c1",
+        courseCodes: ["BB2000", "AA1000", "CC3000"],
+      })
+      .catch(() => undefined);
+    await waitFor(() => expect(pending).toHaveLength(1));
+
+    const second = result.current.reorder
+      .mutateAsync({
+        collectionId: "c1",
+        courseCodes: ["CC3000", "BB2000", "AA1000"],
+      })
+      .catch(() => undefined);
+    await waitFor(() => expect(pending).toHaveLength(2));
+    expect(order()).toEqual(["CC3000", "BB2000", "AA1000"]);
+
+    // The first request fails. It knows nothing about the second move, so it
+    // must not put the list back to how things were before either of them.
+    pending[0]?.reject(new Error("network"));
+    await first;
+    expect(order()).toEqual(["CC3000", "BB2000", "AA1000"]);
+
+    pending[1]?.resolve({
+      collectionId: "c1",
+      courseCodes: ["CC3000", "BB2000", "AA1000"],
+    });
+    await second;
+    expect(order()).toEqual(["CC3000", "BB2000", "AA1000"]);
+  });
+
+  it("applies each move to what the one before it left", async () => {
+    const { result, order } = setup();
+
+    result.current.reorder
+      .mutateAsync({
+        collectionId: "c1",
+        courseCodes: ["BB2000", "AA1000", "CC3000"],
+      })
+      .catch(() => undefined);
+    await waitFor(() =>
+      expect(order()).toEqual(["BB2000", "AA1000", "CC3000"]),
+    );
+
+    // The second nudge is computed from what is on screen, which is only the
+    // first move's result because the cache already carries it.
+    result.current.reorder
+      .mutateAsync({
+        collectionId: "c1",
+        courseCodes: ["BB2000", "CC3000", "AA1000"],
+      })
+      .catch(() => undefined);
+    await waitFor(() =>
+      expect(order()).toEqual(["BB2000", "CC3000", "AA1000"]),
+    );
+  });
+});

--- a/apps/web/features/courses/api/mutations.ts
+++ b/apps/web/features/courses/api/mutations.ts
@@ -1,14 +1,22 @@
 "use client";
 
 import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { applyReorder } from "@/features/courses/lib/collection-order";
 import { useTRPC } from "@/trpc/client";
+import type { Collection } from "./queries";
 
 /**
- * Creating a collection, and moving one course in or out of it.
+ * Every write in the `collections` router, in one hook.
  *
- * Each write refetches `collections.list`, which is what the picker's ticks are
- * drawn from — there is no second copy of that state to keep in step. All three
- * procedures are protected, so the card only reaches them once a session exists.
+ * Two surfaces call these: the course card's picker, which puts *this* course
+ * into a collection, and the Collections page, which manages the collections
+ * themselves. They are different UIs over the same seven procedures, so the
+ * write path is defined once — a second copy would be a second set of cache
+ * keys to keep in step, and `collections.list` is the only state any of it has.
+ *
+ * Each write refetches `collections.list`, which is what the picker's ticks and
+ * the page's grid are both drawn from. Every procedure is protected, so nothing
+ * here is reached before a session exists.
  */
 export function useCollectionMutations() {
   const trpc = useTRPC();
@@ -20,6 +28,12 @@ export function useCollectionMutations() {
   const create = useMutation(
     trpc.collections.create.mutationOptions({ onSuccess: invalidate }),
   );
+  const rename = useMutation(
+    trpc.collections.rename.mutationOptions({ onSuccess: invalidate }),
+  );
+  const deleteCollection = useMutation(
+    trpc.collections.delete.mutationOptions({ onSuccess: invalidate }),
+  );
   const addCourse = useMutation(
     trpc.collections.addCourse.mutationOptions({ onSuccess: invalidate }),
   );
@@ -27,7 +41,51 @@ export function useCollectionMutations() {
     trpc.collections.removeCourse.mutationOptions({ onSuccess: invalidate }),
   );
 
-  return { create, addCourse, removeCourse };
+  /**
+   * Reordering writes the new order into the cache before the request lands.
+   *
+   * Not for the animation: a reader nudging a course up twice computes the
+   * second move from what is on screen, and without this that is still the
+   * pre-move order — so the two clicks would send the same swap twice and the
+   * course would move one place, not two.
+   */
+  const reorder = useMutation(
+    trpc.collections.reorder.mutationOptions({
+      onMutate: async ({ collectionId, courseCodes }) => {
+        await queryClient.cancelQueries({ queryKey: listKey });
+        const previous = queryClient.getQueryData<Collection[]>(listKey);
+        queryClient.setQueryData<Collection[]>(listKey, (collections) =>
+          collections?.map((collection) =>
+            collection.id === collectionId
+              ? {
+                  ...collection,
+                  courseCodes: applyReorder(
+                    collection.courseCodes,
+                    courseCodes,
+                  ),
+                }
+              : collection,
+          ),
+        );
+        return { previous };
+      },
+      onError: (_error, _input, context) => {
+        if (context?.previous) {
+          queryClient.setQueryData(listKey, context.previous);
+        }
+      },
+      onSettled: invalidate,
+    }),
+  );
+
+  return {
+    create,
+    rename,
+    deleteCollection,
+    reorder,
+    addCourse,
+    removeCourse,
+  };
 }
 
 /**

--- a/apps/web/features/courses/api/mutations.ts
+++ b/apps/web/features/courses/api/mutations.ts
@@ -1,6 +1,7 @@
 "use client";
 
 import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { useRef } from "react";
 import { applyReorder } from "@/features/courses/lib/collection-order";
 import { useTRPC } from "@/trpc/client";
 import type { Collection } from "./queries";
@@ -48,12 +49,34 @@ export function useCollectionMutations() {
    * second move from what is on screen, and without this that is still the
    * pre-move order — so the two clicks would send the same swap twice and the
    * course would move one place, not two.
+   *
+   * ## Why a failure does not roll back
+   *
+   * Nudging twice quickly puts two reorders in flight at once, and a snapshot
+   * rollback is wrong for exactly that case: the first request's `onMutate`
+   * captured the list as it was *before either* move, so restoring it when that
+   * request fails also erases the second move — which may well be on its way to
+   * succeeding. There is no snapshot that is right, because the state a
+   * rollback should return to depends on writes that happened after it was
+   * taken.
+   *
+   * So there is no rollback. `collections.reorder` rewrites every position in
+   * one statement from the codes it is given, so the last request to reach the
+   * server decides the order outright, and refetching is the only thing that
+   * can be relied on to agree with it. A failed reorder shows its optimistic
+   * order until that refetch lands — a moment, alongside the toast the caller
+   * raises — rather than showing a different wrong order with more confidence.
+   *
+   * The refetch waits for the last reorder to settle. Invalidating while
+   * another is still in flight would pull the pre-*that*-move order back over
+   * its optimistic state, making the list jump backwards mid-gesture.
    */
+  const pendingReorders = useRef(0);
   const reorder = useMutation(
     trpc.collections.reorder.mutationOptions({
       onMutate: async ({ collectionId, courseCodes }) => {
+        pendingReorders.current += 1;
         await queryClient.cancelQueries({ queryKey: listKey });
-        const previous = queryClient.getQueryData<Collection[]>(listKey);
         queryClient.setQueryData<Collection[]>(listKey, (collections) =>
           collections?.map((collection) =>
             collection.id === collectionId
@@ -67,14 +90,11 @@ export function useCollectionMutations() {
               : collection,
           ),
         );
-        return { previous };
       },
-      onError: (_error, _input, context) => {
-        if (context?.previous) {
-          queryClient.setQueryData(listKey, context.previous);
-        }
+      onSettled: () => {
+        pendingReorders.current -= 1;
+        if (pendingReorders.current === 0) invalidate();
       },
-      onSettled: invalidate,
     }),
   );
 

--- a/apps/web/features/courses/api/queries.ts
+++ b/apps/web/features/courses/api/queries.ts
@@ -5,6 +5,8 @@ import { type RouterOutputs, useTRPC } from "@/trpc/client";
 
 export type CourseDetails = RouterOutputs["course"]["details"];
 export type CourseSummary = RouterOutputs["course"]["summary"];
+/** One of the viewer's collections: its name, and its courses in stored order. */
+export type Collection = RouterOutputs["collections"]["list"][number];
 
 export function useCourseDetails(courseCode: string | undefined) {
   const trpc = useTRPC();

--- a/apps/web/features/courses/index.ts
+++ b/apps/web/features/courses/index.ts
@@ -2,13 +2,22 @@
  * The cross-feature API of the courses feature.
  *
  * What Explore (#89), Saved (#90) and Collections (#91) need in order to render
- * a course card, and nothing else. The card's mapper, its formatting helpers
- * and the tRPC hooks behind the picker are all reachable through
- * `CourseCardItem`, so they stay inside the feature — a barrel that exports its
- * own internals turns each of them into a promise to three other pages.
+ * a course card, and to manage the collections a card can be put into. The
+ * card's mapper and its formatting helpers stay inside the feature, reachable
+ * through `CourseCardItem` — a barrel that exports its own internals turns each
+ * of them into a promise to three other pages.
+ *
+ * The collection hooks are the exception, and deliberately so. The card's
+ * picker and the Collections page are two surfaces over the same seven
+ * procedures; exporting the one hook that holds those writes is what stops the
+ * second surface from growing a second write path with its own cache keys.
  */
 
+/** Every `collections` write. Shared by the card's picker and the page. */
+export { useCollectionMutations } from "./api/mutations";
 export {
+  type Collection,
+  useCollections,
   useCourseDetails,
   useCourseStats,
   useCourseSummaries,

--- a/apps/web/features/courses/lib/collection-order.spec.ts
+++ b/apps/web/features/courses/lib/collection-order.spec.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it } from "vitest";
+import { applyReorder } from "./collection-order";
+
+/**
+ * These hold `applyReorder` against `reorderCollectionCourses` in
+ * `server/collections/service.ts` — the optimistic order the picker shows has to
+ * be the order the server is about to store, or the list jumps when the refetch
+ * lands.
+ */
+describe("applyReorder", () => {
+  const MEMBERS = ["AA1000", "BB2000", "CC3000", "DD4000"];
+
+  it("puts the named codes first, in the order named", () => {
+    expect(applyReorder(MEMBERS, ["CC3000", "AA1000"])).toEqual([
+      "CC3000",
+      "AA1000",
+      "BB2000",
+      "DD4000",
+    ]);
+  });
+
+  it("keeps the members it does not name behind them, in their own order", () => {
+    expect(applyReorder(MEMBERS, ["DD4000"])).toEqual([
+      "DD4000",
+      "AA1000",
+      "BB2000",
+      "CC3000",
+    ]);
+  });
+
+  it("takes a complete order as it is given", () => {
+    const reversed = [...MEMBERS].reverse();
+    expect(applyReorder(MEMBERS, reversed)).toEqual(reversed);
+  });
+
+  // The server rejects a non-member outright, and the UI only ever reorders
+  // codes it is already rendering. Dropping it leaves the optimistic list equal
+  // to what a request that succeeds returns.
+  it("drops a code that is not a member", () => {
+    expect(applyReorder(MEMBERS, ["ZZ9000", "BB2000"])).toEqual([
+      "BB2000",
+      "AA1000",
+      "CC3000",
+      "DD4000",
+    ]);
+  });
+
+  it("counts a repeated code once, at its first mention", () => {
+    expect(applyReorder(MEMBERS, ["BB2000", "AA1000", "BB2000"])).toEqual([
+      "BB2000",
+      "AA1000",
+      "CC3000",
+      "DD4000",
+    ]);
+  });
+
+  it("leaves an empty request untouched", () => {
+    expect(applyReorder(MEMBERS, [])).toEqual(MEMBERS);
+  });
+});

--- a/apps/web/features/courses/lib/collection-order.ts
+++ b/apps/web/features/courses/lib/collection-order.ts
@@ -11,6 +11,15 @@
  * rejects one outright, and the UI never sends one — it reorders codes it is
  * already rendering — so dropping it keeps the optimistic list equal to what
  * comes back on a request that succeeds, and harmless on the one that throws.
+ *
+ * ## Why this lives under `courses` and not `collections`
+ *
+ * It is used by exactly one caller, `useCollectionMutations`, which is here
+ * because the course card's picker needs it. `features/collections` imports
+ * `CourseCardItem` from `@/features/courses`, so moving this the other way
+ * would put a cycle between the two feature barrels. The page's own move
+ * gesture — `moveCourse` in `features/collections/lib/collection-model.ts` —
+ * stays with the page for the same reason, in the direction that works.
  */
 export function applyReorder(
   current: readonly string[],

--- a/apps/web/features/courses/lib/collection-order.ts
+++ b/apps/web/features/courses/lib/collection-order.ts
@@ -1,0 +1,30 @@
+/**
+ * What `collections.reorder` does to a collection's order, in the browser.
+ *
+ * The procedure accepts a **prefix**: the codes it names come first, in the
+ * order given, and every member left out keeps its relative order behind them.
+ * `reorderCollectionCourses` in `server/collections/service.ts` is the
+ * authority; this mirrors it so an optimistic cache update shows the order the
+ * server is about to store rather than a guess at it.
+ *
+ * A code that is not a member is dropped rather than inserted. The server
+ * rejects one outright, and the UI never sends one — it reorders codes it is
+ * already rendering — so dropping it keeps the optimistic list equal to what
+ * comes back on a request that succeeds, and harmless on the one that throws.
+ */
+export function applyReorder(
+  current: readonly string[],
+  requested: readonly string[],
+): string[] {
+  const members = new Set(current);
+
+  const named: string[] = [];
+  const seen = new Set<string>();
+  for (const courseCode of requested) {
+    if (!members.has(courseCode) || seen.has(courseCode)) continue;
+    seen.add(courseCode);
+    named.push(courseCode);
+  }
+
+  return [...named, ...current.filter((code) => !seen.has(code))];
+}

--- a/apps/web/features/shell/components/rail.tsx
+++ b/apps/web/features/shell/components/rail.tsx
@@ -1,6 +1,14 @@
 "use client";
 
-import { Bookmark, BookOpen, LogOut, Search, UserRound, X } from "lucide-react";
+import {
+  Bookmark,
+  BookOpen,
+  Layers,
+  LogOut,
+  Search,
+  UserRound,
+  X,
+} from "lucide-react";
 import Link from "next/link";
 import { usePathname } from "next/navigation";
 import type { AuthReason } from "@/features/auth";
@@ -49,6 +57,16 @@ type NavItem = {
  * which is where and how `Course Community - Explore.dc.html` line 30 draws it.
  * Until then the rail is knowingly one item short of the artboard.
  */
+/**
+ * A second, opposite deferral: "Collections" is *not* in the artboard's rail
+ * either, because `Course Community - Saved.dc.html` reaches Collections by
+ * importing that artboard as a section of the Saved page. Saved does not render
+ * it yet (#90), so without this entry the route is unreachable — and an
+ * unreachable page is a worse deviation than an extra link.
+ *
+ * **#90 should take this out** when Saved embeds `Collections` and the design's
+ * own way in exists.
+ */
 const NAV: readonly NavItem[] = [
   { href: "/search", label: "Explore", icon: Search, strokeWidth: 2.4 },
   {
@@ -57,6 +75,7 @@ const NAV: readonly NavItem[] = [
     icon: Bookmark,
     strokeWidth: 2,
   },
+  { href: "/collections", label: "Collections", icon: Layers, strokeWidth: 2 },
   { href: "/profile", label: "My Page", icon: UserRound, strokeWidth: 2 },
 ];
 

--- a/apps/web/features/shell/lib/page-title.spec.ts
+++ b/apps/web/features/shell/lib/page-title.spec.ts
@@ -15,6 +15,7 @@ const ROUTES_INSIDE_THE_SHELL = [
   "/course",
   "/course/DD2380",
   "/favorites",
+  "/collections",
   "/profile",
   "/reviews",
   "/about",
@@ -37,6 +38,7 @@ describe("pageTitleFor", () => {
     expect(pageTitleFor("/contact")).toBe("Contact");
     expect(pageTitleFor("/newsletter")).toBe("Newsletter");
     expect(pageTitleFor("/reviews")).toBe("Reviews");
+    expect(pageTitleFor("/collections")).toBe("Collections");
   });
 
   it.each(ROUTES_INSIDE_THE_SHELL)(

--- a/apps/web/features/shell/lib/page-title.ts
+++ b/apps/web/features/shell/lib/page-title.ts
@@ -36,6 +36,7 @@ const TITLES: ReadonlyArray<readonly [string, string]> = [
   ["/favorites", "Saved courses"],
   ["/profile", "My Page"],
   // Routes the design does not key, titled after the page's own heading.
+  ["/collections", "Collections"],
   // #96 owns About and Contact if it wants different words.
   ["/newsletter", "Newsletter"],
   ["/contact", "Contact"],


### PR DESCRIPTION
Closes #91.

The Collections page: the viewer's named groups of saved courses, and every write that changes them — `list`, `create`, `rename`, `delete`, `reorder`, `addCourse`, `removeCourse`.

## The rule the page is built around

**A course may only join a collection its owner has also saved.** Both places that offer courses — the new-collection dialog and the detail's "Add course" menu — are derived *from* `user.savedCourseCodes` rather than filtered down to it, so there is no path that offers an unsaved course and lets the server refuse it. `addableCourseCodes` is the whole of that decision and it is tested in the `logic` project as well as through a render.

The same composite foreign key runs the other way with `on delete cascade`: **unsaving a course removes it from every collection it was in.** The page never caches membership separately, so it follows `collections.list` and cannot disagree with the database about it.

## Not found, never forbidden

`?collection=<id>` names the open collection, which is what makes the state reachable at all. An id that is not one of the viewer's own is simply absent from `collections.list` — ownership is scoped in the query, so the server never learns whether a stranger's id exists — and the page says exactly what the server says: *"Collection not found. There is no such collection. It may have been deleted."* A test asserts the copy never says "belongs to" or "permission".

One subtlety worth naming: creating a collection opens it *before* its refetch lands, so a naive check paints "not found" for a frame. The page treats an open-but-absent id as **arriving** while the list is fetching, and only as missing once it has settled.

## Reusing #86's work rather than duplicating it

`useCollectionPicker` is **not** reused, and should not be: it is card-local (open/draft state for *one* course, and a save-then-add path for a course that may not be saved yet). What is shared is the thing that mattered — **the write path**. `useCollectionMutations` grew `rename`, `delete` and `reorder` beside the three it had, and is now exported from the courses barrel. The card's picker and this page are two surfaces over one hook with one set of cache keys, rather than two copies.

Reordering writes the new order into the `collections.list` cache before the request lands. Not for the animation: two nudges in a row would otherwise both be computed from the pre-move order, and the course would move one place instead of two. `applyReorder` mirrors `reorderCollectionCourses` exactly, prefix semantics included, so the optimistic list equals what the server returns.

## Design vs schema — every contradiction hit

| The design assumed | The schema / codebase has | Minimal change made |
|---|---|---|
| `cc-store.js` collections carry an `updated` display string, rendered in the tile footer | `collections` has `created_at` and **no `updated_at`**, and nothing in `server/` would write one | The line is dropped. The footer keeps the count. No relative time is rendered with nothing behind it. |
| The detail row is `{{ r.code }} · {{ r.title }} · {{ r.meta }}` where `meta` is `hp · period · school` | `period` and `school` are not columns; `credits` and `department` are | **This is the one place I chose the larger change and want it read closely.** The rows are `CourseCardItem` at `EXPANDED_CARD_GEOMETRY`, not trimmed one-line rows. #86 built `removeLabel` documenting it as "Saved and Collections pass one", and `card-geometry.ts` documents "Saved and Collections simply pin an end" — the card's API was built expecting this page. The strictly minimal reading was to trim the `meta` string and keep the row; I took the codebase's own expectation instead. Say the word and it goes back to rows. |
| The artboard has no reorder control at all | `collection_courses.position` is the only ordering the schema carries, and #91 requires reorder to work | Added a pair of move buttons per course. Smallest control that reaches `collections.reorder`, and one a keyboard can drive — a drag handle is not. |
| Guest copy: "Sign up or log in to create collections, **compare courses with AI**, and sync across devices" | There is no comparison feature (#68 decision 1) | The clause is deleted. The copy now matches the card's own `SignUpPrompt` word for word. |
| The artboard names the entity "comparison" throughout — "No comparisons yet", "New comparison", "All comparisons", "Comparison name", "Open comparison X" | `CONTEXT.md` settles the word as **Collection** | Every one says *collection*. The subtitle "Group courses you want to compare." survives: that is a verb describing why someone groups courses, not a promise of a feature. |
| The artboard has an "AI comparison" panel in the detail — generate, loading, error, a result table, missing-data notes | No such feature exists anywhere | Deleted entirely. |
| When there are no collections the artboard renders the grid (with its "New collection" tile) **and** the empty panel below it | — | The empty panel replaces the grid. Two stacked create affordances read as a design bug rather than a state. |
| `EXAMINATION_KEYS` has five keys | Six, `seminars` included | Not touched here — no chart on this page. |

## Where this page sits, and one deviation to undo later

`Course Community - Saved.dc.html` line 82 imports the Collections artboard **as a section of the Saved page**, in its `compact` variant. That embedding is Saved's to build (#90). Two consequences:

- `Collections` is exported from `features/collections`, so #90 renders *this* component rather than a second copy.
- The design gives Collections no rail entry, because its way in is Saved. Saved does not embed it yet, so **`rail.tsx` gains a "Collections" link** — an unreachable page is a worse deviation than an extra link. It is commented as **#90's to remove** once Saved embeds the section.

The artboard's `compact` chip layout and its `onDetailChange` callback are **deliberately not built**: they have no caller on this base, and an untested second layout for a consumer that cannot use it yet is worse than leaving it to whoever embeds it.

## Tests

`ui` (17): the saved-only constraint in both pickers, a reorder in both directions plus the disabled ends, both empty states ("no collections", "empty collection"), not-found never reading as forbidden, not-found not flashing mid-refetch, Escape closing the menu and returning focus, rename and delete from the tile menu, and the visitor prompt promising no AI.
`logic`: `applyReorder` against the service's prefix semantics, plus `moveCourse`, `addableCourseCodes` and the count labels.

Gates green after rebasing onto `3aae444`: `bun run test:web` (472), `npx tsc --noEmit`, `bun run lint`.

## Notes

- `proxy.ts` is deliberately **not** given `/collections`. The artboard designs a visitor state for this page, and a cookie gate would replace it with a redirect.
- Deleting a collection is immediate and irreversible, with a confirmation strip afterwards rather than a dialog before. That is the artboard's own behaviour; flagging it in case the product owner wants a confirm.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01D3d7V2JceJZvtJED18HXFJ
