### PR TITLE
feat(taken): Taken courses — the list, editing in place, and the Ladok transcript import

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -55,7 +55,7 @@ apps/web/
 - These layers are **enforced by Biome**, not just convention: a router importing a `repository`, or a repository importing a `service`/`router`, fails `bun run lint`. See the `noRestrictedImports` overrides in `biome.json`.
 - Cross-domain calls go service → service (e.g. `search/service.ts` imports `../course/service`). Routers never import another domain's router; compose them in `server/api/root.ts`.
 - Feature `api/` exposes wrapped `useQuery` / `useMutation` hooks, not raw queryOptions factories.
-- `protectedProcedure` is the real auth gate (`ctx.session.user`). `proxy.ts` (Next 16; not `middleware.ts`) only checks that a session cookie exists for `/profile` and `/saved`. Visitors may browse courses, search, and read reviews.
+- `protectedProcedure` is the real auth gate (`ctx.session.user`). `proxy.ts` (Next 16; not `middleware.ts`) only checks that a session cookie exists for `/profile`, `/saved` and `/taken`. Visitors may browse courses, search, and read reviews.
 - Browser calls same-origin `/api/trpc` and `/api/auth`. Multipart profile pictures POST to `/api/user/profile-picture` (not tRPC).
 - Tests colocate as `*.spec.ts` next to server code; mock repositories, not the database.
 - Domain words: `CONTEXT.md`. Decisions: `docs/adr/NNNN-slug.md`.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -55,7 +55,7 @@ apps/web/
 - These layers are **enforced by Biome**, not just convention: a router importing a `repository`, or a repository importing a `service`/`router`, fails `bun run lint`. See the `noRestrictedImports` overrides in `biome.json`.
 - Cross-domain calls go service → service (e.g. `search/service.ts` imports `../course/service`). Routers never import another domain's router; compose them in `server/api/root.ts`.
 - Feature `api/` exposes wrapped `useQuery` / `useMutation` hooks, not raw queryOptions factories.
-- `protectedProcedure` is the real auth gate (`ctx.session.user`). `proxy.ts` (Next 16; not `middleware.ts`) only checks that a session cookie exists for `/profile` and `/saved`. Visitors may browse courses, search, and read reviews.
+- `protectedProcedure` is the real auth gate (`ctx.session.user`). `proxy.ts` (Next 16; not `middleware.ts`) only checks that a session cookie exists for `/profile`, `/saved` and `/taken`. Visitors may browse courses, search, and read reviews.
 - Browser calls same-origin `/api/trpc` and `/api/auth`. Multipart profile pictures POST to `/api/user/profile-picture` (not tRPC).
 - Tests colocate as `*.spec.ts` next to server code; mock repositories, not the database.
 - Domain words: `CONTEXT.md`. Decisions: `docs/adr/NNNN-slug.md`.

--- a/apps/web/app/(service)/taken/page.tsx
+++ b/apps/web/app/(service)/taken/page.tsx
@@ -1,0 +1,5 @@
+import { TakenCourses } from "@/features/taken/components/taken-courses";
+
+export default function Page() {
+  return <TakenCourses />;
+}

--- a/apps/web/features/courses/index.ts
+++ b/apps/web/features/courses/index.ts
@@ -11,16 +11,23 @@
  * picker and the Collections page are two surfaces over the same seven
  * procedures; exporting the one hook that holds those writes is what stops the
  * second surface from growing a second write path with its own cache keys.
+ *
+ * `useTakenCourses` and `useMarkCourseTaken` are here for the same reason. The
+ * card reads the viewer's taken courses to tick its Taken control and writes
+ * one with `taken.add`; Taken courses (#92) reads the same list and builds its
+ * other three writes on the same invalidation, so both surfaces share one query
+ * key and one `taken.add`.
  */
 
 /** Every `collections` write. Shared by the card's picker and the page. */
-export { useCollectionMutations } from "./api/mutations";
+export { useCollectionMutations, useMarkCourseTaken } from "./api/mutations";
 export {
   type Collection,
   useCollections,
   useCourseDetails,
   useCourseStats,
   useCourseSummaries,
+  useTakenCourses,
 } from "./api/queries";
 /** The presentational card: takes a model, and measures nothing. */
 export { CourseCard } from "./components/course-card";

--- a/apps/web/features/my-page/components/my-page.tsx
+++ b/apps/web/features/my-page/components/my-page.tsx
@@ -409,7 +409,7 @@ export function MyPage() {
           key={editing.review.id}
           courseCode={editing.courseCode}
           editing={editing.review}
-          onEditingClose={() => setEditing(null)}
+          onClose={() => setEditing(null)}
         />
       ) : null}
 

--- a/apps/web/features/reviews/components/review-list.tsx
+++ b/apps/web/features/reviews/components/review-list.tsx
@@ -89,7 +89,7 @@ export function ReviewList({ courseCode, reviews }: Readonly<ReviewListProps>) {
           key={editing.id}
           courseCode={courseCode}
           editing={editing}
-          onEditingClose={() => setEditing(null)}
+          onClose={() => setEditing(null)}
         />
       ) : null}
 

--- a/apps/web/features/reviews/components/review.tsx
+++ b/apps/web/features/reviews/components/review.tsx
@@ -110,15 +110,33 @@ type ReviewProps = {
    * independently — an id belonging to someone else is refused there.
    */
   editing?: EditableReview;
-  /** Required alongside `editing`: the parent owns the dialog's open state. */
-  onEditingClose?: () => void;
+  /**
+   * Renders no trigger button of its own, leaving the opening to `openOnLoad`.
+   *
+   * Taken courses (#92) walks a queue of unreviewed courses and mounts one of
+   * these per course; the row the reader clicked is the trigger, so a second
+   * "Add Review" button sitting under the list would open a dialog that is
+   * already open. `editing` implies this — a review being rewritten is opened
+   * from its own card.
+   */
+  triggerless?: boolean;
+  /**
+   * Called whenever the dialog closes, whether the review was published or
+   * abandoned.
+   *
+   * Required alongside `editing`, where the parent owns the open state, and
+   * alongside `triggerless`, where the parent is what decides whether anything
+   * opens next.
+   */
+  onClose?: () => void;
 };
 
 export function Review({
   courseCode,
   openOnLoad = false,
   editing,
-  onEditingClose,
+  triggerless = false,
+  onClose,
 }: Readonly<ReviewProps>) {
   const { userId, isLoading } = useMe();
   const addReview = useAddReview();
@@ -152,7 +170,7 @@ export function Review({
         : await addReview(courseCode, value);
       if (success) {
         setDialogIsOpen(false);
-        onEditingClose?.();
+        onClose?.();
         form.reset();
       }
     },
@@ -176,11 +194,11 @@ export function Review({
           setDialogIsOpen(open);
           if (!open) {
             form.reset();
-            onEditingClose?.();
+            onClose?.();
           }
         }}
       >
-        {editing ? null : (
+        {editing || triggerless ? null : (
           <DialogTrigger asChild>
             <Button className="flex-1" type="button" aria-label="Add review">
               Add Review

--- a/apps/web/features/search/index.ts
+++ b/apps/web/features/search/index.ts
@@ -1,1 +1,14 @@
+/**
+ * The cross-feature API of the search feature.
+ *
+ * `Explore` is the workspace. `useSearchCourses` and `useDebouncedQuery` cross
+ * the boundary because a second surface looks courses up in the catalogue:
+ * Taken courses (#92) has to find the course a reader is adding by hand, and
+ * `search.courses` is the only procedure that finds one by code or name. It
+ * reuses this hook rather than wrapping the procedure again, so both surfaces
+ * share one query key and one debounce.
+ */
+
+export { useSearchCourses } from "./api/queries";
 export { Explore } from "./components/explore";
+export { useDebouncedQuery } from "./hooks/use-debounced-query";

--- a/apps/web/features/shell/components/rail.tsx
+++ b/apps/web/features/shell/components/rail.tsx
@@ -1,6 +1,14 @@
 "use client";
 
-import { Bookmark, BookOpen, LogOut, Search, UserRound, X } from "lucide-react";
+import {
+  Bookmark,
+  BookOpen,
+  CircleCheck,
+  LogOut,
+  Search,
+  UserRound,
+  X,
+} from "lucide-react";
 import Link from "next/link";
 import { usePathname } from "next/navigation";
 import type { AuthReason } from "@/features/auth";
@@ -35,19 +43,15 @@ type NavItem = {
 };
 
 /**
- * A contradiction between the artboard and the codebase: the rail's fourth link
- * is "Taken courses", and no such route exists. Per #68 the codebase wins, and
- * the smallest change that keeps the design intact is to drop the one element
- * rather than ship a link that 404s on every page.
+ * "Taken courses" is back, which #85 deferred only because `/taken` did not
+ * exist yet and it would not ship a link that 404s. #92 built the route, so the
+ * rail is the artboard's four items again.
  *
- * This is a deferral, not a design change. **#92 must put it back** when it
- * builds the route: one more entry here, third in the list, between "Saved
- * courses" and "My Page" —
- *
- *   { href: <its route>, label: "Taken courses", icon: CircleCheck, strokeWidth: 1.8 }
- *
- * which is where and how `Course Community - Explore.dc.html` line 30 draws it.
- * Until then the rail is knowingly one item short of the artboard.
+ * It is **fourth**, after "My Page", which is where the artboards draw it —
+ * `Course Community - Explore.dc.html` and `Course Community - Taken
+ * Courses.dc.html` both order the group Explore, Saved courses, My Page, Taken
+ * courses. #85's note said "third in the list" in the same breath as calling it
+ * "the rail's fourth link"; the artboards settle it.
  */
 /**
  * "Collections" is deliberately *not* here, and #91's stopgap entry for it was
@@ -65,6 +69,12 @@ const NAV: readonly NavItem[] = [
     strokeWidth: 2,
   },
   { href: "/profile", label: "My Page", icon: UserRound, strokeWidth: 2 },
+  {
+    href: "/taken",
+    label: "Taken courses",
+    icon: CircleCheck,
+    strokeWidth: 1.8,
+  },
 ];
 
 function isActive(pathname: string, href: string) {

--- a/apps/web/features/shell/lib/page-title.spec.ts
+++ b/apps/web/features/shell/lib/page-title.spec.ts
@@ -15,6 +15,7 @@ const ROUTES_INSIDE_THE_SHELL = [
   "/course",
   "/course/DD2380",
   "/saved",
+  "/taken",
   "/collections",
   "/profile",
   "/reviews",
@@ -29,6 +30,7 @@ describe("pageTitleFor", () => {
     ["/search", "Explore courses"],
     ["/saved", "Saved courses"],
     ["/profile", "My Page"],
+    ["/taken", "Taken courses"],
   ])("names %s the way the design names it", (pathname, title) => {
     expect(pageTitleFor(pathname)).toBe(title);
   });

--- a/apps/web/features/shell/lib/page-title.ts
+++ b/apps/web/features/shell/lib/page-title.ts
@@ -31,10 +31,11 @@ export const WORDMARK = "Course Community";
  * their section's title.
  */
 const TITLES: ReadonlyArray<readonly [string, string]> = [
-  // The design's own five, less `taken`, whose route #92 still has to build.
+  // The design's own five.
   ["/search", "Explore courses"],
   ["/saved", "Saved courses"],
   ["/profile", "My Page"],
+  ["/taken", "Taken courses"],
   // Routes the design does not key, titled after the page's own heading.
   ["/collections", "Collections"],
   // #96 owns About and Contact if it wants different words.

--- a/apps/web/features/taken/api/mutations.ts
+++ b/apps/web/features/taken/api/mutations.ts
@@ -1,0 +1,47 @@
+"use client";
+
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { useMarkCourseTaken } from "@/features/courses";
+import { useTRPC } from "@/trpc/client";
+
+/**
+ * Every write to a reader's own taken courses, in one hook.
+ *
+ * `add` is the courses feature's `useMarkCourseTaken` rather than a second
+ * `taken.add` mutation: the course card already marks a course taken, and a
+ * second copy would be a second set of cache keys to keep in step with the
+ * first. The three writes added here invalidate exactly what it invalidates —
+ * `taken.list`, which every taken surface reads, and `course.stats`, whose
+ * taken count is drawn from the same table and is stale the moment any of
+ * these succeeds.
+ *
+ * `confirmImport` is the only thing on this page that writes a transcript's
+ * rows. Uploading and parsing write nothing at all; see `api/transcript.ts`.
+ */
+export function useTakenMutations() {
+  const trpc = useTRPC();
+  const queryClient = useQueryClient();
+  const takenKey = trpc.taken.list.queryKey();
+  // `queryKey()` with no input matches every batch of stats.
+  const statsKey = trpc.course.stats.queryKey();
+
+  const invalidate = async () => {
+    await Promise.all([
+      queryClient.invalidateQueries({ queryKey: takenKey }),
+      queryClient.invalidateQueries({ queryKey: statsKey }),
+    ]);
+  };
+
+  const add = useMarkCourseTaken();
+  const update = useMutation(
+    trpc.taken.update.mutationOptions({ onSuccess: invalidate }),
+  );
+  const remove = useMutation(
+    trpc.taken.remove.mutationOptions({ onSuccess: invalidate }),
+  );
+  const confirmImport = useMutation(
+    trpc.transcript.confirm.mutationOptions({ onSuccess: invalidate }),
+  );
+
+  return { add, update, remove, confirmImport };
+}

--- a/apps/web/features/taken/api/transcript.ts
+++ b/apps/web/features/taken/api/transcript.ts
@@ -1,0 +1,65 @@
+"use client";
+
+import type { TranscriptProposal } from "@/server/ingest/transcript/service";
+
+/**
+ * The largest file `POST /api/user/transcript` accepts, mirroring the route's
+ * own `MAX_BYTES`. Checked here so an oversized file is refused before it is
+ * uploaded, not after four megabytes have gone over the wire.
+ */
+export const MAX_TRANSCRIPT_BYTES = 4 * 1024 * 1024;
+
+/** What the drop zone tells the reader the limit is. Kept beside the bound. */
+export const MAX_TRANSCRIPT_LABEL = "4 MB";
+
+const GENERIC_FAILURE =
+  "We could not read that transcript. Try downloading a fresh Resultatintyg from Ladok.";
+
+async function failureMessage(response: Response): Promise<string> {
+  try {
+    const body: unknown = await response.json();
+    const message =
+      typeof body === "object" && body !== null && "message" in body
+        ? (body as { message: unknown }).message
+        : null;
+    return typeof message === "string" && message.trim() !== ""
+      ? message
+      : GENERIC_FAILURE;
+  } catch {
+    return GENERIC_FAILURE;
+  }
+}
+
+/**
+ * Uploads one transcript and returns what the parser made of it.
+ *
+ * The file is handed straight to `fetch` and is never kept: it is a student's
+ * academic record, so nothing here stores it, logs it or puts it in state, and
+ * the route it posts to writes nothing either. What comes back is a
+ * **proposal** — candidate rows plus the course codes the catalogue does not
+ * have — and it stays a proposal until `transcript.confirm` is called.
+ *
+ * Multipart does not go through tRPC in this repo, which is why this is a
+ * `fetch` rather than a procedure — and a plain function rather than the
+ * `useMutation` wrapper the other `api/` files expose. A mutation keeps its
+ * last `variables` for as long as the hook is mounted, and the variable here is
+ * the student's transcript; awaiting a function leaves the file unreferenced as
+ * soon as the request is built.
+ */
+export async function uploadTranscript(
+  file: File,
+): Promise<TranscriptProposal> {
+  if (file.size > MAX_TRANSCRIPT_BYTES) {
+    throw new Error(`Transcript must be less than ${MAX_TRANSCRIPT_LABEL}`);
+  }
+
+  const body = new FormData();
+  body.append("file", file);
+
+  const response = await fetch("/api/user/transcript", {
+    method: "POST",
+    body,
+  });
+  if (!response.ok) throw new Error(await failureMessage(response));
+  return (await response.json()) as TranscriptProposal;
+}

--- a/apps/web/features/taken/api/transcript.ts
+++ b/apps/web/features/taken/api/transcript.ts
@@ -7,7 +7,7 @@ import type { TranscriptProposal } from "@/server/ingest/transcript/service";
  * own `MAX_BYTES`. Checked here so an oversized file is refused before it is
  * uploaded, not after four megabytes have gone over the wire.
  */
-export const MAX_TRANSCRIPT_BYTES = 4 * 1024 * 1024;
+const MAX_TRANSCRIPT_BYTES = 4 * 1024 * 1024;
 
 /** What the drop zone tells the reader the limit is. Kept beside the bound. */
 export const MAX_TRANSCRIPT_LABEL = "4 MB";

--- a/apps/web/features/taken/components/add-taken-course-dialog.tsx
+++ b/apps/web/features/taken/components/add-taken-course-dialog.tsx
@@ -74,7 +74,18 @@ export function AddTakenCourseDialog({
     setYear("");
   }
 
+  /**
+   * Dismissal, but never over a write still in flight.
+   *
+   * Closing clears the draft, and a request that later rejects has nothing
+   * left to hand back — the reader would have to pick the course and retype
+   * the grade, credits and year to try again. So while `isSaving` this is a
+   * no-op, which covers every way out at once: `open` is the parent's state,
+   * so Escape and the overlay come through `onOpenChange` and stop here too,
+   * the same guard the inline row editor puts on its own Cancel.
+   */
   function close() {
+    if (isSaving) return;
     reset();
     onClose();
   }
@@ -125,8 +136,9 @@ export function AddTakenCourseDialog({
           <button
             type="button"
             onClick={close}
+            disabled={isSaving}
             aria-label="Cancel"
-            className="flex size-7 flex-none cursor-pointer items-center justify-center rounded-[7px] text-[18px] text-cc-dim leading-none hover:bg-cc-pill"
+            className="flex size-7 flex-none cursor-pointer items-center justify-center rounded-[7px] text-[18px] text-cc-dim leading-none hover:bg-cc-pill disabled:cursor-not-allowed disabled:opacity-50"
           >
             ×
           </button>
@@ -292,7 +304,8 @@ export function AddTakenCourseDialog({
             <button
               type="button"
               onClick={close}
-              className="flex h-[38px] cursor-pointer items-center rounded-[9px] border border-cc-rule3 bg-cc-surface px-3.5 font-medium text-[13px] text-cc-chip-ink hover:border-cc-hov"
+              disabled={isSaving}
+              className="flex h-[38px] cursor-pointer items-center rounded-[9px] border border-cc-rule3 bg-cc-surface px-3.5 font-medium text-[13px] text-cc-chip-ink hover:border-cc-hov disabled:cursor-not-allowed disabled:opacity-55"
             >
               Cancel
             </button>

--- a/apps/web/features/taken/components/add-taken-course-dialog.tsx
+++ b/apps/web/features/taken/components/add-taken-course-dialog.tsx
@@ -1,0 +1,325 @@
+"use client";
+
+import { Search } from "lucide-react";
+import { useState } from "react";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { useDebouncedQuery, useSearchCourses } from "@/features/search";
+import { creditsLabel, type TakenEdits } from "../lib/taken-rows";
+
+/** The credits a KTH course usually carries, as the artboard's own chips. */
+const CREDIT_CHOICES = [6, 7.5, 9, 15];
+
+/** The grades a KTH transcript prints. Self-reported, so nothing validates them. */
+const GRADES = ["A", "B", "C", "D", "E", "F", "P"];
+
+type Picked = { courseCode: string; name: string; credits: number | null };
+
+type Props = {
+  open: boolean;
+  /** Course codes already on the list, so the picker cannot offer one twice. */
+  takenCourseCodes: readonly string[];
+  onClose: () => void;
+  onAdd: (courseCode: string, edits: TakenEdits) => void;
+};
+
+/**
+ * Adding one course to the list by hand — the artboard's "Add a course by hand"
+ * modal.
+ *
+ * **The course has to be one the catalogue has.** The artboard offers a
+ * free-form course with no code ("Add ... as a free-form course"), and the
+ * schema cannot hold one: `user_taken_courses.course_code` is a foreign key to
+ * `courses.code`, so a row with no catalogue course has nowhere to be stored.
+ * The code and name fields are therefore filled from a catalogue search rather
+ * than typed, and the free-form path is gone; everything else about the form —
+ * the credit chips, the year box, the grade chips — is the artboard's.
+ *
+ * The grade chips are shown always, where the artboard shows them only when its
+ * transcript switch is on. That switch decides what an *import* keeps; a course
+ * being typed in by hand has no transcript to keep a grade from.
+ */
+export function AddTakenCourseDialog({
+  open,
+  takenCourseCodes,
+  onClose,
+  onAdd,
+}: Props) {
+  const [query, setQuery] = useState("");
+  const [debounced] = useDebouncedQuery(query);
+  const [picked, setPicked] = useState<Picked | null>(null);
+  const [credits, setCredits] = useState<number | null>(null);
+  const [grade, setGrade] = useState<string | null>(null);
+  const [year, setYear] = useState("");
+
+  const search = useSearchCourses({ q: debounced });
+  const results = search.data?.results ?? [];
+  const alreadyTaken = new Set(takenCourseCodes);
+
+  function reset() {
+    setQuery("");
+    setPicked(null);
+    setCredits(null);
+    setGrade(null);
+    setYear("");
+  }
+
+  function close() {
+    reset();
+    onClose();
+  }
+
+  function submit() {
+    if (!picked) return;
+    const parsedYear = /^\d{4}$/.test(year) ? Number(year) : null;
+    const course = picked;
+    reset();
+    onClose();
+    onAdd(course.courseCode, {
+      grade,
+      earnedCredits: credits,
+      attendanceYear: parsedYear,
+    });
+  }
+
+  const creditChoices = [
+    ...new Set(
+      picked?.credits != null
+        ? [picked.credits, ...CREDIT_CHOICES]
+        : CREDIT_CHOICES,
+    ),
+  ].sort((a, b) => a - b);
+
+  return (
+    <Dialog open={open} onOpenChange={(next) => !next && close()}>
+      <DialogContent
+        showCloseButton={false}
+        overlayClassName="bg-[rgba(14,26,44,0.34)] supports-backdrop-filter:backdrop-blur-none"
+        className="cc-theme w-[560px] max-w-[calc(100vw-2rem)] gap-0 rounded-[14px] border-cc-rule2 bg-cc-surface p-[22px] text-cc-ink shadow-[0_18px_48px_rgba(20,30,45,0.26)]"
+      >
+        <div className="flex items-start justify-between gap-3.5">
+          <div>
+            <p className="m-0 font-semibold text-[11px] text-cc-brand uppercase tracking-[0.06em]">
+              Add missing course
+            </p>
+            <DialogTitle className="mt-[7px] font-semibold text-[19px] leading-[1.25]">
+              Add a course by hand
+            </DialogTitle>
+          </div>
+          <button
+            type="button"
+            onClick={close}
+            aria-label="Cancel"
+            className="flex size-7 flex-none cursor-pointer items-center justify-center rounded-[7px] text-[18px] text-cc-dim leading-none hover:bg-cc-pill"
+          >
+            ×
+          </button>
+        </div>
+        <DialogDescription className="sr-only">
+          Find a course in the KTH catalogue and record the credits, grade and
+          year you got for it.
+        </DialogDescription>
+
+        <div className="mt-3.5">
+          <span className="font-medium text-[11.5px] text-cc-dim">
+            Search the KTH catalogue
+          </span>
+          <div className="mt-1.5 flex h-[42px] items-center gap-2.5 rounded-[9px] border border-cc-rule3 bg-cc-surface px-[13px]">
+            <Search
+              size={16}
+              strokeWidth={2}
+              aria-hidden
+              className="flex-none text-cc-dim"
+            />
+            <input
+              value={query}
+              onChange={(event) => {
+                setQuery(event.target.value);
+                setPicked(null);
+              }}
+              placeholder="Course code or name, e.g. DD2421"
+              aria-label="Search the KTH catalogue"
+              className="min-w-0 flex-1 border-none bg-transparent text-[13.5px] text-cc-ink outline-none"
+            />
+          </div>
+        </div>
+
+        {picked === null && debounced.trim() !== "" ? (
+          <div className="mt-2 overflow-hidden rounded-[10px] border border-cc-rule">
+            {search.isPending ? (
+              <p className="m-0 bg-cc-pg px-3.5 py-[13px] text-[13px] text-cc-muted">
+                Searching…
+              </p>
+            ) : results.length === 0 ? (
+              <p className="m-0 bg-cc-pg px-3.5 py-[13px] text-[13px] text-cc-muted">
+                Nothing in the catalogue matches “{debounced}”. Only courses KTH
+                has can be added — there is no way to record one that is not in
+                the catalogue.
+              </p>
+            ) : (
+              <ul className="m-0 flex max-h-[220px] list-none flex-col overflow-y-auto p-0">
+                {results.map((course) => {
+                  const isTaken = alreadyTaken.has(course.courseCode);
+                  return (
+                    <li key={course.courseCode} className="m-0">
+                      <button
+                        type="button"
+                        disabled={isTaken}
+                        onClick={() => {
+                          setPicked({
+                            courseCode: course.courseCode,
+                            name: course.titleEng,
+                            credits: course.credits ?? null,
+                          });
+                          setCredits(course.credits ?? null);
+                        }}
+                        className="flex w-full cursor-pointer items-center gap-[11px] border-cc-rule border-b px-3 py-2.5 text-left last:border-b-0 hover:bg-cc-pill disabled:cursor-not-allowed disabled:opacity-55 disabled:hover:bg-transparent"
+                      >
+                        <span className="w-[74px] flex-none font-medium font-mono text-[12.5px] text-cc-brand">
+                          {course.courseCode}
+                        </span>
+                        <span className="min-w-0 flex-1 truncate text-[13.5px]">
+                          {course.titleEng}
+                        </span>
+                        <span className="flex-none text-[12.5px] text-cc-dim">
+                          {isTaken
+                            ? "In your list"
+                            : creditsLabel(course.credits ?? null)}
+                        </span>
+                      </button>
+                    </li>
+                  );
+                })}
+              </ul>
+            )}
+          </div>
+        ) : null}
+
+        {picked ? (
+          <>
+            <div className="mt-3.5 flex items-center gap-[11px] rounded-[10px] bg-cc-pill px-3 py-2.5">
+              <span className="font-medium font-mono text-[12.5px] text-cc-brand">
+                {picked.courseCode}
+              </span>
+              <span className="min-w-0 flex-1 truncate text-[13.5px]">
+                {picked.name}
+              </span>
+            </div>
+
+            <div className="mt-3.5 grid grid-cols-2 gap-3">
+              <fieldset className="m-0 min-w-0 border-none p-0">
+                <legend className="font-medium text-[11.5px] text-cc-dim">
+                  Credits (hp)
+                </legend>
+                <div className="mt-1.5 flex flex-wrap gap-1.5">
+                  {creditChoices.map((choice) => (
+                    <Chip
+                      key={choice}
+                      on={credits === choice}
+                      label={String(choice)}
+                      onClick={() =>
+                        setCredits(credits === choice ? null : choice)
+                      }
+                    />
+                  ))}
+                </div>
+              </fieldset>
+              <div className="min-w-0">
+                <label
+                  htmlFor="taken-add-year"
+                  className="font-medium text-[11.5px] text-cc-dim"
+                >
+                  Year
+                </label>
+                <input
+                  id="taken-add-year"
+                  value={year}
+                  inputMode="numeric"
+                  maxLength={4}
+                  placeholder="2025"
+                  onChange={(event) =>
+                    setYear(event.target.value.replace(/\D/g, "").slice(0, 4))
+                  }
+                  className="mt-1.5 box-border h-[34px] w-full rounded-[8px] border border-cc-rule3 bg-cc-surface px-[11px] text-[13px] text-cc-ink tabular-nums outline-none focus:border-cc-brand"
+                />
+              </div>
+            </div>
+
+            <fieldset className="m-0 mt-3.5 border-none p-0">
+              <legend className="font-medium text-[11.5px] text-cc-dim">
+                Grade
+              </legend>
+              <div className="mt-1.5 flex flex-wrap gap-1.5">
+                {GRADES.map((option) => (
+                  <Chip
+                    key={option}
+                    on={grade === option}
+                    label={option}
+                    onClick={() => setGrade(grade === option ? null : option)}
+                  />
+                ))}
+                <Chip
+                  on={grade === null}
+                  label="no grade"
+                  onClick={() => setGrade(null)}
+                />
+              </div>
+            </fieldset>
+          </>
+        ) : null}
+
+        <div className="mt-[18px] flex items-center justify-between gap-3 border-cc-rule border-t pt-3.5">
+          <p className="m-0 text-[12px] text-cc-dim2">
+            Credits, grade and year are your own entries, not a KTH record.
+          </p>
+          <div className="flex gap-2.5">
+            <button
+              type="button"
+              onClick={close}
+              className="flex h-[38px] cursor-pointer items-center rounded-[9px] border border-cc-rule3 bg-cc-surface px-3.5 font-medium text-[13px] text-cc-chip-ink hover:border-cc-hov"
+            >
+              Cancel
+            </button>
+            <button
+              type="button"
+              onClick={submit}
+              disabled={picked === null}
+              className="flex h-[38px] cursor-pointer items-center rounded-[9px] bg-cc-btn px-4 font-semibold text-[13px] text-cc-btn-fg hover:opacity-[0.88] disabled:cursor-not-allowed disabled:opacity-55"
+            >
+              Add course
+            </button>
+          </div>
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+function Chip({
+  on,
+  label,
+  onClick,
+}: {
+  on: boolean;
+  label: string;
+  onClick: () => void;
+}) {
+  return (
+    <button
+      type="button"
+      aria-pressed={on}
+      onClick={onClick}
+      className={`flex h-[34px] cursor-pointer items-center rounded-[8px] border px-3 text-[13px] tabular-nums hover:border-cc-brand ${
+        on
+          ? "border-cc-brand bg-cc-pill font-semibold text-cc-brand"
+          : "border-cc-rule3 bg-cc-surface font-medium text-cc-muted"
+      }`}
+    >
+      {label}
+    </button>
+  );
+}

--- a/apps/web/features/taken/components/add-taken-course-dialog.tsx
+++ b/apps/web/features/taken/components/add-taken-course-dialog.tsx
@@ -24,7 +24,12 @@ type Props = {
   /** Course codes already on the list, so the picker cannot offer one twice. */
   takenCourseCodes: readonly string[];
   onClose: () => void;
-  onAdd: (courseCode: string, edits: TakenEdits) => void;
+  /**
+   * Records the course. Rejecting is how the parent says the write did not
+   * land: the dialog stays open holding the draft, so nothing the reader typed
+   * has to be typed twice.
+   */
+  onAdd: (courseCode: string, edits: TakenEdits) => Promise<void>;
 };
 
 /**
@@ -55,6 +60,7 @@ export function AddTakenCourseDialog({
   const [credits, setCredits] = useState<number | null>(null);
   const [grade, setGrade] = useState<string | null>(null);
   const [year, setYear] = useState("");
+  const [isSaving, setIsSaving] = useState(false);
 
   const search = useSearchCourses({ q: debounced });
   const results = search.data?.results ?? [];
@@ -73,17 +79,23 @@ export function AddTakenCourseDialog({
     onClose();
   }
 
-  function submit() {
-    if (!picked) return;
+  async function submit() {
+    if (!picked || isSaving) return;
     const parsedYear = /^\d{4}$/.test(year) ? Number(year) : null;
-    const course = picked;
-    reset();
-    onClose();
-    onAdd(course.courseCode, {
-      grade,
-      earnedCredits: credits,
-      attendanceYear: parsedYear,
-    });
+    setIsSaving(true);
+    try {
+      await onAdd(picked.courseCode, {
+        grade,
+        earnedCredits: credits,
+        attendanceYear: parsedYear,
+      });
+      reset();
+      onClose();
+    } catch {
+      // The parent has already said so. The draft stays where it is.
+    } finally {
+      setIsSaving(false);
+    }
   }
 
   const creditChoices = [
@@ -286,11 +298,11 @@ export function AddTakenCourseDialog({
             </button>
             <button
               type="button"
-              onClick={submit}
-              disabled={picked === null}
+              onClick={() => void submit()}
+              disabled={picked === null || isSaving}
               className="flex h-[38px] cursor-pointer items-center rounded-[9px] bg-cc-btn px-4 font-semibold text-[13px] text-cc-btn-fg hover:opacity-[0.88] disabled:cursor-not-allowed disabled:opacity-55"
             >
-              Add course
+              {isSaving ? "Adding…" : "Add course"}
             </button>
           </div>
         </div>

--- a/apps/web/features/taken/components/taken-course-row.tsx
+++ b/apps/web/features/taken/components/taken-course-row.tsx
@@ -30,7 +30,12 @@ type Props = {
   isReviewed: boolean | null;
   /** A write for this row is in flight; its controls wait for it. */
   isBusy: boolean;
-  onSave: (edits: TakenEdits) => void;
+  /**
+   * Saves the corrected fields. Rejecting is how the parent says the write did
+   * not land: the editor stays open holding what the reader typed rather than
+   * closing back over the old values.
+   */
+  onSave: (edits: TakenEdits) => Promise<void>;
   onRemove: () => void;
 };
 
@@ -55,6 +60,7 @@ export function TakenCourseRow({
     credits: string;
     year: string;
   } | null>(null);
+  const [isSaving, setIsSaving] = useState(false);
 
   const edits = draft === null ? null : draftEdits(draft);
 
@@ -66,10 +72,17 @@ export function TakenCourseRow({
     });
   }
 
-  function save() {
-    if (!edits) return;
-    setDraft(null);
-    onSave(edits);
+  async function save() {
+    if (!edits || isSaving) return;
+    setIsSaving(true);
+    try {
+      await onSave(edits);
+      setDraft(null);
+    } catch {
+      // The parent has already said so. The draft stays where it is.
+    } finally {
+      setIsSaving(false);
+    }
   }
 
   return (
@@ -162,8 +175,8 @@ export function TakenCourseRow({
         <div className="flex items-center justify-end gap-2">
           <button
             type="button"
-            onClick={save}
-            disabled={edits === null}
+            onClick={() => void save()}
+            disabled={edits === null || isSaving}
             title={
               edits === null
                 ? "Credits and year have to be a number"
@@ -177,6 +190,7 @@ export function TakenCourseRow({
           <button
             type="button"
             onClick={() => setDraft(null)}
+            disabled={isSaving}
             aria-label={`Cancel editing ${row.courseCode}`}
             className={`${ICON_BUTTON} hover:border-cc-hov`}
           >

--- a/apps/web/features/taken/components/taken-course-row.tsx
+++ b/apps/web/features/taken/components/taken-course-row.tsx
@@ -1,0 +1,210 @@
+"use client";
+
+import { Check, CircleCheck, Pencil, Trash2, X } from "lucide-react";
+import { useState } from "react";
+import {
+  creditsLabel,
+  draftEdits,
+  type TakenEdits,
+  type TakenRow,
+} from "../lib/taken-rows";
+
+/**
+ * The list's seven columns, shared by the header and every row so the two can
+ * never drift. Straight from the artboard's own `grid-template-columns`.
+ */
+export const TAKEN_GRID =
+  "grid w-full min-w-[640px] box-border items-center gap-[clamp(8px,1.4vw,18px)] [grid-template-columns:minmax(64px,96px)_minmax(140px,1fr)_minmax(50px,70px)_minmax(64px,90px)_minmax(50px,70px)_minmax(76px,108px)_minmax(110px,170px)]";
+
+const ICON_BUTTON =
+  "flex size-[30px] flex-none cursor-pointer items-center justify-center rounded-[7px] border border-cc-rule3 bg-cc-surface disabled:cursor-not-allowed disabled:opacity-50";
+
+type Props = {
+  row: TakenRow;
+  /**
+   * Whether this course carries a review by the viewer, or `null` when the
+   * review lists did not load. Null renders neither "Done" nor "Not yet":
+   * a course whose reviews are unknown is not the same as one with none, and
+   * a taken row carries no satisfaction state of its own to fall back on.
+   */
+  isReviewed: boolean | null;
+  /** A write for this row is in flight; its controls wait for it. */
+  isBusy: boolean;
+  onSave: (edits: TakenEdits) => void;
+  onRemove: () => void;
+};
+
+/**
+ * One taken course in the list, with the artboard's in-place editor for the
+ * three self-reported fields it shows.
+ *
+ * Credits, grade and year are the student's own entries — a transcript is not
+ * authoritative and an imported row stays editable, which is why the pencil is
+ * offered on every row regardless of where the row came from. Editing does not
+ * change its provenance: `taken.update` preserves `transcript_imported_at`.
+ */
+export function TakenCourseRow({
+  row,
+  isReviewed,
+  isBusy,
+  onSave,
+  onRemove,
+}: Props) {
+  const [draft, setDraft] = useState<{
+    grade: string;
+    credits: string;
+    year: string;
+  } | null>(null);
+
+  const edits = draft === null ? null : draftEdits(draft);
+
+  function startEditing() {
+    setDraft({
+      grade: row.grade ?? "",
+      credits: row.earnedCredits === null ? "" : String(row.earnedCredits),
+      year: row.attendanceYear === null ? "" : String(row.attendanceYear),
+    });
+  }
+
+  function save() {
+    if (!edits) return;
+    setDraft(null);
+    onSave(edits);
+  }
+
+  return (
+    <div
+      className={`${TAKEN_GRID} border-cc-rule border-b px-4 py-[11px] hover:bg-cc-pg`}
+    >
+      <div className="font-medium font-mono text-[13px] text-cc-brand">
+        {row.courseCode}
+      </div>
+
+      <div className="flex min-w-0 items-center gap-2">
+        <span className="truncate font-medium text-[13.5px]">{row.name}</span>
+        {row.transcriptImportedAt ? (
+          <span className="flex-none rounded-[5px] bg-cc-pill px-[7px] py-0.5 font-medium text-[11px] text-cc-muted">
+            Imported
+          </span>
+        ) : null}
+      </div>
+
+      {draft ? (
+        <input
+          value={draft.credits}
+          inputMode="decimal"
+          aria-label={`Credits for ${row.courseCode}`}
+          onChange={(event) =>
+            setDraft({ ...draft, credits: event.target.value })
+          }
+          className="box-border h-7 w-14 rounded-[6px] border border-cc-brand px-1.5 text-[13px] text-cc-ink outline-none"
+        />
+      ) : (
+        <div className="text-[13px] text-cc-ink2 tabular-nums">
+          {creditsLabel(row.earnedCredits)}
+        </div>
+      )}
+
+      {draft ? (
+        <input
+          value={draft.grade}
+          maxLength={1}
+          placeholder="—"
+          aria-label={`Grade for ${row.courseCode}`}
+          onChange={(event) =>
+            setDraft({ ...draft, grade: event.target.value.toUpperCase() })
+          }
+          className="box-border h-7 w-[34px] rounded-[6px] border border-cc-brand text-center font-semibold text-[13px] text-cc-ink uppercase outline-none"
+        />
+      ) : (
+        <div>
+          <span className="inline-flex items-center rounded-[7px] bg-cc-pill px-[9px] py-[3px] font-semibold text-[13px] text-cc-brand">
+            {row.grade ?? "—"}
+          </span>
+        </div>
+      )}
+
+      {draft ? (
+        <input
+          value={draft.year}
+          inputMode="numeric"
+          maxLength={4}
+          placeholder="2025"
+          aria-label={`Year for ${row.courseCode}`}
+          onChange={(event) =>
+            setDraft({
+              ...draft,
+              year: event.target.value.replace(/\D/g, "").slice(0, 4),
+            })
+          }
+          className="box-border h-7 w-[58px] rounded-[6px] border border-cc-brand px-1.5 text-center text-[13px] text-cc-ink outline-none"
+        />
+      ) : (
+        <div className="text-[13px] text-cc-ink2 tabular-nums">
+          {row.attendanceYear ?? "—"}
+        </div>
+      )}
+
+      <div className="flex min-w-0 items-center">
+        {isReviewed === null ? (
+          <span className="text-[11.5px] text-cc-dim2">—</span>
+        ) : isReviewed ? (
+          <span className="inline-flex items-center gap-1.5 font-semibold text-[12px] text-cc-success">
+            <CircleCheck size={14} strokeWidth={2.1} aria-hidden />
+            Done
+          </span>
+        ) : (
+          <span className="text-[11.5px] text-cc-dim2">Not yet</span>
+        )}
+      </div>
+
+      {draft ? (
+        <div className="flex items-center justify-end gap-2">
+          <button
+            type="button"
+            onClick={save}
+            disabled={edits === null}
+            title={
+              edits === null
+                ? "Credits and year have to be a number"
+                : `Save ${row.courseCode}`
+            }
+            aria-label={`Save ${row.courseCode}`}
+            className={`${ICON_BUTTON} border-transparent bg-cc-btn text-cc-btn-fg hover:opacity-[0.88]`}
+          >
+            <Check size={14} strokeWidth={2.2} aria-hidden />
+          </button>
+          <button
+            type="button"
+            onClick={() => setDraft(null)}
+            aria-label={`Cancel editing ${row.courseCode}`}
+            className={`${ICON_BUTTON} hover:border-cc-hov`}
+          >
+            <X size={14} strokeWidth={2} aria-hidden />
+          </button>
+        </div>
+      ) : (
+        <div className="flex items-center justify-end gap-2">
+          <button
+            type="button"
+            onClick={startEditing}
+            disabled={isBusy}
+            aria-label={`Edit credits, grade and year for ${row.courseCode}`}
+            className={`${ICON_BUTTON} text-cc-brand hover:border-cc-brand`}
+          >
+            <Pencil size={14} strokeWidth={1.9} aria-hidden />
+          </button>
+          <button
+            type="button"
+            onClick={onRemove}
+            disabled={isBusy}
+            aria-label={`Remove ${row.courseCode} from your taken courses`}
+            className={`${ICON_BUTTON} text-cc-chip-ink hover:border-cc-danger`}
+          >
+            <Trash2 size={14} strokeWidth={1.9} aria-hidden />
+          </button>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/apps/web/features/taken/components/taken-courses.spec.tsx
+++ b/apps/web/features/taken/components/taken-courses.spec.tsx
@@ -1,0 +1,441 @@
+import { render, screen, waitFor, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { TranscriptProposal } from "@/server/ingest/transcript/service";
+import type { TakenCourse } from "../lib/taken-rows";
+import { TakenCourses } from "./taken-courses";
+
+const takenList = vi.fn<() => TakenCourse[]>();
+const unreviewed =
+  vi.fn<
+    () => { courses: TakenCourse[]; isLoading: boolean; isUnavailable: boolean }
+  >();
+const searchResults =
+  vi.fn<
+    () => Array<{ courseCode: string; titleEng: string; credits: number }>
+  >();
+const addTaken = vi.fn();
+const updateTaken = vi.fn();
+const removeTaken = vi.fn();
+const confirmImport = vi.fn();
+const uploadTranscript = vi.fn();
+const toastError = vi.fn();
+const toastSuccess = vi.fn();
+
+vi.mock("@/features/auth", () => ({
+  useMe: () => ({ isLoading: false }),
+  useRequireSession: () => ({}),
+}));
+vi.mock("@/features/courses", () => ({
+  useTakenCourses: () => ({ data: takenList(), isPending: false }),
+  useCourseSummaries: (codes: string[]) =>
+    codes.map((courseCode) => ({ data: CATALOGUE[courseCode] })),
+}));
+vi.mock("@/features/reviews/api/queries", () => ({
+  useUnreviewedTakenCourses: () => unreviewed(),
+}));
+// Stubbed so the real `UnreviewedCard` still renders: this test is about which
+// course the page hands the review dialog, not about the dialog's own form.
+vi.mock("@/features/reviews/components/review", () => ({
+  Review: ({ courseCode }: { courseCode: string }) => (
+    <div data-testid="reviewer">Reviewing {courseCode}</div>
+  ),
+}));
+vi.mock("@/features/search", () => ({
+  useDebouncedQuery: (value: string) => [value, vi.fn()] as const,
+  useSearchCourses: ({ q }: { q: string }) => ({
+    data: q.trim() ? { results: searchResults() } : undefined,
+    isPending: false,
+  }),
+}));
+vi.mock("../api/mutations", () => ({
+  useTakenMutations: () => ({
+    add: { mutateAsync: addTaken, isPending: false },
+    update: { mutateAsync: updateTaken, isPending: false },
+    remove: { mutateAsync: removeTaken, isPending: false },
+    confirmImport: { mutateAsync: confirmImport, isPending: false },
+  }),
+}));
+vi.mock("../api/transcript", () => ({
+  MAX_TRANSCRIPT_LABEL: "4 MB",
+  uploadTranscript: (file: File) => uploadTranscript(file),
+}));
+vi.mock("sonner", () => ({
+  toast: {
+    error: (...args: unknown[]) => toastError(...args),
+    success: (...args: unknown[]) => toastSuccess(...args),
+  },
+}));
+
+const CATALOGUE: Record<
+  string,
+  { courseCode: string; titleEng: string; credits: number }
+> = {
+  DD1337: { courseCode: "DD1337", titleEng: "Programming", credits: 7.5 },
+  DD2380: {
+    courseCode: "DD2380",
+    titleEng: "Artificial Intelligence",
+    credits: 6,
+  },
+};
+
+function takenCourse(overrides: Partial<TakenCourse> = {}): TakenCourse {
+  return {
+    courseCode: "DD1337",
+    grade: "B",
+    earnedCredits: 7.5,
+    attendancePeriods: "P1, P2",
+    attendanceYear: 2025,
+    transcriptImportedAt: null,
+    createdAt: "2026-01-01T00:00:00.000Z",
+    updatedAt: "2026-01-01T00:00:00.000Z",
+    ...overrides,
+  };
+}
+
+function proposal(
+  overrides: Partial<TranscriptProposal> = {},
+): TranscriptProposal {
+  return {
+    candidates: [
+      {
+        courseCode: "DD1337",
+        transcriptName: "Programmering",
+        catalogueName: "Programming",
+        grade: "B",
+        earnedCredits: 7.5,
+        attendanceYear: 2025,
+      },
+    ],
+    unmatched: [],
+    ...overrides,
+  };
+}
+
+const PDF = () =>
+  new File(["%PDF-1.4"], "resultatintyg.pdf", { type: "application/pdf" });
+
+async function uploadPdf() {
+  await userEvent.upload(screen.getByLabelText("Ladok transcript PDF"), PDF());
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  takenList.mockReturnValue([takenCourse()]);
+  unreviewed.mockReturnValue({
+    courses: [],
+    isLoading: false,
+    isUnavailable: false,
+  });
+  searchResults.mockReturnValue([CATALOGUE.DD2380]);
+  addTaken.mockResolvedValue({ courseCode: "DD2380", created: true });
+  updateTaken.mockResolvedValue({ courseCode: "DD1337" });
+  removeTaken.mockResolvedValue({ courseCode: "DD1337" });
+  confirmImport.mockResolvedValue({ inserted: 1, updated: 0 });
+  uploadTranscript.mockResolvedValue(proposal());
+});
+
+describe("the list", () => {
+  it("names a taken course from the catalogue and shows what the student reported", () => {
+    render(<TakenCourses />);
+
+    expect(screen.getByText("Programming")).toBeInTheDocument();
+    expect(screen.getByText("7.5 hp")).toBeInTheDocument();
+    expect(screen.getByText("B")).toBeInTheDocument();
+    expect(screen.getByText("2025")).toBeInTheDocument();
+  });
+
+  it("falls back to the course code, because a taken row stores no title", () => {
+    takenList.mockReturnValue([takenCourse({ courseCode: "SF1625" })]);
+    render(<TakenCourses />);
+
+    expect(screen.getAllByText("SF1625").length).toBeGreaterThan(0);
+  });
+
+  it("says a course is not reviewed only once the review lists have arrived", () => {
+    unreviewed.mockReturnValue({
+      courses: [takenCourse()],
+      isLoading: false,
+      isUnavailable: false,
+    });
+    render(<TakenCourses />);
+
+    expect(screen.getByText("Not yet")).toBeInTheDocument();
+  });
+
+  it("claims nothing about a review it could not load", () => {
+    unreviewed.mockReturnValue({
+      courses: [],
+      isLoading: false,
+      isUnavailable: true,
+    });
+    render(<TakenCourses />);
+
+    expect(screen.queryByText("Done")).not.toBeInTheDocument();
+    expect(screen.queryByText("Not yet")).not.toBeInTheDocument();
+  });
+});
+
+describe("manual and imported rows", () => {
+  it("marks a row a transcript filled in, and dates the read", () => {
+    takenList.mockReturnValue([
+      takenCourse({ transcriptImportedAt: "2026-08-24T09:00:00.000Z" }),
+    ]);
+    render(<TakenCourses />);
+
+    expect(screen.getByText("Imported")).toBeInTheDocument();
+    expect(screen.getByText("Last read 24 Aug 2026")).toBeInTheDocument();
+  });
+
+  it("leaves a hand-entered row unmarked and says so", () => {
+    render(<TakenCourses />);
+
+    expect(screen.queryByText("Imported")).not.toBeInTheDocument();
+    expect(screen.getByText("Added by hand")).toBeInTheDocument();
+  });
+});
+
+describe("editing in place", () => {
+  it("carries the stored attendance periods through a grade correction", async () => {
+    render(<TakenCourses />);
+
+    await userEvent.click(
+      screen.getByLabelText("Edit credits, grade and year for DD1337"),
+    );
+    const grade = screen.getByLabelText("Grade for DD1337");
+    await userEvent.clear(grade);
+    await userEvent.type(grade, "A");
+    await userEvent.click(screen.getByLabelText("Save DD1337"));
+
+    expect(updateTaken).toHaveBeenCalledWith({
+      courseCode: "DD1337",
+      grade: "A",
+      earnedCredits: 7.5,
+      attendanceYear: 2025,
+      attendancePeriods: "P1, P2",
+    });
+  });
+
+  it("refuses to send a year that is not one", async () => {
+    render(<TakenCourses />);
+
+    await userEvent.click(
+      screen.getByLabelText("Edit credits, grade and year for DD1337"),
+    );
+    const year = screen.getByLabelText("Year for DD1337");
+    await userEvent.clear(year);
+    await userEvent.type(year, "20");
+
+    expect(screen.getByLabelText("Save DD1337")).toBeDisabled();
+    expect(updateTaken).not.toHaveBeenCalled();
+  });
+});
+
+describe("adding by hand", () => {
+  it("records a course the reader picked out of the catalogue", async () => {
+    render(<TakenCourses />);
+
+    await userEvent.click(
+      screen.getByRole("button", { name: "Add a course by hand" }),
+    );
+    await userEvent.type(
+      screen.getByLabelText("Search the KTH catalogue"),
+      "DD2380",
+    );
+    await userEvent.click(
+      screen.getByRole("button", { name: /DD2380\s*Artificial Intelligence/ }),
+    );
+    await userEvent.click(screen.getByRole("button", { name: "Add course" }));
+
+    expect(addTaken).toHaveBeenCalledWith({
+      courseCode: "DD2380",
+      grade: null,
+      earnedCredits: 6,
+      attendanceYear: null,
+    });
+  });
+
+  it("cannot offer a course already on the list", async () => {
+    searchResults.mockReturnValue([CATALOGUE.DD1337]);
+    render(<TakenCourses />);
+
+    await userEvent.click(
+      screen.getByRole("button", { name: "Add a course by hand" }),
+    );
+    await userEvent.type(
+      screen.getByLabelText("Search the KTH catalogue"),
+      "DD1337",
+    );
+
+    expect(
+      screen.getByRole("button", { name: /DD1337\s*Programming/ }),
+    ).toBeDisabled();
+  });
+});
+
+describe("removing", () => {
+  it("removes the course and nothing else", async () => {
+    render(<TakenCourses />);
+
+    await userEvent.click(
+      screen.getByLabelText("Remove DD1337 from your taken courses"),
+    );
+
+    expect(removeTaken).toHaveBeenCalledWith({ courseCode: "DD1337" });
+    expect(updateTaken).not.toHaveBeenCalled();
+  });
+
+  it("puts a hand-entered row back exactly as it was, periods included", async () => {
+    render(<TakenCourses />);
+    await userEvent.click(
+      screen.getByLabelText("Remove DD1337 from your taken courses"),
+    );
+
+    await waitFor(() => expect(toastSuccess).toHaveBeenCalled());
+    const [, options] = toastSuccess.mock.calls[0];
+    options.action.onClick();
+
+    expect(addTaken).toHaveBeenCalledWith({
+      courseCode: "DD1337",
+      grade: "B",
+      earnedCredits: 7.5,
+      attendancePeriods: "P1, P2",
+      attendanceYear: 2025,
+    });
+  });
+
+  it("offers no undo for an imported row, which would come back re-labelled", async () => {
+    takenList.mockReturnValue([
+      takenCourse({ transcriptImportedAt: "2026-08-24T09:00:00.000Z" }),
+    ]);
+    render(<TakenCourses />);
+    await userEvent.click(
+      screen.getByLabelText("Remove DD1337 from your taken courses"),
+    );
+
+    await waitFor(() => expect(toastSuccess).toHaveBeenCalled());
+    expect(toastSuccess.mock.calls[0][1].action).toBeUndefined();
+  });
+});
+
+describe("reading a transcript", () => {
+  beforeEach(() => takenList.mockReturnValue([]));
+
+  it("turns an upload into a proposal and writes nothing", async () => {
+    render(<TakenCourses />);
+    await uploadPdf();
+
+    expect(await screen.findByText("1 course read")).toBeInTheDocument();
+    expect(uploadTranscript).toHaveBeenCalledTimes(1);
+    expect(confirmImport).not.toHaveBeenCalled();
+    expect(
+      screen.getByText("Nothing is saved to your list until you confirm."),
+    ).toBeInTheDocument();
+  });
+
+  it("names the course codes the catalogue does not have", async () => {
+    uploadTranscript.mockResolvedValue(
+      proposal({
+        unmatched: [{ courseCode: "XX9999", courseName: "Something else" }],
+      }),
+    );
+    render(<TakenCourses />);
+    await uploadPdf();
+
+    expect(
+      await screen.findByText("1 row was not a KTH catalogue course"),
+    ).toBeInTheDocument();
+    expect(screen.getByText("XX9999 — Something else")).toBeInTheDocument();
+  });
+
+  it("writes the proposal only when the reader confirms it", async () => {
+    render(<TakenCourses />);
+    await uploadPdf();
+    await userEvent.click(
+      await screen.findByRole("button", { name: "Looks right" }),
+    );
+
+    await waitFor(() =>
+      expect(confirmImport).toHaveBeenCalledWith({
+        courses: [
+          {
+            courseCode: "DD1337",
+            grade: null,
+            earnedCredits: 7.5,
+            attendanceYear: 2025,
+          },
+        ],
+      }),
+    );
+  });
+
+  it("keeps the transcript's grades once the reader asks for them", async () => {
+    render(<TakenCourses />);
+    await userEvent.click(
+      screen.getByRole("switch", { name: /Read grades from transcript/ }),
+    );
+    await uploadPdf();
+    await userEvent.click(
+      await screen.findByRole("button", { name: "Looks right" }),
+    );
+
+    await waitFor(() =>
+      expect(confirmImport).toHaveBeenCalledWith({
+        courses: [expect.objectContaining({ grade: "B" })],
+      }),
+    );
+  });
+
+  it("discards a proposal without writing it", async () => {
+    render(<TakenCourses />);
+    await uploadPdf();
+    await userEvent.click(
+      await screen.findByRole("button", { name: "Discard" }),
+    );
+
+    expect(confirmImport).not.toHaveBeenCalled();
+    expect(
+      await screen.findByText("Drop your Ladok transcript here"),
+    ).toBeInTheDocument();
+  });
+
+  it("says an unreadable file was unreadable, and writes nothing", async () => {
+    uploadTranscript.mockRejectedValue(
+      new Error("No course rows came out of that file."),
+    );
+    render(<TakenCourses />);
+    await uploadPdf();
+
+    expect(
+      await screen.findByText("We could not read that transcript"),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText("No course rows came out of that file."),
+    ).toBeInTheDocument();
+    expect(screen.getByText("Nothing was saved")).toBeInTheDocument();
+    expect(confirmImport).not.toHaveBeenCalled();
+    expect(addTaken).not.toHaveBeenCalled();
+  });
+});
+
+describe("the unreviewed prompt", () => {
+  it("opens the reviewer in place rather than leaving the page", async () => {
+    unreviewed.mockReturnValue({
+      courses: [takenCourse()],
+      isLoading: false,
+      isUnavailable: false,
+    });
+    render(<TakenCourses />);
+
+    const prompt = screen
+      .getByText("You have 1 unreviewed course.")
+      .closest("div")?.parentElement?.parentElement as HTMLElement;
+    await userEvent.click(
+      within(prompt).getByRole("button", { name: /DD1337/ }),
+    );
+
+    expect(screen.getByTestId("reviewer")).toHaveTextContent(
+      "Reviewing DD1337",
+    );
+  });
+});

--- a/apps/web/features/taken/components/taken-courses.spec.tsx
+++ b/apps/web/features/taken/components/taken-courses.spec.tsx
@@ -1,4 +1,4 @@
-import { render, screen, waitFor } from "@testing-library/react";
+import { act, render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { TranscriptProposal } from "@/server/ingest/transcript/service";
@@ -6,6 +6,11 @@ import type { TakenCourse } from "../lib/taken-rows";
 import { TakenCourses } from "./taken-courses";
 
 const takenList = vi.fn<() => TakenCourse[]>();
+const listFailed = vi.fn<() => boolean>();
+const refetchTaken =
+  vi.fn<
+    () => Promise<{ data?: TakenCourse[] | undefined; isError?: boolean }>
+  >();
 const unreviewed =
   vi.fn<
     () => { courses: TakenCourse[]; isLoading: boolean; isUnavailable: boolean }
@@ -30,9 +35,11 @@ vi.mock("@/features/courses", () => ({
   useTakenCourses: () => ({
     data: takenList(),
     isPending: false,
+    isError: listFailed(),
     // The screen re-reads the list before it plans an import, so the mock has
-    // to answer a refetch the way the real query does.
-    refetch: () => Promise.resolve({ data: takenList() }),
+    // to answer a refetch the way the real query does — including on failure,
+    // where TanStack keeps the last good `data` and raises `isError`.
+    refetch: () => refetchTaken(),
   }),
   useCourseSummaries: (codes: string[]) =>
     codes.map((courseCode) => ({ data: CATALOGUE[courseCode] })),
@@ -128,6 +135,10 @@ async function uploadPdf() {
 beforeEach(() => {
   vi.clearAllMocks();
   takenList.mockReturnValue([takenCourse()]);
+  listFailed.mockReturnValue(false);
+  refetchTaken.mockImplementation(() =>
+    Promise.resolve({ data: takenList(), isError: false }),
+  );
   unreviewed.mockReturnValue({
     courses: [],
     isLoading: false,
@@ -179,6 +190,47 @@ describe("the list", () => {
 
     expect(screen.queryByText("Done")).not.toBeInTheDocument();
     expect(screen.queryByText("Not yet")).not.toBeInTheDocument();
+  });
+
+  it("does not mistake a failed read for an empty list", () => {
+    // A failed query holds no rows, and the screen for no rows is the
+    // first-run one: it would tell a reader who has taken twenty courses that
+    // they have taken none, and offer to import a transcript over a list this
+    // page cannot see.
+    listFailed.mockReturnValue(true);
+    takenList.mockReturnValue([]);
+    render(<TakenCourses />);
+
+    expect(screen.getByText("Your taken courses did not load")).toBeVisible();
+    expect(
+      screen.queryByText("Drop your Ladok transcript here"),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", { name: "Update transcript" }),
+    ).not.toBeInTheDocument();
+  });
+
+  it("counts no courses off a read that failed", () => {
+    // A failed query can still be holding what an earlier one returned. A
+    // count beside "did not load" would outlive the read it came from.
+    listFailed.mockReturnValue(true);
+    takenList.mockReturnValue([
+      takenCourse(),
+      takenCourse({ courseCode: "DD2380" }),
+    ]);
+    render(<TakenCourses />);
+
+    expect(screen.getByText("Your taken courses did not load")).toBeVisible();
+    expect(screen.queryByText("2")).not.toBeInTheDocument();
+    expect(screen.queryByText("DD1337")).not.toBeInTheDocument();
+  });
+
+  it("offers the read again", async () => {
+    listFailed.mockReturnValue(true);
+    render(<TakenCourses />);
+    await userEvent.click(screen.getByRole("button", { name: "Try again" }));
+
+    expect(refetchTaken).toHaveBeenCalled();
   });
 });
 
@@ -511,6 +563,79 @@ describe("reading a transcript", () => {
     expect(
       await screen.findByText("Drop your Ladok transcript here"),
     ).toBeInTheDocument();
+  });
+
+  it("writes nothing and says so when the list cannot be re-read", async () => {
+    render(<TakenCourses />);
+    await uploadPdf();
+    await screen.findByText("1 course read");
+    // A failed refetch keeps the last good `data`, which is the very snapshot
+    // the re-read exists to distrust. Planning against it would put back the
+    // overwrite this re-read was added to prevent.
+    refetchTaken.mockResolvedValue({ data: takenList(), isError: true });
+    await userEvent.click(screen.getByRole("button", { name: "Looks right" }));
+
+    expect(
+      await screen.findByText(/could not re-read your course list/),
+    ).toBeInTheDocument();
+    expect(confirmImport).not.toHaveBeenCalled();
+    expect(updateTaken).not.toHaveBeenCalled();
+    // The proposal is still there to confirm again once the read works.
+    expect(screen.getByRole("button", { name: "Looks right" })).toBeVisible();
+  });
+
+  it("explains a rejected re-read rather than sitting there silently", async () => {
+    render(<TakenCourses />);
+    await uploadPdf();
+    await screen.findByText("1 course read");
+    refetchTaken.mockRejectedValue(new Error("The list did not come back."));
+    await userEvent.click(screen.getByRole("button", { name: "Looks right" }));
+
+    expect(
+      await screen.findByText(/The list did not come back\./),
+    ).toBeInTheDocument();
+    expect(confirmImport).not.toHaveBeenCalled();
+  });
+
+  it("takes one confirm even when the button is pressed twice", async () => {
+    // A candidate the list does not have yet, so confirming makes a create.
+    uploadTranscript.mockResolvedValue(
+      proposal({
+        candidates: [
+          {
+            courseCode: "DD2380",
+            transcriptName: "Artificiell intelligens",
+            catalogueName: "Artificial Intelligence",
+            grade: "A",
+            earnedCredits: 6,
+            attendanceYear: 2026,
+          },
+        ],
+      }),
+    );
+    let release = () => {};
+    confirmImport.mockImplementation(
+      () =>
+        new Promise((resolve) => {
+          release = () => resolve({ inserted: 1, updated: 0 });
+        }),
+    );
+    render(<TakenCourses />);
+    await uploadPdf();
+    const confirm = await screen.findByRole("button", { name: "Looks right" });
+    await userEvent.click(confirm);
+    await waitFor(() => expect(confirmImport).toHaveBeenCalledTimes(1));
+    // "Saving…" holds for the whole confirm, so a second press does nothing.
+    const saving = screen.getByRole("button", { name: "Saving…" });
+    expect(saving).toBeDisabled();
+    await userEvent.click(saving);
+
+    expect(confirmImport).toHaveBeenCalledTimes(1);
+    await act(async () => {
+      release();
+    });
+    expect(screen.queryByText("1 course read")).not.toBeInTheDocument();
+    expect(confirmImport).toHaveBeenCalledTimes(1);
   });
 
   it("says an unreadable file was unreadable, and writes nothing", async () => {

--- a/apps/web/features/taken/components/taken-courses.spec.tsx
+++ b/apps/web/features/taken/components/taken-courses.spec.tsx
@@ -568,15 +568,19 @@ describe("reading a transcript", () => {
     );
 
     await waitFor(() =>
-      expect(updateTaken).toHaveBeenCalledWith({
-        courseCode: "DD1337",
-        grade: "B",
-        earnedCredits: 9,
-        attendanceYear: 2025,
-        attendancePeriods: "P3",
+      expect(confirmImport).toHaveBeenCalledWith({
+        courses: [],
+        fills: [
+          expect.objectContaining({
+            courseCode: "DD1337",
+            grade: "B",
+            earnedCredits: 9,
+            attendanceYear: 2025,
+          }),
+        ],
       }),
     );
-    expect(confirmImport).not.toHaveBeenCalled();
+    expect(updateTaken).not.toHaveBeenCalled();
   });
 
   it("keeps the transcript's grades once the reader asks for them", async () => {

--- a/apps/web/features/taken/components/taken-courses.spec.tsx
+++ b/apps/web/features/taken/components/taken-courses.spec.tsx
@@ -536,8 +536,8 @@ describe("reading a transcript", () => {
     await uploadPdf();
     await screen.findByText("1 course read");
     // Another tab records DD1337 by hand while the proposal sits on screen.
-    // Planning against the render's snapshot would send it as a create, and
-    // `transcript.confirm`'s upsert would overwrite what that tab entered.
+    // Planning against the render's snapshot would unnecessarily try to create
+    // it; the confirmation endpoint is also insert-only as a race-safe guard.
     takenList.mockReturnValue([takenCourse()]);
     await userEvent.click(screen.getByRole("button", { name: "Looks right" }));
 

--- a/apps/web/features/taken/components/taken-courses.spec.tsx
+++ b/apps/web/features/taken/components/taken-courses.spec.tsx
@@ -216,6 +216,22 @@ describe("editing in place", () => {
     });
   });
 
+  it("keeps the editor open holding the draft when the write is refused", async () => {
+    updateTaken.mockRejectedValue(new Error("nope"));
+    render(<TakenCourses />);
+
+    await userEvent.click(
+      screen.getByLabelText("Edit credits, grade and year for DD1337"),
+    );
+    const grade = screen.getByLabelText("Grade for DD1337");
+    await userEvent.clear(grade);
+    await userEvent.type(grade, "A");
+    await userEvent.click(screen.getByLabelText("Save DD1337"));
+
+    await waitFor(() => expect(toastError).toHaveBeenCalled());
+    expect(screen.getByLabelText("Grade for DD1337")).toHaveValue("A");
+  });
+
   it("refuses to send a year that is not one", async () => {
     render(<TakenCourses />);
 
@@ -253,6 +269,28 @@ describe("adding by hand", () => {
       earnedCredits: 6,
       attendanceYear: null,
     });
+  });
+
+  it("keeps the draft when the write is refused", async () => {
+    addTaken.mockRejectedValue(new Error("nope"));
+    render(<TakenCourses />);
+
+    await userEvent.click(
+      screen.getByRole("button", { name: "Add a course by hand" }),
+    );
+    await userEvent.type(
+      screen.getByLabelText("Search the KTH catalogue"),
+      "DD2380",
+    );
+    await userEvent.click(
+      screen.getByRole("button", { name: /DD2380\s*Artificial Intelligence/ }),
+    );
+    await userEvent.click(screen.getByRole("button", { name: "Add course" }));
+
+    await waitFor(() => expect(toastError).toHaveBeenCalled());
+    // The dialog is still open, still holding the course the reader picked.
+    expect(screen.getByRole("button", { name: "Add course" })).toBeEnabled();
+    expect(screen.getAllByText("DD2380").length).toBeGreaterThan(0);
   });
 
   it("cannot offer a course already on the list", async () => {
@@ -367,6 +405,57 @@ describe("reading a transcript", () => {
         ],
       }),
     );
+  });
+
+  it("leaves a course the reader already corrected exactly as they left it", async () => {
+    // Not the empty list this block sets up: the reader has DD1337 already,
+    // graded A where the transcript says B.
+    takenList.mockReturnValue([takenCourse({ grade: "A" })]);
+    render(<TakenCourses />);
+    await userEvent.click(
+      screen.getByRole("button", { name: "Update transcript" }),
+    );
+    await uploadPdf();
+    await userEvent.click(
+      await screen.findByRole("button", { name: "Looks right" }),
+    );
+
+    await waitFor(() =>
+      expect(
+        screen.getByText("Transcript read — nothing new in it"),
+      ).toBeInTheDocument(),
+    );
+    expect(confirmImport).not.toHaveBeenCalled();
+    expect(updateTaken).not.toHaveBeenCalled();
+  });
+
+  it("fills only an empty field, and keeps the periods while doing it", async () => {
+    takenList.mockReturnValue([
+      takenCourse({ grade: null, earnedCredits: 9, attendancePeriods: "P3" }),
+    ]);
+    render(<TakenCourses />);
+    // The switch lives in the update dialog once the list has courses in it.
+    await userEvent.click(
+      screen.getByRole("button", { name: "Update transcript" }),
+    );
+    await userEvent.click(
+      screen.getByRole("switch", { name: /Read grades from transcript/ }),
+    );
+    await uploadPdf();
+    await userEvent.click(
+      await screen.findByRole("button", { name: "Looks right" }),
+    );
+
+    await waitFor(() =>
+      expect(updateTaken).toHaveBeenCalledWith({
+        courseCode: "DD1337",
+        grade: "B",
+        earnedCredits: 9,
+        attendanceYear: 2025,
+        attendancePeriods: "P3",
+      }),
+    );
+    expect(confirmImport).not.toHaveBeenCalled();
   });
 
   it("keeps the transcript's grades once the reader asks for them", async () => {

--- a/apps/web/features/taken/components/taken-courses.spec.tsx
+++ b/apps/web/features/taken/components/taken-courses.spec.tsx
@@ -27,7 +27,13 @@ vi.mock("@/features/auth", () => ({
   useRequireSession: () => ({}),
 }));
 vi.mock("@/features/courses", () => ({
-  useTakenCourses: () => ({ data: takenList(), isPending: false }),
+  useTakenCourses: () => ({
+    data: takenList(),
+    isPending: false,
+    // The screen re-reads the list before it plans an import, so the mock has
+    // to answer a refetch the way the real query does.
+    refetch: () => Promise.resolve({ data: takenList() }),
+  }),
   useCourseSummaries: (codes: string[]) =>
     codes.map((courseCode) => ({ data: CATALOGUE[courseCode] })),
 }));
@@ -419,6 +425,25 @@ describe("reading a transcript", () => {
     await userEvent.click(
       await screen.findByRole("button", { name: "Looks right" }),
     );
+
+    await waitFor(() =>
+      expect(
+        screen.getByText("Transcript read — nothing new in it"),
+      ).toBeInTheDocument(),
+    );
+    expect(confirmImport).not.toHaveBeenCalled();
+    expect(updateTaken).not.toHaveBeenCalled();
+  });
+
+  it("plans against the list as it is now, not as it was when the page loaded", async () => {
+    render(<TakenCourses />);
+    await uploadPdf();
+    await screen.findByText("1 course read");
+    // Another tab records DD1337 by hand while the proposal sits on screen.
+    // Planning against the render's snapshot would send it as a create, and
+    // `transcript.confirm`'s upsert would overwrite what that tab entered.
+    takenList.mockReturnValue([takenCourse()]);
+    await userEvent.click(screen.getByRole("button", { name: "Looks right" }));
 
     await waitFor(() =>
       expect(

--- a/apps/web/features/taken/components/taken-courses.spec.tsx
+++ b/apps/web/features/taken/components/taken-courses.spec.tsx
@@ -1,4 +1,4 @@
-import { render, screen, waitFor, within } from "@testing-library/react";
+import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { TranscriptProposal } from "@/server/ingest/transcript/service";
@@ -23,7 +23,7 @@ const toastError = vi.fn();
 const toastSuccess = vi.fn();
 
 vi.mock("@/features/auth", () => ({
-  useMe: () => ({ isLoading: false }),
+  useMe: () => ({ isLoading: false, isAuthenticated: true }),
   useRequireSession: () => ({}),
 }));
 vi.mock("@/features/courses", () => ({
@@ -427,11 +427,11 @@ describe("the unreviewed prompt", () => {
     });
     render(<TakenCourses />);
 
-    const prompt = screen
-      .getByText("You have 1 unreviewed course.")
-      .closest("div")?.parentElement?.parentElement as HTMLElement;
+    // The prompt's own row button, which `UnreviewedCard` renders in place of
+    // its link once a screen passes `onSelect`. Its accessible name is the
+    // course code and title; the table's controls are labelled differently.
     await userEvent.click(
-      within(prompt).getByRole("button", { name: /DD1337/ }),
+      screen.getByRole("button", { name: /^DD1337\s*Programming$/ }),
     );
 
     expect(screen.getByTestId("reviewer")).toHaveTextContent(

--- a/apps/web/features/taken/components/taken-courses.spec.tsx
+++ b/apps/web/features/taken/components/taken-courses.spec.tsx
@@ -351,6 +351,50 @@ describe("adding by hand", () => {
     expect(screen.getAllByText("DD2380").length).toBeGreaterThan(0);
   });
 
+  it("cannot be dismissed out from under a write still in flight", async () => {
+    // Cancelling clears the draft, and a request that later rejects has
+    // nothing to hand back — the reader would retype everything to retry.
+    let reject = (_: Error) => {};
+    addTaken.mockImplementation(
+      () =>
+        new Promise((_resolve, rejectAdd) => {
+          reject = rejectAdd;
+        }),
+    );
+    render(<TakenCourses />);
+
+    await userEvent.click(
+      screen.getByRole("button", { name: "Add a course by hand" }),
+    );
+    await userEvent.type(
+      screen.getByLabelText("Search the KTH catalogue"),
+      "DD2380",
+    );
+    await userEvent.click(
+      screen.getByRole("button", { name: /DD2380\s*Artificial Intelligence/ }),
+    );
+    await userEvent.click(screen.getByRole("button", { name: "Add course" }));
+
+    // Every way out is shut while the write is in flight — the × and the
+    // footer button both read "Cancel", and Escape comes through the same
+    // guard because the parent owns `open`.
+    const cancels = screen.getAllByRole("button", { name: "Cancel" });
+    expect(cancels).toHaveLength(2);
+    for (const cancel of cancels) {
+      expect(cancel).toBeDisabled();
+      await userEvent.click(cancel);
+    }
+    await userEvent.keyboard("{Escape}");
+    expect(screen.getByRole("button", { name: "Adding…" })).toBeVisible();
+
+    await act(async () => {
+      reject(new Error("nope"));
+    });
+    // Still open, still holding what the reader picked.
+    expect(screen.getByRole("button", { name: "Add course" })).toBeEnabled();
+    expect(screen.getAllByText("DD2380").length).toBeGreaterThan(0);
+  });
+
   it("cannot offer a course already on the list", async () => {
     searchResults.mockReturnValue([CATALOGUE.DD1337]);
     render(<TakenCourses />);

--- a/apps/web/features/taken/components/taken-courses.tsx
+++ b/apps/web/features/taken/components/taken-courses.tsx
@@ -220,13 +220,13 @@ export function TakenCourses() {
         includeGrades,
       );
       const written =
-        plan.create.length > 0
-          ? await confirmImport.mutateAsync({ courses: plan.create })
-          : { inserted: 0, updated: 0 };
-      // Sequential, so a failure stops rather than firing the rest at a server
-      // that has just refused one. What did land stays landed, and the retry
-      // re-reads the list and asks only for the remainder.
-      for (const row of plan.fill) await update.mutateAsync(row);
+        plan.create.length === 0 && plan.fill.length === 0
+          ? { inserted: 0, updated: 0 }
+          : await confirmImport.mutateAsync(
+              plan.fill.length > 0
+                ? { courses: plan.create, fills: plan.fill }
+                : { courses: plan.create },
+            );
       setProposal(null);
       setBanner(
         importedSummary(written.inserted + written.updated, plan.fill.length),

--- a/apps/web/features/taken/components/taken-courses.tsx
+++ b/apps/web/features/taken/components/taken-courses.tsx
@@ -187,19 +187,10 @@ export function TakenCourses() {
    * corrected by hand — see `planTranscriptImport`.
    *
    * **The plan is built against a freshly read list, not the render's copy.**
-   * Two things depend on that. A course added in another tab while this
-   * proposal sat on screen would otherwise be planned as a create, and
-   * `transcript.confirm`'s upsert sets every column from the incoming row — so
-   * it would overwrite that entry and clear its periods. And a confirm that
-   * failed part way through is re-planned against what actually reached the
-   * database, so pressing the button again writes only what is still missing
-   * rather than repeating what already landed.
-   *
-   * It narrows the window rather than closing it: nothing here is one
-   * transaction, and only `transcript.confirm` learning to leave existing rows
-   * alone would make it atomic. That is a change to a server contract #92 does
-   * not own — the issue states outright that "the write upserts on (userId,
-   * courseCode)" — so it is reported on the PR rather than made here.
+   * It lets the page fill fields that are already empty, and it makes retries
+   * plan from what actually reached the database. `transcript.confirm` also
+   * inserts only absent rows atomically, so a course another tab creates after
+   * this refresh remains that tab's manual entry rather than being overwritten.
    *
    * **A re-read that fails writes nothing.** The render's copy is the very
    * snapshot the re-read exists to distrust, so falling back to it would put

--- a/apps/web/features/taken/components/taken-courses.tsx
+++ b/apps/web/features/taken/components/taken-courses.tsx
@@ -109,7 +109,8 @@ export function TakenCourses() {
   // `taken.list` is protected, so it waits for a session rather than sending a
   // request that would be refused — the same guard `useUnreviewedTakenCourses`
   // puts on the very same query.
-  const { data: taken, isPending } = useTakenCourses(isAuthenticated);
+  const takenQuery = useTakenCourses(isAuthenticated);
+  const { data: taken, isPending } = takenQuery;
   const { add, update, remove, confirmImport } = useTakenMutations();
 
   const takenCourses = taken ?? [];
@@ -182,13 +183,29 @@ export function TakenCourses() {
    * Courses the reader already has are only touched to fill an empty field,
    * and then through `taken.update`, which cannot overwrite what they
    * corrected by hand — see `planTranscriptImport`.
+   *
+   * **The plan is built against a freshly read list, not the render's copy.**
+   * Two things depend on that. A course added in another tab while this
+   * proposal sat on screen would otherwise be planned as a create, and
+   * `transcript.confirm`'s upsert sets every column from the incoming row — so
+   * it would overwrite that entry and clear its periods. And a confirm that
+   * failed part way through is re-planned against what actually reached the
+   * database, so pressing the button again writes only what is still missing
+   * rather than repeating what already landed.
+   *
+   * It narrows the window rather than closing it: nothing here is one
+   * transaction, and only `transcript.confirm` learning to leave existing rows
+   * alone would make it atomic. That is a change to a server contract #92 does
+   * not own — the issue states outright that "the write upserts on (userId,
+   * courseCode)" — so it is reported on the PR rather than made here.
    */
   async function confirmProposal() {
     if (!proposal) return;
     setConfirmError(null);
+    const current = await takenQuery.refetch();
     const plan = planTranscriptImport(
       proposal.candidates,
-      takenCourses,
+      current.data ?? takenCourses,
       includeGrades,
     );
     try {
@@ -196,7 +213,10 @@ export function TakenCourses() {
         plan.create.length > 0
           ? await confirmImport.mutateAsync({ courses: plan.create })
           : { inserted: 0, updated: 0 };
-      await Promise.all(plan.fill.map((row) => update.mutateAsync(row)));
+      // Sequential, so a failure stops rather than firing the rest at a server
+      // that has just refused one. What did land stays landed, and the retry
+      // re-reads the list and asks only for the remainder.
+      for (const row of plan.fill) await update.mutateAsync(row);
       setProposal(null);
       setBanner(
         importedSummary(written.inserted + written.updated, plan.fill.length),

--- a/apps/web/features/taken/components/taken-courses.tsx
+++ b/apps/web/features/taken/components/taken-courses.tsx
@@ -109,13 +109,16 @@ function importedSummary(result: {
  */
 export function TakenCourses() {
   useRequireSession();
-  const { isLoading: isSessionLoading } = useMe();
-  const { data: taken, isPending } = useTakenCourses(!isSessionLoading);
+  const { isAuthenticated, isLoading: isSessionLoading } = useMe();
+  // `taken.list` is protected, so it waits for a session rather than sending a
+  // request that would be refused — the same guard `useUnreviewedTakenCourses`
+  // puts on the very same query.
+  const { data: taken, isPending } = useTakenCourses(isAuthenticated);
   const { add, update, remove, confirmImport } = useTakenMutations();
 
   const takenCourses = taken ?? [];
   const courseCodes = takenCourses.map((course) => course.courseCode);
-  const summaries = useCourseSummaries(courseCodes, !isSessionLoading);
+  const summaries = useCourseSummaries(courseCodes, isAuthenticated);
   const names = new Map(
     summaries.flatMap((query) =>
       query.data ? [[query.data.courseCode, query.data.titleEng] as const] : [],
@@ -245,7 +248,9 @@ export function TakenCourses() {
   }
 
   function screen() {
-    if (isSessionLoading || isPending) return <ListSkeleton />;
+    if (isSessionLoading || (isAuthenticated && isPending)) {
+      return <ListSkeleton />;
+    }
 
     if (proposal) {
       return (

--- a/apps/web/features/taken/components/taken-courses.tsx
+++ b/apps/web/features/taken/components/taken-courses.tsx
@@ -22,10 +22,10 @@ import { useTakenMutations } from "../api/mutations";
 import { uploadTranscript } from "../api/transcript";
 import {
   lastTranscriptImport,
+  planTranscriptImport,
   type TakenEdits,
   type TakenRow,
   takenUpdateInput,
-  toConfirmedCourses,
   toTakenRows,
 } from "../lib/taken-rows";
 import { AddTakenCourseDialog } from "./add-taken-course-dialog";
@@ -54,21 +54,16 @@ function readDate(iso: string): string {
   });
 }
 
-function importedSummary(result: {
-  inserted: number;
-  updated: number;
-}): string {
+function importedSummary(added: number, filled: number): string {
   const parts: string[] = [];
-  if (result.inserted > 0) {
-    parts.push(
-      result.inserted === 1 ? "1 new course" : `${result.inserted} new courses`,
-    );
+  if (added > 0) {
+    parts.push(added === 1 ? "1 new course" : `${added} new courses`);
   }
-  if (result.updated > 0) {
+  if (filled > 0) {
     parts.push(
-      result.updated === 1
-        ? "1 course updated"
-        : `${result.updated} courses updated`,
+      filled === 1
+        ? "1 course had a missing field filled in"
+        : `${filled} courses had missing fields filled in`,
     );
   }
   return parts.length > 0
@@ -90,9 +85,10 @@ function importedSummary(result: {
  * relationships and this page never lets one stand in for another.
  *
  * **Nothing a transcript says is written until the reader confirms it.**
- * `POST /api/user/transcript` parses and returns a proposal; `transcript.confirm`
- * is the only write, and it upserts on `(userId, courseCode)` so a second read
- * of the same file updates rather than duplicates. The file itself is handed to
+ * `POST /api/user/transcript` parses and returns a proposal; the writes happen
+ * only on "Looks right", and `planTranscriptImport` decides what they are — a
+ * re-read adds courses that are new and fills fields that are empty, and never
+ * overwrites a correction the reader made by hand. The file itself is handed to
  * `uploadTranscript` and never kept — not in state, not in a cache, never in
  * `localStorage`.
  *
@@ -179,15 +175,32 @@ export function TakenCourses() {
     }
   }
 
+  /**
+   * Makes the writes the confirmed proposal describes, and only those.
+   *
+   * New courses go through `transcript.confirm`, which stamps them imported.
+   * Courses the reader already has are only touched to fill an empty field,
+   * and then through `taken.update`, which cannot overwrite what they
+   * corrected by hand — see `planTranscriptImport`.
+   */
   async function confirmProposal() {
     if (!proposal) return;
     setConfirmError(null);
+    const plan = planTranscriptImport(
+      proposal.candidates,
+      takenCourses,
+      includeGrades,
+    );
     try {
-      const result = await confirmImport.mutateAsync({
-        courses: toConfirmedCourses(proposal.candidates, includeGrades),
-      });
+      const written =
+        plan.create.length > 0
+          ? await confirmImport.mutateAsync({ courses: plan.create })
+          : { inserted: 0, updated: 0 };
+      await Promise.all(plan.fill.map((row) => update.mutateAsync(row)));
       setProposal(null);
-      setBanner(importedSummary(result));
+      setBanner(
+        importedSummary(written.inserted + written.updated, plan.fill.length),
+      );
     } catch (error) {
       setConfirmError(
         error instanceof Error && error.message
@@ -197,10 +210,15 @@ export function TakenCourses() {
     }
   }
 
-  function addCourse(courseCode: string, edits: TakenEdits) {
-    add
-      .mutateAsync({ courseCode, ...edits })
-      .catch(() => toast.error(`Could not add ${courseCode} to your courses.`));
+  async function addCourse(courseCode: string, edits: TakenEdits) {
+    try {
+      await add.mutateAsync({ courseCode, ...edits });
+    } catch (error) {
+      toast.error(`Could not add ${courseCode} to your courses.`);
+      // Rethrown so the dialog keeps the draft the reader typed rather than
+      // closing over a write that never landed.
+      throw error;
+    }
   }
 
   /**
@@ -221,10 +239,14 @@ export function TakenCourses() {
       );
   }
 
-  function saveEdits(row: TakenRow, edits: TakenEdits) {
-    update
-      .mutateAsync(takenUpdateInput(row, edits))
-      .catch(() => toast.error(`Could not save your changes to ${row.name}.`));
+  async function saveEdits(row: TakenRow, edits: TakenEdits) {
+    try {
+      await update.mutateAsync(takenUpdateInput(row, edits));
+    } catch (error) {
+      toast.error(`Could not save your changes to ${row.name}.`);
+      // Rethrown so the row stays in its editor holding what the reader typed.
+      throw error;
+    }
   }
 
   function removeCourse(row: TakenRow) {

--- a/apps/web/features/taken/components/taken-courses.tsx
+++ b/apps/web/features/taken/components/taken-courses.tsx
@@ -1,0 +1,567 @@
+"use client";
+
+import { CircleCheck, FileWarning, Info, Plus, RefreshCw } from "lucide-react";
+import { useState } from "react";
+import { toast } from "sonner";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { useMe, useRequireSession } from "@/features/auth";
+import { useCourseSummaries, useTakenCourses } from "@/features/courses";
+import {
+  Review,
+  UnreviewedCard,
+  useUnreviewedTakenCourses,
+} from "@/features/reviews";
+import { PageColumn, PageHeader } from "@/features/shell";
+import type { TranscriptProposal } from "@/server/ingest/transcript/service";
+import { useTakenMutations } from "../api/mutations";
+import { uploadTranscript } from "../api/transcript";
+import {
+  lastTranscriptImport,
+  type TakenEdits,
+  type TakenRow,
+  takenUpdateInput,
+  toConfirmedCourses,
+  toTakenRows,
+} from "../lib/taken-rows";
+import { AddTakenCourseDialog } from "./add-taken-course-dialog";
+import { TAKEN_GRID, TakenCourseRow } from "./taken-course-row";
+import { TranscriptDropZone } from "./transcript-drop-zone";
+import { TranscriptProposalReview } from "./transcript-proposal";
+
+const READ_FAILED_TITLE = "We could not read that transcript";
+
+const COLUMNS = [
+  "Code",
+  "Course",
+  "Credits",
+  "Grade",
+  "Year",
+  "Reviewed",
+  "Actions",
+] as const;
+
+/** "24 Aug 2026", as the artboard prints it. */
+function readDate(iso: string): string {
+  return new Date(iso).toLocaleDateString("en-GB", {
+    day: "numeric",
+    month: "short",
+    year: "numeric",
+  });
+}
+
+function importedSummary(result: {
+  inserted: number;
+  updated: number;
+}): string {
+  const parts: string[] = [];
+  if (result.inserted > 0) {
+    parts.push(
+      result.inserted === 1 ? "1 new course" : `${result.inserted} new courses`,
+    );
+  }
+  if (result.updated > 0) {
+    parts.push(
+      result.updated === 1
+        ? "1 course updated"
+        : `${result.updated} courses updated`,
+    );
+  }
+  return parts.length > 0
+    ? `Transcript saved — ${parts.join(", ")}`
+    : "Transcript read — nothing new in it";
+}
+
+/**
+ * The reader's taken courses — `docs/design/Course Community - Taken
+ * Courses.dc.html`.
+ *
+ * Four things about this screen are worth knowing before changing it.
+ *
+ * **A taken course has no title and no verdict.** `user_taken_courses` stores a
+ * course code plus self-reported grade, credits, attendance and provenance.
+ * Names are looked up here through `course.summary`; nothing on a row is a
+ * review, and the Reviewed column reads the viewer's reviews rather than
+ * anything on the row. Saving, taking and reviewing are three independent
+ * relationships and this page never lets one stand in for another.
+ *
+ * **Nothing a transcript says is written until the reader confirms it.**
+ * `POST /api/user/transcript` parses and returns a proposal; `transcript.confirm`
+ * is the only write, and it upserts on `(userId, courseCode)` so a second read
+ * of the same file updates rather than duplicates. The file itself is handed to
+ * `uploadTranscript` and never kept — not in state, not in a cache, never in
+ * `localStorage`.
+ *
+ * **Course codes the catalogue does not have are reported, not invented.**
+ * They come back on the proposal as `unmatched` and are named on the confirm
+ * screen. This page offers no way to create the missing course, because
+ * `user_taken_courses.course_code` is a foreign key to `courses.code`.
+ *
+ * **The reviewer is the review form, not a second one.** The artboard draws a
+ * bespoke card stack asking the same six questions the review dialog already
+ * asks; building it would give a review two write paths and two validators.
+ * `UnreviewedCard`'s `onSelect` and `onStart` fill a queue instead, and each
+ * course opens `Review` in place — see the PR for the deviation.
+ */
+export function TakenCourses() {
+  useRequireSession();
+  const { isLoading: isSessionLoading } = useMe();
+  const { data: taken, isPending } = useTakenCourses(!isSessionLoading);
+  const { add, update, remove, confirmImport } = useTakenMutations();
+
+  const takenCourses = taken ?? [];
+  const courseCodes = takenCourses.map((course) => course.courseCode);
+  const summaries = useCourseSummaries(courseCodes, !isSessionLoading);
+  const names = new Map(
+    summaries.flatMap((query) =>
+      query.data ? [[query.data.courseCode, query.data.titleEng] as const] : [],
+    ),
+  );
+  const rows = toTakenRows(takenCourses, names);
+
+  const {
+    courses: unreviewed,
+    isLoading: isReviewsLoading,
+    isUnavailable: areReviewsUnavailable,
+  } = useUnreviewedTakenCourses();
+  // A course is "not reviewed" only once every review list has arrived. While
+  // they are in flight, or when one failed, the column says nothing rather than
+  // marking everything done.
+  const reviewsKnown = !isReviewsLoading && !areReviewsUnavailable;
+  const unreviewedCodes = new Set(
+    unreviewed.map((course) => course.courseCode),
+  );
+
+  const [addOpen, setAddOpen] = useState(false);
+  const [updateOpen, setUpdateOpen] = useState(false);
+  const [includeGrades, setIncludeGrades] = useState(false);
+  const [proposal, setProposal] = useState<TranscriptProposal | null>(null);
+  const [isReading, setIsReading] = useState(false);
+  const [readError, setReadError] = useState<string | null>(null);
+  const [confirmError, setConfirmError] = useState<string | null>(null);
+  const [banner, setBanner] = useState<string | null>(null);
+  const [reviewQueue, setReviewQueue] = useState<string[]>([]);
+
+  const reviewing = reviewQueue[0] ?? null;
+  const lastImport = lastTranscriptImport(takenCourses);
+  const isBusy = update.isPending || remove.isPending || add.isPending;
+
+  /**
+   * Reads one transcript. The file is a parameter and never becomes state, so
+   * it is unreferenced the moment the request has been built — which is the
+   * whole point: it is a student's academic record and this page may not keep
+   * it. What is kept, until the reader confirms or discards it, is the
+   * proposal, which holds no file and writes nothing.
+   */
+  async function readTranscript(file: File) {
+    setUpdateOpen(false);
+    setReadError(null);
+    setConfirmError(null);
+    setBanner(null);
+    setIsReading(true);
+    try {
+      setProposal(await uploadTranscript(file));
+    } catch (error) {
+      setReadError(
+        error instanceof Error && error.message
+          ? error.message
+          : "The file could not be read.",
+      );
+    } finally {
+      setIsReading(false);
+    }
+  }
+
+  async function confirmProposal() {
+    if (!proposal) return;
+    setConfirmError(null);
+    try {
+      const result = await confirmImport.mutateAsync({
+        courses: toConfirmedCourses(proposal.candidates, includeGrades),
+      });
+      setProposal(null);
+      setBanner(importedSummary(result));
+    } catch (error) {
+      setConfirmError(
+        error instanceof Error && error.message
+          ? error.message
+          : "That import did not reach the server.",
+      );
+    }
+  }
+
+  function addCourse(courseCode: string, edits: TakenEdits) {
+    add
+      .mutateAsync({ courseCode, ...edits })
+      .catch(() => toast.error(`Could not add ${courseCode} to your courses.`));
+  }
+
+  /**
+   * Puts a removed row back exactly as it was, periods included — the row is
+   * the whole record, not the three fields the table happens to show.
+   */
+  function restoreCourse(row: TakenRow) {
+    add
+      .mutateAsync({
+        courseCode: row.courseCode,
+        grade: row.grade,
+        earnedCredits: row.earnedCredits,
+        attendancePeriods: row.attendancePeriods,
+        attendanceYear: row.attendanceYear,
+      })
+      .catch(() =>
+        toast.error(`Could not put ${row.courseCode} back in your courses.`),
+      );
+  }
+
+  function saveEdits(row: TakenRow, edits: TakenEdits) {
+    update
+      .mutateAsync(takenUpdateInput(row, edits))
+      .catch(() => toast.error(`Could not save your changes to ${row.name}.`));
+  }
+
+  function removeCourse(row: TakenRow) {
+    remove
+      .mutateAsync({ courseCode: row.courseCode })
+      .then(() => {
+        // Undo is offered only for a row nobody imported. Putting an imported
+        // row back would go through `taken.add`, which writes no
+        // `transcript_imported_at` — the course would come back quietly
+        // re-labelled as hand-entered, and nothing in the API can set that
+        // column back to what it was.
+        toast.success(`Removed ${row.courseCode}`, {
+          action: row.transcriptImportedAt
+            ? undefined
+            : { label: "Undo", onClick: () => restoreCourse(row) },
+        });
+      })
+      .catch(() =>
+        toast.error(`Could not remove ${row.courseCode} from your courses.`),
+      );
+  }
+
+  function screen() {
+    if (isSessionLoading || isPending) return <ListSkeleton />;
+
+    if (proposal) {
+      return (
+        <TranscriptProposalReview
+          proposal={proposal}
+          includeGrades={includeGrades}
+          isConfirming={confirmImport.isPending}
+          error={confirmError}
+          onConfirm={() => void confirmProposal()}
+          onCancel={() => {
+            setProposal(null);
+            setConfirmError(null);
+          }}
+        />
+      );
+    }
+
+    if (isReading) return <ReadingTranscript />;
+
+    if (readError) {
+      return (
+        <ReadFailed
+          message={readError}
+          onRetry={() => setReadError(null)}
+          onAddByHand={() => {
+            setReadError(null);
+            setAddOpen(true);
+          }}
+        />
+      );
+    }
+
+    if (rows.length === 0) {
+      return (
+        <div className="flex justify-center px-5 pt-3.5 pb-10">
+          <div className="w-full max-w-[480px]">
+            <TranscriptDropZone
+              variant="first"
+              includeGrades={includeGrades}
+              onIncludeGradesChange={setIncludeGrades}
+              onFile={(file) => void readTranscript(file)}
+              onAddByHand={() => setAddOpen(true)}
+            />
+          </div>
+        </div>
+      );
+    }
+
+    return (
+      <div className="flex min-w-0 flex-1 flex-col px-5">
+        <div className="border-cc-rule border-b pt-5 pb-[18px]">
+          <div className="flex flex-wrap items-center justify-between gap-x-6 gap-y-4">
+            <p className="m-0 text-[13.5px] text-cc-muted">
+              <span className="font-semibold text-cc-ink tabular-nums">
+                {rows.length}
+              </span>{" "}
+              {rows.length === 1 ? "course" : "courses"}
+            </p>
+            <div className="flex min-w-0 flex-col items-end gap-1.5">
+              <button
+                type="button"
+                onClick={() => setUpdateOpen(true)}
+                className="flex h-[38px] cursor-pointer items-center gap-2 rounded-[9px] border border-cc-rule3 bg-cc-surface px-3.5 font-medium text-[13px] text-cc-chip-ink hover:border-cc-hov"
+              >
+                <RefreshCw size={15} strokeWidth={1.9} aria-hidden />
+                Update transcript
+              </button>
+              <span className="whitespace-nowrap text-[12px] text-cc-dim2">
+                {lastImport
+                  ? `Last read ${readDate(lastImport)}`
+                  : "Added by hand"}
+              </span>
+            </div>
+          </div>
+
+          {banner ? (
+            <output className="mt-4 flex items-start gap-[11px] rounded-[11px] border border-cc-success/40 bg-cc-surface px-[15px] py-[13px]">
+              <CircleCheck
+                size={16}
+                strokeWidth={2.1}
+                aria-hidden
+                className="mt-px flex-none text-cc-success"
+              />
+              <span className="min-w-0 flex-1">
+                <span className="block font-semibold text-[13.5px] text-cc-success">
+                  {banner}
+                </span>
+                <span className="mt-1 block text-[12.5px] text-cc-muted leading-[1.5]">
+                  Courses already in your list kept the edits you made.
+                </span>
+              </span>
+              <button
+                type="button"
+                onClick={() => setBanner(null)}
+                aria-label="Dismiss"
+                className="flex size-6 flex-none cursor-pointer items-center justify-center rounded-[6px] text-[16px] text-cc-success leading-none"
+              >
+                ×
+              </button>
+            </output>
+          ) : null}
+        </div>
+
+        <div className="flex flex-1 flex-col gap-[18px] pt-[18px]">
+          {reviewsKnown ? (
+            <UnreviewedCard
+              courses={unreviewed.map((course) => ({
+                code: course.courseCode,
+                name: names.get(course.courseCode),
+              }))}
+              line={
+                unreviewed.length === 1
+                  ? "You have 1 unreviewed course."
+                  : `You have ${unreviewed.length} unreviewed courses.`
+              }
+              onStart={() =>
+                setReviewQueue(unreviewed.map((course) => course.courseCode))
+              }
+              onSelect={(courseCode) => setReviewQueue([courseCode])}
+            />
+          ) : null}
+
+          <div className="overflow-x-auto overflow-y-hidden rounded-[12px] border border-cc-rule bg-cc-surface">
+            <div
+              className={`${TAKEN_GRID} border-cc-rule border-b bg-cc-pg px-4 py-3.5 font-semibold text-[11px] text-cc-dim uppercase tracking-[0.06em]`}
+            >
+              {COLUMNS.map((column) => (
+                <div
+                  key={column}
+                  className={column === "Actions" ? "text-right" : undefined}
+                >
+                  {column}
+                </div>
+              ))}
+            </div>
+
+            <button
+              type="button"
+              onClick={() => setAddOpen(true)}
+              className="m-px flex w-[calc(100%-2px)] min-w-[600px] cursor-pointer items-center gap-2.5 rounded-[9px] border border-cc-brand/40 border-dashed bg-cc-brand/6 px-[15px] py-[11px] text-cc-brand hover:border-cc-brand hover:bg-cc-brand/11"
+            >
+              <Plus size={15} strokeWidth={2} aria-hidden />
+              <span className="font-medium text-[13.5px]">
+                Add a course by hand
+              </span>
+            </button>
+
+            {rows.map((row) => (
+              <TakenCourseRow
+                key={row.courseCode}
+                row={row}
+                isReviewed={
+                  reviewsKnown ? !unreviewedCodes.has(row.courseCode) : null
+                }
+                isBusy={isBusy}
+                onSave={(edits) => saveEdits(row, edits)}
+                onRemove={() => removeCourse(row)}
+              />
+            ))}
+          </div>
+        </div>
+
+        <p className="m-0 flex items-center gap-2 pt-[18px] pb-[26px] text-[11.5px] text-cc-dim2">
+          <Info size={13} strokeWidth={1.9} aria-hidden className="flex-none" />
+          Course Community is run by KTH AI Society, a student organisation.
+          Credits and grades shown here are your own entries — not an official
+          KTH record.
+        </p>
+      </div>
+    );
+  }
+
+  return (
+    <PageColumn>
+      <PageHeader title="Taken courses" subtitle="Your completed courses." />
+      {screen()}
+
+      <AddTakenCourseDialog
+        open={addOpen}
+        takenCourseCodes={courseCodes}
+        onClose={() => setAddOpen(false)}
+        onAdd={addCourse}
+      />
+
+      <Dialog open={updateOpen} onOpenChange={setUpdateOpen}>
+        <DialogContent
+          showCloseButton={false}
+          overlayClassName="bg-[rgba(14,26,44,0.34)] supports-backdrop-filter:backdrop-blur-none"
+          className="cc-theme w-[460px] max-w-[calc(100vw-2rem)] gap-0 rounded-[14px] border-cc-rule2 bg-cc-surface p-[22px] text-cc-ink shadow-[0_18px_48px_rgba(20,30,45,0.26)]"
+        >
+          <DialogTitle className="font-semibold text-[19px] leading-[1.25]">
+            Read a newer transcript
+          </DialogTitle>
+          <DialogDescription className="sr-only">
+            Upload a newer Ladok Resultatintyg. Nothing is saved until you
+            confirm what it read.
+          </DialogDescription>
+          <div className="mt-3.5">
+            <TranscriptDropZone
+              variant="update"
+              includeGrades={includeGrades}
+              onIncludeGradesChange={setIncludeGrades}
+              onFile={(file) => void readTranscript(file)}
+              lastReadLine={
+                lastImport ? `Last read ${readDate(lastImport)}` : null
+              }
+              onCancel={() => setUpdateOpen(false)}
+            />
+          </div>
+        </DialogContent>
+      </Dialog>
+
+      {reviewing ? (
+        <Review
+          key={reviewing}
+          courseCode={reviewing}
+          openOnLoad
+          triggerless
+          onClose={() => setReviewQueue((queue) => queue.slice(1))}
+        />
+      ) : null}
+    </PageColumn>
+  );
+}
+
+/** The artboard's `isParsing` screen. Nothing has been written at this point. */
+function ReadingTranscript() {
+  return (
+    <div className="flex justify-center px-5 pt-[30px] pb-10">
+      <div className="w-full max-w-[520px]">
+        <h2 className="m-0 font-semibold text-[22px] leading-[1.2] tracking-[-0.015em]">
+          Reading your transcript
+        </h2>
+        <p className="m-0 mt-2 text-[13.5px] text-cc-muted">
+          Nothing is saved until you confirm.
+        </p>
+        <output
+          aria-label="Reading your transcript"
+          className="mt-5 block h-1.5 overflow-hidden rounded-full bg-cc-pill"
+        >
+          <span className="block h-full w-1/3 animate-pulse rounded-full bg-cc-btn" />
+        </output>
+      </div>
+    </div>
+  );
+}
+
+/**
+ * The artboard's `isFailed` screen. It says outright that nothing was saved,
+ * because nothing was: the parse is a read and the write is a separate call
+ * that this path never reaches.
+ */
+function ReadFailed({
+  message,
+  onRetry,
+  onAddByHand,
+}: {
+  message: string;
+  onRetry: () => void;
+  onAddByHand: () => void;
+}) {
+  return (
+    <div className="flex justify-center px-5 pt-[18px] pb-10">
+      <div className="w-full max-w-[620px]">
+        <div className="flex items-center gap-2.5">
+          <span className="flex size-[26px] items-center justify-center rounded-full bg-cc-danger/12 text-cc-danger">
+            <FileWarning size={15} strokeWidth={2.2} aria-hidden />
+          </span>
+          <p className="m-0 font-semibold text-[11px] text-cc-danger uppercase tracking-[0.09em]">
+            Reading failed
+          </p>
+        </div>
+        <h2 className="m-0 mt-3 font-semibold text-[22px] leading-[1.2] tracking-[-0.015em]">
+          {READ_FAILED_TITLE}
+        </h2>
+        <p
+          role="alert"
+          className="m-0 mt-2 text-[14px] text-cc-muted leading-[1.55]"
+        >
+          {message}
+        </p>
+        <p className="m-0 mt-4 flex items-center gap-3 rounded-[12px] border border-cc-danger/30 bg-cc-surface px-4 py-3.5 text-[13px] text-cc-ink2">
+          <span className="flex-1">
+            Download the certificate straight from Ladok rather than scanning it
+            — if no text selects in the PDF, it is a scan and there is nothing
+            to read.
+          </span>
+          <span className="flex-none font-medium text-[12.5px] text-cc-danger">
+            Nothing was saved
+          </span>
+        </p>
+        <div className="mt-[18px] flex items-center gap-[11px]">
+          <button
+            type="button"
+            onClick={onRetry}
+            className="flex h-11 cursor-pointer items-center rounded-[9px] bg-cc-btn px-5 font-semibold text-[14px] text-cc-btn-fg hover:opacity-[0.88]"
+          >
+            Try another file
+          </button>
+          <button
+            type="button"
+            onClick={onAddByHand}
+            className="flex h-11 cursor-pointer items-center rounded-[9px] border border-cc-rule3 bg-cc-surface px-4 font-medium text-[13.5px] text-cc-chip-ink hover:border-cc-hov"
+          >
+            Add courses manually
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function ListSkeleton() {
+  return (
+    <div aria-hidden className="px-5 pt-5">
+      <div className="h-[300px] animate-pulse rounded-[12px] border border-cc-rule bg-cc-surface" />
+    </div>
+  );
+}

--- a/apps/web/features/taken/components/taken-courses.tsx
+++ b/apps/web/features/taken/components/taken-courses.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { CircleCheck, FileWarning, Info, Plus, RefreshCw } from "lucide-react";
+import Link from "next/link";
 import { useState } from "react";
 import { toast } from "sonner";
 import {
@@ -110,7 +111,7 @@ export function TakenCourses() {
   // request that would be refused — the same guard `useUnreviewedTakenCourses`
   // puts on the very same query.
   const takenQuery = useTakenCourses(isAuthenticated);
-  const { data: taken, isPending } = takenQuery;
+  const { data: taken, isPending, isError } = takenQuery;
   const { add, update, remove, confirmImport } = useTakenMutations();
 
   const takenCourses = taken ?? [];
@@ -144,6 +145,7 @@ export function TakenCourses() {
   const [readError, setReadError] = useState<string | null>(null);
   const [confirmError, setConfirmError] = useState<string | null>(null);
   const [banner, setBanner] = useState<string | null>(null);
+  const [isConfirming, setIsConfirming] = useState(false);
   const [reviewQueue, setReviewQueue] = useState<string[]>([]);
 
   const reviewing = reviewQueue[0] ?? null;
@@ -198,17 +200,34 @@ export function TakenCourses() {
    * alone would make it atomic. That is a change to a server contract #92 does
    * not own — the issue states outright that "the write upserts on (userId,
    * courseCode)" — so it is reported on the PR rather than made here.
+   *
+   * **A re-read that fails writes nothing.** The render's copy is the very
+   * snapshot the re-read exists to distrust, so falling back to it would put
+   * back the overwrite this function was written to prevent — quietly, at the
+   * one moment there is most reason to doubt it. A refused refresh stops the
+   * import and says so, and a rejected one is caught here rather than escaping
+   * as an unhandled rejection that leaves the proposal open explaining nothing.
    */
   async function confirmProposal() {
-    if (!proposal) return;
+    if (!proposal || isConfirming) return;
     setConfirmError(null);
-    const current = await takenQuery.refetch();
-    const plan = planTranscriptImport(
-      proposal.candidates,
-      current.data ?? takenCourses,
-      includeGrades,
-    );
+    setIsConfirming(true);
     try {
+      const current = await takenQuery.refetch();
+      // A failed refetch keeps whatever the last good read returned, so the
+      // error flag — not the presence of data — is what says this list can be
+      // planned against.
+      if (current.isError || !current.data) {
+        setConfirmError(
+          "We could not re-read your course list, so nothing was imported.",
+        );
+        return;
+      }
+      const plan = planTranscriptImport(
+        proposal.candidates,
+        current.data,
+        includeGrades,
+      );
       const written =
         plan.create.length > 0
           ? await confirmImport.mutateAsync({ courses: plan.create })
@@ -227,6 +246,8 @@ export function TakenCourses() {
           ? error.message
           : "That import did not reach the server.",
       );
+    } finally {
+      setIsConfirming(false);
     }
   }
 
@@ -295,11 +316,15 @@ export function TakenCourses() {
     }
 
     if (proposal) {
+      // `isConfirming` is the whole confirm, not just the create call: the
+      // re-read before it and the fills after it are as much of the import as
+      // the create is, and a button that went live between them would invite a
+      // second one over a list the first is still changing.
       return (
         <TranscriptProposalReview
           proposal={proposal}
           includeGrades={includeGrades}
-          isConfirming={confirmImport.isPending}
+          isConfirming={isConfirming}
           error={confirmError}
           onConfirm={() => void confirmProposal()}
           onCancel={() => {
@@ -323,6 +348,15 @@ export function TakenCourses() {
           }}
         />
       );
+    }
+
+    // An empty `rows` is what a failed read leaves behind, and the screen
+    // below it is the first-run one: it would tell a reader whose list simply
+    // did not arrive that they have taken nothing yet, and invite them to
+    // import a transcript over a list nobody can see. A failed read is not an
+    // empty list, so it says which of the two this is.
+    if (isError) {
+      return <ListFailed onRetry={() => void takenQuery.refetch()} />;
     }
 
     if (rows.length === 0) {
@@ -599,6 +633,58 @@ function ReadFailed({
           >
             Add courses manually
           </button>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+/**
+ * The read of `taken.list` did not come back.
+ *
+ * It says outright that nothing was changed, because nothing was: the list is
+ * a read. It offers no transcript drop zone — an import planned against a list
+ * this page cannot see is exactly the overwrite `confirmProposal` re-reads to
+ * avoid — so the one thing on offer is reading the list again.
+ */
+function ListFailed({ onRetry }: { onRetry: () => void }) {
+  return (
+    <div className="flex justify-center px-5 pt-[30px] pb-10">
+      <div className="w-full max-w-[520px]">
+        <div className="flex items-center gap-2.5">
+          <span className="flex size-[26px] items-center justify-center rounded-full bg-cc-danger/12 text-cc-danger">
+            <FileWarning size={15} strokeWidth={2.2} aria-hidden />
+          </span>
+          <p className="m-0 font-semibold text-[11px] text-cc-danger uppercase tracking-[0.09em]">
+            Could not load
+          </p>
+        </div>
+        <h2 className="m-0 mt-3 font-semibold text-[22px] leading-[1.2] tracking-[-0.015em]">
+          Your taken courses did not load
+        </h2>
+        <p
+          role="alert"
+          className="m-0 mt-2 text-[14px] text-cc-muted leading-[1.55]"
+        >
+          The request for your course list did not come back, so this page
+          cannot say what is in it. Nothing is lost — this is a read, and
+          nothing of yours was changed.
+        </p>
+        <div className="mt-[18px] flex items-center gap-[11px]">
+          <button
+            type="button"
+            onClick={onRetry}
+            className="flex h-11 cursor-pointer items-center gap-2 rounded-[9px] bg-cc-btn px-5 font-semibold text-[14px] text-cc-btn-fg hover:opacity-[0.88]"
+          >
+            <RefreshCw size={15} strokeWidth={1.9} aria-hidden />
+            Try again
+          </button>
+          <Link
+            href="/search"
+            className="flex h-11 items-center rounded-[9px] border border-cc-rule3 bg-cc-surface px-4 font-medium text-[13.5px] text-cc-chip-ink no-underline hover:border-cc-hov"
+          >
+            Browse courses instead
+          </Link>
         </div>
       </div>
     </div>

--- a/apps/web/features/taken/components/transcript-drop-zone.tsx
+++ b/apps/web/features/taken/components/transcript-drop-zone.tsx
@@ -1,0 +1,194 @@
+"use client";
+
+import { FileText, Info, Upload } from "lucide-react";
+import { type DragEvent, useId, useRef, useState } from "react";
+import { MAX_TRANSCRIPT_LABEL } from "../api/transcript";
+
+type Props = {
+  /** The first read of a transcript, or a re-read over a list that exists. */
+  variant: "first" | "update";
+  includeGrades: boolean;
+  onIncludeGradesChange: (next: boolean) => void;
+  /** Handed the chosen file and nothing else. Nothing here keeps it. */
+  onFile: (file: File) => void;
+  /** "Last read 24 Aug 2026" — only the update flow has one to show. */
+  lastReadLine?: string | null;
+  /** Offered on the first-read screen: skip the file and type a course in. */
+  onAddByHand?: () => void;
+  /** Offered in the update dialog. */
+  onCancel?: () => void;
+};
+
+/**
+ * Where a Ladok transcript goes in — `docs/design/Course Community - Taken
+ * Courses.dc.html`, the `isEmpty` screen and the `isUpdateModal` body, which
+ * draw the same zone at two sizes.
+ *
+ * It hands the file up and forgets it. The file never reaches component state,
+ * `localStorage` or a log: it is a student's academic record, it is read once
+ * on the server, and what comes back is a proposal rather than a row.
+ *
+ * **The grades switch is not a parse option.** The artboard says grade columns
+ * are "left out of the parse", but the parse runs on the server and always
+ * reads them; the switch decides what is *kept* when the proposal is confirmed.
+ * The copy here says that instead, which is the smallest change that stops the
+ * page promising something the server does not do.
+ */
+export function TranscriptDropZone({
+  variant,
+  includeGrades,
+  onIncludeGradesChange,
+  onFile,
+  lastReadLine,
+  onAddByHand,
+  onCancel,
+}: Props) {
+  const inputRef = useRef<HTMLInputElement>(null);
+  const [dragging, setDragging] = useState(false);
+  const switchId = useId();
+  const isFirst = variant === "first";
+
+  function take(file: File | undefined) {
+    if (file) onFile(file);
+  }
+
+  function drop(event: DragEvent<HTMLElement>) {
+    event.preventDefault();
+    setDragging(false);
+    take(event.dataTransfer.files[0]);
+  }
+
+  return (
+    <div className="w-full">
+      {isFirst ? (
+        <div className="flex items-start gap-2.5 rounded-[10px] bg-cc-pill px-[13px] py-[11px] text-left">
+          <Info
+            size={15}
+            aria-hidden
+            className="mt-px flex-none text-cc-dim"
+            strokeWidth={2}
+          />
+          <p className="m-0 text-[12.5px] text-cc-ink2 leading-[1.5]">
+            Remember to pick{" "}
+            <span className="font-semibold">Resultatintyg</span> in Ladok, and
+            make sure course codes are included.
+          </p>
+        </div>
+      ) : (
+        <p className="m-0 text-[13.5px] text-cc-muted leading-[1.55]">
+          Upload a newer Resultatintyg. Courses already in your list keep the
+          edits you made — a re-read updates them rather than adding them twice.
+        </p>
+      )}
+
+      <div
+        className={`mt-3.5 flex items-start justify-between gap-4 ${
+          isFirst
+            ? "border-cc-rule border-b py-3.5"
+            : "rounded-[12px] border border-cc-rule bg-cc-pg p-[15px]"
+        }`}
+      >
+        <div className="min-w-0">
+          <label
+            htmlFor={switchId}
+            className="cursor-pointer font-semibold text-[13.5px]"
+          >
+            Read grades from transcript
+          </label>
+          <p className="m-0 mt-[3px] text-[12.5px] text-cc-muted leading-[1.5]">
+            {includeGrades
+              ? "Grades from the file are kept with your courses when you confirm. Only you can see them."
+              : "Grades are dropped when you confirm, so no grade of yours is stored. Credits, names and years are still read."}
+          </p>
+        </div>
+        <button
+          type="button"
+          id={switchId}
+          role="switch"
+          aria-checked={includeGrades}
+          onClick={() => onIncludeGradesChange(!includeGrades)}
+          className={`flex h-6 w-[42px] flex-none cursor-pointer items-center rounded-full p-[3px] transition-colors ${
+            includeGrades
+              ? "justify-end bg-cc-brand"
+              : "justify-start bg-cc-rule3"
+          }`}
+        >
+          <span
+            aria-hidden
+            className="size-[18px] rounded-full bg-cc-surface shadow-[0_1px_2px_rgba(20,30,45,.28)]"
+          />
+        </button>
+      </div>
+
+      <button
+        type="button"
+        onClick={() => inputRef.current?.click()}
+        onDragOver={(event) => {
+          event.preventDefault();
+          setDragging(true);
+        }}
+        onDragLeave={() => setDragging(false)}
+        onDrop={drop}
+        className={`mt-5 flex w-full cursor-pointer flex-col items-center rounded-[14px] border-2 border-dashed bg-cc-pill text-center ${
+          isFirst ? "px-7 py-10" : "px-[22px] py-[30px]"
+        } ${dragging ? "border-cc-brand" : "border-cc-hov"}`}
+      >
+        <span className="flex size-12 items-center justify-center rounded-[13px] bg-cc-pill text-cc-brand">
+          <Upload size={21} strokeWidth={1.9} aria-hidden />
+        </span>
+        <span className="mt-3.5 font-semibold text-[16px]">
+          {dragging
+            ? "Drop to start reading"
+            : isFirst
+              ? "Drop your Ladok transcript here"
+              : "Drop the new PDF here"}
+        </span>
+        <span className="mt-[5px] text-[12.5px] text-cc-muted">
+          PDF from Ladok · up to {MAX_TRANSCRIPT_LABEL}
+        </span>
+        <span className="mt-4 flex h-[38px] items-center gap-2 rounded-[9px] bg-cc-btn px-[15px] font-semibold text-[13px] text-cc-btn-fg">
+          <FileText size={14} strokeWidth={2} aria-hidden />
+          Choose a PDF
+        </span>
+      </button>
+
+      <input
+        ref={inputRef}
+        type="file"
+        accept="application/pdf,.pdf"
+        className="sr-only"
+        aria-label="Ladok transcript PDF"
+        onChange={(event) => {
+          take(event.target.files?.[0]);
+          // The picker keeps its selection, so choosing the same file twice in
+          // a row would not fire again. Clearing it also drops this component's
+          // last handle on the file.
+          event.target.value = "";
+        }}
+      />
+
+      <div className="mt-4 flex items-center justify-between gap-3 text-[12.5px]">
+        {onAddByHand ? (
+          <button
+            type="button"
+            onClick={onAddByHand}
+            className="cursor-pointer font-medium text-cc-brand hover:underline"
+          >
+            Add courses manually instead
+          </button>
+        ) : (
+          <span className="text-cc-dim">{lastReadLine ?? ""}</span>
+        )}
+        {onCancel ? (
+          <button
+            type="button"
+            onClick={onCancel}
+            className="cursor-pointer font-medium text-cc-brand hover:underline"
+          >
+            Cancel
+          </button>
+        ) : null}
+      </div>
+    </div>
+  );
+}

--- a/apps/web/features/taken/components/transcript-proposal.tsx
+++ b/apps/web/features/taken/components/transcript-proposal.tsx
@@ -9,7 +9,12 @@ type Props = {
   /** The reader's grades switch, applied to what is shown and to what is written. */
   includeGrades: boolean;
   isConfirming: boolean;
-  /** Set when `transcript.confirm` refused the rows. Nothing was written. */
+  /**
+   * Set when a confirm did not finish. Some of it may already have landed, so
+   * the message says what confirming again will do rather than claiming
+   * nothing was written — the screen re-reads the list and asks only for the
+   * rows that are still missing.
+   */
   error?: string | null;
   onConfirm: () => void;
   onCancel: () => void;
@@ -31,8 +36,8 @@ function unmatchedTitle(count: number): string {
  *
  * Two rules from #66's server work are visible here and must stay that way.
  * **Nothing is stored until "Looks right".** The rows on this screen came back
- * from a parse that wrote nothing; `transcript.confirm` is the only write, and
- * it is behind that button.
+ * from a parse that wrote nothing; every write this flow makes is behind that
+ * button, and `planTranscriptImport` decides what they are.
  *
  * **Unmatched codes are reported, never invented.** A row whose course code the
  * catalogue does not have cannot become a taken course — `user_taken_courses`
@@ -130,7 +135,7 @@ export function TranscriptProposalReview({
             role="alert"
             className="m-0 mt-4 rounded-[10px] border border-cc-danger/40 bg-cc-surface px-[13px] py-[11px] text-[12.5px] text-cc-danger"
           >
-            {error} Nothing was saved.
+            {error} Confirming again writes only what is still missing.
           </p>
         ) : null}
 

--- a/apps/web/features/taken/components/transcript-proposal.tsx
+++ b/apps/web/features/taken/components/transcript-proposal.tsx
@@ -1,0 +1,157 @@
+"use client";
+
+import { Info } from "lucide-react";
+import type { TranscriptProposal } from "@/server/ingest/transcript/service";
+import { creditsLabel } from "../lib/taken-rows";
+
+type Props = {
+  proposal: TranscriptProposal;
+  /** The reader's grades switch, applied to what is shown and to what is written. */
+  includeGrades: boolean;
+  isConfirming: boolean;
+  /** Set when `transcript.confirm` refused the rows. Nothing was written. */
+  error?: string | null;
+  onConfirm: () => void;
+  onCancel: () => void;
+};
+
+function headline(count: number): string {
+  return count === 1 ? "1 course read" : `${count} courses read`;
+}
+
+function unmatchedTitle(count: number): string {
+  return count === 1
+    ? "1 row was not a KTH catalogue course"
+    : `${count} rows were not KTH catalogue courses`;
+}
+
+/**
+ * What a parsed transcript is offering, before any of it is written —
+ * the artboard's `isPreview` screen.
+ *
+ * Two rules from #66's server work are visible here and must stay that way.
+ * **Nothing is stored until "Looks right".** The rows on this screen came back
+ * from a parse that wrote nothing; `transcript.confirm` is the only write, and
+ * it is behind that button.
+ *
+ * **Unmatched codes are reported, never invented.** A row whose course code the
+ * catalogue does not have cannot become a taken course — `user_taken_courses`
+ * has a foreign key to `courses.code` — so it is named here rather than dropped
+ * silently, and this screen offers no way to create the missing course.
+ *
+ * The candidate rows are listed, which the artboard's own preview does not do:
+ * it shows only a count. A screen whose one button writes to a reader's record
+ * has to show what it is about to write.
+ */
+export function TranscriptProposalReview({
+  proposal,
+  includeGrades,
+  isConfirming,
+  error,
+  onConfirm,
+  onCancel,
+}: Props) {
+  const { candidates, unmatched } = proposal;
+
+  return (
+    <div className="flex justify-center px-5 pt-[30px] pb-10">
+      <div className="w-full max-w-[560px]">
+        <p className="m-0 font-semibold text-[11px] text-cc-brand uppercase tracking-[0.09em]">
+          Transcript read
+        </p>
+        <h2 className="m-0 mt-2.5 font-semibold text-[24px] leading-[1.2] tracking-[-0.015em]">
+          {headline(candidates.length)}
+        </h2>
+        <p className="m-0 mt-2 text-[14px] text-cc-muted leading-[1.55]">
+          Nothing is saved to your list until you confirm.
+        </p>
+
+        {unmatched.length > 0 ? (
+          <div className="mt-4 flex items-start gap-[11px] rounded-[11px] border border-cc-rule2 bg-cc-pill px-[15px] py-[13px]">
+            <Info
+              size={16}
+              strokeWidth={2}
+              aria-hidden
+              className="mt-px flex-none text-cc-dim"
+            />
+            <div className="min-w-0 flex-1">
+              <p className="m-0 font-semibold text-[13.5px]">
+                {unmatchedTitle(unmatched.length)}
+              </p>
+              <p className="m-0 mt-1 text-[12.5px] text-cc-muted leading-[1.5]">
+                These rows do not match a course in the KTH catalogue, so they
+                are left out.
+              </p>
+              <ul className="m-0 mt-2 flex list-none flex-col gap-1 p-0">
+                {unmatched.map((row) => (
+                  <li
+                    key={row.courseCode}
+                    className="truncate text-[12.5px] text-cc-ink2"
+                  >
+                    {row.courseCode} — {row.courseName}
+                  </li>
+                ))}
+              </ul>
+            </div>
+          </div>
+        ) : null}
+
+        {candidates.length > 0 ? (
+          <ul className="m-0 mt-4 flex max-h-[320px] list-none flex-col overflow-y-auto rounded-[12px] border border-cc-rule bg-cc-surface p-0">
+            {candidates.map((row) => (
+              <li
+                key={row.courseCode}
+                className="flex items-center gap-3 border-cc-rule border-b px-4 py-2.5 last:border-b-0"
+              >
+                <span className="w-[74px] flex-none font-medium font-mono text-[12.5px] text-cc-brand">
+                  {row.courseCode}
+                </span>
+                <span className="min-w-0 flex-1 truncate text-[13.5px]">
+                  {row.catalogueName}
+                </span>
+                <span className="flex-none text-[12.5px] text-cc-dim tabular-nums">
+                  {creditsLabel(row.earnedCredits)}
+                </span>
+                <span className="w-[52px] flex-none text-right text-[12.5px] text-cc-ink2">
+                  {includeGrades ? (row.grade ?? "—") : "not kept"}
+                </span>
+              </li>
+            ))}
+          </ul>
+        ) : (
+          <p className="m-0 mt-4 rounded-[12px] border border-cc-rule bg-cc-surface px-4 py-3.5 text-[13px] text-cc-muted leading-[1.55]">
+            No row in that file matched a course in the KTH catalogue, so there
+            is nothing to add. Nothing was saved.
+          </p>
+        )}
+
+        {error ? (
+          <p
+            role="alert"
+            className="m-0 mt-4 rounded-[10px] border border-cc-danger/40 bg-cc-surface px-[13px] py-[11px] text-[12.5px] text-cc-danger"
+          >
+            {error} Nothing was saved.
+          </p>
+        ) : null}
+
+        <div className="mt-5 flex items-center gap-[11px]">
+          <button
+            type="button"
+            onClick={onConfirm}
+            disabled={isConfirming || candidates.length === 0}
+            className="flex h-11 cursor-pointer items-center rounded-[9px] bg-cc-btn px-5 font-semibold text-[14px] text-cc-btn-fg hover:opacity-[0.88] disabled:cursor-not-allowed disabled:opacity-60"
+          >
+            {isConfirming ? "Saving…" : "Looks right"}
+          </button>
+          <button
+            type="button"
+            onClick={onCancel}
+            className="flex h-11 cursor-pointer items-center rounded-[9px] border border-cc-rule3 bg-cc-surface px-4 font-medium text-[13.5px] text-cc-chip-ink hover:border-cc-hov"
+          >
+            Discard
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/features/taken/index.ts
+++ b/apps/web/features/taken/index.ts
@@ -1,0 +1,13 @@
+/**
+ * The cross-feature API of the taken feature.
+ *
+ * Taking a course is a relationship other surfaces act on — the course card
+ * marks one taken, and this page adds, edits and removes them — so the write
+ * path is what crosses the boundary. The `/taken` screen does not: `app/`
+ * imports its route component from `components/`, as every page does.
+ *
+ * `useTakenMutations`' `add` is the card's own `useMarkCourseTaken`, so
+ * `taken.add` still has exactly one write path and one set of cache keys.
+ */
+
+export { useTakenMutations } from "./api/mutations";

--- a/apps/web/features/taken/lib/taken-rows.spec.ts
+++ b/apps/web/features/taken/lib/taken-rows.spec.ts
@@ -1,0 +1,182 @@
+import { describe, expect, it } from "vitest";
+import {
+  creditsLabel,
+  draftEdits,
+  lastTranscriptImport,
+  type ProposalRow,
+  parseCredits,
+  parseYear,
+  type TakenCourse,
+  takenUpdateInput,
+  toConfirmedCourses,
+  toTakenRows,
+} from "./taken-rows";
+
+function takenCourse(overrides: Partial<TakenCourse> = {}): TakenCourse {
+  return {
+    courseCode: "DD1337",
+    grade: "B",
+    earnedCredits: 7.5,
+    attendancePeriods: "P1",
+    attendanceYear: 2025,
+    transcriptImportedAt: null,
+    createdAt: "2026-01-01T00:00:00.000Z",
+    updatedAt: "2026-01-01T00:00:00.000Z",
+    ...overrides,
+  };
+}
+
+function proposalRow(overrides: Partial<ProposalRow> = {}): ProposalRow {
+  return {
+    courseCode: "DD1337",
+    transcriptName: "Programmering",
+    catalogueName: "Programming",
+    grade: "B",
+    earnedCredits: 7.5,
+    attendanceYear: 2025,
+    ...overrides,
+  };
+}
+
+describe("toTakenRows", () => {
+  it("names a course from the catalogue", () => {
+    const rows = toTakenRows(
+      [takenCourse()],
+      new Map([["DD1337", "Introduction to Computer Science"]]),
+    );
+    expect(rows[0].name).toBe("Introduction to Computer Science");
+  });
+
+  it("falls back to the course code, because a taken row stores no title", () => {
+    const rows = toTakenRows([takenCourse()], new Map());
+    expect(rows[0].name).toBe("DD1337");
+  });
+});
+
+describe("lastTranscriptImport", () => {
+  it("is null when every row was entered by hand", () => {
+    expect(lastTranscriptImport([takenCourse()])).toBeNull();
+  });
+
+  it("is the most recent import stamp on the list", () => {
+    const at = lastTranscriptImport([
+      takenCourse({ transcriptImportedAt: "2026-08-24T09:00:00.000Z" }),
+      takenCourse({
+        courseCode: "DD2380",
+        transcriptImportedAt: "2027-01-18T09:00:00.000Z",
+      }),
+      takenCourse({ courseCode: "SF1625" }),
+    ]);
+    expect(at).toBe("2027-01-18T09:00:00.000Z");
+  });
+});
+
+describe("takenUpdateInput", () => {
+  it("carries the stored attendance periods through an edit that cannot see them", () => {
+    const input = takenUpdateInput(
+      takenCourse({ attendancePeriods: "P3, P4" }),
+      { grade: "A", earnedCredits: 9, attendanceYear: 2024 },
+    );
+    expect(input).toEqual({
+      courseCode: "DD1337",
+      grade: "A",
+      earnedCredits: 9,
+      attendanceYear: 2024,
+      attendancePeriods: "P3, P4",
+    });
+  });
+
+  it("clears a field the reader emptied", () => {
+    const input = takenUpdateInput(takenCourse(), {
+      grade: null,
+      earnedCredits: null,
+      attendanceYear: null,
+    });
+    expect(input.grade).toBeNull();
+    expect(input.earnedCredits).toBeNull();
+  });
+});
+
+describe("toConfirmedCourses", () => {
+  it("keeps the transcript's grades when the reader asked for them", () => {
+    expect(toConfirmedCourses([proposalRow()], true)).toEqual([
+      {
+        courseCode: "DD1337",
+        grade: "B",
+        earnedCredits: 7.5,
+        attendanceYear: 2025,
+      },
+    ]);
+  });
+
+  it("drops every grade when the reader did not, and keeps the rest", () => {
+    const [confirmed] = toConfirmedCourses([proposalRow()], false);
+    expect(confirmed.grade).toBeNull();
+    expect(confirmed.earnedCredits).toBe(7.5);
+    expect(confirmed.attendanceYear).toBe(2025);
+  });
+
+  it("never sends a name: a taken course has none to store", () => {
+    const [confirmed] = toConfirmedCourses([proposalRow()], true);
+    expect(Object.keys(confirmed).sort()).toEqual([
+      "attendanceYear",
+      "courseCode",
+      "earnedCredits",
+      "grade",
+    ]);
+  });
+});
+
+describe("parseCredits", () => {
+  it.each([
+    ["", null],
+    ["7.5", 7.5],
+    ["7,5", 7.5],
+    ["0", 0],
+  ])("reads %j as %j", (text, expected) => {
+    expect(parseCredits(text)).toBe(expected);
+  });
+
+  it.each(["abc", "-1", "1001"])("refuses %j", (text) => {
+    expect(parseCredits(text)).toBeUndefined();
+  });
+});
+
+describe("parseYear", () => {
+  it("reads an empty box as cleared", () => {
+    expect(parseYear("")).toBeNull();
+  });
+
+  it("reads a four-digit year", () => {
+    expect(parseYear("2025")).toBe(2025);
+  });
+
+  it.each(["25", "20255", "1899", "2201", "20x5"])("refuses %j", (text) => {
+    expect(parseYear(text)).toBeUndefined();
+  });
+});
+
+describe("draftEdits", () => {
+  it("upper-cases a grade and leaves it unvalidated", () => {
+    expect(draftEdits({ grade: "b", credits: "6", year: "2024" })).toEqual({
+      grade: "B",
+      earnedCredits: 6,
+      attendanceYear: 2024,
+    });
+  });
+
+  it("is null while a box holds something unreadable", () => {
+    expect(draftEdits({ grade: "A", credits: "six", year: "2024" })).toBeNull();
+    expect(draftEdits({ grade: "A", credits: "6", year: "24" })).toBeNull();
+  });
+});
+
+describe("creditsLabel", () => {
+  it("says nothing where the student reported nothing", () => {
+    expect(creditsLabel(null)).toBe("—");
+  });
+
+  it("labels credits in hp", () => {
+    expect(creditsLabel(7.5)).toBe("7.5 hp");
+  });
+});

--- a/apps/web/features/taken/lib/taken-rows.spec.ts
+++ b/apps/web/features/taken/lib/taken-rows.spec.ts
@@ -6,9 +6,9 @@ import {
   type ProposalRow,
   parseCredits,
   parseYear,
+  planTranscriptImport,
   type TakenCourse,
   takenUpdateInput,
-  toConfirmedCourses,
   toTakenRows,
 } from "./taken-rows";
 
@@ -97,9 +97,11 @@ describe("takenUpdateInput", () => {
   });
 });
 
-describe("toConfirmedCourses", () => {
-  it("keeps the transcript's grades when the reader asked for them", () => {
-    expect(toConfirmedCourses([proposalRow()], true)).toEqual([
+describe("planTranscriptImport", () => {
+  it("writes a course the reader does not have yet, grades and all", () => {
+    const plan = planTranscriptImport([proposalRow()], [], true);
+
+    expect(plan.create).toEqual([
       {
         courseCode: "DD1337",
         grade: "B",
@@ -107,22 +109,89 @@ describe("toConfirmedCourses", () => {
         attendanceYear: 2025,
       },
     ]);
+    expect(plan.fill).toEqual([]);
   });
 
-  it("drops every grade when the reader did not, and keeps the rest", () => {
-    const [confirmed] = toConfirmedCourses([proposalRow()], false);
-    expect(confirmed.grade).toBeNull();
-    expect(confirmed.earnedCredits).toBe(7.5);
-    expect(confirmed.attendanceYear).toBe(2025);
+  it("drops every grade the reader did not ask for, and keeps the rest", () => {
+    const [created] = planTranscriptImport([proposalRow()], [], false).create;
+
+    expect(created.grade).toBeNull();
+    expect(created.earnedCredits).toBe(7.5);
+    expect(created.attendanceYear).toBe(2025);
   });
 
   it("never sends a name: a taken course has none to store", () => {
-    const [confirmed] = toConfirmedCourses([proposalRow()], true);
-    expect(Object.keys(confirmed).sort()).toEqual([
+    const [created] = planTranscriptImport([proposalRow()], [], true).create;
+
+    expect(Object.keys(created).sort()).toEqual([
       "attendanceYear",
       "courseCode",
       "earnedCredits",
       "grade",
+    ]);
+  });
+
+  it("leaves a course the reader corrected by hand exactly as they left it", () => {
+    const plan = planTranscriptImport(
+      [proposalRow({ grade: "B", earnedCredits: 7.5, attendanceYear: 2025 })],
+      [takenCourse({ grade: "A", earnedCredits: 9, attendanceYear: 2024 })],
+      true,
+    );
+
+    expect(plan.create).toEqual([]);
+    expect(plan.fill).toEqual([]);
+    expect(plan.unchanged).toBe(1);
+  });
+
+  it("fills only the fields that are empty, and carries the periods", () => {
+    const plan = planTranscriptImport(
+      [proposalRow({ grade: "B", earnedCredits: 7.5, attendanceYear: 2025 })],
+      [
+        takenCourse({
+          grade: null,
+          earnedCredits: 9,
+          attendanceYear: null,
+          attendancePeriods: "P3, P4",
+        }),
+      ],
+      true,
+    );
+
+    expect(plan.create).toEqual([]);
+    expect(plan.fill).toEqual([
+      {
+        courseCode: "DD1337",
+        grade: "B",
+        // The reader's 9 hp survives the transcript's 7.5.
+        earnedCredits: 9,
+        attendanceYear: 2025,
+        attendancePeriods: "P3, P4",
+      },
+    ]);
+  });
+
+  it("never fills a grade the reader asked not to read", () => {
+    const plan = planTranscriptImport(
+      [proposalRow({ grade: "B" })],
+      [takenCourse({ grade: null, earnedCredits: 7.5, attendanceYear: 2025 })],
+      false,
+    );
+
+    expect(plan.fill).toEqual([]);
+    expect(plan.unchanged).toBe(1);
+  });
+
+  it("never clears a grade the reader typed in themselves", () => {
+    const plan = planTranscriptImport(
+      [proposalRow({ grade: null, earnedCredits: 7.5 })],
+      [takenCourse({ grade: "A", earnedCredits: null })],
+      false,
+    );
+
+    // The empty credits are filled; the grade the reader typed is left alone,
+    // even with the transcript's grades switched off.
+    expect(plan.fill).toEqual([
+      expect.objectContaining({ grade: "A", earnedCredits: 7.5 }),
     ]);
   });
 });

--- a/apps/web/features/taken/lib/taken-rows.ts
+++ b/apps/web/features/taken/lib/taken-rows.ts
@@ -1,0 +1,161 @@
+import type { TranscriptProposal } from "@/server/ingest/transcript/service";
+import type { RouterOutputs } from "@/trpc/client";
+
+/**
+ * One taken course as `taken.list` returns it: a course code and the facts the
+ * student reported about their own attendance. Nothing on it is a review.
+ */
+export type TakenCourse = RouterOutputs["taken"]["list"][number];
+
+/**
+ * A taken course joined with the catalogue's name for it.
+ *
+ * `user_taken_courses` stores only `course_code`, so the title is looked up per
+ * screen and falls back to the code when the lookup has not answered — the same
+ * fallback `UnreviewedCard` makes.
+ */
+export type TakenRow = TakenCourse & { name: string };
+
+/** One course a parsed transcript is offering. Nothing has been written yet. */
+export type ProposalRow = TranscriptProposal["candidates"][number];
+
+/** Exactly the input `taken.update` takes. */
+export type TakenUpdateInput = {
+  courseCode: string;
+  grade: string | null;
+  earnedCredits: number | null;
+  attendancePeriods: string | null;
+  attendanceYear: number | null;
+};
+
+/** The three self-reported fields the list lets a reader correct in place. */
+export type TakenEdits = {
+  grade: string | null;
+  earnedCredits: number | null;
+  attendanceYear: number | null;
+};
+
+export function toTakenRows(
+  courses: readonly TakenCourse[],
+  names: ReadonlyMap<string, string>,
+): TakenRow[] {
+  return courses.map((course) => ({
+    ...course,
+    name: names.get(course.courseCode) ?? course.courseCode,
+  }));
+}
+
+/**
+ * When this list was last filled in from a transcript, or null if none of it
+ * was. `transcript_imported_at` is the only thing that distinguishes an
+ * imported row from a hand-entered one, and a manual edit keeps it.
+ */
+export function lastTranscriptImport(
+  courses: readonly TakenCourse[],
+): string | null {
+  let latest: string | null = null;
+  for (const course of courses) {
+    const at = course.transcriptImportedAt;
+    if (at && (latest === null || at > latest)) latest = at;
+  }
+  return latest;
+}
+
+/**
+ * The whole row `taken.update` writes.
+ *
+ * `taken.update` replaces every self-reported field — its router says outright
+ * that omitting one "is the same as clearing it" — while the list only ever
+ * edits three. `attendancePeriods` is carried through from the stored row so
+ * that correcting a grade cannot silently erase a period, which the design's
+ * table has no column for and so could never show the reader losing.
+ */
+export function takenUpdateInput(
+  row: TakenCourse,
+  edits: TakenEdits,
+): TakenUpdateInput {
+  return {
+    courseCode: row.courseCode,
+    grade: edits.grade,
+    earnedCredits: edits.earnedCredits,
+    attendanceYear: edits.attendanceYear,
+    attendancePeriods: row.attendancePeriods,
+  };
+}
+
+/**
+ * What the reader confirmed, in the shape `transcript.confirm` takes.
+ *
+ * `includeGrades` is the design's "Read grades from transcript" switch. It is
+ * applied here, on the way into the write, because that is the only place it
+ * can bite: the parse happens on the server and always reads the grade column,
+ * so the switch drops grades from what gets stored rather than from what gets
+ * read. Nothing is written either way until this result is sent.
+ *
+ * `attendancePeriods` is absent by construction — a Ladok transcript has no
+ * period column and `ConfirmedTranscriptRow` omits the field for that reason.
+ */
+export function toConfirmedCourses(
+  rows: readonly ProposalRow[],
+  includeGrades: boolean,
+): Array<{
+  courseCode: string;
+  grade: string | null;
+  earnedCredits: number | null;
+  attendanceYear: number | null;
+}> {
+  return rows.map((row) => ({
+    courseCode: row.courseCode,
+    grade: includeGrades ? row.grade : null,
+    earnedCredits: row.earnedCredits,
+    attendanceYear: row.attendanceYear,
+  }));
+}
+
+/** `null` when the box is empty; `undefined` when what is in it is not credits. */
+export function parseCredits(text: string): number | null | undefined {
+  const trimmed = text.trim().replace(",", ".");
+  if (trimmed === "") return null;
+  const credits = Number(trimmed);
+  if (!Number.isFinite(credits) || credits < 0 || credits > 1000) {
+    return undefined;
+  }
+  return credits;
+}
+
+/**
+ * `null` when the box is empty; `undefined` when what is in it is not a year.
+ *
+ * The bounds are `taken.update`'s own — a year outside them is refused by the
+ * procedure, so the editor refuses to send it rather than showing a failure.
+ */
+export function parseYear(text: string): number | null | undefined {
+  const trimmed = text.trim();
+  if (trimmed === "") return null;
+  if (!/^\d{4}$/.test(trimmed)) return undefined;
+  const year = Number(trimmed);
+  return year >= 1900 && year <= 2200 ? year : undefined;
+}
+
+/** `null` when the box is empty. A grade is self-reported and never validated. */
+export function parseGrade(text: string): string | null {
+  const trimmed = text.trim().toUpperCase();
+  return trimmed === "" ? null : trimmed.slice(0, 16);
+}
+
+/** The edits an inline draft describes, or null while one of its boxes is unreadable. */
+export function draftEdits(draft: {
+  grade: string;
+  credits: string;
+  year: string;
+}): TakenEdits | null {
+  const earnedCredits = parseCredits(draft.credits);
+  const attendanceYear = parseYear(draft.year);
+  if (earnedCredits === undefined || attendanceYear === undefined) return null;
+  return { grade: parseGrade(draft.grade), earnedCredits, attendanceYear };
+}
+
+/** `7.5 hp`, or an em dash where the student reported no credits. */
+export function creditsLabel(credits: number | null): string {
+  return credits === null ? "—" : `${credits} hp`;
+}

--- a/apps/web/features/taken/lib/taken-rows.ts
+++ b/apps/web/features/taken/lib/taken-rows.ts
@@ -98,14 +98,9 @@ export type ConfirmedCourse = {
  * keep the edits you made — only new rows and missing fields are filled in."*
  * Two things in the write path make that a split rather than one call.
  *
- * `transcript.confirm` upserts, and its conflict clause sets **every**
- * self-reported column from the incoming row — including `attendance_periods`,
- * which `ConfirmedTranscriptRow` has no field for and which therefore arrives
- * as null. Sending a course the reader already has would overwrite the credits,
- * grade and year they corrected by hand, and erase the periods outright.
- *
  * So a course the reader does not have yet goes through `transcript.confirm`,
- * which is what stamps `transcript_imported_at`. A course they already have is
+ * which atomically inserts only absent rows and stamps `transcript_imported_at`.
+ * A course they already have is
  * only touched when the transcript can fill a field that is still empty, and
  * then through `taken.update`, which writes the whole row — stored values
  * included, periods carried — and leaves provenance alone.

--- a/apps/web/features/taken/lib/taken-rows.ts
+++ b/apps/web/features/taken/lib/taken-rows.ts
@@ -83,33 +83,92 @@ export function takenUpdateInput(
   };
 }
 
-/**
- * What the reader confirmed, in the shape `transcript.confirm` takes.
- *
- * `includeGrades` is the design's "Read grades from transcript" switch. It is
- * applied here, on the way into the write, because that is the only place it
- * can bite: the parse happens on the server and always reads the grade column,
- * so the switch drops grades from what gets stored rather than from what gets
- * read. Nothing is written either way until this result is sent.
- *
- * `attendancePeriods` is absent by construction — a Ladok transcript has no
- * period column and `ConfirmedTranscriptRow` omits the field for that reason.
- */
-export function toConfirmedCourses(
-  rows: readonly ProposalRow[],
-  includeGrades: boolean,
-): Array<{
+/** One row in the shape `transcript.confirm` takes. It carries no periods. */
+export type ConfirmedCourse = {
   courseCode: string;
   grade: string | null;
   earnedCredits: number | null;
   attendanceYear: number | null;
-}> {
-  return rows.map((row) => ({
-    courseCode: row.courseCode,
-    grade: includeGrades ? row.grade : null,
-    earnedCredits: row.earnedCredits,
-    attendanceYear: row.attendanceYear,
-  }));
+};
+
+/**
+ * What confirming a proposal actually does, split by what the write has to be.
+ *
+ * The design's own rule, from the update dialog: *"Courses already in your list
+ * keep the edits you made — only new rows and missing fields are filled in."*
+ * Two things in the write path make that a split rather than one call.
+ *
+ * `transcript.confirm` upserts, and its conflict clause sets **every**
+ * self-reported column from the incoming row — including `attendance_periods`,
+ * which `ConfirmedTranscriptRow` has no field for and which therefore arrives
+ * as null. Sending a course the reader already has would overwrite the credits,
+ * grade and year they corrected by hand, and erase the periods outright.
+ *
+ * So a course the reader does not have yet goes through `transcript.confirm`,
+ * which is what stamps `transcript_imported_at`. A course they already have is
+ * only touched when the transcript can fill a field that is still empty, and
+ * then through `taken.update`, which writes the whole row — stored values
+ * included, periods carried — and leaves provenance alone.
+ */
+export type TranscriptImportPlan = {
+  /** Courses with no row yet. Written by `transcript.confirm`, stamped imported. */
+  create: ConfirmedCourse[];
+  /** Rows that exist and have an empty field the transcript can fill. */
+  fill: TakenUpdateInput[];
+  /** Rows the reader already has with nothing missing. Nothing writes to these. */
+  unchanged: number;
+};
+
+/**
+ * Turns a proposal and the reader's current list into the writes to make.
+ *
+ * `includeGrades` is the design's "Read grades from transcript" switch. It is
+ * applied here, on the way into the write, because that is the only place it
+ * can bite: the parse runs on the server and always reads the grade column, so
+ * the switch drops grades from what gets *stored* rather than from what gets
+ * read. With the switch off no grade from the file is ever written — and a
+ * grade the reader typed in themselves is still left exactly where it is.
+ *
+ * Nothing is written by this function. It describes writes; the screen makes
+ * them, after the reader has confirmed.
+ */
+export function planTranscriptImport(
+  candidates: readonly ProposalRow[],
+  existing: readonly TakenCourse[],
+  includeGrades: boolean,
+): TranscriptImportPlan {
+  const stored = new Map(existing.map((row) => [row.courseCode, row]));
+  const plan: TranscriptImportPlan = { create: [], fill: [], unchanged: 0 };
+
+  for (const candidate of candidates) {
+    const grade = includeGrades ? candidate.grade : null;
+    const row = stored.get(candidate.courseCode);
+
+    if (!row) {
+      plan.create.push({
+        courseCode: candidate.courseCode,
+        grade,
+        earnedCredits: candidate.earnedCredits,
+        attendanceYear: candidate.attendanceYear,
+      });
+      continue;
+    }
+
+    const filled: TakenEdits = {
+      grade: row.grade ?? grade,
+      earnedCredits: row.earnedCredits ?? candidate.earnedCredits,
+      attendanceYear: row.attendanceYear ?? candidate.attendanceYear,
+    };
+    const fillsSomething =
+      filled.grade !== row.grade ||
+      filled.earnedCredits !== row.earnedCredits ||
+      filled.attendanceYear !== row.attendanceYear;
+
+    if (fillsSomething) plan.fill.push(takenUpdateInput(row, filled));
+    else plan.unchanged += 1;
+  }
+
+  return plan;
 }
 
 /** `null` when the box is empty; `undefined` when what is in it is not credits. */

--- a/apps/web/proxy.ts
+++ b/apps/web/proxy.ts
@@ -25,5 +25,5 @@ export function proxy(request: NextRequest) {
  * same commit that moved the page (#90).
  */
 export const config = {
-  matcher: ["/profile/:path*", "/saved/:path*"],
+  matcher: ["/profile/:path*", "/saved/:path*", "/taken/:path*"],
 };

--- a/apps/web/server/ingest/transcript/router.ts
+++ b/apps/web/server/ingest/transcript/router.ts
@@ -31,9 +31,15 @@ export const transcriptRouter = createTRPCRouter({
     .input(
       z.object({
         courses: z.array(confirmedCourse).max(MAX_CONFIRMED_COURSES),
+        fills: z.array(confirmedCourse).max(MAX_CONFIRMED_COURSES).default([]),
       }),
     )
     .mutation(({ ctx, input }) =>
-      confirmTranscriptImport(ctx.session.user.id, input.courses, new Date()),
+      confirmTranscriptImport(
+        ctx.session.user.id,
+        input.courses,
+        new Date(),
+        input.fills,
+      ),
     ),
 });

--- a/apps/web/server/ingest/transcript/service.spec.ts
+++ b/apps/web/server/ingest/transcript/service.spec.ts
@@ -92,7 +92,7 @@ describe("buildTranscriptProposal", () => {
 
     await buildTranscriptProposal(fixture("ladok-english.txt"));
 
-    expect(takenService.recordTakenCourses).not.toHaveBeenCalled();
+    expect(takenService.recordTranscriptCoursesIfAbsent).not.toHaveBeenCalled();
   });
 });
 
@@ -118,7 +118,7 @@ describe("confirmTranscriptImport", () => {
     vi.mocked(courseService.getSummariesByCodes).mockResolvedValue(
       catalogue("SF1625", "DD1337"),
     );
-    vi.mocked(takenService.recordTakenCourses).mockResolvedValue({
+    vi.mocked(takenService.recordTranscriptCoursesIfAbsent).mockResolvedValue({
       inserted: 2,
       updated: 0,
     });
@@ -129,8 +129,10 @@ describe("confirmTranscriptImport", () => {
       importedAt,
     );
 
-    expect(takenService.recordTakenCourses).toHaveBeenCalledTimes(1);
-    expect(takenService.recordTakenCourses).toHaveBeenCalledWith(
+    expect(takenService.recordTranscriptCoursesIfAbsent).toHaveBeenCalledTimes(
+      1,
+    );
+    expect(takenService.recordTranscriptCoursesIfAbsent).toHaveBeenCalledWith(
       "user-1",
       [
         {
@@ -146,7 +148,7 @@ describe("confirmTranscriptImport", () => {
           attendanceYear: 2023,
         },
       ],
-      { source: "transcript", importedAt },
+      importedAt,
     );
     expect(result).toEqual({ inserted: 2, updated: 0 });
   });
@@ -163,24 +165,27 @@ describe("confirmTranscriptImport", () => {
         importedAt,
       ),
     ).rejects.toBeInstanceOf(NotFoundError);
-    expect(takenService.recordTakenCourses).not.toHaveBeenCalled();
+    expect(takenService.recordTranscriptCoursesIfAbsent).not.toHaveBeenCalled();
   });
 
-  it("sends one row per course code when a transcript is imported twice", async () => {
+  it("delegates repeated transcript confirmations to the insert-only write", async () => {
     vi.mocked(courseService.getSummariesByCodes).mockResolvedValue(
       catalogue("SF1625", "DD1337"),
     );
-    vi.mocked(takenService.recordTakenCourses).mockResolvedValue({
+    vi.mocked(takenService.recordTranscriptCoursesIfAbsent).mockResolvedValue({
       inserted: 0,
-      updated: 2,
+      updated: 0,
     });
 
     await confirmTranscriptImport("user-1", confirmed, importedAt);
     await confirmTranscriptImport("user-1", confirmed, importedAt);
 
-    expect(takenService.recordTakenCourses).toHaveBeenCalledTimes(2);
-    for (const [, rows] of vi.mocked(takenService.recordTakenCourses).mock
-      .calls) {
+    expect(takenService.recordTranscriptCoursesIfAbsent).toHaveBeenCalledTimes(
+      2,
+    );
+    for (const [, rows] of vi.mocked(
+      takenService.recordTranscriptCoursesIfAbsent,
+    ).mock.calls) {
       expect(rows.map((row) => row.courseCode)).toEqual(["SF1625", "DD1337"]);
     }
   });
@@ -189,7 +194,7 @@ describe("confirmTranscriptImport", () => {
     vi.mocked(courseService.getSummariesByCodes).mockResolvedValue(
       catalogue("SF1625"),
     );
-    vi.mocked(takenService.recordTakenCourses).mockResolvedValue({
+    vi.mocked(takenService.recordTranscriptCoursesIfAbsent).mockResolvedValue({
       inserted: 1,
       updated: 0,
     });
@@ -200,7 +205,8 @@ describe("confirmTranscriptImport", () => {
       importedAt,
     );
 
-    const [, rows] = vi.mocked(takenService.recordTakenCourses).mock.calls[0];
+    const [, rows] = vi.mocked(takenService.recordTranscriptCoursesIfAbsent)
+      .mock.calls[0];
     expect(rows).toEqual([
       {
         courseCode: "SF1625",
@@ -215,7 +221,7 @@ describe("confirmTranscriptImport", () => {
     const result = await confirmTranscriptImport("user-1", [], importedAt);
 
     expect(result).toEqual({ inserted: 0, updated: 0 });
-    expect(takenService.recordTakenCourses).not.toHaveBeenCalled();
+    expect(takenService.recordTranscriptCoursesIfAbsent).not.toHaveBeenCalled();
     expect(courseService.getSummariesByCodes).not.toHaveBeenCalled();
   });
 });

--- a/apps/web/server/ingest/transcript/service.ts
+++ b/apps/web/server/ingest/transcript/service.ts
@@ -1,6 +1,7 @@
 import { getSummariesByCodes } from "../../course/service";
 import { NotFoundError } from "../../errors";
 import {
+  fillTranscriptCourseFields,
   recordTranscriptCoursesIfAbsent,
   type TakenCourseInput,
 } from "../../taken/service";
@@ -102,6 +103,7 @@ export async function confirmTranscriptImport(
   userId: string,
   rows: ConfirmedTranscriptRow[],
   importedAt: Date,
+  fills: ConfirmedTranscriptRow[] = [],
 ): Promise<{ inserted: number; updated: number }> {
   const inputs: TakenCourseInput[] = rows.map((row) => ({
     courseCode: row.courseCode.trim().toUpperCase(),
@@ -111,7 +113,13 @@ export async function confirmTranscriptImport(
   }));
   if (inputs.length === 0) return { inserted: 0, updated: 0 };
 
-  const codes = inputs.map((input) => input.courseCode);
+  const fillInputs: TakenCourseInput[] = fills.map((row) => ({
+    courseCode: row.courseCode.trim().toUpperCase(),
+    grade: row.grade ?? null,
+    earnedCredits: row.earnedCredits ?? null,
+    attendanceYear: row.attendanceYear ?? null,
+  }));
+  const codes = [...inputs, ...fillInputs].map((input) => input.courseCode);
   const known = new Set(
     (await getSummariesByCodes(codes)).map((summary) => summary.courseCode),
   );
@@ -122,5 +130,16 @@ export async function confirmTranscriptImport(
     );
   }
 
-  return recordTranscriptCoursesIfAbsent(userId, inputs, importedAt);
+  const created = await recordTranscriptCoursesIfAbsent(
+    userId,
+    inputs,
+    importedAt,
+  );
+  return {
+    inserted: created.inserted,
+    updated:
+      fillInputs.length > 0
+        ? await fillTranscriptCourseFields(userId, fillInputs)
+        : 0,
+  };
 }

--- a/apps/web/server/ingest/transcript/service.ts
+++ b/apps/web/server/ingest/transcript/service.ts
@@ -1,6 +1,9 @@
 import { getSummariesByCodes } from "../../course/service";
 import { NotFoundError } from "../../errors";
-import { recordTakenCourses, type TakenCourseInput } from "../../taken/service";
+import {
+  recordTranscriptCoursesIfAbsent,
+  type TakenCourseInput,
+} from "../../taken/service";
 import { matchCandidates, type UnmatchedCandidate } from "./match";
 import { parseLadokTranscript, type TranscriptCandidate } from "./parse";
 
@@ -91,9 +94,9 @@ export type ConfirmedTranscriptRow = Omit<
  * client from confirming a code that was never proposed. Only catalogue courses
  * become taken courses.
  *
- * The write itself belongs to `server/taken`. Its upsert is what makes a second
- * import of the same transcript update rather than duplicate, and it collapses
- * a course code repeated inside one batch; neither is re-implemented here.
+ * The write itself belongs to `server/taken`. It inserts only when the user
+ * does not already have a row for the course, so a manual entry that races this
+ * confirmation is never overwritten by transcript values.
  */
 export async function confirmTranscriptImport(
   userId: string,
@@ -119,8 +122,5 @@ export async function confirmTranscriptImport(
     );
   }
 
-  return recordTakenCourses(userId, inputs, {
-    source: "transcript",
-    importedAt,
-  });
+  return recordTranscriptCoursesIfAbsent(userId, inputs, importedAt);
 }

--- a/apps/web/server/taken/repository.ts
+++ b/apps/web/server/taken/repository.ts
@@ -88,6 +88,40 @@ export async function upsertTakenCourses(
 }
 
 /**
+ * Inserts transcript rows without replacing a row that another client already
+ * recorded. The primary-key conflict decision happens in PostgreSQL with the
+ * insert, so a manual write that lands between a browser's list refresh and
+ * transcript confirmation is preserved.
+ *
+ * Returns the codes that this statement actually inserted. `ON CONFLICT DO
+ * NOTHING` also handles a course duplicated within one transcript batch.
+ */
+export async function insertTakenCoursesIfAbsent(
+  userId: string,
+  rows: TakenCourseWrite[],
+  importedAt: Date,
+): Promise<string[]> {
+  if (rows.length === 0) return [];
+  const inserted = await db
+    .insert(schema.userTakenCourses)
+    .values(
+      rows.map((row) => ({
+        userId,
+        ...row,
+        transcriptImportedAt: importedAt,
+      })),
+    )
+    .onConflictDoNothing({
+      target: [
+        schema.userTakenCourses.userId,
+        schema.userTakenCourses.courseCode,
+      ],
+    })
+    .returning({ courseCode: schema.userTakenCourses.courseCode });
+  return inserted.map((row) => row.courseCode);
+}
+
+/**
  * Edits an existing row and nothing else. One statement, so a concurrent
  * delete cannot slip between a check and the write and be undone by it —
  * unlike `upsertTakenCourses`, this never inserts.

--- a/apps/web/server/taken/repository.ts
+++ b/apps/web/server/taken/repository.ts
@@ -121,6 +121,29 @@ export async function insertTakenCoursesIfAbsent(
   return inserted.map((row) => row.courseCode);
 }
 
+/** Fills only fields that are still null, preserving concurrent edits. */
+export async function fillTakenCourseFieldsIfEmpty(
+  userId: string,
+  row: TakenCourseWrite,
+): Promise<boolean> {
+  const updated = await db
+    .update(schema.userTakenCourses)
+    .set({
+      grade: sql`coalesce(${schema.userTakenCourses.grade}, ${row.grade})`,
+      earnedCredits: sql`coalesce(${schema.userTakenCourses.earnedCredits}, ${row.earnedCredits})`,
+      attendanceYear: sql`coalesce(${schema.userTakenCourses.attendanceYear}, ${row.attendanceYear})`,
+      updatedAt: new Date(),
+    })
+    .where(
+      and(
+        eq(schema.userTakenCourses.userId, userId),
+        eq(schema.userTakenCourses.courseCode, row.courseCode),
+      ),
+    )
+    .returning({ courseCode: schema.userTakenCourses.courseCode });
+  return updated.length > 0;
+}
+
 /**
  * Edits an existing row and nothing else. One statement, so a concurrent
  * delete cannot slip between a check and the write and be undone by it —

--- a/apps/web/server/taken/service.spec.ts
+++ b/apps/web/server/taken/service.spec.ts
@@ -5,6 +5,7 @@ import {
   addTakenCourse,
   listTakenCourses,
   recordTakenCourses,
+  recordTranscriptCoursesIfAbsent,
   removeTakenCourse,
   updateTakenCourse,
 } from "./service";
@@ -140,6 +141,35 @@ describe("recordTakenCourses", () => {
     const result = await recordTakenCourses("u1", [], { source: "manual" });
 
     expect(result).toEqual({ inserted: 0, updated: 0 });
+    expect(takenRepo.upsertTakenCourses).not.toHaveBeenCalled();
+  });
+});
+
+describe("recordTranscriptCoursesIfAbsent", () => {
+  it("uses an atomic insert-only write so an existing row is preserved", async () => {
+    vi.mocked(takenRepo.insertTakenCoursesIfAbsent).mockResolvedValue([]);
+
+    await expect(
+      recordTranscriptCoursesIfAbsent(
+        "u1",
+        [{ courseCode: "SF1625", grade: "A" }],
+        importedAt,
+      ),
+    ).resolves.toEqual({ inserted: 0, updated: 0 });
+
+    expect(takenRepo.insertTakenCoursesIfAbsent).toHaveBeenCalledWith(
+      "u1",
+      [
+        {
+          courseCode: "SF1625",
+          grade: "A",
+          earnedCredits: null,
+          attendancePeriods: null,
+          attendanceYear: null,
+        },
+      ],
+      importedAt,
+    );
     expect(takenRepo.upsertTakenCourses).not.toHaveBeenCalled();
   });
 });

--- a/apps/web/server/taken/service.ts
+++ b/apps/web/server/taken/service.ts
@@ -108,6 +108,26 @@ export async function recordTakenCourses(
   return { inserted: deduped.length - updated, updated };
 }
 
+/**
+ * Records transcript rows only when no taken-course row exists yet.
+ *
+ * Unlike the manual upsert path, transcript confirmation must never overwrite
+ * a course the reader added or corrected in another session. The repository
+ * makes that decision atomically with `ON CONFLICT DO NOTHING`.
+ */
+export async function recordTranscriptCoursesIfAbsent(
+  userId: string,
+  rows: TakenCourseInput[],
+  importedAt: Date,
+): Promise<{ inserted: number; updated: number }> {
+  const inserted = await takenRepo.insertTakenCoursesIfAbsent(
+    userId,
+    dedupeByCourseCode(rows).map(toWrite),
+    importedAt,
+  );
+  return { inserted: inserted.length, updated: 0 };
+}
+
 /** Records one course the user says they took. Idempotent. */
 export async function addTakenCourse(
   userId: string,

--- a/apps/web/server/taken/service.ts
+++ b/apps/web/server/taken/service.ts
@@ -128,6 +128,20 @@ export async function recordTranscriptCoursesIfAbsent(
   return { inserted: inserted.length, updated: 0 };
 }
 
+/** Atomically fills transcript facts only where the stored row is still empty. */
+export async function fillTranscriptCourseFields(
+  userId: string,
+  rows: TakenCourseInput[],
+): Promise<number> {
+  let updated = 0;
+  for (const row of dedupeByCourseCode(rows)) {
+    if (await takenRepo.fillTakenCourseFieldsIfEmpty(userId, toWrite(row))) {
+      updated += 1;
+    }
+  }
+  return updated;
+}
+
 /** Records one course the user says they took. Idempotent. */
 export async function addTakenCourse(
   userId: string,


### PR DESCRIPTION
Builds `/taken` from `docs/design/Course Community - Taken Courses.dc.html`: the list of a reader's taken courses, adding one by hand, correcting the self-reported fields in place, removing one, and reading a Ladok transcript.

Closes #92

## What it does

- **The list.** `taken.list` joined with `course.summary` for the titles — `user_taken_courses` stores only a course code, so the lookup is the screen's job and a name that has not arrived falls back to the code. Code, course, credits, grade, year, reviewed, actions, as the artboard's own seven columns.
- **Add by hand.** A catalogue search (`search.courses`) picks the course; credits, grade and year are the reader's own entries.
- **Edit in place.** The pencil opens the artboard's inline editor for credits, grade and year, on every row regardless of where the row came from — a transcript is not authoritative, and `taken.update` preserves `transcript_imported_at`, so an edit keeps its provenance.
- **Remove**, with an undo that puts the whole record back.
- **Transcript import.** `POST /api/user/transcript` reads the file and returns a proposal; nothing is written until "Looks right". A re-read adds the courses that are new and fills the fields that are empty, and never overwrites a correction the reader made by hand — see contradiction 12. Unmatched course codes are named on the confirm screen. An unreadable file gets the artboard's failure screen, which says outright that nothing was saved — because nothing was.
- **The rail's "Taken courses" entry is back**, which #85 deferred only because the route did not exist. `/taken` is titled in the mobile header and added to `proxy.ts`'s matcher.

## The transcript file

It is a parameter to `uploadTranscript` and nothing else. It never becomes component state, never reaches `localStorage`, and is not held by a mutation either — that is why `uploadTranscript` is a plain async function rather than the `useMutation` wrapper the other `api/` files expose: a mutation keeps its last `variables` for as long as its hook is mounted, and the variable here is a student's academic record. What is kept, until the reader confirms or discards it, is the proposal, which holds no file.

## Consumed, not rebuilt

`useUnreviewedTakenCourses`, `UnreviewedCard` (#88), `PageColumn` / `PageHeader` (#85), `useSearchCourses` (#89). `taken.add` still has exactly one write path: `useTakenMutations().add` **is** the course card's `useMarkCourseTaken`, so the two surfaces share one set of cache keys.

## Design vs schema — every contradiction I hit

Per #68's precedence rule: design decides layout, spacing, type, colour, copy, states and responsive; the schema decides what data exists, what it is called, its shape and nullability.

1. **Free-form courses cannot exist.** The artboard's add modal offers `Add "<query>" as a free-form course` — a taken row with no course code — and carries a `match: "freeform"` state through the list, the badges and the reviewer. `user_taken_courses.course_code` is `NOT NULL` with a foreign key to `courses.code`. **Minimal change:** the add form fills code and name from a catalogue search; the free-form path, its explanatory note and the per-row "Free-form course" / "No catalog match" badges are gone. The artboard's own script agrees with the schema here (`"Rows with no catalog match cannot be stored — user_taken_courses has an FK to courses.code"`); only its UI does not.

2. **`taken.update` replaces the whole row.** The artboard's inline editor writes three fields; the procedure's own comment says an omitted field "is the same as clearing it". `attendance_periods` has no column in the design's table, so editing a grade would have silently erased it. `takenUpdateInput` carries the stored value through. Tested in both projects.

3. **The grades switch is not a parse option.** The artboard says grade columns are "left out of the parse, so no grade of yours is stored anywhere". The parse runs on the server and always reads the grade column; there is no request flag and adding one would be server work. **Minimal change:** the copy now says grades are dropped when you confirm, and `planTranscriptImport` strips them from the write. The promise the design actually makes still holds — with the switch off, no grade of the reader's is stored.

4. **10 MB vs 4 MB.** The artboard says "PDF from Ladok · up to 10 MB" in both drop zones. `app/api/user/transcript/route.ts` caps the body at 4 MB and returns 413 above it. The copy follows the server, and the client refuses an oversized file before uploading it.

5. **The "Correct what the parser read" modal has nothing left to correct.** Its fields are code, name and term, and it offers "Revert to the parsed values" against a stored snapshot of what the parse said. Code and name belong to the catalogue, and nothing persists what a parse originally read. Dropped; the row's in-place editor covers the three fields that really are the reader's.

6. **"New" and "Edited" row badges have nothing behind them.** They are session-local flags on the artboard's client state. The durable distinction is `transcript_imported_at` — the one thing that separates an imported row from a manual one — shown as an "Imported" chip on the row and as "Last read 24 Aug 2026" / "Added by hand" in the header.

7. **Undo is offered on hand-entered rows only.** Restoring a removed row goes through `taken.add`, which writes no `transcript_imported_at` and gives no way to set one, so undoing the removal of an imported row would quietly re-label it hand-entered. Rather than lie about provenance, the toast for an imported row carries no Undo.

8. **The proposal has no per-row issues.** The artboard's `checkHeadline` ("N rows need your eyes") counts rows with an `issue` — "No grade in this row of the file" and so on. `TranscriptProposal` reports `candidates` and `unmatched`, nothing else. The confirm screen shows the count and the unmatched list.

9. **The confirm screen lists what it is about to write.** This is the one place I went *past* the artboard rather than trimming it: its `isPreview` screen shows a count, the skipped panel and one button, and no list of the rows. A screen whose single button writes to a reader's academic record has to show what it is about to write, so the candidates are listed in a compact scroller. Everything else on that screen is the artboard's.

10. **The quick reviewer is the review form, not a second one.** The artboard draws a bespoke card stack with its own examination-split dragger, theory slider, two 1–10 sliders, happy-took pair and text box — the same six answers `Review` (#87) already collects, on the same 1–10 scale. Building it would give one review two forms, two validators and two write paths. `UnreviewedCard`'s `onSelect` and `onStart` fill a queue instead and each course opens `Review` in place, which is what #88 built `onSelect` for. Two knock-ons worth naming:
    - The artboard makes the review's text optional ("Optional. You can write the full review later"); `reviewFormSchema({ requireMessage: true })` requires prose for a *first* review. The codebase wins.
    - The artboard's `METHODS` has the design's five examination keys; the schema has six (`seminars`). `Review` already handles six, which is another reason not to draw a second form.

11. **`transcript.confirm` cannot be the whole write.** The design's update dialog promises *"Courses already in your list keep the edits you made — only new rows and missing fields are filled in."* `transcript.confirm` upserts, and its conflict clause sets every self-reported column from the incoming row, `attendance_periods` included — a column `ConfirmedTranscriptRow` has no field for, so it arrives as null. Sending a course the reader already has would replace the credits, grade and year they corrected and erase the periods. **Minimal change, no server work:** `planTranscriptImport` splits the write. A course with no row yet goes through `transcript.confirm`, which is what stamps `transcript_imported_at`; a course the reader already has is touched only to fill a field that is still empty, and then through `taken.update`, which writes the whole row with the stored values and the periods carried, and leaves provenance alone. Found by Greptile; see round 1 on this PR.

12. **Where the rail entry goes.** #85's note said "third in the list, between 'Saved courses' and 'My Page'" in the same breath as calling it "the rail's fourth link". `Explore.dc.html` and `Taken Courses.dc.html` both order the group Explore, Saved courses, My Page, Taken courses. It is fourth.

**No `--cc-*` token was invented.** The artboard's raw hexes for the success banner (`#e9f3ef` / `#1c6b60`), the failure screen (`#fbeceb` / `#a3452a`) and the grade pill (`#fdf7ea` / `#6b4c0d`) are `--cc-success`, `--cc-danger` and `--cc-pill` with token-derived alpha instead.

## Shared code touched

- `Review` gains `triggerless` (renders no trigger button of its own) and its `onEditingClose` is renamed `onClose`, since it already fired on every close and Taken courses needs it to advance its queue. One call site updated.
- `@/features/courses` now exports `useTakenCourses` and `useMarkCourseTaken`; `@/features/search` now exports `useSearchCourses` and `useDebouncedQuery`. Both so a second surface shares one query key rather than wrapping the same procedure again.

## Never touched

`docs/design/` is unchanged.

## Gates

`bun run test:web` (547 passing, 48 files), `npx tsc --noEmit`, `bun run lint` all green. New `ui` tests cover the list, the manual/imported split, add, edit, remove and undo, an upload producing a proposal, confirm writing it, unmatched codes visible, discarding without writing, an unparseable file erroring without writing, the in-place reviewer, a re-read leaving a corrected course alone while filling an empty field, and a refused write keeping the reader's draft.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01D3d7V2JceJZvtJED18HXFJ
