### PR TITLE
feat(explore): enforce viewport results-scroll contract

### DIFF
--- a/apps/web/app/globals.css
+++ b/apps/web/app/globals.css
@@ -322,6 +322,17 @@
   }
 }
 
+/* Explore owns its list's scroll surface. Hiding its rail keeps that surface
+   visually quiet while retaining wheel, touch, keyboard, and programmatic
+   scrolling. */
+@utility scrollbar-hidden {
+  scrollbar-width: none;
+
+  &::-webkit-scrollbar {
+    display: none;
+  }
+}
+
 /* Course Community surfaces cross-fade between themes. Scoped to the opted-in
    subtree — a global `*` transition would animate every existing screen too. */
 @utility cc-theme {

--- a/apps/web/features/search/components/explore.spec.tsx
+++ b/apps/web/features/search/components/explore.spec.tsx
@@ -1,4 +1,10 @@
-import { render, screen, waitFor, within } from "@testing-library/react";
+import {
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+  within,
+} from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { CourseSummary } from "@/types";
@@ -10,6 +16,7 @@ const useMe = vi.fn();
 const useSearchCourses = vi.fn();
 
 let search = "";
+let containerWidth = 500;
 
 vi.mock("next/navigation", () => ({
   useRouter: () => ({ push, replace }),
@@ -95,11 +102,26 @@ function results(...courses: CourseSummary[]) {
 
 beforeEach(() => {
   search = "";
-  vi.stubGlobal("matchMedia", () => ({
-    matches: false,
-    addEventListener: vi.fn(),
-    removeEventListener: vi.fn(),
-  }));
+  containerWidth = 500;
+  window.sessionStorage.clear();
+  push.mockClear();
+  replace.mockClear();
+  vi.stubGlobal(
+    "ResizeObserver",
+    class {
+      constructor(private readonly callback: ResizeObserverCallback) {}
+
+      observe() {
+        this.callback(
+          [{ contentRect: { width: containerWidth } } as ResizeObserverEntry],
+          this as unknown as ResizeObserver,
+        );
+      }
+
+      disconnect() {}
+      unobserve() {}
+    },
+  );
   useMe.mockReturnValue({ user: { userId: "u1", savedCourseCodes: [] } });
   useSearchCourses.mockReturnValue(results());
 });
@@ -170,11 +192,7 @@ describe("Explore", () => {
     });
 
     it("opens courses in the resizable desktop workspace", async () => {
-      vi.stubGlobal("matchMedia", () => ({
-        matches: true,
-        addEventListener: vi.fn(),
-        removeEventListener: vi.fn(),
-      }));
+      containerWidth = 900;
       render(<Explore />);
 
       await userEvent.click(
@@ -189,6 +207,42 @@ describe("Explore", () => {
         screen.getByRole("button", { name: "Resize workspace" }),
       ).toHaveAttribute("title", "Drag to resize · double-click to reset");
       expect(push).not.toHaveBeenCalled();
+    });
+
+    it("continues to route at an intermediate container width", async () => {
+      containerWidth = 767;
+      render(<Explore />);
+
+      await userEvent.click(
+        within(screen.getAllByRole("article")[0] as HTMLElement).getByRole(
+          "button",
+          { name: /Artificial Intelligence/ },
+        ),
+      );
+
+      expect(push).toHaveBeenCalledWith("/course/DD2380");
+      expect(screen.queryByLabelText("Open courses")).not.toBeInTheDocument();
+    });
+
+    it("stops resizing when a pointer gesture is cancelled", async () => {
+      containerWidth = 900;
+      render(<Explore />);
+      await userEvent.click(
+        within(screen.getAllByRole("article")[0] as HTMLElement).getByRole(
+          "button",
+          { name: /Artificial Intelligence/ },
+        ),
+      );
+
+      const host = screen.getByTestId("workspace-pane-host");
+      const resize = screen.getByRole("button", { name: "Resize workspace" });
+      expect(host).toHaveStyle({ width: "412px" });
+
+      fireEvent.pointerDown(resize, { clientX: 500 });
+      fireEvent.pointerCancel(window);
+      fireEvent.pointerMove(window, { clientX: 800 });
+
+      expect(host).toHaveStyle({ width: "412px" });
     });
   });
 

--- a/apps/web/features/search/components/explore.spec.tsx
+++ b/apps/web/features/search/components/explore.spec.tsx
@@ -47,6 +47,13 @@ vi.mock("@/features/courses/api/mutations", () => ({
 
 vi.mock("sonner", () => ({ toast: { error: vi.fn() } }));
 
+// Explore owns the viewport contract; the pane's detailed content is covered
+// in its own suite. This keeps the desktop interaction test focused on the
+// host and avoids pulling its editor CSS into this screen test.
+vi.mock("@/features/workspace/components/workspace-pane", () => ({
+  WorkspacePane: () => <section aria-label="Open courses" />,
+}));
+
 // `toSearchCoursesInput` stays real: that the browser sends a star threshold and
 // never a 1-10 score is the point of it (#67).
 vi.mock("../api/queries", async (importOriginal) => ({
@@ -88,6 +95,11 @@ function results(...courses: CourseSummary[]) {
 
 beforeEach(() => {
   search = "";
+  vi.stubGlobal("matchMedia", () => ({
+    matches: false,
+    addEventListener: vi.fn(),
+    removeEventListener: vi.fn(),
+  }));
   useMe.mockReturnValue({ user: { userId: "u1", savedCourseCodes: [] } });
   useSearchCourses.mockReturnValue(results());
 });
@@ -145,6 +157,38 @@ describe("Explore", () => {
         ),
       );
       expect(push).toHaveBeenCalledWith("/course/DD2380");
+    });
+
+    it("keeps the results as the only mobile scrolling surface", () => {
+      render(<Explore />);
+
+      expect(screen.getByTestId("explore-results")).toHaveClass(
+        "scrollbar-hidden",
+        "overflow-y-auto",
+      );
+      expect(screen.queryByLabelText("Open courses")).not.toBeInTheDocument();
+    });
+
+    it("opens courses in the resizable desktop workspace", async () => {
+      vi.stubGlobal("matchMedia", () => ({
+        matches: true,
+        addEventListener: vi.fn(),
+        removeEventListener: vi.fn(),
+      }));
+      render(<Explore />);
+
+      await userEvent.click(
+        within(screen.getAllByRole("article")[0] as HTMLElement).getByRole(
+          "button",
+          { name: /Artificial Intelligence/ },
+        ),
+      );
+
+      expect(screen.getByLabelText("Open courses")).toBeInTheDocument();
+      expect(
+        screen.getByRole("button", { name: "Resize workspace" }),
+      ).toHaveAttribute("title", "Drag to resize · double-click to reset");
+      expect(push).not.toHaveBeenCalled();
     });
   });
 

--- a/apps/web/features/search/components/explore.spec.tsx
+++ b/apps/web/features/search/components/explore.spec.tsx
@@ -187,6 +187,7 @@ describe("Explore", () => {
       expect(screen.getByTestId("explore-results")).toHaveClass(
         "scrollbar-hidden",
         "overflow-y-auto",
+        "max-w-[1136px]",
       );
       expect(screen.queryByLabelText("Open courses")).not.toBeInTheDocument();
     });

--- a/apps/web/features/search/components/explore.tsx
+++ b/apps/web/features/search/components/explore.tsx
@@ -128,7 +128,7 @@ export function Explore() {
           ref={resultsRef}
           data-testid="explore-results"
           className={`scrollbar-hidden min-h-0 min-w-0 flex-1 overflow-x-hidden overflow-y-auto ${
-            workspace.hasOpenCourses ? "max-w-none" : "mx-auto max-w-[1148px]"
+            workspace.hasOpenCourses ? "max-w-none" : "mx-auto max-w-[1136px]"
           }`}
         >
           <div className="flex min-w-0 flex-col gap-3.5">

--- a/apps/web/features/search/components/explore.tsx
+++ b/apps/web/features/search/components/explore.tsx
@@ -7,7 +7,7 @@ import { useCallback, useEffect, useRef, useState } from "react";
 import { AuthReasonDialog } from "@/features/auth";
 import { CourseCardItem, courseCardGeometry } from "@/features/courses";
 import { PageColumn, PageHeader } from "@/features/shell";
-import { useWorkspacePane } from "@/features/workspace/hooks/use-workspace-pane";
+import { useWorkspacePane } from "@/features/workspace";
 import {
   MAX_RATING_STARS,
   RATING_STAR_OPTIONS,
@@ -18,10 +18,7 @@ import { useResultsWidth } from "../hooks/use-results-width";
 // The pane is inactive for ordinary browsing and has its own data-heavy
 // details/review views. Load it only once a desktop reader opens a course.
 const WorkspacePane = dynamic(
-  () =>
-    import("@/features/workspace/components/workspace-pane").then(
-      (module) => module.WorkspacePane,
-    ),
+  () => import("@/features/workspace").then((module) => module.WorkspacePane),
   { ssr: false },
 );
 
@@ -68,7 +65,8 @@ const WorkspacePane = dynamic(
 export function Explore() {
   const explore = useExplore();
   const workspace = useWorkspacePane();
-  const [desktopWorkspace, setDesktopWorkspace] = useState(false);
+  const containerRef = useRef<HTMLDivElement>(null);
+  const desktopWorkspace = useContainerBreakpoint(containerRef, 768);
   const rowRef = useRef<HTMLDivElement>(null);
   const pane = useWorkspaceWidth(rowRef, workspace.hasOpenCourses);
   const [resultsRef, resultsWidth] = useResultsWidth();
@@ -80,15 +78,6 @@ export function Explore() {
   // The desktop pane intentionally does not replace the mobile course route:
   // #133 owns the mobile sheet host. Keeping that established route means a
   // phone's Drawer and course controls remain keyboard-reachable today.
-  useEffect(() => {
-    if (typeof window.matchMedia !== "function") return;
-    const query = window.matchMedia("(min-width: 768px)");
-    const sync = () => setDesktopWorkspace(query.matches);
-    sync();
-    query.addEventListener("change", sync);
-    return () => query.removeEventListener("change", sync);
-  }, []);
-
   function openCourse(courseCode: string, kind: "details" | "review") {
     if (desktopWorkspace) {
       workspace.open(courseCode, kind);
@@ -102,6 +91,7 @@ export function Explore() {
     <PageColumn
       className="h-full min-h-0 overflow-hidden"
       contentClassName="h-full min-h-0 pb-0"
+      containerRef={containerRef}
     >
       <PageHeader
         title="Explore courses"
@@ -205,6 +195,7 @@ export function Explore() {
 
         {workspace.hasOpenCourses ? (
           <div
+            data-testid="workspace-pane-host"
             className="relative hidden min-h-0 min-w-[356px] @3xl:flex"
             style={{ width: pane.width }}
           >
@@ -228,6 +219,28 @@ export function Explore() {
       />
     </PageColumn>
   );
+}
+
+/** Matches Explore's `@3xl` layout transition against the actual container,
+ * not the wider browser viewport. */
+function useContainerBreakpoint(
+  containerRef: React.RefObject<HTMLDivElement | null>,
+  minimumWidth: number,
+) {
+  const [matches, setMatches] = useState(false);
+
+  useEffect(() => {
+    const container = containerRef.current;
+    if (!container || typeof ResizeObserver !== "function") return;
+    const observer = new ResizeObserver(([entry]) => {
+      const width = entry?.contentRect.width ?? container.clientWidth;
+      setMatches(width >= minimumWidth);
+    });
+    observer.observe(container);
+    return () => observer.disconnect();
+  }, [containerRef, minimumWidth]);
+
+  return matches;
 }
 
 const RESULTS_FLOOR = 470;
@@ -274,18 +287,20 @@ function WorkspaceResizeHandle({
 }: {
   pane: ReturnType<typeof useWorkspaceWidth>;
 }) {
-  const start = useRef<{ x: number; width: number } | null>(null);
+  const drag = useRef<{
+    onMove: (event: PointerEvent) => void;
+  } | null>(null);
 
-  function finish() {
-    start.current = null;
-    window.removeEventListener("pointermove", onMove);
+  const finish = useCallback(() => {
+    const activeDrag = drag.current;
+    if (!activeDrag) return;
+    window.removeEventListener("pointermove", activeDrag.onMove);
     window.removeEventListener("pointerup", finish);
-  }
+    window.removeEventListener("pointercancel", finish);
+    drag.current = null;
+  }, []);
 
-  function onMove(event: PointerEvent) {
-    if (!start.current) return;
-    pane.resize(start.current.width - (event.clientX - start.current.x));
-  }
+  useEffect(() => finish, [finish]);
 
   return (
     <button
@@ -295,9 +310,16 @@ function WorkspaceResizeHandle({
       onDoubleClick={pane.reset}
       onPointerDown={(event) => {
         event.preventDefault();
-        start.current = { x: event.clientX, width: pane.width };
+        finish();
+        const startX = event.clientX;
+        const startWidth = pane.width;
+        const onMove = (moveEvent: PointerEvent) => {
+          pane.resize(startWidth - (moveEvent.clientX - startX));
+        };
+        drag.current = { onMove };
         window.addEventListener("pointermove", onMove);
         window.addEventListener("pointerup", finish, { once: true });
+        window.addEventListener("pointercancel", finish, { once: true });
       }}
       className="-left-[14px] absolute top-0 hidden h-full w-[11px] cursor-col-resize items-center justify-center @3xl:flex"
     >

--- a/apps/web/features/search/components/explore.tsx
+++ b/apps/web/features/search/components/explore.tsx
@@ -1,16 +1,29 @@
 "use client";
 
 import { RotateCcw, Search as SearchIcon, TriangleAlert } from "lucide-react";
+import dynamic from "next/dynamic";
 import type { ReactNode } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import { AuthReasonDialog } from "@/features/auth";
 import { CourseCardItem, courseCardGeometry } from "@/features/courses";
 import { PageColumn, PageHeader } from "@/features/shell";
+import { useWorkspacePane } from "@/features/workspace/hooks/use-workspace-pane";
 import {
   MAX_RATING_STARS,
   RATING_STAR_OPTIONS,
   useExplore,
 } from "../hooks/use-explore";
 import { useResultsWidth } from "../hooks/use-results-width";
+
+// The pane is inactive for ordinary browsing and has its own data-heavy
+// details/review views. Load it only once a desktop reader opens a course.
+const WorkspacePane = dynamic(
+  () =>
+    import("@/features/workspace/components/workspace-pane").then(
+      (module) => module.WorkspacePane,
+    ),
+  { ssr: false },
+);
 
 /**
  * Explore: the search-and-browse workspace, and the app's front door to the
@@ -54,20 +67,48 @@ import { useResultsWidth } from "../hooks/use-results-width";
  */
 export function Explore() {
   const explore = useExplore();
+  const workspace = useWorkspacePane();
+  const [desktopWorkspace, setDesktopWorkspace] = useState(false);
+  const rowRef = useRef<HTMLDivElement>(null);
+  const pane = useWorkspaceWidth(rowRef, workspace.hasOpenCourses);
   const [resultsRef, resultsWidth] = useResultsWidth();
   const geo = courseCardGeometry(resultsWidth);
 
   const { results, hasQuery, isLoading, isError } = explore;
   const showEmpty = hasQuery && !isLoading && !isError && results.length === 0;
 
+  // The desktop pane intentionally does not replace the mobile course route:
+  // #133 owns the mobile sheet host. Keeping that established route means a
+  // phone's Drawer and course controls remain keyboard-reachable today.
+  useEffect(() => {
+    if (typeof window.matchMedia !== "function") return;
+    const query = window.matchMedia("(min-width: 768px)");
+    const sync = () => setDesktopWorkspace(query.matches);
+    sync();
+    query.addEventListener("change", sync);
+    return () => query.removeEventListener("change", sync);
+  }, []);
+
+  function openCourse(courseCode: string, kind: "details" | "review") {
+    if (desktopWorkspace) {
+      workspace.open(courseCode, kind);
+      return;
+    }
+    if (kind === "details") explore.onOpenCourse(courseCode);
+    else explore.onReviewCourse(courseCode);
+  }
+
   return (
-    <PageColumn>
+    <PageColumn
+      className="h-full min-h-0 overflow-hidden"
+      contentClassName="h-full min-h-0 pb-0"
+    >
       <PageHeader
         title="Explore courses"
         subtitle="Search the KTH catalogue and see what students said about a course before you pick it."
       />
 
-      <search className="flex flex-col items-center gap-2.5 px-6 pt-[18px] pb-3.5">
+      <search className="flex shrink-0 flex-col items-center gap-2.5 px-6 pt-[18px] pb-3.5">
         <form onSubmit={explore.onSubmit} className="w-full max-w-[560px]">
           <div className="flex h-[42px] items-center gap-2.5 rounded-[10px] border border-cc-rule3 bg-cc-surface px-3.5">
             <SearchIcon
@@ -92,68 +133,92 @@ export function Explore() {
         <Filters explore={explore} />
       </search>
 
-      <div
-        ref={resultsRef}
-        className="mx-auto flex w-full max-w-[1148px] flex-col gap-3.5 px-5 pb-5"
-      >
-        {/* The live region stays mounted whatever the column is showing: one
+      <div ref={rowRef} className="flex min-h-0 flex-1 gap-[18px] px-5 pb-5">
+        <div
+          ref={resultsRef}
+          data-testid="explore-results"
+          className={`scrollbar-hidden min-h-0 min-w-0 flex-1 overflow-x-hidden overflow-y-auto ${
+            workspace.hasOpenCourses ? "max-w-none" : "mx-auto max-w-[1148px]"
+          }`}
+        >
+          <div className="flex min-w-0 flex-col gap-3.5">
+            {/* The live region stays mounted whatever the column is showing: one
             that appears together with its first message is announced
             unreliably. Before anything is searched it has nothing to say — the
             panel below carries that — so it says nothing. */}
-        <div className="flex items-baseline gap-2 pl-0.5 text-[12px] text-cc-muted">
-          <span aria-live="polite">{resultsLabel(explore)}</span>
-          {hasQuery ? (
-            <button
-              type="button"
-              onClick={explore.onClearQuery}
-              className="cursor-pointer font-medium text-cc-brand hover:underline"
-            >
-              Clear search
-            </button>
-          ) : null}
+            <div className="flex items-baseline gap-2 pl-0.5 text-[12px] text-cc-muted">
+              <span aria-live="polite">{resultsLabel(explore)}</span>
+              {hasQuery ? (
+                <button
+                  type="button"
+                  onClick={explore.onClearQuery}
+                  className="cursor-pointer font-medium text-cc-brand hover:underline"
+                >
+                  Clear search
+                </button>
+              ) : null}
+            </div>
+
+            {isLoading && results.length === 0 ? <ResultsSkeleton /> : null}
+
+            {isError ? <ResultsError onRetry={explore.onRetry} /> : null}
+
+            {showEmpty ? (
+              <Panel dashed>
+                <div className="font-semibold text-[14.5px]">
+                  No courses match “{explore.query}”
+                </div>
+                <div className="mt-[5px] text-[13px] text-cc-muted">
+                  Try a course code, a subject, or{" "}
+                  <button
+                    type="button"
+                    onClick={explore.onClearQuery}
+                    className="cursor-pointer font-medium text-cc-brand hover:underline"
+                  >
+                    clear the search
+                  </button>
+                  .
+                </div>
+              </Panel>
+            ) : null}
+
+            {!hasQuery && !isError ? (
+              <StartHere onSuggest={explore.onSuggestQuery} />
+            ) : null}
+
+            {results.map((course, index) => (
+              <CourseCardItem
+                key={course.courseCode}
+                course={course}
+                stats={explore.statsFor(course.courseCode)}
+                action="save"
+                geo={geo}
+                // The last card's picker would open past the foot of the column.
+                pickerAbove={results.length > 1 && index === results.length - 1}
+                onOpen={() => openCourse(course.courseCode, "details")}
+                onReview={() => openCourse(course.courseCode, "review")}
+                onRequestAuth={explore.setAuthReason}
+              />
+            ))}
+          </div>
         </div>
 
-        {isLoading && results.length === 0 ? <ResultsSkeleton /> : null}
-
-        {isError ? <ResultsError onRetry={explore.onRetry} /> : null}
-
-        {showEmpty ? (
-          <Panel dashed>
-            <div className="font-semibold text-[14.5px]">
-              No courses match “{explore.query}”
-            </div>
-            <div className="mt-[5px] text-[13px] text-cc-muted">
-              Try a course code, a subject, or{" "}
-              <button
-                type="button"
-                onClick={explore.onClearQuery}
-                className="cursor-pointer font-medium text-cc-brand hover:underline"
-              >
-                clear the search
-              </button>
-              .
-            </div>
-          </Panel>
+        {workspace.hasOpenCourses ? (
+          <div
+            className="relative hidden min-h-0 min-w-[356px] @3xl:flex"
+            style={{ width: pane.width }}
+          >
+            <WorkspaceResizeHandle pane={pane} />
+            <WorkspacePane
+              className="min-w-0 flex-1"
+              openCourses={workspace.openCourses}
+              activeId={workspace.activeId}
+              onActivate={workspace.activate}
+              onClose={workspace.close}
+              onOpen={workspace.open}
+            />
+          </div>
         ) : null}
-
-        {!hasQuery && !isError ? (
-          <StartHere onSuggest={explore.onSuggestQuery} />
-        ) : null}
-
-        {results.map((course, index) => (
-          <CourseCardItem
-            key={course.courseCode}
-            course={course}
-            stats={explore.statsFor(course.courseCode)}
-            action="save"
-            geo={geo}
-            // The last card's picker would open past the foot of the column.
-            pickerAbove={results.length > 1 && index === results.length - 1}
-            onOpen={() => explore.onOpenCourse(course.courseCode)}
-            onReview={() => explore.onReviewCourse(course.courseCode)}
-            onRequestAuth={explore.setAuthReason}
-          />
-        ))}
       </div>
 
       <AuthReasonDialog
@@ -162,6 +227,85 @@ export function Explore() {
         onClose={() => explore.setAuthReason(null)}
       />
     </PageColumn>
+  );
+}
+
+const RESULTS_FLOOR = 470;
+const PANE_MIN = 356;
+const PANE_DEFAULT = 504;
+const WORKSPACE_GAP = 18;
+
+function useWorkspaceWidth(
+  rowRef: React.RefObject<HTMLDivElement | null>,
+  active: boolean,
+) {
+  const [width, setWidth] = useState(PANE_DEFAULT);
+  const [rowWidth, setRowWidth] = useState(0);
+
+  useEffect(() => {
+    const row = rowRef.current;
+    if (!row || typeof ResizeObserver !== "function") return;
+    const observer = new ResizeObserver(([entry]) => {
+      setRowWidth(entry?.contentRect.width ?? row.clientWidth);
+    });
+    observer.observe(row);
+    return () => observer.disconnect();
+  }, [rowRef]);
+
+  const max = Math.max(PANE_MIN, rowWidth - RESULTS_FLOOR - WORKSPACE_GAP);
+  const clamp = useCallback(
+    (next: number) => Math.max(PANE_MIN, Math.min(next, max)),
+    [max],
+  );
+
+  useEffect(() => {
+    if (active) setWidth((current) => clamp(current));
+  }, [active, clamp]);
+
+  return {
+    width: clamp(width),
+    resize: (next: number) => setWidth(clamp(next)),
+    reset: () => setWidth(clamp(PANE_DEFAULT)),
+  };
+}
+
+function WorkspaceResizeHandle({
+  pane,
+}: {
+  pane: ReturnType<typeof useWorkspaceWidth>;
+}) {
+  const start = useRef<{ x: number; width: number } | null>(null);
+
+  function finish() {
+    start.current = null;
+    window.removeEventListener("pointermove", onMove);
+    window.removeEventListener("pointerup", finish);
+  }
+
+  function onMove(event: PointerEvent) {
+    if (!start.current) return;
+    pane.resize(start.current.width - (event.clientX - start.current.x));
+  }
+
+  return (
+    <button
+      type="button"
+      aria-label="Resize workspace"
+      title="Drag to resize · double-click to reset"
+      onDoubleClick={pane.reset}
+      onPointerDown={(event) => {
+        event.preventDefault();
+        start.current = { x: event.clientX, width: pane.width };
+        window.addEventListener("pointermove", onMove);
+        window.addEventListener("pointerup", finish, { once: true });
+      }}
+      className="-left-[14px] absolute top-0 hidden h-full w-[11px] cursor-col-resize items-center justify-center @3xl:flex"
+    >
+      <span
+        aria-hidden
+        className="h-[34px] w-[2px] rounded-[2px] bg-cc-rule3"
+      />
+    </button>
   );
 }
 

--- a/apps/web/features/shell/components/app-shell.spec.tsx
+++ b/apps/web/features/shell/components/app-shell.spec.tsx
@@ -74,6 +74,13 @@ describe("AppShell", () => {
     expect(screen.getByText("Page body")).toBeInTheDocument();
   });
 
+  it("does not give Explore a competing page scroll surface", () => {
+    renderShell();
+    expect(screen.getByText("Page body").closest("main")).toHaveClass(
+      "overflow-hidden",
+    );
+  });
+
   describe("signed out", () => {
     it("still offers the whole catalogue — browsing needs no account", () => {
       renderShell();

--- a/apps/web/features/shell/components/app-shell.tsx
+++ b/apps/web/features/shell/components/app-shell.tsx
@@ -72,7 +72,13 @@ export function AppShell({ children }: { children: ReactNode }) {
           <ThemeToggle />
         </header>
 
-        <main className="min-h-0 flex-1 overflow-y-auto overflow-x-hidden">
+        <main
+          className={
+            pathname === "/search"
+              ? "min-h-0 flex-1 overflow-hidden"
+              : "min-h-0 flex-1 overflow-y-auto overflow-x-hidden"
+          }
+        >
           {children}
         </main>
       </div>

--- a/apps/web/features/shell/components/page-column.tsx
+++ b/apps/web/features/shell/components/page-column.tsx
@@ -1,4 +1,4 @@
-import type { ReactNode } from "react";
+import type { ReactNode, RefObject } from "react";
 import { cn } from "@/lib/utils";
 
 /**
@@ -23,13 +23,16 @@ export function PageColumn({
   children,
   className,
   contentClassName,
+  containerRef,
 }: {
   children: ReactNode;
   className?: string;
   contentClassName?: string;
+  /** Lets a route match its layout behavior to this container's breakpoints. */
+  containerRef?: RefObject<HTMLDivElement | null>;
 }) {
   return (
-    <div className={cn("@container", className)}>
+    <div ref={containerRef} className={cn("@container", className)}>
       <div
         className={cn(
           "mx-auto flex w-full max-w-[1216px] flex-col pb-15 @2xl:px-5",

--- a/apps/web/features/shell/components/page-column.tsx
+++ b/apps/web/features/shell/components/page-column.tsx
@@ -1,4 +1,5 @@
 import type { ReactNode } from "react";
+import { cn } from "@/lib/utils";
 
 /**
  * The content column every page renders inside, beneath the shell's topbar.
@@ -18,10 +19,23 @@ import type { ReactNode } from "react";
  * nothing for the text. The breakpoint is a container query on the column
  * itself, not the viewport, matching how the artboards respond.
  */
-export function PageColumn({ children }: { children: ReactNode }) {
+export function PageColumn({
+  children,
+  className,
+  contentClassName,
+}: {
+  children: ReactNode;
+  className?: string;
+  contentClassName?: string;
+}) {
   return (
-    <div className="@container">
-      <div className="mx-auto flex w-full max-w-[1216px] flex-col pb-15 @2xl:px-5">
+    <div className={cn("@container", className)}>
+      <div
+        className={cn(
+          "mx-auto flex w-full max-w-[1216px] flex-col pb-15 @2xl:px-5",
+          contentClassName,
+        )}
+      >
         {children}
       </div>
     </div>


### PR DESCRIPTION
Closes #130\n\n- keep Explore chrome fixed within the app viewport and give results the only hidden-scroll surface\n- mount the existing resizable workspace on sufficiently wide desktop interactions while keeping the mobile route/Drawer behavior\n- add focused desktop and mobile regression coverage\n\nValidation:\n- focused UI tests: 43 passing\n- full test suite: 599 passing\n- TypeScript: passing\n- Biome check: no new errors (pre-existing repository warnings only)