### PR TITLE
fix(shell): align mobile navigation contract

### DIFF
--- a/apps/web/features/shell/components/app-shell.spec.tsx
+++ b/apps/web/features/shell/components/app-shell.spec.tsx
@@ -74,6 +74,14 @@ describe("AppShell", () => {
     expect(screen.getByText("Page body")).toBeInTheDocument();
   });
 
+  it("uses its named shell container for the title transition", () => {
+    const { container } = renderShell();
+    expect(container.firstElementChild).toHaveClass("@container/shell");
+    expect(
+      within(screen.getByRole("banner")).getByRole("heading", { level: 1 }),
+    ).toHaveClass("@3xl/shell:hidden");
+  });
+
   it("does not give Explore a competing page scroll surface", () => {
     renderShell();
     expect(screen.getByText("Page body").closest("main")).toHaveClass(
@@ -92,6 +100,9 @@ describe("AppShell", () => {
       expect(
         within(nav).getByRole("link", { name: /my page/i }),
       ).toHaveAttribute("href", "/profile");
+      expect(
+        within(nav).getByRole("link", { name: /taken courses/i }),
+      ).toHaveAttribute("href", "/taken");
     });
 
     it("says what an account adds rather than what it locks", () => {
@@ -208,7 +219,12 @@ describe("AppShell", () => {
     it("names the page the visitor is on, not the app", () => {
       pathname = "/search";
       renderShell();
-      expect(screen.getByRole("banner")).toHaveTextContent("Explore courses");
+      expect(
+        within(screen.getByRole("banner")).getByRole("heading", {
+          level: 1,
+          name: "Explore courses",
+        }),
+      ).toBeInTheDocument();
     });
 
     // Every route inside the shell is titled, so this only shows up on a path
@@ -216,11 +232,38 @@ describe("AppShell", () => {
     it("falls back to the wordmark where there is no page to name", () => {
       pathname = "/nothing-here";
       renderShell();
-      expect(screen.getByRole("banner")).toHaveTextContent("Course Community");
+      expect(
+        within(screen.getByRole("banner")).getByRole("heading", {
+          level: 1,
+          name: "Course Community",
+        }),
+      ).toBeInTheDocument();
     });
   });
 
   describe("the drawer", () => {
+    it("keeps every primary route available on mobile", async () => {
+      const user = userEvent.setup();
+      renderShell();
+
+      await user.click(screen.getByRole("button", { name: /open menu/i }));
+      const drawer = await screen.findByRole("dialog");
+      const nav = within(drawer).getByRole("navigation", { name: "Main" });
+
+      expect(
+        within(nav).getByRole("link", { name: /explore/i }),
+      ).toHaveAttribute("href", "/search");
+      expect(
+        within(nav).getByRole("link", { name: /saved courses/i }),
+      ).toHaveAttribute("href", "/saved");
+      expect(
+        within(nav).getByRole("link", { name: /my page/i }),
+      ).toHaveAttribute("href", "/profile");
+      expect(
+        within(nav).getByRole("link", { name: /taken courses/i }),
+      ).toHaveAttribute("href", "/taken");
+    });
+
     it("brings the rail back on a narrow frame and closes after a tap", async () => {
       const user = userEvent.setup();
       renderShell();

--- a/apps/web/features/shell/components/app-shell.tsx
+++ b/apps/web/features/shell/components/app-shell.tsx
@@ -33,8 +33,8 @@ export function AppShell({ children }: { children: ReactNode }) {
   const [authReason, setAuthReason] = useState<AuthReason | null>(null);
 
   return (
-    <div className="@container cc-theme flex h-dvh w-full overflow-hidden bg-cc-pg text-cc-ink text-sm">
-      <aside className="hidden w-[236px] shrink-0 @3xl:block">
+    <div className="@container/shell cc-theme flex h-dvh w-full overflow-hidden bg-cc-pg text-cc-ink text-sm">
+      <aside className="hidden w-[236px] shrink-0 @3xl/shell:block">
         <Rail onRequestAuth={setAuthReason} />
       </aside>
 
@@ -54,21 +54,21 @@ export function AppShell({ children }: { children: ReactNode }) {
       </Sheet>
 
       <div className="flex min-w-0 flex-1 flex-col">
-        <header className="flex h-[66px] shrink-0 items-center gap-2.5 border-cc-rule border-b px-3.5 @3xl:justify-end @3xl:px-7">
+        <header className="flex h-[66px] shrink-0 items-center gap-2.5 border-cc-rule border-b px-3.5 @3xl/shell:justify-end @3xl/shell:px-7">
           <button
             type="button"
             onClick={() => setDrawerOpen(true)}
             aria-label="Open menu"
-            className="flex size-[36px] shrink-0 cursor-pointer items-center justify-center rounded-[9px] text-cc-brand hover:bg-cc-pill @3xl:hidden"
+            className="flex size-[36px] shrink-0 cursor-pointer items-center justify-center rounded-[9px] text-cc-brand hover:bg-cc-pill @3xl/shell:hidden"
           >
             <Menu size={19} strokeWidth={2} aria-hidden />
           </button>
           {/* The page you are on, named the way the Mobile Preview names it —
               from the route, so it is right on the first paint. The brand is
               not lost with the rail: the drawer carries it, as it does there. */}
-          <span className="min-w-0 flex-1 truncate font-semibold text-[16px] leading-[1.2] @3xl:hidden">
+          <h1 className="min-w-0 flex-1 truncate font-semibold text-[16px] leading-[1.2] @3xl/shell:hidden">
             {pageTitleFor(pathname)}
-          </span>
+          </h1>
           <ThemeToggle />
         </header>
 

--- a/apps/web/features/shell/components/page-header.spec.tsx
+++ b/apps/web/features/shell/components/page-header.spec.tsx
@@ -28,4 +28,10 @@ describe("PageHeader", () => {
     const { container } = render(<PageHeader title="Explore" />);
     expect(container.querySelector("h1")?.nextElementSibling).toBeNull();
   });
+
+  it("uses the named shell breakpoint so tablet containers cannot lose the title", () => {
+    const { container } = render(<PageHeader title="Explore courses" />);
+    expect(container.firstElementChild).toHaveClass("hidden");
+    expect(container.firstElementChild).toHaveClass("@3xl/shell:block");
+  });
 });

--- a/apps/web/features/shell/components/page-header.tsx
+++ b/apps/web/features/shell/components/page-header.tsx
@@ -7,15 +7,19 @@ type Props = {
 };
 
 /**
- * The one page-title block every page uses — same padding, size and spacing
- * everywhere, so no page hand-writes its own header markup.
+ * The one page-title block every wide-shell page uses — same padding, size and
+ * spacing everywhere, so no page hand-writes its own header markup.
  *
  * Straight from `docs/design/Course Community - Page Header.dc.html`, which is
  * the whole of that artboard.
  */
 export function PageHeader({ title, subtitle }: Props) {
   return (
-    <div className="px-7 pt-[26px]">
+    // The named shell container is deliberately used here instead of this
+    // component's nearest PageColumn container. It is the same breakpoint the
+    // rail and top-bar heading use, so nested page containers cannot create a
+    // tablet interval with zero (or two) route headings.
+    <div className="hidden px-7 pt-[26px] @3xl/shell:block">
       <h1 className="m-0 font-semibold text-[26px] tracking-[-0.02em]">
         {title}
       </h1>


### PR DESCRIPTION
## Summary

- use the mobile shell title as the single semantic route heading on narrow layouts
- preserve the page-level heading on wide layouts
- cover Explore, Saved courses, My Page, and Taken courses navigation

## Validation

- focused shell component tests
- TypeScript typecheck
- repository lint

Closes #128.