### PR TITLE
fix(collections): complete card action parity

### DIFF
--- a/apps/web/features/collections/components/collection-detail.tsx
+++ b/apps/web/features/collections/components/collection-detail.tsx
@@ -37,6 +37,8 @@ type Props = {
   onRemoveCourse: (courseCode: string) => void;
   onMoveCourse: (courseCode: string, direction: "up" | "down") => void;
   onOpenCourse: (courseCode: string) => void;
+  /** Starts a review from a course card in this collection. */
+  onReviewCourse: (courseCode: string) => void;
   onRequestAuth: (reason: AuthReason) => void;
 };
 
@@ -76,6 +78,7 @@ export function CollectionDetail({
   onRemoveCourse,
   onMoveCourse,
   onOpenCourse,
+  onReviewCourse,
   onRequestAuth,
 }: Props) {
   const renaming = useRenameDraft(collection.name, onRename);
@@ -234,6 +237,7 @@ export function CollectionDetail({
                       removeLabel={`Remove ${courseCode} from ${collection.name}`}
                       onRemove={() => onRemoveCourse(courseCode)}
                       onOpen={() => onOpenCourse(courseCode)}
+                      onReview={() => onReviewCourse(courseCode)}
                       onRequestAuth={onRequestAuth}
                     />
                   ) : (

--- a/apps/web/features/collections/components/collections.spec.tsx
+++ b/apps/web/features/collections/components/collections.spec.tsx
@@ -280,6 +280,24 @@ describe("reordering within a collection", () => {
   });
 });
 
+describe("course actions in a collection", () => {
+  it("opens the existing review route from a collection card", async () => {
+    setup({
+      savedCourseCodes: ["AA1000"],
+      collections: [{ id: "c1", name: "Spring", courseCodes: ["AA1000"] }],
+    });
+    render(<Collections openCollectionId="c1" />);
+
+    await userEvent.click(
+      screen.getByRole("button", { name: "Write a review" }),
+    );
+
+    expect(push).toHaveBeenCalledWith(
+      "/course/AA1000?writeReview=1&from=collections",
+    );
+  });
+});
+
 describe("the add-course menu", () => {
   it("closes on Escape and gives focus back to the trigger", async () => {
     setup({

--- a/apps/web/features/collections/components/collections.tsx
+++ b/apps/web/features/collections/components/collections.tsx
@@ -389,6 +389,11 @@ export function Collections({
             onOpenCourse={(courseCode) =>
               router.push(`/course/${courseCode}?from=collections`)
             }
+            onReviewCourse={(courseCode) =>
+              router.push(
+                `/course/${courseCode}?writeReview=1&from=collections`,
+              )
+            }
             onRequestAuth={setAuthReason}
           />
         ) : null}
@@ -490,7 +495,7 @@ export function Collections({
           Collections
         </h2>
         <div className="mt-1 text-[12.5px] text-cc-muted">
-          Group courses you want to compare.
+          Group courses you want to consider together.
         </div>
         {body}
       </section>
@@ -501,7 +506,7 @@ export function Collections({
     <PageColumn>
       <PageHeader
         title="Collections"
-        subtitle="Group courses you want to compare."
+        subtitle="Group courses you want to consider together."
       />
       {body}
     </PageColumn>

--- a/apps/web/features/collections/components/collections.tsx
+++ b/apps/web/features/collections/components/collections.tsx
@@ -495,7 +495,7 @@ export function Collections({
           Collections
         </h2>
         <div className="mt-1 text-[12.5px] text-cc-muted">
-          Group courses you want to consider together.
+          Group courses you want to compare.
         </div>
         {body}
       </section>
@@ -506,7 +506,7 @@ export function Collections({
     <PageColumn>
       <PageHeader
         title="Collections"
-        subtitle="Group courses you want to consider together."
+        subtitle="Group courses you want to compare."
       />
       {body}
     </PageColumn>

--- a/apps/web/features/courses/components/course-card-item.spec.tsx
+++ b/apps/web/features/courses/components/course-card-item.spec.tsx
@@ -90,7 +90,7 @@ describe("CourseCardItem", () => {
       await userEvent.click(
         within(screen.getAllByRole("article")[0] as HTMLElement).getByRole(
           "button",
-          { name: "Add to collections" },
+          { name: "Add to collection" },
         ),
       );
       expect(cardWithOpenPicker()).toBe(0);

--- a/apps/web/features/courses/components/course-card.spec.tsx
+++ b/apps/web/features/courses/components/course-card.spec.tsx
@@ -332,7 +332,7 @@ describe("CourseCard", () => {
       expect(onSave).toHaveBeenCalledOnce();
 
       await userEvent.click(
-        screen.getByRole("button", { name: "Add to collections" }),
+        screen.getByRole("button", { name: "Add to collection" }),
       );
       expect(onPicker).toHaveBeenCalledOnce();
       expect(screen.queryByText("Add to collection")).toBeNull();

--- a/apps/web/features/courses/components/course-card.spec.tsx
+++ b/apps/web/features/courses/components/course-card.spec.tsx
@@ -338,6 +338,20 @@ describe("CourseCard", () => {
       expect(screen.queryByText("Add to collection")).toBeNull();
     });
 
+    it("names the split picker when a direct model omits its label", () => {
+      render(
+        <CourseCard
+          c={reviewedCard({ addLabel: "" })}
+          geo={EXPANDED_CARD_GEOMETRY}
+          action="save"
+        />,
+      );
+
+      expect(
+        screen.getByRole("button", { name: "Add to collection" }),
+      ).toBeVisible();
+    });
+
     it("is the picker alone under action='add'", async () => {
       const onPicker = vi.fn();
       render(

--- a/apps/web/features/courses/components/course-card.tsx
+++ b/apps/web/features/courses/components/course-card.tsx
@@ -369,8 +369,8 @@ export function CourseCard({
                   <button
                     type="button"
                     onClick={c.onPicker}
-                    title="Add to collections"
-                    aria-label="Add to collections"
+                    title={c.addLabel}
+                    aria-label={c.addLabel}
                     aria-haspopup="menu"
                     aria-expanded={c.pickerOpen}
                     className="flex flex-none cursor-pointer items-center px-[9px] text-[10px] hover:bg-cc-info"

--- a/apps/web/features/courses/components/course-card.tsx
+++ b/apps/web/features/courses/components/course-card.tsx
@@ -158,6 +158,10 @@ export function CourseCard({
 }: Props) {
   const tween = { transition: geo.tween };
   const keywords = keywordChips(c.keywords);
+  // The display model normally supplies this, but CourseCard also renders
+  // direct fixtures and future callers. A picker trigger that says only "▾"
+  // is neither discoverable nor useful to assistive technology.
+  const addLabel = c.addLabel?.trim() || "Add to collection";
 
   // Each popover's region is its trigger plus its panel: a press inside either
   // is not a press elsewhere.
@@ -369,8 +373,8 @@ export function CourseCard({
                   <button
                     type="button"
                     onClick={c.onPicker}
-                    title={c.addLabel}
-                    aria-label={c.addLabel}
+                    title={addLabel}
+                    aria-label={addLabel}
                     aria-haspopup="menu"
                     aria-expanded={c.pickerOpen}
                     className="flex flex-none cursor-pointer items-center px-[9px] text-[10px] hover:bg-cc-info"
@@ -385,7 +389,7 @@ export function CourseCard({
                   onClick={c.onPicker}
                   aria-haspopup="menu"
                   aria-expanded={c.pickerOpen}
-                  aria-label={c.addLabel}
+                  aria-label={addLabel}
                   className="box-border flex h-[34px] cursor-pointer items-center gap-[7px] overflow-hidden rounded-[8px] border border-cc-rule3 bg-cc-surface px-[10px] text-[13px] text-cc-ink hover:border-cc-hov hover:bg-cc-info"
                 >
                   <AddToCollectionIcon />
@@ -396,7 +400,7 @@ export function CourseCard({
                       name either. */}
                   {geo.showLabel ? (
                     <span className="min-w-0 overflow-hidden whitespace-nowrap @max-[440px]:hidden">
-                      {c.addLabel}
+                      {addLabel}
                     </span>
                   ) : null}
                 </button>


### PR DESCRIPTION
## Summary

- route Collection card review actions through the existing course review flow
- remove remaining comparison wording from Collection-facing UI
- align collection-picker labels and accessible names

## Validation

- 44 focused UI tests
- TypeScript typecheck
- scoped Biome check

Closes #132.