### PR TITLE
feat(workspace): add mobile sheet host

### DIFF
--- a/apps/web/features/search/components/explore.spec.tsx
+++ b/apps/web/features/search/components/explore.spec.tsx
@@ -209,6 +209,27 @@ describe("Explore", () => {
       expect(screen.queryByText("DD2380 · Details")).not.toBeInTheDocument();
     });
 
+    it("keeps the workspace sheet open when a drag is cancelled", async () => {
+      render(<Explore />);
+      await userEvent.click(
+        within(screen.getAllByRole("article")[0] as HTMLElement).getByRole(
+          "button",
+          { name: /Artificial Intelligence/ },
+        ),
+      );
+
+      const handle = screen.getByRole("button", {
+        name: "Drag workspace sheet down to dismiss",
+      });
+      fireEvent.pointerDown(handle, { pointerId: 1, clientY: 10 });
+      fireEvent.pointerMove(handle, { pointerId: 1, clientY: 160 });
+      fireEvent.pointerCancel(handle, { pointerId: 1 });
+
+      expect(
+        screen.getByRole("button", { name: "Close DD2380 · Details" }),
+      ).toBeVisible();
+    });
+
     it("keeps the results as the only mobile scrolling surface", () => {
       render(<Explore />);
 

--- a/apps/web/features/search/components/explore.spec.tsx
+++ b/apps/web/features/search/components/explore.spec.tsx
@@ -170,7 +170,7 @@ describe("Explore", () => {
       }
     });
 
-    it("opens a course on its own page", async () => {
+    it("opens a course in the mobile workspace sheet", async () => {
       render(<Explore />);
       await userEvent.click(
         within(screen.getAllByRole("article")[0] as HTMLElement).getByRole(
@@ -178,7 +178,35 @@ describe("Explore", () => {
           { name: /Artificial Intelligence/ },
         ),
       );
-      expect(push).toHaveBeenCalledWith("/course/DD2380");
+      expect(screen.getAllByText("DD2380 · Details")).toHaveLength(2);
+      expect(
+        screen.getByRole("button", { name: "Close DD2380 · Details" }),
+      ).toBeVisible();
+      expect(push).not.toHaveBeenCalled();
+
+      await userEvent.click(
+        screen.getByRole("button", { name: "Close DD2380 · Details" }),
+      );
+      expect(screen.queryByText("DD2380 · Details")).not.toBeInTheDocument();
+    });
+
+    it("dismisses the mobile workspace sheet when its handle is dragged down", async () => {
+      render(<Explore />);
+      await userEvent.click(
+        within(screen.getAllByRole("article")[0] as HTMLElement).getByRole(
+          "button",
+          { name: /Artificial Intelligence/ },
+        ),
+      );
+
+      const handle = screen.getByRole("button", {
+        name: "Drag workspace sheet down to dismiss",
+      });
+      fireEvent.pointerDown(handle, { pointerId: 1, clientY: 10 });
+      fireEvent.pointerMove(handle, { pointerId: 1, clientY: 160 });
+      fireEvent.pointerUp(handle, { pointerId: 1, clientY: 160 });
+
+      expect(screen.queryByText("DD2380 · Details")).not.toBeInTheDocument();
     });
 
     it("keeps the results as the only mobile scrolling surface", () => {

--- a/apps/web/features/search/components/explore.spec.tsx
+++ b/apps/web/features/search/components/explore.spec.tsx
@@ -1,4 +1,5 @@
 import {
+  act,
   fireEvent,
   render,
   screen,
@@ -17,6 +18,17 @@ const useSearchCourses = vi.fn();
 
 let search = "";
 let containerWidth = 500;
+let delayResizeObserver = false;
+let resizeObserverCallbacks: ResizeObserverCallback[] = [];
+
+function deliverResizeObservers() {
+  for (const callback of resizeObserverCallbacks) {
+    callback(
+      [{ contentRect: { width: containerWidth } } as ResizeObserverEntry],
+      {} as ResizeObserver,
+    );
+  }
+}
 
 vi.mock("next/navigation", () => ({
   useRouter: () => ({ push, replace }),
@@ -103,6 +115,8 @@ function results(...courses: CourseSummary[]) {
 beforeEach(() => {
   search = "";
   containerWidth = 500;
+  delayResizeObserver = false;
+  resizeObserverCallbacks = [];
   window.sessionStorage.clear();
   push.mockClear();
   replace.mockClear();
@@ -112,10 +126,8 @@ beforeEach(() => {
       constructor(private readonly callback: ResizeObserverCallback) {}
 
       observe() {
-        this.callback(
-          [{ contentRect: { width: containerWidth } } as ResizeObserverEntry],
-          this as unknown as ResizeObserver,
-        );
+        resizeObserverCallbacks.push(this.callback);
+        if (!delayResizeObserver) deliverResizeObservers();
       }
 
       disconnect() {}
@@ -228,6 +240,27 @@ describe("Explore", () => {
       expect(
         screen.getByRole("button", { name: "Close DD2380 · Details" }),
       ).toBeVisible();
+    });
+
+    it("queues a course open until its container chooses the mobile sheet", async () => {
+      delayResizeObserver = true;
+      render(<Explore />);
+
+      await userEvent.click(
+        within(screen.getAllByRole("article")[0] as HTMLElement).getByRole(
+          "button",
+          { name: /Artificial Intelligence/ },
+        ),
+      );
+      expect(push).not.toHaveBeenCalled();
+      expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+
+      await act(async () => deliverResizeObservers());
+
+      expect(
+        await screen.findByRole("button", { name: "Close DD2380 · Details" }),
+      ).toBeVisible();
+      expect(push).not.toHaveBeenCalled();
     });
 
     it("keeps the results as the only mobile scrolling surface", () => {

--- a/apps/web/features/search/components/explore.tsx
+++ b/apps/web/features/search/components/explore.tsx
@@ -7,7 +7,10 @@ import { useCallback, useEffect, useRef, useState } from "react";
 import { AuthReasonDialog } from "@/features/auth";
 import { CourseCardItem, courseCardGeometry } from "@/features/courses";
 import { PageColumn, PageHeader } from "@/features/shell";
-import { useWorkspacePane } from "@/features/workspace";
+import {
+  MobileWorkspaceSheetHost,
+  useWorkspacePane,
+} from "@/features/workspace";
 import {
   MAX_RATING_STARS,
   RATING_STAR_OPTIONS,
@@ -67,6 +70,7 @@ export function Explore() {
   const workspace = useWorkspacePane();
   const containerRef = useRef<HTMLDivElement>(null);
   const desktopWorkspace = useContainerBreakpoint(containerRef, 768);
+  const mobileWorkspace = !useContainerBreakpoint(containerRef, 640);
   const rowRef = useRef<HTMLDivElement>(null);
   const pane = useWorkspaceWidth(rowRef, workspace.hasOpenCourses);
   const [resultsRef, resultsWidth] = useResultsWidth();
@@ -75,11 +79,15 @@ export function Explore() {
   const { results, hasQuery, isLoading, isError } = explore;
   const showEmpty = hasQuery && !isLoading && !isError && results.length === 0;
 
-  // The desktop pane intentionally does not replace the mobile course route:
-  // #133 owns the mobile sheet host. Keeping that established route means a
-  // phone's Drawer and course controls remain keyboard-reachable today.
+  // The desktop column and phone sheet share the same state machine. The
+  // in-between layout remains a route: it has neither enough width for the
+  // column nor the narrow mobile chrome the sheet was designed for.
   function openCourse(courseCode: string, kind: "details" | "review") {
     if (desktopWorkspace) {
+      workspace.open(courseCode, kind);
+      return;
+    }
+    if (mobileWorkspace) {
       workspace.open(courseCode, kind);
       return;
     }
@@ -211,6 +219,15 @@ export function Explore() {
           </div>
         ) : null}
       </div>
+
+      {mobileWorkspace ? (
+        <MobileWorkspaceSheetHost
+          openCourses={workspace.openCourses}
+          activeId={workspace.activeId}
+          onClose={workspace.close}
+          onOpen={workspace.open}
+        />
+      ) : null}
 
       <AuthReasonDialog
         reason={explore.authReason}

--- a/apps/web/features/search/components/explore.tsx
+++ b/apps/web/features/search/components/explore.tsx
@@ -18,6 +18,8 @@ import {
 } from "../hooks/use-explore";
 import { useResultsWidth } from "../hooks/use-results-width";
 
+type CourseOpen = { courseCode: string; kind: "details" | "review" };
+
 // The pane is inactive for ordinary browsing and has its own data-heavy
 // details/review views. Load it only once a desktop reader opens a course.
 const WorkspacePane = dynamic(
@@ -75,6 +77,9 @@ export function Explore() {
   // container's size. Do not guess a presentation during that window: mounting
   // a Sheet would briefly lock the desktop page's body before the pane wins.
   const mobileWorkspace = compactWorkspace === null ? false : !compactWorkspace;
+  const [pendingCourseOpen, setPendingCourseOpen] = useState<CourseOpen | null>(
+    null,
+  );
   const rowRef = useRef<HTMLDivElement>(null);
   const pane = useWorkspaceWidth(rowRef, workspace.hasOpenCourses);
   const [resultsRef, resultsWidth] = useResultsWidth();
@@ -83,21 +88,43 @@ export function Explore() {
   const { results, hasQuery, isLoading, isError } = explore;
   const showEmpty = hasQuery && !isLoading && !isError && results.length === 0;
 
+  const layoutMeasured = desktopWorkspace !== null && compactWorkspace !== null;
+
   // The desktop column and phone sheet share the same state machine. The
   // in-between layout remains a route: it has neither enough width for the
   // column nor the narrow mobile chrome the sheet was designed for.
-  function openCourse(courseCode: string, kind: "details" | "review") {
-    if (desktopWorkspace) {
-      workspace.open(courseCode, kind);
-      return;
-    }
-    if (mobileWorkspace) {
-      workspace.open(courseCode, kind);
-      return;
-    }
-    if (kind === "details") explore.onOpenCourse(courseCode);
-    else explore.onReviewCourse(courseCode);
-  }
+  const openMeasuredCourse = useCallback(
+    (courseCode: string, kind: CourseOpen["kind"]) => {
+      if (desktopWorkspace) {
+        workspace.open(courseCode, kind);
+        return;
+      }
+      if (mobileWorkspace) {
+        workspace.open(courseCode, kind);
+        return;
+      }
+      if (kind === "details") explore.onOpenCourse(courseCode);
+      else explore.onReviewCourse(courseCode);
+    },
+    [desktopWorkspace, mobileWorkspace, workspace, explore],
+  );
+
+  const openCourse = useCallback(
+    (courseCode: string, kind: CourseOpen["kind"]) => {
+      if (!layoutMeasured) {
+        setPendingCourseOpen({ courseCode, kind });
+        return;
+      }
+      openMeasuredCourse(courseCode, kind);
+    },
+    [layoutMeasured, openMeasuredCourse],
+  );
+
+  useEffect(() => {
+    if (!pendingCourseOpen || !layoutMeasured) return;
+    openMeasuredCourse(pendingCourseOpen.courseCode, pendingCourseOpen.kind);
+    setPendingCourseOpen(null);
+  }, [layoutMeasured, openMeasuredCourse, pendingCourseOpen]);
 
   return (
     <PageColumn

--- a/apps/web/features/search/components/explore.tsx
+++ b/apps/web/features/search/components/explore.tsx
@@ -70,7 +70,11 @@ export function Explore() {
   const workspace = useWorkspacePane();
   const containerRef = useRef<HTMLDivElement>(null);
   const desktopWorkspace = useContainerBreakpoint(containerRef, 768);
-  const mobileWorkspace = !useContainerBreakpoint(containerRef, 640);
+  const compactWorkspace = useContainerBreakpoint(containerRef, 640);
+  // A restored workspace may exist before ResizeObserver reports this
+  // container's size. Do not guess a presentation during that window: mounting
+  // a Sheet would briefly lock the desktop page's body before the pane wins.
+  const mobileWorkspace = compactWorkspace === null ? false : !compactWorkspace;
   const rowRef = useRef<HTMLDivElement>(null);
   const pane = useWorkspaceWidth(rowRef, workspace.hasOpenCourses);
   const [resultsRef, resultsWidth] = useResultsWidth();
@@ -244,7 +248,7 @@ function useContainerBreakpoint(
   containerRef: React.RefObject<HTMLDivElement | null>,
   minimumWidth: number,
 ) {
-  const [matches, setMatches] = useState(false);
+  const [matches, setMatches] = useState<boolean | null>(null);
 
   useEffect(() => {
     const container = containerRef.current;

--- a/apps/web/features/workspace/components/mobile-workspace-sheet-host.tsx
+++ b/apps/web/features/workspace/components/mobile-workspace-sheet-host.tsx
@@ -1,0 +1,116 @@
+"use client";
+
+import { X } from "lucide-react";
+import { useRef, useState } from "react";
+import { Sheet, SheetContent, SheetTitle } from "@/components/ui/sheet";
+import type { OpenCourse, OpenCourseKind } from "../lib/open-courses";
+import { openCourseLabel } from "../lib/open-courses";
+import { WorkspacePane } from "./workspace-pane";
+
+export interface MobileWorkspaceSheetHostProps {
+  /** The host's workspace state; the newest active entry is the visible sheet. */
+  openCourses: OpenCourse[];
+  activeId: string | null;
+  onClose: (id: string) => void;
+  onOpen: (courseCode: string, kind: OpenCourseKind) => void;
+}
+
+const DISMISS_DISTANCE = 120;
+
+/**
+ * Mobile's presentation of the shared workspace.
+ *
+ * The workspace still owns the open-course list; this component only changes
+ * its presentation from the desktop's resizable column to a bottom sheet. A
+ * closed sheet reveals the still-open entry beneath it, so several course
+ * details and review drafts remain available without routing away from the
+ * list that opened them.
+ */
+export function MobileWorkspaceSheetHost({
+  openCourses,
+  activeId,
+  onClose,
+  onOpen,
+}: Readonly<MobileWorkspaceSheetHostProps>) {
+  const active =
+    openCourses.find((entry) => entry.id === activeId) ?? openCourses.at(-1);
+  const dragStart = useRef<number | null>(null);
+  const dragOffset = useRef(0);
+  const [dragY, setDragY] = useState(0);
+
+  if (!active) return null;
+  const activeEntry = active;
+
+  function dismiss() {
+    dragStart.current = null;
+    dragOffset.current = 0;
+    setDragY(0);
+    onClose(activeEntry.id);
+  }
+
+  function finishDrag() {
+    if (dragStart.current === null) return;
+    const shouldDismiss = dragOffset.current >= DISMISS_DISTANCE;
+    dragStart.current = null;
+    dragOffset.current = 0;
+    setDragY(0);
+    if (shouldDismiss) onClose(activeEntry.id);
+  }
+
+  return (
+    <Sheet open onOpenChange={(open) => !open && dismiss()}>
+      <SheetContent
+        side="bottom"
+        showCloseButton={false}
+        aria-describedby={undefined}
+        className="gap-0 overflow-hidden rounded-t-[18px] border-t-[3px] border-cc-brand bg-cc-surface p-0 shadow-[0_-8px_30px_rgba(20,30,45,0.24)] max-h-[82dvh]"
+        style={{ transform: `translateY(${dragY}px)` }}
+      >
+        <SheetTitle className="sr-only">
+          {openCourseLabel(activeEntry)}
+        </SheetTitle>
+        <div className="relative flex h-12 shrink-0 items-center justify-center border-b border-cc-rule bg-cc-info">
+          <button
+            type="button"
+            aria-label="Drag workspace sheet down to dismiss"
+            onPointerDown={(event) => {
+              dragStart.current = event.clientY;
+              event.currentTarget.setPointerCapture?.(event.pointerId);
+            }}
+            onPointerMove={(event) => {
+              if (dragStart.current === null) return;
+              const next = Math.max(0, event.clientY - dragStart.current);
+              dragOffset.current = next;
+              setDragY(next);
+            }}
+            onPointerUp={finishDrag}
+            onPointerCancel={finishDrag}
+            className="absolute inset-x-0 top-0 h-3 cursor-grab touch-none active:cursor-grabbing"
+          >
+            <span className="mx-auto block h-1 w-9 rounded-full bg-cc-rule3" />
+          </button>
+          <span className="text-[12.5px] font-semibold text-cc-ink">
+            {openCourseLabel(activeEntry)}
+          </span>
+          <button
+            type="button"
+            aria-label={`Close ${openCourseLabel(activeEntry)}`}
+            onClick={dismiss}
+            className="absolute top-2 right-2 flex size-[30px] items-center justify-center rounded-[8px] bg-cc-surface text-cc-dim shadow-[0_1px_3px_rgba(20,30,45,0.15)] hover:bg-cc-pill"
+          >
+            <X size={16} aria-hidden />
+          </button>
+        </div>
+        <WorkspacePane
+          className="min-h-0 flex-1 overflow-hidden"
+          openCourses={[activeEntry]}
+          activeId={activeEntry.id}
+          onActivate={() => undefined}
+          onClose={dismiss}
+          onOpen={onOpen}
+          hideTabs
+        />
+      </SheetContent>
+    </Sheet>
+  );
+}

--- a/apps/web/features/workspace/components/mobile-workspace-sheet-host.tsx
+++ b/apps/web/features/workspace/components/mobile-workspace-sheet-host.tsx
@@ -42,18 +42,20 @@ export function MobileWorkspaceSheetHost({
   const activeEntry = active;
 
   function dismiss() {
+    resetDrag();
+    onClose(activeEntry.id);
+  }
+
+  function resetDrag() {
     dragStart.current = null;
     dragOffset.current = 0;
     setDragY(0);
-    onClose(activeEntry.id);
   }
 
   function finishDrag() {
     if (dragStart.current === null) return;
     const shouldDismiss = dragOffset.current >= DISMISS_DISTANCE;
-    dragStart.current = null;
-    dragOffset.current = 0;
-    setDragY(0);
+    resetDrag();
     if (shouldDismiss) onClose(activeEntry.id);
   }
 
@@ -84,7 +86,7 @@ export function MobileWorkspaceSheetHost({
               setDragY(next);
             }}
             onPointerUp={finishDrag}
-            onPointerCancel={finishDrag}
+            onPointerCancel={resetDrag}
             className="absolute inset-x-0 top-0 h-3 cursor-grab touch-none active:cursor-grabbing"
           >
             <span className="mx-auto block h-1 w-9 rounded-full bg-cc-rule3" />

--- a/apps/web/features/workspace/index.ts
+++ b/apps/web/features/workspace/index.ts
@@ -13,6 +13,10 @@
  * screen right now.
  */
 
+export {
+  MobileWorkspaceSheetHost,
+  type MobileWorkspaceSheetHostProps,
+} from "./components/mobile-workspace-sheet-host";
 export type { WorkspacePaneProps } from "./components/workspace-pane";
 export { WorkspacePane } from "./components/workspace-pane";
 export { useWorkspacePane } from "./hooks/use-workspace-pane";


### PR DESCRIPTION
## Summary

- add a reusable mobile workspace-sheet host
- render the existing API-backed workspace content in the mobile sheet
- preserve the desktop workspace pane and intermediate route behavior
- support explicit close and drag-down dismissal

## Validation

- focused Explore UI tests
- TypeScript typecheck
- repository lint with only pre-existing warnings

Closes #133.