### PR TITLE
fix(theme): make the shadcn and Course Community palettes one system

### DIFF
--- a/apps/web/app/globals.css
+++ b/apps/web/app/globals.css
@@ -129,15 +129,25 @@
   --cc-btn-fg: #ffffff;
   --cc-info: rgba(23, 81, 166, 0.07);
 
-  /* `--cc-warn-*` is the **review draft** header tint. It used to be documented
-     here as "the nudge to write a review", which #127 §4 flags as wrong: #88
-     showed the actual nudge is `--cc-btn` on `--cc-surface`, and nothing amber
-     appears on it. The Design System artboard's `BANNERS` names this family
-     "Review draft header", and `Course Community - Workspace Pane.dc.html`
-     paints exactly it in its `isReview` branch — `--cc-warn` behind the draft's
-     title block, `--cc-warn-ink` on its eyebrow, `--cc-warn-border` under the
-     sticky action row and `--cc-warn-solid` as that row's opaque backing.
-     `--cc-warn-btn`/`--cc-warn-btn-fg` are that row's call to action. */
+  /* `--cc-warn-*` is the **review draft** family. It used to be documented here
+     as "the nudge to write a review", which #127 §4 flags as wrong: #88 showed
+     the actual nudge is `--cc-btn` on `--cc-surface`, and nothing amber appears
+     on it.
+
+     The tint half is the draft's header. The Design System artboard names
+     `--warn` "Review draft header" in both `TINTS` and `BANNERS`, and
+     `Course Community - Workspace Pane.dc.html` paints exactly it in its
+     `isReview` branch — `--warn` behind the draft's title block, `--warnInk` on
+     its "Review draft" eyebrow, and `--warnBorder` + `--warnSolid` as the
+     border and opaque backing of the progress row that sticks beneath it.
+
+     `--cc-warn-btn`/`--cc-warn-btn-fg` are a separate pair, and the one place
+     the old wording was not wrong: the Design System demos them under "Status
+     text & buttons" as a **"Write a review"** button. They are an accent, not a
+     banner tint — the filled progress segments and the submit button in
+     `review-draft-panel.tsx`, and the Review Card's accent for a review that
+     was not happy (`Review Card.dc.html:51`). Neither appears anywhere in the
+     Workspace Pane's `isReview` branch. */
   --cc-warn: #fdf7ea;
   --cc-warn-border: #f0e6d2;
   --cc-warn-ink: #7a5309;

--- a/apps/web/app/globals.css
+++ b/apps/web/app/globals.css
@@ -156,12 +156,12 @@
      six tokens are the client half of that contract and the palette can be
      re-skinned here without a data migration.
 
-     They are additions to `cc-theme.css` rather than a mirror of it: the design
-     has no node token at all (`cc-store.js` carries five raw hexes against the
-     schema's six names). Five of these are the design's own hexes reused;
-     `moss` is the sixth the design never assigned. Provisional, like the
-     examination palette's `seminars` — the only requirement is that no two of
-     the six read as each other. */
+     Mirrored, like everything above: the revised `cc-theme.css` names all six
+     (`--nodeAurora` … `--nodeViolet`), and the Design System artboard renders
+     them under "Community graph nodes". They are *unassigned* rather than
+     absent — #68 §3 settled that a node with no configured appearance is
+     `--cc-brand`, and these are the palette personalisation will draw from once
+     a tier writer exists. */
   --cc-node-aurora: #2f9e8e;
   --cc-node-ember: #c96a4a;
   --cc-node-frost: #2f5fa8;
@@ -318,10 +318,10 @@
   --cc-danger: #ff8a80;
   --cc-danger-fg: #2b0a08;
 
-  /* Community graph node colours — dark. The light hues are mixed for the cream
-     page and disappear into `--cc-pg`'s deep blue, so each is lifted to the same
-     hue at a much higher lightness. The names, and which name means which hue,
-     do not change. */
+  /* Community graph node colours — dark. The design lifts each light hue to the
+     same hue at a much higher lightness, because the light set is mixed for the
+     cream page and disappears into `--cc-pg`'s deep blue. The names, and which
+     name means which hue, do not change. */
   --cc-node-aurora: #5fd8c4;
   --cc-node-ember: #f2946f;
   --cc-node-frost: #8ec2ff;

--- a/apps/web/app/globals.css
+++ b/apps/web/app/globals.css
@@ -12,11 +12,8 @@
   --color-popover-foreground: var(--popover-foreground);
   --color-primary: var(--primary);
   --color-primary-foreground: var(--primary-foreground);
-  --color-primary-dark: var(--primary-dark);
-  --color-primary-light: var(--primary-light);
   --color-secondary: var(--secondary);
   --color-secondary-foreground: var(--secondary-foreground);
-  --color-secondary-light: var(--secondary-light);
   --color-muted: var(--muted);
   --color-muted-foreground: var(--muted-foreground);
   --color-accent: var(--accent);
@@ -46,7 +43,8 @@
   --radius-3xl: calc(var(--radius) * 2.2);
   --radius-4xl: calc(var(--radius) * 2.6);
 
-  /* Course Community design tokens (see cc-theme.css in the design project). */
+  /* Course Community design tokens — see `docs/design_ref_new/cc-theme.css`,
+     which the `:root` and `.dark` blocks below mirror verbatim. */
   --color-cc-pg: var(--cc-pg);
   --color-cc-surface: var(--cc-surface);
   --color-cc-inset: var(--cc-inset);
@@ -96,50 +94,21 @@
 }
 
 :root {
-  --background: #faf8f1;
-  --foreground: oklch(0.145 0 0);
-  --card: oklch(1 0 0);
-  --card-foreground: oklch(0.145 0 0);
-  --popover: oklch(1 0 0);
-  --popover-foreground: oklch(0.145 0 0);
-  --primary: #243744;
-  --primary-dark: #18242d;
-  --primary-light: #778c9c;
-  --primary-foreground: white;
-  --secondary: #423842;
-  --secondary-light: #6b5b6b;
-  --secondary-foreground: white;
-  --muted: oklch(0.97 0 0);
-  --muted-foreground: oklch(0.556 0 0);
-  --accent: oklch(0.97 0 0);
-  --accent-foreground: oklch(0.205 0 0);
-  --destructive: oklch(0.577 0.245 27.325);
-  --border: oklch(0.922 0 0);
-  --input: oklch(0.922 0 0);
-  --ring: oklch(0.708 0 0);
-  --chart-1: oklch(0.87 0 0);
-  --chart-2: oklch(0.556 0 0);
-  --chart-3: oklch(0.439 0 0);
-  --chart-4: oklch(0.371 0 0);
-  --chart-5: oklch(0.269 0 0);
-  --radius: 0.625rem;
-  --sidebar: oklch(0.985 0 0);
-  --sidebar-foreground: oklch(0.145 0 0);
-  --sidebar-primary: #243744;
-  --sidebar-primary-foreground: white;
-  --sidebar-accent: oklch(0.97 0 0);
-  --sidebar-accent-foreground: oklch(0.205 0 0);
-  --sidebar-border: oklch(0.922 0 0);
-  --sidebar-ring: oklch(0.708 0 0);
+  /* Course Community — light palette, mirrored verbatim from
+     `docs/design_ref_new/cc-theme.css`. That file is the design's single
+     definition of both palettes, so nothing here is tuned locally: a colour
+     change belongs in the design and arrives here as a re-mirror.
 
-  /* Course Community — light palette.
-     pg  page background   surface cards, fields, menus   inset recessed panel
-     pill chips and tracks  rail the sidebar (brand blue in both themes)
+     pg page background  surface cards, fields, menus  inset recessed panel
+     pill chips, tracks and hover fills
+     rail the sidebar — it darkens with the theme rather than holding one brand
+     blue across both, which is what `cc-theme.css` now says and what #127 §2
+     corrects: light `#1751a6`, dark `#0d2e5e`
      ink primary text  ink2 secondary  muted supporting  dim/dim2 labels and hints
-     chip-ink text on a pill  rule/2/3 hairline, border, strong border
-     hov hover border  brand links and brand text  btn/btn-fg filled button
-     warn/warn-border/warn-ink the nudge to write a review, and
-     warn-btn/warn-btn-fg its call to action — amber in dark, blue in light */
+     chip-ink text on a pill
+     rule/rule2/rule3 hairline between rows, card border, control border
+     hov hover and focus border  brand links and brand text
+     btn/btn-fg the filled button and its foreground */
   --cc-pg: #faf8f1;
   --cc-surface: #ffffff;
   --cc-inset: #faf8f1;
@@ -159,6 +128,16 @@
   --cc-btn: #1751a6;
   --cc-btn-fg: #ffffff;
   --cc-info: rgba(23, 81, 166, 0.07);
+
+  /* `--cc-warn-*` is the **review draft** header tint. It used to be documented
+     here as "the nudge to write a review", which #127 §4 flags as wrong: #88
+     showed the actual nudge is `--cc-btn` on `--cc-surface`, and nothing amber
+     appears on it. The Design System artboard's `BANNERS` names this family
+     "Review draft header", and `Course Community - Workspace Pane.dc.html`
+     paints exactly it in its `isReview` branch — `--cc-warn` behind the draft's
+     title block, `--cc-warn-ink` on its eyebrow, `--cc-warn-border` under the
+     sticky action row and `--cc-warn-solid` as that row's opaque backing.
+     `--cc-warn-btn`/`--cc-warn-btn-fg` are that row's call to action. */
   --cc-warn: #fdf7ea;
   --cc-warn-border: #f0e6d2;
   --cc-warn-ink: #7a5309;
@@ -189,6 +168,13 @@
   --cc-node-moss: #4a7c2f;
   --cc-node-slate: #57646f;
   --cc-node-violet: #6a4ea8;
+
+  /* The panel-tint families. A tint, its border and its ink are three separate
+     tokens because a banner needs all three and none of them is derivable from
+     `--cc-success` / `--cc-danger`: dark states them as alpha over the page,
+     light as flat mixes that are not a percentage of anything. Anything
+     deriving one with `color-mix` is reading the palette from before these
+     existed (#127 §1). */
   --cc-success-tint: #e9f3ef;
   --cc-success-tint-border: #cfe4de;
   --cc-success-ink: #1c6b60;
@@ -196,47 +182,107 @@
   --cc-danger-tint-border: #f0d7cf;
   --cc-danger-ink: #a3452a;
   --cc-danger-ink2: #7a3b26;
+
+  /* "Mark as taken" and "Save" once they are on, plus that state's hover. */
   --cc-checked-tint: rgba(23, 81, 166, 0.08);
   --cc-checked-hover-tint: rgba(23, 81, 166, 0.14);
-}
 
-.dark {
-  --background: oklch(0.28 0.04 260);
-  --foreground: #e5e7eb;
-  --card: #0f172a;
-  --card-foreground: #e5e7eb;
-  --popover: #0f172a;
-  --popover-foreground: #e5e7eb;
-  --primary: oklch(0.21 0.04 266);
-  --primary-dark: #18242d;
-  --primary-light: #5b86a5;
-  --primary-foreground: #f8fafc;
-  --secondary: oklch(0.71 0.04 257);
-  --secondary-light: #6b5b6b;
-  --secondary-foreground: #e5e7eb;
-  --muted: oklch(0.269 0 0);
-  --muted-foreground: oklch(0.708 0 0);
-  --accent: oklch(0.269 0 0);
-  --accent-foreground: oklch(0.985 0 0);
-  --destructive: oklch(0.704 0.191 22.216);
-  --border: oklch(1 0 0 / 10%);
-  --input: oklch(1 0 0 / 15%);
-  --ring: oklch(0.556 0 0);
+  /* ── shadcn primitives, expressed in Course Community tokens ──────────────
+     `components/ui/**` is a stock shadcn set and styles itself against
+     `--background`, `--card`, `--muted` and friends. Those used to be a second,
+     unrelated neutral palette sitting beside `--cc-*` and disagreeing with it:
+     light `--background` was the design's cream while dark `--background` was a
+     blue-grey nothing like `--cc-pg`, and `--card` was pure white against a
+     `#0f172a` dark. That is the whole reason dark "worked better" than light —
+     the design's dark palette is self-consistent, so it was only in light that
+     the two systems sat side by side and every seam showed.
+
+     So every shadcn token is now an alias onto the `--cc-*` token that means
+     the same thing. There is one palette, and a dialog, popover or button
+     inherits the theme without knowing the design exists.
+
+     The aliases are declared once, here, rather than repeated under `.dark`. A
+     custom property is substituted at computed-value time, so `var(--cc-pg)`
+     resolves against whichever `--cc-*` values are in scope *on the element the
+     alias is declared on*. `next-themes` is configured `attribute="class"` in
+     `app/layout.tsx`, which puts `.dark` on `<html>` — the same element as
+     `:root` — so one declaration covers both themes. A second `.dark` nested on
+     a descendant would not re-resolve them; nothing in the repo does that, and
+     Tailwind's `@custom-variant dark (&:is(.dark *))` assumes the same. */
+  --background: var(--cc-pg);
+  --foreground: var(--cc-ink);
+  --card: var(--cc-surface);
+  --card-foreground: var(--cc-ink);
+  /* A popover is a menu, and `--cc-surface` is "cards, fields, menus". */
+  --popover: var(--cc-surface);
+  --popover-foreground: var(--cc-ink);
+  --primary: var(--cc-btn);
+  --primary-foreground: var(--cc-btn-fg);
+  /* shadcn's `secondary` is a *filled* quiet control, not the design's outlined
+     "Secondary" button. The design's quiet fill is the pill, and `--cc-chip-ink`
+     is literally "text on a pill". */
+  --secondary: var(--cc-pill);
+  --secondary-foreground: var(--cc-chip-ink);
+  --muted: var(--cc-pill);
+  --muted-foreground: var(--cc-muted);
+  /* `accent` is the hover or selected fill inside menus and lists. The Design
+     System lists "hover" under `--pill` alongside chips and tracks, and text on
+     a hover fill stays primary ink rather than dropping to chip ink. */
+  --accent: var(--cc-pill);
+  --accent-foreground: var(--cc-ink);
+  --destructive: var(--cc-danger);
+  /* `RULES` in the Design System splits these: `--rule2` is the card border,
+     `--rule3` the control border. shadcn's `--input` is only ever a control's
+     border (and `bg-input/30` its dark fill), so it takes `--cc-rule3` rather
+     than joining `--border` on `--cc-rule2`. */
+  --border: var(--cc-rule2);
+  --input: var(--cc-rule3);
+  /* The focus ring. `--cc-hov` is the palette's own emphasis border and is
+     already what the feedback form focuses to, so the ring matches the design
+     instead of introducing a colour the design does not have. */
+  --ring: var(--cc-hov);
+  --radius: 0.625rem;
+
+  /* The rail family. `bg-sidebar` has no consumer today — this repo's rail is
+     `features/shell/components/rail.tsx`, not shadcn's `Sidebar`, which is not
+     even vendored — but leaving these on stock greys would reintroduce the
+     second palette the moment anyone reached for one.
+
+     The rail is the one surface the design paints without tokens: there is no
+     `--cc-rail-fg`, and the artboard draws on it in plain white at varying
+     alpha in both themes. `rail.tsx` says the same and uses the same `white/nn`
+     values, so these mirror it — `.16` is the active nav item, `.20` the
+     divider above the signed-out block, and the filled button is white with
+     `--cc-rail` ink, which is the artboard's "Sign up". */
+  --sidebar: var(--cc-rail);
+  --sidebar-foreground: #ffffff;
+  --sidebar-primary: #ffffff;
+  --sidebar-primary-foreground: var(--cc-rail);
+  --sidebar-accent: rgba(255, 255, 255, 0.16);
+  --sidebar-accent-foreground: #ffffff;
+  --sidebar-border: rgba(255, 255, 255, 0.2);
+  --sidebar-ring: #ffffff;
+
+  /* `--chart-*` stays on its stock neutral ramp: it has no honest `--cc-*`
+     counterpart. The six `--cc-node-*` are the community graph's palette, and
+     #68 settled that they are what personalisation will assign to a person —
+     they are not a categorical chart scale. The one chart this repo draws, the
+     examination split, carries its own literals in
+     `features/reviews/lib/examination-palette.ts` for the reason recorded
+     there, and `components/ui/chart.tsx` has no consumer at all. Greys read
+     acceptably on either ground, so they are left rather than forced. */
   --chart-1: oklch(0.87 0 0);
   --chart-2: oklch(0.556 0 0);
   --chart-3: oklch(0.439 0 0);
   --chart-4: oklch(0.371 0 0);
   --chart-5: oklch(0.269 0 0);
-  --sidebar: oklch(0.205 0 0);
-  --sidebar-foreground: oklch(0.985 0 0);
-  --sidebar-primary: oklch(0.21 0.04 266);
-  --sidebar-primary-foreground: #f8fafc;
-  --sidebar-accent: oklch(0.269 0 0);
-  --sidebar-accent-foreground: oklch(0.985 0 0);
-  --sidebar-border: oklch(1 0 0 / 10%);
-  --sidebar-ring: oklch(0.556 0 0);
+}
 
-  /* Course Community — dark palette. */
+/* Course Community — dark palette, again `cc-theme.css` verbatim. Only the
+   `--cc-*` tokens are restated: every shadcn alias in `:root` is written in
+   terms of these and `.dark` lands on that same `<html>` element, so the whole
+   primitive set swaps with them. */
+.dark {
   --cc-pg: #071831;
   --cc-surface: #0b254c;
   --cc-inset: #040f1f;
@@ -256,8 +302,9 @@
   --cc-btn: #8bb3ef;
   --cc-btn-fg: #0a2449;
   --cc-info: rgba(226, 236, 251, 0.1);
-  /* The warn button is amber here where light is blue. That hue change is the
-     design's, not a mistake: on the dark blue surface a blue button vanishes. */
+  /* The review draft's call to action is amber here where light is blue. That
+     hue change is the design's, not a mistake: on the dark blue surface a blue
+     button vanishes. */
   --cc-warn: rgba(223, 165, 60, 0.16);
   --cc-warn-border: rgba(223, 165, 60, 0.3);
   --cc-warn-ink: #f2c879;
@@ -281,6 +328,10 @@
   --cc-node-moss: #a5d47c;
   --cc-node-slate: #b3c1d0;
   --cc-node-violet: #bda2f0;
+
+  /* The tints are alpha over the page here rather than the flat mixes light
+     uses, and the inks collapse onto the solid colour: at this lightness
+     `--cc-success` and `--cc-danger` already read as text. */
   --cc-success-tint: rgba(95, 208, 138, 0.14);
   --cc-success-tint-border: rgba(95, 208, 138, 0.3);
   --cc-success-ink: #5fd08a;

--- a/apps/web/app/layout.tsx
+++ b/apps/web/app/layout.tsx
@@ -36,11 +36,45 @@ export default function RootLayout({
         className={`${geistSans.variable} ${geistMono.variable} antialiased bg-background`}
       >
         <TRPCReactProvider>
+          {/*
+            Three deliberate deviations from what the artboards do, each for a
+            reason the artboards have no way to express.
+
+            `attribute="class"`. The design drives the theme with a
+            `data-cc-theme` attribute on the root element. This repo drives it
+            with a `.dark` class, because Tailwind's
+            `@custom-variant dark (&:is(.dark *))` in `globals.css` is defined
+            against that class and every `dark:` utility in `components/ui/**`
+            depends on it. Switching the mechanism would be a large blast radius
+            for nothing a reader could see, so the class stays and only the
+            storage and the wording follow the design.
+
+            `defaultTheme="system"` with `enableSystem`, where the design
+            defaults to light. `cc-store.js` reads `localStorage` with a `false`
+            fallback because a static HTML mock has no way to ask the operating
+            system anything — "default light" is that limitation, not a
+            decision. Honouring `prefers-color-scheme` is a real accessibility
+            win for a reader who has already told their OS they want dark, and
+            for everyone else the OS default *is* light, so the artboard's first
+            paint is what they get anyway. An explicit choice always wins over
+            both.
+
+            `storageKey="cc:theme"`. The design persists under that key and
+            `next-themes` defaults to `"theme"`; matching costs nothing and
+            keeps one name for one thing across the two.
+
+            `disableTransitionOnChange` is deliberately *not* set. It suppresses
+            every transition for a frame while the class flips, which would kill
+            the cross-fade the `cc-theme` utility exists to provide —
+            `cc-theme.css` transitions `background-color`, `color` and
+            `border-color` on the whole subtree for exactly this moment, and
+            `AppShell` opts every route into it.
+          */}
           <ThemeProvider
             attribute="class"
             defaultTheme="system"
             enableSystem
-            disableTransitionOnChange
+            storageKey="cc:theme"
           >
             <Toaster />
             {children}

--- a/apps/web/app/layout.tsx
+++ b/apps/web/app/layout.tsx
@@ -61,7 +61,11 @@ export default function RootLayout({
 
             `storageKey="cc:theme"`. The design persists under that key and
             `next-themes` defaults to `"theme"`; matching costs nothing and
-            keeps one name for one thing across the two.
+            keeps one name for one thing across the two. It does not cost a
+            reader their existing choice either — `ThemeProvider` carries a
+            one-time migration of the old key, which has to run before
+            `next-themes`' own pre-paint script and so lives there rather than
+            in an effect.
 
             `disableTransitionOnChange` is deliberately *not* set. It suppresses
             every transition for a frame while the class flips, which would kill

--- a/apps/web/components/theme-provider.tsx
+++ b/apps/web/components/theme-provider.tsx
@@ -3,9 +3,38 @@
 import { ThemeProvider as NextThemesProvider } from "next-themes";
 import type * as React from "react";
 
+/**
+ * The one-time move of a saved theme preference onto the design's key.
+ *
+ * `next-themes` persists under `theme` by default and this app now asks it for
+ * `cc:theme`, which is the key the artboards use. `next-themes` only ever reads
+ * the key it is configured with, so without this a reader who had already
+ * chosen dark would be handed their system theme instead, once, silently, and
+ * would have to choose again.
+ *
+ * It is a string rather than a `useEffect` because of *when* it has to run.
+ * `next-themes` writes the theme class from its own blocking script before
+ * first paint, and that script has already decided by the time any React effect
+ * runs — so migrating in an effect would still flash the wrong theme for a
+ * frame. Rendering this before `NextThemesProvider` puts it earlier in the HTML
+ * than that script, so the value is in place before anything reads it.
+ *
+ * It is deliberately conservative: it never overwrites an existing `cc:theme`,
+ * it copies only the three values `next-themes` itself writes, and the whole
+ * thing is inside a `try` because reading `localStorage` throws outright in
+ * some privacy modes rather than returning null.
+ */
+export const THEME_KEY_MIGRATION = `(function(){try{var s=window.localStorage;if(s.getItem("cc:theme")!==null)return;var v=s.getItem("theme");if(v==="light"||v==="dark"||v==="system")s.setItem("cc:theme",v)}catch(e){}})()`;
+
 export function ThemeProvider({
   children,
   ...props
 }: React.ComponentProps<typeof NextThemesProvider>) {
-  return <NextThemesProvider {...props}>{children}</NextThemesProvider>;
+  return (
+    <>
+      {/* biome-ignore lint/security/noDangerouslySetInnerHtml: a fixed literal with no interpolation; it has to be inline to beat next-themes' own pre-paint script. */}
+      <script dangerouslySetInnerHTML={{ __html: THEME_KEY_MIGRATION }} />
+      <NextThemesProvider {...props}>{children}</NextThemesProvider>
+    </>
+  );
 }

--- a/apps/web/data/course-card-sample.ts
+++ b/apps/web/data/course-card-sample.ts
@@ -1,7 +1,7 @@
 /**
  * Course card fixtures, extracted from the design.
  *
- * Source: `docs/design/Course Community - Course Card.dc.html` — the
+ * Source: `docs/design_ref_new/Course Community - Course Card.dc.html` — the
  * `SAMPLE_GEO` / `SAMPLE_COURSE` literals in its trailing
  * `<script type="text/x-dc">` block.
  *

--- a/apps/web/features/about/components/about.tsx
+++ b/apps/web/features/about/components/about.tsx
@@ -3,7 +3,7 @@ import { FeedbackForm } from "@/features/feedback";
 import { PageColumn, PageHeader } from "@/features/shell";
 
 /**
- * `/about` — `docs/design/Course Community - About.dc.html`.
+ * `/about` — `docs/design_ref_new/Course Community - About.dc.html`.
  *
  * The artboard is one page called "About & contact": a page header, the
  * open-source card, and the Contact Form artboard imported underneath it. So the

--- a/apps/web/features/collections/components/collection-chip.spec.tsx
+++ b/apps/web/features/collections/components/collection-chip.spec.tsx
@@ -1,0 +1,72 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it, vi } from "vitest";
+import type { Collection } from "@/features/courses";
+import { CollectionChip } from "./collection-chip";
+
+/**
+ * The chip on its own. `collections.spec.tsx` covers it inside the page, which
+ * is where its behaviour belongs; what is here is the part of it the page test
+ * cannot see — which tokens its destructive item paints with.
+ */
+
+const COLLECTION: Collection = {
+  id: "c1",
+  name: "Machine learning",
+  createdAt: "2026-01-01T00:00:00.000Z",
+  courseCodes: ["DD2380", "DD2421"],
+};
+
+function renderChip() {
+  const onDelete = vi.fn();
+  render(
+    <CollectionChip
+      collection={COLLECTION}
+      onOpen={vi.fn()}
+      onRename={vi.fn()}
+      onDelete={onDelete}
+    />,
+  );
+  return { onDelete };
+}
+
+describe("CollectionChip", () => {
+  /**
+   * `Course Community - Collections.dc.html` draws this item as `#a4402a` over
+   * a `#fdf3ef` hover, which is `--cc-danger-ink` over `--cc-danger-tint`. The
+   * chip used to derive that hover with
+   * `color-mix(in srgb, var(--cc-danger) 12%, var(--cc-surface))` because the
+   * tint family did not exist yet (#127 §1) — and no mix of the solid colour
+   * could have reached it in dark, where the design states the tint as alpha
+   * over the page instead.
+   *
+   * Classes rather than computed colours: jsdom runs no Tailwind, so what is
+   * assertable is the token the component asked for, which is what regressed.
+   */
+  it("paints Delete in the danger tint family, not a colour-mixed derivation", async () => {
+    const user = userEvent.setup({ delay: null });
+    renderChip();
+
+    await user.click(
+      screen.getByRole("button", { name: "More actions for Machine learning" }),
+    );
+
+    const remove = screen.getByRole("menuitem", { name: "Delete" });
+    expect(remove).toHaveClass("text-cc-danger-ink", "hover:bg-cc-danger-tint");
+    expect(remove.className).not.toContain("color-mix");
+  });
+
+  it("asks the page to delete rather than deleting anything itself", async () => {
+    const user = userEvent.setup({ delay: null });
+    const { onDelete } = renderChip();
+
+    await user.click(
+      screen.getByRole("button", { name: "More actions for Machine learning" }),
+    );
+    await user.click(screen.getByRole("menuitem", { name: "Delete" }));
+
+    expect(onDelete).toHaveBeenCalledOnce();
+    // The menu closes with it, so a second click cannot re-fire the mutation.
+    expect(screen.queryByRole("menuitem", { name: "Delete" })).toBeNull();
+  });
+});

--- a/apps/web/features/collections/components/collection-chip.tsx
+++ b/apps/web/features/collections/components/collection-chip.tsx
@@ -103,6 +103,13 @@ export function CollectionChip({
             >
               Rename
             </button>
+            {/* The artboard's own pair — `#a4402a` on a `#fdf3ef` hover — which
+                is `--cc-danger-ink` over `--cc-danger-tint` now that the tint
+                family exists. This used to derive the hover with `color-mix`
+                against `--cc-danger`, because when the chip was built the
+                palette stopped at the solid colour (#127 §1). The derivation
+                was never the design's: dark states the tint as alpha over the
+                page, so no percentage of the solid reaches it. */}
             <button
               type="button"
               role="menuitem"
@@ -110,7 +117,7 @@ export function CollectionChip({
                 menu.close();
                 onDelete();
               }}
-              className="block w-full cursor-pointer rounded-[6px] px-[9px] py-2 text-left text-[12.5px] text-cc-danger hover:bg-[color-mix(in_srgb,var(--cc-danger)_12%,var(--cc-surface))]"
+              className="block w-full cursor-pointer rounded-[6px] px-[9px] py-2 text-left text-[12.5px] text-cc-danger-ink hover:bg-cc-danger-tint"
             >
               Delete
             </button>

--- a/apps/web/features/collections/components/collection-tile.spec.tsx
+++ b/apps/web/features/collections/components/collection-tile.spec.tsx
@@ -1,0 +1,67 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it, vi } from "vitest";
+import type { Collection } from "@/features/courses";
+import { CollectionTile } from "./collection-tile";
+
+/**
+ * The tile on its own, for the same reason as {@link CollectionChip}'s spec:
+ * `collections.spec.tsx` owns the page behaviour, and this owns the one thing
+ * that behaviour cannot show — which tokens the destructive item paints with.
+ */
+
+const COLLECTION: Collection = {
+  id: "c1",
+  name: "Machine learning",
+  createdAt: "2026-01-01T00:00:00.000Z",
+  courseCodes: ["DD2380"],
+};
+
+function renderTile() {
+  const onDelete = vi.fn();
+  render(
+    <CollectionTile
+      collection={COLLECTION}
+      courseFor={() => undefined}
+      onOpen={vi.fn()}
+      onRename={vi.fn()}
+      onDelete={onDelete}
+    />,
+  );
+  return { onDelete };
+}
+
+describe("CollectionTile", () => {
+  /**
+   * Same pair as the chip's, from the same artboard rows — `--cc-danger-ink`
+   * over a `--cc-danger-tint` hover. Both were `color-mix` derivations against
+   * `--cc-danger` before the tint family existed (#127 §1), and both are
+   * asserted separately because they are two components that happen to agree,
+   * not one shared control.
+   */
+  it("paints Delete in the danger tint family, not a colour-mixed derivation", async () => {
+    const user = userEvent.setup({ delay: null });
+    renderTile();
+
+    await user.click(
+      screen.getByRole("button", { name: "More actions for Machine learning" }),
+    );
+
+    const remove = screen.getByRole("menuitem", { name: "Delete" });
+    expect(remove).toHaveClass("text-cc-danger-ink", "hover:bg-cc-danger-tint");
+    expect(remove.className).not.toContain("color-mix");
+  });
+
+  it("asks the page to delete rather than deleting anything itself", async () => {
+    const user = userEvent.setup({ delay: null });
+    const { onDelete } = renderTile();
+
+    await user.click(
+      screen.getByRole("button", { name: "More actions for Machine learning" }),
+    );
+    await user.click(screen.getByRole("menuitem", { name: "Delete" }));
+
+    expect(onDelete).toHaveBeenCalledOnce();
+    expect(screen.queryByRole("menuitem", { name: "Delete" })).toBeNull();
+  });
+});

--- a/apps/web/features/collections/components/collection-tile.tsx
+++ b/apps/web/features/collections/components/collection-tile.tsx
@@ -113,6 +113,11 @@ export function CollectionTile({
               >
                 Rename
               </button>
+              {/* Same pair as the chip's Delete, and the artboard's own:
+                  `--cc-danger-ink` over a `--cc-danger-tint` hover. The
+                  `color-mix` this replaces predated the tint family (#127 §1)
+                  and could not have reproduced it — dark states the tint as
+                  alpha over the page, not as a share of the solid colour. */}
               <button
                 type="button"
                 role="menuitem"
@@ -120,7 +125,7 @@ export function CollectionTile({
                   menu.close();
                   onDelete();
                 }}
-                className="block w-full cursor-pointer rounded-[6px] px-[9px] py-2 text-left text-[12.5px] text-cc-danger hover:bg-[color-mix(in_srgb,var(--cc-danger)_12%,var(--cc-surface))]"
+                className="block w-full cursor-pointer rounded-[6px] px-[9px] py-2 text-left text-[12.5px] text-cc-danger-ink hover:bg-cc-danger-tint"
               >
                 Delete
               </button>

--- a/apps/web/features/courses/components/course-card.tsx
+++ b/apps/web/features/courses/components/course-card.tsx
@@ -8,7 +8,7 @@ import type { CardGeometry, CourseCardAction, CourseCardModel } from "@/types";
 /**
  * The course card, shared by Explore, Saved and Collections.
  *
- * Straight from `docs/design/Course Community - Course Card.dc.html`. It renders
+ * Straight from `docs/design_ref_new/Course Community - Course Card.dc.html`. It renders
  * `c` and measures nothing: geometry arrives as one `geo` object so the parent
  * owns the collapse ramp, and the only structural difference between the pages
  * is `action` — Explore's split Save button, or the picker on its own. That is
@@ -75,7 +75,7 @@ function geometryVars(geo: CardGeometry): CSSProperties {
 
 /**
  * The phone end of the ramp, from
- * `docs/design/reference/Course Community - Mobile Preview.dc.html`. It is a
+ * `docs/design_ref_new/Course Community - Mobile Preview.dc.html`. It is a
  * container query rather than a viewport one because a card is narrow whenever
  * its column is, phone or not.
  */

--- a/apps/web/features/courses/lib/card-geometry.ts
+++ b/apps/web/features/courses/lib/card-geometry.ts
@@ -7,9 +7,9 @@
  * of the ramp. That split is the reason the card is one component and not two.
  *
  * Every number here is the artboard's:
- * `docs/design/Course Community - Explore.dc.html` computes exactly this ramp,
+ * `docs/design_ref_new/Course Community - Explore.dc.html` computes exactly this ramp,
  * and at full width it lands on the `SAMPLE_GEO` literal in
- * `docs/design/Course Community - Course Card.dc.html`, which the fixture
+ * `docs/design_ref_new/Course Community - Course Card.dc.html`, which the fixture
  * mirrors — `card-geometry.spec.ts` holds those two together.
  */
 

--- a/apps/web/features/feedback/components/feedback-form.spec.tsx
+++ b/apps/web/features/feedback/components/feedback-form.spec.tsx
@@ -1,4 +1,4 @@
-import { render, screen } from "@testing-library/react";
+import { render, screen, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { FeedbackForm } from "./feedback-form";
@@ -69,6 +69,39 @@ describe("FeedbackForm", () => {
       expect(
         screen.queryByRole("button", { name: "Send message" }),
       ).not.toBeInTheDocument();
+    });
+
+    /**
+     * The panel was built when the palette had no green and borrowed
+     * `--cc-info` with `--cc-brand` ink, which read as information rather than
+     * success. The tint family exists now (#127 §1) and its three tokens are
+     * the artboard's three hexes exactly, so the panel says "this worked" in
+     * the design's own colours in both themes.
+     *
+     * Classes rather than computed colours: jsdom runs no Tailwind, so a
+     * colour assertion here would only ever observe the absence of a
+     * stylesheet. What regressed before was the token choice, and that is what
+     * a class name records.
+     */
+    it("confirms in the success tint rather than a colour-mixed stand-in", async () => {
+      const user = userEvent.setup({ delay: null });
+      render(<FeedbackForm />);
+
+      await fillIn(user, {
+        name: "Elsa",
+        email: "elsa@kth.se",
+        message: "Hello",
+      });
+      await send(user);
+
+      const sent = await screen.findByRole("status");
+      expect(sent).toHaveClass(
+        "bg-cc-success-tint",
+        "border-cc-success-tint-border",
+      );
+      expect(within(sent).getByText("Message sent")).toHaveClass(
+        "text-cc-success-ink",
+      );
     });
 
     it("never offers or asks for an account", () => {
@@ -144,9 +177,12 @@ describe("FeedbackForm", () => {
     });
     await send(user);
 
-    expect(await screen.findByRole("alert")).toHaveTextContent(
-      "That did not send. Please try again.",
-    );
+    const failure = await screen.findByRole("alert");
+    expect(failure).toHaveTextContent("That did not send. Please try again.");
+    // The artboard's `#a3452a` is `--cc-danger-ink`. The line used to borrow
+    // `--cc-warn-ink` for want of a token, which turns out to be the review
+    // draft's amber and says nothing about a failure (#127 §1, §4).
+    expect(failure).toHaveClass("text-cc-danger-ink");
     expect(screen.queryByRole("status")).not.toBeInTheDocument();
     expect(screen.getByLabelText("Message")).toHaveValue("Hello");
   });

--- a/apps/web/features/feedback/components/feedback-form.tsx
+++ b/apps/web/features/feedback/components/feedback-form.tsx
@@ -7,7 +7,7 @@ import { cn } from "@/lib/utils";
 import { useSubmitFeedback } from "../api/mutations";
 
 /**
- * The **Feedback form** — `docs/design/Course Community - Contact Form.dc.html`,
+ * The **Feedback form** — `docs/design_ref_new/Course Community - Contact Form.dc.html`,
  * which the About artboard imports as a section and `/contact` renders on its
  * own.
  *
@@ -105,22 +105,22 @@ export function FeedbackForm() {
       // role is `status`, which is what announces the confirmation.
       //
       // The artboard paints this panel green — `#e9f3ef` on `#cfe4de` with
-      // `#1c6b60` ink — and the palette has no green. There is no success or
-      // danger family among the 24 `--cc-*` tokens at all, and inventing one
-      // here would desynchronise `globals.css` from `cc-theme.css`, which it
-      // mirrors. So the panel takes the nearest family that swaps correctly for
-      // dark — `--cc-info` on `--cc-rule` with `--cc-brand` ink — and the tick
-      // carries the "this worked" reading that the hue no longer does. The PR
-      // reports the gap so the design gets a success token at source.
-      <output className="mt-4 flex animate-in items-start gap-[11px] rounded-[12px] border border-cc-rule bg-cc-info px-4 py-[15px] duration-200 ease-out fade-in slide-in-from-bottom-[6px]">
+      // `#1c6b60` ink — and when the form was built the palette had no green at
+      // all, so the panel borrowed `--cc-info` on `--cc-rule` with `--cc-brand`
+      // ink and the PR reported the gap. The gap is closed: those three hexes
+      // are now `--cc-success-tint`, `--cc-success-tint-border` and
+      // `--cc-success-ink` verbatim, and the Design System artboard's `BANNERS`
+      // names this exact combination "Upload success banner" (#127 §1). The
+      // tick stays, because a colour is not what should carry "this worked".
+      <output className="mt-4 flex animate-in items-start gap-[11px] rounded-[12px] border border-cc-success-tint-border bg-cc-success-tint px-4 py-[15px] duration-200 ease-out fade-in slide-in-from-bottom-[6px]">
         <CircleCheck
           size={17}
           strokeWidth={2.1}
           aria-hidden
-          className="mt-px shrink-0 text-cc-brand"
+          className="mt-px shrink-0 text-cc-success-ink"
         />
         <div>
-          <div className="font-semibold text-[14px] text-cc-brand">
+          <div className="font-semibold text-[14px] text-cc-success-ink">
             Message sent
           </div>
           <div className="mt-[3px] text-[12.5px] text-cc-ink2">
@@ -211,12 +211,13 @@ export function FeedbackForm() {
         >
           {submitFeedback.isPending ? "Sending…" : "Send message"}
         </button>
-        {/* The artboard's `#a3452a` has no token either, and `--cc-warn-ink` is
-            the palette's only ink that means "look at this" and swaps for dark.
-            `role="alert"` is what actually carries the message, so the reading
-            does not rest on the hue. Reported in the PR with the panel above. */}
+        {/* The artboard's `#a3452a` is `--cc-danger-ink` exactly. It had no
+            token when this was written, so the line borrowed `--cc-warn-ink`;
+            it has one now (#127 §1), and `--cc-warn-*` turns out to mean the
+            review draft rather than anything that failed. `role="alert"` is
+            still what carries the message — the hue only agrees with it. */}
         {error ? (
-          <p className="mt-2 text-[12.5px] text-cc-warn-ink" role="alert">
+          <p className="mt-2 text-[12.5px] text-cc-danger-ink" role="alert">
             {error}
           </p>
         ) : null}

--- a/apps/web/features/reviews/lib/examination-palette.ts
+++ b/apps/web/features/reviews/lib/examination-palette.ts
@@ -8,7 +8,7 @@ type ExaminationKey = (typeof EXAMINATION_DISTRIBUTION_KEYS)[number];
 
 /**
  * Fill colours for the examination split, extracted from `EXAMINATION_COLORS`
- * in `docs/design/cc-store.js`.
+ * in `docs/design_ref_new/cc-store.js`.
  *
  * These are literal hexes rather than `--cc-*` tokens on purpose, and it is the
  * one place in this feature that is not styled against a token. A stacked bar

--- a/apps/web/features/shell/components/page-column.spec.tsx
+++ b/apps/web/features/shell/components/page-column.spec.tsx
@@ -10,7 +10,7 @@ describe("PageColumn", () => {
       </PageColumn>,
     );
     const column = screen.getByText("Page body").parentElement;
-    // `PAGE_MAX_WIDTH` in docs/design/cc-store.js.
+    // `PAGE_MAX_WIDTH` in docs/design_ref_new/cc-store.js.
     expect(column).toHaveClass("max-w-[1216px]");
   });
 

--- a/apps/web/features/shell/components/page-column.tsx
+++ b/apps/web/features/shell/components/page-column.tsx
@@ -4,7 +4,7 @@ import { cn } from "@/lib/utils";
 /**
  * The content column every page renders inside, beneath the shell's topbar.
  *
- * `docs/design/cc-store.js` keeps the cap as one shared constant rather than a
+ * `docs/design_ref_new/cc-store.js` keeps the cap as one shared constant rather than a
  * literal per artboard —
  *
  *   "Shared page-content cap. Every top-level page shell reads this instead of

--- a/apps/web/features/shell/components/page-header.tsx
+++ b/apps/web/features/shell/components/page-header.tsx
@@ -10,7 +10,7 @@ type Props = {
  * The one page-title block every wide-shell page uses — same padding, size and
  * spacing everywhere, so no page hand-writes its own header markup.
  *
- * Straight from `docs/design/Course Community - Page Header.dc.html`, which is
+ * Straight from `docs/design_ref_new/Course Community - Page Header.dc.html`, which is
  * the whole of that artboard.
  */
 export function PageHeader({ title, subtitle }: Props) {

--- a/apps/web/features/shell/components/rail.tsx
+++ b/apps/web/features/shell/components/rail.tsx
@@ -18,11 +18,21 @@ import { cn } from "@/lib/utils";
 /**
  * The rail: the blue column every page renders beside.
  *
- * It is `--cc-rail` in both themes — deliberate, not an unswapped token — so its
- * own foreground is fixed too. There is no `--cc-rail-fg` in the palette, and
- * the artboard paints on it with plain white at varying alpha, which is what the
- * `white/nn` utilities here do. That is the one place this file is not reading a
- * `--cc-*` token, and it is the design's own decision.
+ * It is `--cc-rail` in both themes, but that token is **not** one colour in
+ * both: `cc-theme.css` now calls it "the sidebar (darkens with the theme)" and
+ * gives it `#1751a6` in light and `#0d2e5e` in dark. #85 was told the opposite
+ * — "brand blue in both themes" — and #127 §2 corrects it. Nothing here changes
+ * as a result; the token already swaps and the rail already reads it. Against
+ * the revised dark page (`--cc-pg` `#071831`) the darker rail is still the
+ * lighter of the two, so the column still separates from the content beside it
+ * without the light theme's full brand blue glaring out of a dark screen.
+ *
+ * Its foreground is fixed even though its background is not. There is no
+ * `--cc-rail-fg` in the palette, and the artboard paints on the rail with plain
+ * white at varying alpha in both themes — which is what the `white/nn`
+ * utilities here do, and what `--sidebar-*` in `globals.css` mirrors. That is
+ * the one place this file is not reading a `--cc-*` token, and it is the
+ * design's own decision.
  *
  * Two rail colours the artboard states outright have no token behind them — the
  * avatar chip (`#7ea6d8` on `#0d2f5e`) and the sign-up button's ink (`#12417f`).

--- a/apps/web/features/shell/components/theme-migration.spec.tsx
+++ b/apps/web/features/shell/components/theme-migration.spec.tsx
@@ -1,3 +1,6 @@
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
 import { renderToStaticMarkup } from "react-dom/server";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
@@ -117,5 +120,36 @@ describe("where the migration sits in the document", () => {
     // The `biome-ignore` on `dangerouslySetInnerHTML` is only defensible while
     // the string stays a fixed literal, so pin that rather than trust the note.
     expect(THEME_KEY_MIGRATION).not.toMatch(/\$\{|<\/script/i);
+  });
+});
+
+/**
+ * The migration writes `cc:theme` as a literal, and `app/layout.tsx` asks
+ * `next-themes` for `cc:theme` as a separate literal. Two spellings of one name
+ * in two files is precisely the drift `theme-tokens.spec.tsx` exists to catch on
+ * the colour side, and here it fails *silently*: change the provider's key alone
+ * and the migration keeps happily populating a key nothing reads.
+ */
+describe("the key the migration writes", () => {
+  const layout = readFileSync(
+    path.resolve(
+      path.dirname(fileURLToPath(import.meta.url)),
+      "../../../app/layout.tsx",
+    ),
+    "utf8",
+  );
+
+  it("is the key `app/layout.tsx` configures next-themes with", () => {
+    const configured = /storageKey=\{?"([^"]+)"/.exec(layout)?.[1];
+    expect(configured).toBe("cc:theme");
+    expect(THEME_KEY_MIGRATION).toContain(`s.setItem("${configured}"`);
+    expect(THEME_KEY_MIGRATION).toContain(`s.getItem("${configured}")`);
+  });
+
+  it("reads next-themes' own default key as the source", () => {
+    // `next-themes` persists under `theme` when no `storageKey` is given, which
+    // is what every returning reader has. The provider passed no key before this
+    // PR, so that is the only legacy spelling there can be.
+    expect(THEME_KEY_MIGRATION).toContain(`s.getItem("theme")`);
   });
 });

--- a/apps/web/features/shell/components/theme-migration.spec.tsx
+++ b/apps/web/features/shell/components/theme-migration.spec.tsx
@@ -1,0 +1,121 @@
+import { renderToStaticMarkup } from "react-dom/server";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  THEME_KEY_MIGRATION,
+  ThemeProvider,
+} from "@/components/theme-provider";
+
+/**
+ * The one-time move of a saved theme preference from `next-themes`' default
+ * `theme` onto the design's `cc:theme`.
+ *
+ * It is a script string rather than a component, because it has to execute
+ * before `next-themes`' own pre-paint script rather than in an effect. So it is
+ * exercised the way the browser will: evaluated against a real `localStorage`,
+ * with the outcome read back out of storage.
+ *
+ * It lives beside the shell for the reason `theme-tokens.spec.tsx` does —
+ * vitest's `ui` project is the only glob that reaches this code, `components/`
+ * is not in any of them, and the shell is what mounts and flips the theme.
+ */
+
+function run() {
+  // biome-ignore lint/security/noGlobalEval: the subject under test is a script string; running it is the test.
+  eval(THEME_KEY_MIGRATION);
+}
+
+beforeEach(() => {
+  window.localStorage.clear();
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("the theme storage-key migration", () => {
+  it.each(["light", "dark", "system"])(
+    "carries a saved %s over to the design's key",
+    (choice) => {
+      window.localStorage.setItem("theme", choice);
+      run();
+      expect(window.localStorage.getItem("cc:theme")).toBe(choice);
+    },
+  );
+
+  it("leaves a choice already made under the new key alone", () => {
+    window.localStorage.setItem("theme", "light");
+    window.localStorage.setItem("cc:theme", "dark");
+    run();
+    // The newer key is the one the reader has actually been using; the old one
+    // is a leftover, and running twice must not undo the second choice.
+    expect(window.localStorage.getItem("cc:theme")).toBe("dark");
+  });
+
+  it("copies nothing when there is nothing to copy", () => {
+    run();
+    expect(window.localStorage.getItem("cc:theme")).toBeNull();
+  });
+
+  it("ignores a legacy value next-themes would never have written", () => {
+    window.localStorage.setItem("theme", "midnight");
+    run();
+    expect(window.localStorage.getItem("cc:theme")).toBeNull();
+  });
+
+  /**
+   * Reading `localStorage` throws outright in some privacy modes rather than
+   * returning null, and this runs inline in the document — an exception here
+   * would abort the script and take the theme with it.
+   */
+  it("survives storage being unreadable", () => {
+    vi.spyOn(Storage.prototype, "getItem").mockImplementation(() => {
+      throw new Error("The operation is insecure.");
+    });
+    expect(() => run()).not.toThrow();
+  });
+});
+
+/**
+ * The whole fix rests on *when* the migration runs, and that in turn rests on
+ * one structural fact: both scripts are inline, so the parser runs them in
+ * document order, and `next-themes` renders its pre-paint script as the first
+ * child of its own provider. Rendering the migration as a sibling *before* that
+ * provider is therefore the entire ordering guarantee — and it is a one-line
+ * edit away from being silently lost, with no visible symptom except a returning
+ * reader's preference being ignored again.
+ *
+ * So the order is asserted on the server render, which is the artefact the
+ * browser actually parses. RTL's `render` would not do: React does not execute
+ * a script it creates on the client, so a client render says nothing about
+ * first paint.
+ */
+describe("where the migration sits in the document", () => {
+  const scriptsOf = (html: string) =>
+    [...html.matchAll(/<script[^>]*>([\s\S]*?)<\/script>/g)].map((m) => m[1]);
+
+  it("is emitted before next-themes' own pre-paint script", () => {
+    const html = renderToStaticMarkup(
+      <ThemeProvider
+        attribute="class"
+        defaultTheme="system"
+        enableSystem
+        storageKey="cc:theme"
+      >
+        <div />
+      </ThemeProvider>,
+    );
+
+    const scripts = scriptsOf(html);
+    expect(scripts).toHaveLength(2);
+    expect(scripts[0]).toBe(THEME_KEY_MIGRATION);
+    // next-themes' script is the one that resolves `prefers-color-scheme` and
+    // writes the class; by then `cc:theme` is already populated.
+    expect(scripts[1]).toContain("prefers-color-scheme");
+  });
+
+  it("is inert markup — no interpolation reaches the inline script", () => {
+    // The `biome-ignore` on `dangerouslySetInnerHTML` is only defensible while
+    // the string stays a fixed literal, so pin that rather than trust the note.
+    expect(THEME_KEY_MIGRATION).not.toMatch(/\$\{|<\/script/i);
+  });
+});

--- a/apps/web/features/shell/components/theme-toggle.spec.tsx
+++ b/apps/web/features/shell/components/theme-toggle.spec.tsx
@@ -1,0 +1,95 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { renderToStaticMarkup } from "react-dom/server";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { ThemeToggle } from "./theme-toggle";
+
+/**
+ * The toggle on its own, which is where the first-paint behaviour can actually
+ * be seen. `app-shell.spec.tsx` covers it in place, but only after mount —
+ * `render` flushes effects, so a shell test can never observe the frame the
+ * reader complains about.
+ */
+
+const setTheme = vi.fn();
+const useThemeResult = vi.fn();
+
+vi.mock("next-themes", () => ({ useTheme: () => useThemeResult() }));
+
+beforeEach(() => {
+  setTheme.mockClear();
+  useThemeResult.mockReturnValue({ resolvedTheme: "light", setTheme });
+});
+
+describe("the theme toggle", () => {
+  it("offers dark from light", async () => {
+    const user = userEvent.setup();
+    render(<ThemeToggle />);
+
+    await user.click(
+      screen.getByRole("button", { name: "Switch to dark mode" }),
+    );
+    expect(setTheme).toHaveBeenCalledWith("dark");
+  });
+
+  it("offers light from dark", async () => {
+    useThemeResult.mockReturnValue({ resolvedTheme: "dark", setTheme });
+    const user = userEvent.setup();
+    render(<ThemeToggle />);
+
+    await user.click(
+      screen.getByRole("button", { name: "Switch to light mode" }),
+    );
+    expect(setTheme).toHaveBeenCalledWith("light");
+  });
+
+  /**
+   * The regression behind #127's "the themes are not mapped consistently": the
+   * toggle used to render one glyph chosen from `resolvedTheme`, which is
+   * unknowable on the server, so every dark-theme page load painted a moon and
+   * then flipped it to a sun. Both glyphs are in the tree now and the `dark:`
+   * variant hides one, so the decision happens in CSS — before paint, and with
+   * nothing for hydration to disagree about.
+   *
+   * Asserting the variant classes rather than what is visible is deliberate:
+   * jsdom has no Tailwind, so visibility here would only ever be the absence of
+   * a stylesheet. The classes are the contract.
+   */
+  it("renders both glyphs so the first paint needs no correction", () => {
+    useThemeResult.mockReturnValue({ resolvedTheme: undefined, setTheme });
+    render(<ThemeToggle />);
+
+    const glyphs = [...screen.getByRole("button").querySelectorAll("svg")].map(
+      (glyph) => glyph.getAttribute("class"),
+    );
+
+    expect(glyphs).toHaveLength(2);
+    expect(glyphs.some((cls) => cls?.includes("dark:hidden"))).toBe(true);
+    expect(glyphs.some((cls) => cls?.includes("hidden dark:block"))).toBe(true);
+  });
+
+  /**
+   * The server render, which is the only place the pre-mount state can be seen
+   * — `render` flushes effects, so `mounted` is already true by the time any
+   * assertion above runs.
+   *
+   * It is asserted because getting it wrong is a hydration mismatch rather than
+   * a cosmetic slip. An earlier attempt at this replaced the `mounted` gate
+   * with `resolvedTheme === undefined`, on the assumption that `next-themes`
+   * reports nothing until it has read storage. It reports `defaultTheme` while
+   * rendering on the server and `undefined` on the first client render, so the
+   * two sides named the button differently and React said so. The generic name
+   * here is what proves the gate is not reading the theme.
+   */
+  it("names itself without claiming a theme, in the render the server sends", () => {
+    // Whatever `next-themes` says on the server must not reach the markup.
+    useThemeResult.mockReturnValue({ resolvedTheme: "light", setTheme });
+
+    const markup = renderToStaticMarkup(<ThemeToggle />);
+
+    expect(markup).toContain('aria-label="Switch theme"');
+    expect(markup).not.toContain("Switch to dark mode");
+    // Both glyphs ship in that first payload, so neither has to be swapped in.
+    expect(markup.match(/<svg/g)).toHaveLength(2);
+  });
+});

--- a/apps/web/features/shell/components/theme-toggle.tsx
+++ b/apps/web/features/shell/components/theme-toggle.tsx
@@ -12,9 +12,27 @@ import { useEffect, useState } from "react";
  * is configured with `attribute="class"` in `app/layout.tsx` and that mechanism
  * wins. Only the icon and the wording come from the artboard.
  *
- * Nothing about the resolved theme is known on the server, so the first paint
- * always shows the "switch to dark" face and corrects itself once mounted —
- * rendering the real face before then is a hydration mismatch.
+ * **The icon is chosen by CSS, not by React.** Nothing about the resolved theme
+ * is knowable on the server, so a component that renders one glyph has to pick
+ * the light one and correct itself after mount — a moon visibly flipping to a
+ * sun on every dark-theme page load, which is the flash #127 asks about.
+ * Rendering *both* glyphs and letting the `dark:` variant hide one moves the
+ * decision into the stylesheet, and `next-themes` writes `.dark` onto `<html>`
+ * from a blocking script before first paint, so the right glyph is the only one
+ * ever painted. Both are in the tree in both themes, so there is nothing for
+ * hydration to disagree about.
+ *
+ * The accessible name cannot be done that way — a name is text, and a
+ * `display:none` label is not reliably ignored by every screen reader — so it
+ * keeps the `mounted` gate and reads "Switch theme" for one frame.
+ *
+ * That gate has to be `mounted` rather than `resolvedTheme === undefined`, and
+ * the difference is not cosmetic: `next-themes` seeds `resolvedTheme` from
+ * `defaultTheme` while it renders on the server but leaves it `undefined` on
+ * the first client render, so a component branching on it renders one name on
+ * each side and React reports the mismatch. `mounted` is false in both places
+ * by construction. The name is only ever generic for that first frame, and
+ * generic is true in both themes rather than wrong in one.
  */
 export function ThemeToggle() {
   const { resolvedTheme, setTheme } = useTheme();
@@ -22,8 +40,12 @@ export function ThemeToggle() {
 
   useEffect(() => setMounted(true), []);
 
-  const isDark = mounted && resolvedTheme === "dark";
-  const label = isDark ? "Switch to light mode" : "Switch to dark mode";
+  const isDark = resolvedTheme === "dark";
+  const label = !mounted
+    ? "Switch theme"
+    : isDark
+      ? "Switch to light mode"
+      : "Switch to dark mode";
 
   return (
     <button
@@ -33,11 +55,13 @@ export function ThemeToggle() {
       onClick={() => setTheme(isDark ? "light" : "dark")}
       className="flex size-[34px] shrink-0 cursor-pointer items-center justify-center rounded-[8px] text-cc-chip-ink hover:bg-cc-pill"
     >
-      {isDark ? (
-        <Sun size={16} strokeWidth={1.8} aria-hidden />
-      ) : (
-        <Moon size={15} strokeWidth={1.8} aria-hidden />
-      )}
+      <Moon size={15} strokeWidth={1.8} aria-hidden className="dark:hidden" />
+      <Sun
+        size={16}
+        strokeWidth={1.8}
+        aria-hidden
+        className="hidden dark:block"
+      />
     </button>
   );
 }

--- a/apps/web/features/shell/components/theme-tokens.spec.tsx
+++ b/apps/web/features/shell/components/theme-tokens.spec.tsx
@@ -1,0 +1,194 @@
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+
+/**
+ * `app/globals.css` read as data, against the design's own token file.
+ *
+ * Two things are guarded here, and neither can be caught by rendering anything.
+ *
+ * **Parity.** `docs/design_ref_new/cc-theme.css` is the single definition of
+ * both palettes; the `:root` and `.dark` blocks are a mirror of it. A mirror
+ * nobody checks drifts, and #127 §2 exists because one did. So every `--cc-*`
+ * token is compared value for value, in both themes and in both directions — a
+ * token the design adds and the app never mirrors fails as loudly as a value
+ * someone tuned locally.
+ *
+ * **One palette.** `components/ui/**` styles itself against the stock shadcn
+ * tokens. Those used to be a second, unrelated neutral set sitting beside
+ * `--cc-*` and disagreeing with it, which is what made light look worse than
+ * dark. They are aliases now — `--background: var(--cc-pg)` and so on — and
+ * this asserts they stay aliases, because the failure mode is a literal quietly
+ * reappearing and nothing noticing until someone opens a dialog.
+ *
+ * It lives beside the shell because the shell is what mounts the theme and
+ * flips it, and because vitest's `ui` project (`features/**` + `*.spec.tsx`) is
+ * the only glob reaching feature code outside a `lib/` folder — hence a `.tsx`
+ * extension on a file that renders nothing.
+ */
+
+const here = path.dirname(fileURLToPath(import.meta.url));
+const globals = readFileSync(
+  path.resolve(here, "../../../app/globals.css"),
+  "utf8",
+);
+const design = readFileSync(
+  path.resolve(here, "../../../../../docs/design_ref_new/cc-theme.css"),
+  "utf8",
+);
+
+/**
+ * The custom-property declarations of one top-level rule.
+ *
+ * Comments go first: `#faf8f1` appears inside several of them and would
+ * otherwise read as a declaration. The selector is matched anchored to the
+ * start of a line, because `.dark` also occurs inside
+ * `@custom-variant dark (&:is(.dark *))` near the top of the file. Nesting is
+ * counted rather than assumed, so an inner block cannot swallow the closing
+ * brace.
+ */
+function declarationsOf(css: string, selector: string): Map<string, string> {
+  const source = css.replace(/\/\*[\s\S]*?\*\//g, "");
+  const rule = new RegExp(
+    `^${selector.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")}\\s*\\{`,
+    "m",
+  ).exec(source);
+  if (!rule) throw new Error(`${selector} is missing from the stylesheet`);
+
+  let depth = 0;
+  let cursor = source.indexOf("{", rule.index);
+  const open = cursor;
+  for (;;) {
+    if (source[cursor] === "{") depth += 1;
+    else if (source[cursor] === "}" && --depth === 0) break;
+    cursor += 1;
+  }
+
+  const declarations = new Map<string, string>();
+  const body = source.slice(open + 1, cursor);
+  for (const [, name, value] of body.matchAll(/(--[\w-]+)\s*:\s*([^;]+);/g)) {
+    declarations.set(name, normalise(value));
+  }
+  return declarations;
+}
+
+/**
+ * The two files write the same colour differently — the design has
+ * `rgba(23, 81, 166, .07)` where Biome has reformatted ours to `0.07` — so the
+ * channels of an `rgb()` are compared as numbers. Everything else is a hex,
+ * which both files already write in lower case.
+ */
+function normalise(value: string): string {
+  const text = value.trim().toLowerCase();
+  const channels = /^rgba?\(([^)]*)\)$/.exec(text);
+  if (!channels) return text;
+  const parts = channels[1].split(",").map((part) => Number(part.trim()));
+  return `rgba(${parts.join(", ")})`;
+}
+
+/** `--warnBtnFg` in the design is `--cc-warn-btn-fg` here. */
+function ccNameFor(designToken: string): string {
+  return `--cc-${designToken.slice(2).replace(/[A-Z]/g, "-$&").toLowerCase()}`;
+}
+
+const PALETTES = [
+  { theme: "light", ours: ":root", theirs: ":root" },
+  { theme: "dark", ours: ".dark", theirs: '[data-cc-theme="dark"]' },
+] as const;
+
+describe.each(PALETTES)("the $theme palette", (palette) => {
+  const ours = declarationsOf(globals, palette.ours);
+  const designed = new Map(
+    [...declarationsOf(design, palette.theirs)].map(([token, value]) => [
+      ccNameFor(token),
+      value,
+    ]),
+  );
+
+  it("mirrors every token in cc-theme.css, value for value", () => {
+    const mirrored = new Map([...ours].filter(([name]) => designed.has(name)));
+    expect(Object.fromEntries(mirrored)).toEqual(Object.fromEntries(designed));
+  });
+
+  it("adds nothing to the `--cc-*` namespace the design does not define", () => {
+    const extra = [...ours.keys()].filter(
+      (name) => name.startsWith("--cc-") && !designed.has(name),
+    );
+    expect(extra).toEqual([]);
+  });
+});
+
+describe("the shadcn primitives", () => {
+  const root = declarationsOf(globals, ":root");
+
+  /**
+   * The tokens that honestly have no `--cc-*` counterpart, each with its reason
+   * recorded in `globals.css` beside it: the radius is a length, `--chart-*` is
+   * a categorical scale the design never drew and nothing consumes, and the
+   * rail is the one surface the design paints in plain white at alpha because
+   * there is no `--cc-rail-fg`.
+   */
+  const LITERALS = new Set([
+    "--radius",
+    "--chart-1",
+    "--chart-2",
+    "--chart-3",
+    "--chart-4",
+    "--chart-5",
+    "--sidebar-foreground",
+    "--sidebar-primary",
+    "--sidebar-accent",
+    "--sidebar-accent-foreground",
+    "--sidebar-border",
+    "--sidebar-ring",
+  ]);
+
+  it("are aliases onto Course Community tokens, not a second palette", () => {
+    const literals = [...root]
+      .filter(([name]) => !name.startsWith("--cc-") && !LITERALS.has(name))
+      .filter(([, value]) => !/^var\(--cc-[\w-]+\)$/.test(value))
+      .map(([name]) => name);
+
+    expect(literals).toEqual([]);
+  });
+
+  it("cover every token `components/ui/**` paints with", () => {
+    for (const token of [
+      "--background",
+      "--foreground",
+      "--card",
+      "--card-foreground",
+      "--popover",
+      "--popover-foreground",
+      "--primary",
+      "--primary-foreground",
+      "--secondary",
+      "--secondary-foreground",
+      "--muted",
+      "--muted-foreground",
+      "--accent",
+      "--accent-foreground",
+      "--destructive",
+      "--border",
+      "--input",
+      "--ring",
+      "--sidebar",
+      "--sidebar-primary-foreground",
+    ]) {
+      expect(root.get(token), token).toMatch(/^var\(--cc-[\w-]+\)$/);
+    }
+  });
+
+  it("are declared once, on the element the theme class lands on", () => {
+    // An alias resolves against whichever `--cc-*` are in scope where it is
+    // declared, and `next-themes` puts `.dark` on the same `<html>` that
+    // `:root` selects, so one declaration covers both themes. Repeating one
+    // under `.dark` would be a second copy to keep in step, and a copy left on
+    // a stale value is exactly the drift this file exists to catch.
+    const dark = declarationsOf(globals, ".dark");
+    expect(
+      [...dark.keys()].filter((name) => !name.startsWith("--cc-")),
+    ).toEqual([]);
+  });
+});

--- a/apps/web/types/course-card.ts
+++ b/apps/web/types/course-card.ts
@@ -1,7 +1,7 @@
 /**
  * The course card's prop shape.
  *
- * Extracted from `docs/design/Course Community - Course Card.dc.html` — the
+ * Extracted from `docs/design_ref_new/Course Community - Course Card.dc.html` — the
  * `data-props` attribute on its trailing `<script type="text/x-dc">` block names
  * `c: CourseCardModel` and `geo: CardGeometry`, and the markup below it is what
  * reads each field. `apps/web/data/course-card-sample.ts` carries the artboard's


### PR DESCRIPTION
## Why

`apps/web/app/globals.css` carried **two unrelated colour systems**. `components/ui/**` is a stock shadcn set and styles itself against `--background`, `--card`, `--muted`, `--popover`, `--border`; the pages style themselves against `--cc-*`. The two disagreed completely — light `--background` was the design's cream `#faf8f1` while dark `--background` was `oklch(0.28 0.04 260)`, a blue-grey nothing like `--cc-pg`'s `#071831`, and `--card` was pure white in light against `#0f172a` in dark.

That is the root cause behind "dark mode works better than light" and "the themes are not mapped consistently". The design's dark palette is self-consistent on its own, so it was only in **light** that the two systems sat side by side and every seam showed — every dialog, popover, toast, skeleton and shadcn button in the app rendered on the wrong palette in both themes, but light is where you could see it.

Base: `681c474`. Target: `feat/frontend`.

## 1. The shadcn → `--cc-*` mapping

Declared **once** on `:root`. A custom property is substituted at computed-value time, so `var(--cc-pg)` resolves against whichever `--cc-*` are in scope *on the element the alias is declared on*; `next-themes` is `attribute="class"`, which puts `.dark` on `<html>` — the same element `:root` selects — so one declaration covers both themes and `.dark` restates only the palette. Verified at runtime in the browser, both themes (below).

| shadcn token | → | rationale |
|---|---|---|
| `--background` | `--cc-pg` | The page ground. `layout.tsx` paints `<body class="bg-background">`. |
| `--foreground` | `--cc-ink` | Primary text. |
| `--card` | `--cc-surface` | `--surface` is defined as "cards, fields, menus". |
| `--card-foreground` | `--cc-ink` | Text on a surface. |
| `--popover` | `--cc-surface` | A popover is a menu, and menus are `--surface`. |
| `--popover-foreground` | `--cc-ink` | Same. |
| `--primary` | `--cc-btn` | The design's filled button. |
| `--primary-foreground` | `--cc-btn-fg` | Its foreground; dark inverts it (`#8bb3ef` on `#0a2449`). |
| `--secondary` | `--cc-pill` | shadcn's `secondary` is a *filled* quiet control, not the design's outlined "Secondary" button. The design's quiet fill is the pill. |
| `--secondary-foreground` | `--cc-chip-ink` | Literally "text on a pill". |
| `--muted` | `--cc-pill` | Chips, tracks and quiet fills. |
| `--muted-foreground` | `--cc-muted` | Supporting copy. |
| `--accent` | `--cc-pill` | The hover/selected fill in menus and lists; the Design System lists "hover" under `--pill`. Stock shadcn already gave `--accent` and `--muted` identical values, so collapsing both preserves that. |
| `--accent-foreground` | `--cc-ink` | Text on a hover fill stays primary ink. |
| `--destructive` | `--cc-danger` | |
| `--border` | `--cc-rule2` | `RULES` names `--rule2` "card border". |
| `--input` | `--cc-rule3` | **Refinement of the brief**, which asked for `--cc-rule2` here too. `RULES` names `--rule3` "control border", and shadcn's `--input` is only ever a control's border (plus `bg-input/30` as its dark fill). Splitting them is what the design actually draws. |
| `--ring` | `--cc-hov` | The palette's own emphasis border, and already what `feedback-form.tsx` focuses to. Avoids inventing a focus colour the design does not have. |
| `--sidebar` | `--cc-rail` | |
| `--sidebar-primary-foreground` | `--cc-rail` | The artboard's "Sign up" button is white with rail ink. |
| `--sidebar-foreground`, `--sidebar-primary`, `--sidebar-accent`, `--sidebar-accent-foreground`, `--sidebar-border`, `--sidebar-ring` | *white at alpha* | The rail is the one surface the design paints **without tokens**: there is no `--cc-rail-fg`, and the artboard draws on it in plain white at varying alpha in both themes. These mirror the exact `white/nn` values `rail.tsx` already uses — `.16` the active nav item, `.20` the divider. Nothing consumes `bg-sidebar` today (shadcn's `Sidebar` is not vendored; the rail is `features/shell/components/rail.tsx`), but leaving them on stock greys would reintroduce the second palette the moment anyone reached for one. |
| `--chart-1` … `--chart-5` | **left alone** | No honest counterpart. The six `--cc-node-*` are the community graph's palette and #68 settled they are what personalisation will assign to a *person* — not a categorical chart scale. The one chart in the repo (the examination split) carries its own literals for the reason recorded in `examination-palette.ts`, and `components/ui/chart.tsx` has no consumer at all. Neutral greys read acceptably on either ground. |
| `--primary-dark`, `--primary-light`, `--secondary-light` | **deleted** | Not shadcn tokens, from neither palette, zero consumers anywhere in `app/`, `features/` or `components/`. Their `@theme inline` entries went with them. |

**No mapping had to be abandoned to keep a primitive working.** The consumers that change are `card`, `dialog`, `alert-dialog`, `popover`, `dropdown-menu`, `sheet`, `input`, `field`, `skeleton`, `button`, `badge`, `alert`, `empty` and `sonner` — and each moves *onto* the design rather than away from it. Two worth calling out:

- **`sonner`** passes `--popover` / `--popover-foreground` / `--border` straight through as its toast variables. Toasts previously rendered `#0f172a` inside a `#071831` page; they now sit on `--cc-surface`.
- **Button's `outline` variant** uses `bg-background`, so an outline button inside a dialog is now `--cc-pg` on `--cc-surface` — slightly recessed, as it already was in light (cream on white). No regression, and it is the design's own relationship between page and surface.

## 2. Token drift against `cc-theme.css`

**None.** Every `--cc-*` value in `globals.css` was diffed against `docs/design_ref_new/cc-theme.css` token by token, both palettes, in both directions (normalising `rgba(…, .07)` vs `0.07`). All 51 tokens per theme agree exactly, and the app adds nothing to the `--cc-*` namespace the design does not define.

Since a mirror nobody checks is exactly how #127 §2's drift happened, **that diff is now a test**: `features/shell/components/theme-tokens.spec.tsx` reads `globals.css` as data and asserts parity both ways, plus that the shadcn tokens stay aliases. Mutation-checked — flipping one hex digit and one alias fails three assertions.

### The two comments that were factually wrong

- **`--cc-rail`** said "brand blue in both themes". It is `#1751a6` light and `#0d2e5e` dark; `cc-theme.css` now describes it as "the sidebar (darkens with the theme)". `features/shell/components/rail.tsx` carried the same stale paragraph and is corrected too. **Checked against the revised dark page:** at `#0d2e5e` on `--cc-pg` `#071831` the rail is still the lighter of the two and still separates from the content, without the light theme's full brand blue glaring out of a dark screen. Screenshotted in both themes.
- **`--cc-warn-*`** said "the nudge to write a review". #88 showed the actual nudge is `--cc-btn` on `--cc-surface`. The **tint** half is the review draft's header: the Design System names `--warn` **"Review draft header"** in both `TINTS` and `BANNERS`, and `Course Community - Workspace Pane.dc.html` paints exactly it in its `isReview` branch — `--warn` behind the title block, `--warnInk` on the "Review draft" eyebrow, `--warnBorder` + `--warnSolid` as the border and opaque backing of the *progress* row beneath it.
  **A first pass got the rest of this wrong and it is corrected in `bc38ad9`:** it called that sticky row an "action row" whose call to action is `--cc-warn-btn`. That row is `progressLabel` + `progressSegs` and has no button in it, and `--warnBtn` / `--warnBtnFg` do not appear in the `isReview` branch at all. They are a separate pair — and the one place the original "write a review" wording was **not** wrong: the Design System demos them under "Status text & buttons" as a **"Write a review"** button. In the repo they are the draft's filled progress segments and its submit button, plus the Review Card's accent for a review that was not happy (`Review Card.dc.html:51`).

- **The `--cc-node-*` block** said the design "has no node token at all" and that `moss` was "the sixth the design never assigned". That was true of the deleted `docs/design/` export and is false of the revised one: `cc-theme.css` names all six (`--nodeAurora` … `--nodeViolet`, `moss` included, at exactly the hexes here) and the Design System artboard renders them under **"Community graph nodes"**. They are *unassigned*, not absent — #68 §3 settled that a node with no configured appearance is `--cc-brand`. Corrected. This is precisely the stale-citation hazard `CLAUDE.md` warns about, and it is why the parity test asserts in **both** directions: the values were already right, so only prose could be wrong, and prose is what a test cannot read.

### Two rail colours the design states as raw hex

`rail.tsx` says this and the comment needs the PR to back it, so: the artboards paint two things on the rail that no token covers — the avatar chip (`background:#7ea6d8; color:#0d2f5e`, in About, Explore, My Page, Saved and Landing) and the signed-out **Sign up** button's ink (`color:#12417f`, `Landing.dc.html:151`). Neither is in `cc-theme.css`, and #68 forbids inventing a token. The rail keeps both on the white-alpha family the rest of that surface uses — `bg-white/25` + `text-white` for the chip, `bg-white` + `text-cc-rail` for the button. Flagging it here rather than hard-coding the hexes is how the design gets corrected at source; a `--cc-rail-fg` / `--cc-rail-chip` pair would settle it.

## 3. `color-mix` derivations replaced

The tint families did not exist when these screens were built, so each derived what it needed. **Neither derivation could have been correct**: light states a tint as a flat mix and dark states it as alpha over the page, so no percentage of `--cc-danger` reaches `--cc-danger-tint` in both themes.

| site | was | now | artboard |
|---|---|---|---|
| `collection-chip.tsx:113` | `text-cc-danger` + `color-mix(… --cc-danger 12%, --cc-surface)` | `text-cc-danger-ink` + `hover:bg-cc-danger-tint` | `Collections.dc.html:124` — `#a4402a` on `#fdf3ef` |
| `collection-tile.tsx:123` | same | same | `Collections.dc.html:163` |
| `feedback-form.tsx` sent panel | `--cc-info` / `--cc-rule` / `--cc-brand`, with a comment saying "the palette has no green" | `--cc-success-tint` / `--cc-success-tint-border` / `--cc-success-ink` | `Contact Form.dc.html:15-18` — `#e9f3ef` / `#cfe4de` / `#1c6b60`, exactly these three tokens |
| `feedback-form.tsx` error line | `--cc-warn-ink` | `--cc-danger-ink` | `Contact Form.dc.html:41` — `#a3452a` |

### Three `color-mix` sites I do not own — please route

- `apps/web/features/search/components/explore.tsx:471` — `color-mix(in srgb, var(--cc-danger) 12%, var(--cc-surface))` on the error panel's icon. Wants `bg-cc-danger-tint`.
- `apps/web/features/workspace/components/pane-parts.tsx:28` — `color-mix(in srgb, var(--cc-btn) 40%, var(--cc-surface))`. No token for this one; it is a 40% brand wash, not a status tint. Needs a judgement call, not a swap.
- `apps/web/features/workspace/components/review-draft-panel.tsx:705` — `color-mix(in srgb, var(--cc-success) 12%, var(--cc-surface))`. Wants `--cc-success-tint`.

(`components/ui/bubble.tsx` and `button.tsx` also use `color-mix`, but they mix a token with `--foreground` to make a hover step, which is not a tint derivation and now composes correctly since both operands are `--cc-*`.)

## 4. The theme default, and the toggle

**`system` is kept**, and this is a deliberate deviation from the artboard.

`cc-store.js` reads `localStorage` with a `false` fallback because a static HTML mock has no way to ask the operating system anything — "default light" is that limitation, not a decision. Honouring `prefers-color-scheme` is a real accessibility win for a reader who has already told their OS they want dark, and for everyone else the OS default *is* light, so the artboard's first paint is what they get anyway. An explicit choice still wins over both.

Two further changes in the same area:

- **`storageKey="cc:theme"`** now matches the design's own key (`next-themes` defaults to `"theme"`).
- **`disableTransitionOnChange` is dropped.** It suppresses every transition for the frame the class flips — which is precisely the frame the `cc-theme` utility exists for. `cc-theme.css` cross-fades `background-color`, `color` and `border-color` on the whole subtree, and `AppShell` opts every route into it. The flag was silently defeating the design's own theme animation.

### The first-paint flash

`theme-toggle.tsx` admitted it "always shows the 'switch to dark' face until mounted". Fixed: **both glyphs now ship and the `dark:` variant hides one**, so the choice happens in CSS, and `next-themes` writes `.dark` onto `<html>` from a blocking script before first paint — the right glyph is the only one ever painted, and both are in the tree in both themes so there is nothing for hydration to disagree about.

The accessible *name* cannot be done that way (a name is text, and a `display:none` label is not reliably ignored by every screen reader), so it keeps the `mounted` gate and reads the state-free "Switch theme" for one frame.

> **A first attempt replaced that gate with `resolvedTheme === undefined`, and it was wrong.** `next-themes` seeds `resolvedTheme` from `defaultTheme` while rendering on the server but leaves it `undefined` on the first client render, so the two sides named the button differently and Next's overlay reported the mismatch. Caught by running the app, reverted, and now pinned by a `renderToStaticMarkup` assertion on the server render — the only place that state is observable, since RTL's `render` flushes effects.

**Not changed:** the `.dark` class mechanism. Tailwind's `@custom-variant dark (&:is(.dark *))` and every `dark:` utility in `components/ui/**` depend on it; switching to the design's `data-cc-theme` is a large blast radius for nothing a reader could see. Deliberate deviation, recorded in `layout.tsx`.

## 5. Carrying an existing preference onto `cc:theme`

**Greptile's finding on the previous head, fixed.** Renaming the persisted key silently dropped a choice a reader had already made: `next-themes` only ever reads the key it is configured with, so a saved `dark` became "your system theme" once, with nothing to explain it.

`ThemeProvider` now renders a one-time migration ahead of `NextThemesProvider`. It copies `theme` onto `cc:theme`, once, and only if `cc:theme` is unset.

**Why an inline script and not an effect.** `next-themes` decides the theme class from its own blocking script *before first paint*; by the time any React effect fires that decision is already on screen, so migrating in an effect would still flash the wrong theme for a frame. Both scripts are inline, so the parser runs them in document order, and `next-themes` renders its script as the **first child of its own provider** (`t.createElement(x.Provider, …, t.createElement(_, …), children)` in `next-themes@0.4.6`). Being a sibling rendered *before* that provider is the entire ordering guarantee — and it is one line away from being silently lost, with no symptom except the bug coming back.

So the order is pinned by a `renderToStaticMarkup` assertion on the server render, which is the artefact the browser actually parses. A client render would prove nothing: React deliberately creates `<script>` elements in a way that does not execute them, so RTL's `render` says nothing about first paint. **Mutation-checked** — swapping the two siblings fails the assertion with `expected '((e,i,s,u,m,a,l,h)=>{let d=document.d…' to be '(function(){try{var s=window.localSto…'`.

It is deliberately conservative:

- it returns early if `cc:theme` is already set, so a later explicit choice is never undone and running twice is a no-op;
- it copies only `light` / `dark` / `system`, which is exhaustive — the app passes no custom `themes`, so those are the only values `next-themes` writes;
- the whole body is inside a `try`, because `localStorage` **throws outright** in some privacy modes rather than returning null, and this runs inline in the document where an exception would abort the script and take the theme with it;
- the old `theme` key is left in place rather than deleted — it costs nothing and keeps a rollback lossless.

No hydration risk: the string is a module constant, so both sides emit byte-identical markup, and the extra sibling is present on both. There is no CSP anywhere in this app, so no nonce is involved.

`features/shell/components/theme-migration.spec.tsx` (11 tests) exercises the script string the way a browser will — evaluated against a real `localStorage`, outcome read back out of storage — covering each of the three values, the existing-`cc:theme` guard, the nothing-to-copy case, a legacy value `next-themes` would never have written, storage throwing on read, the document order, and that the string stays a fixed literal with no interpolation (which is what makes the `biome-ignore` on `dangerouslySetInnerHTML` defensible rather than merely asserted).

## 5. Dangling design references repointed

`docs/design/` was deleted this session, and the artboards were **revised** rather than moved — so a stale citation could be wrong about the design, not only about the path. Each artboard was re-read while its citation was corrected: `about.tsx`, `course-card.tsx` (×2), `card-geometry.ts` (×2), `feedback-form.tsx`, `examination-palette.ts`, `page-column.tsx` + spec, `page-header.tsx`, `types/course-card.ts`, `data/course-card-sample.ts`.

**Every claim still holds** against the current set, so only the paths changed: `cc-store.js` still has `PAGE_MAX_WIDTH` `1216px` / `PAGE_SIDE_PADDING` `20px`; `Explore.dc.html:1063` still computes the ramp as `(resultsW - 470) / 170`; `Course Card.dc.html:190` still carries the `SAMPLE_GEO` the fixture mirrors verbatim; `cc-store.js`'s `EXAMINATION_COLORS` still has five keys against the schema's six. One path also changed shape — the Mobile Preview lived under `docs/design/reference/` and is now top level.


### Nine stale `docs/design/` citations I did not repoint — please route

The repoint above covered the files this branch already had open. A sweep of the whole app finds nine more, all in features three other wave 1 agents are mid-flight in. I am deliberately **not** touching them: they are comment-only, and nine one-line edits spread across five features would hand `recon-routes` and `recon-fasttrack` rebase conflicts for nothing. (`my-page/components/node-profile.tsx` was a tenth; `feat/recon-graph` has already fixed it — which is the proof that touching these collides.)

```
apps/web/features/my-page/components/account-settings.tsx:37
apps/web/features/my-page/components/my-page.tsx:64
apps/web/features/my-page/lib/grade-average.ts:12
apps/web/features/reviews/components/review-card.tsx:19
apps/web/features/reviews/components/unreviewed-card.tsx:81
apps/web/features/saved/components/saved.tsx:33
apps/web/features/search/components/explore.tsx:34
apps/web/features/taken/components/taken-courses.tsx:76
apps/web/features/taken/components/transcript-drop-zone.tsx:23
```

Every target file exists under `docs/design_ref_new/` under the same name, so the path half is mechanical — but `CLAUDE.md` is explicit that the artboards were **revised** rather than moved, so each comment's *claim* has to be re-read before the path is trusted. That is a re-read of six artboards against five features, which is #134's job against a settled `feat/frontend`, not a drive-by `sed` here. **Suggest folding it into wave 3 (#134).**

## Sequencing with #146 (the hero canvas repaint)

**Nothing to sequence.** `git diff 681c474..HEAD -- apps/web/app/globals.css` shows **zero** changed `--cc-*` declarations — this PR remaps the *shadcn* tokens onto the `--cc-*` ones and corrects comments; it does not touch a palette value. The tokens `hero-network.tsx` reads (`--cc-hov`, `--cc-brand`, `--cc-ink`, `--cc-surface`) and the six `--cc-node-*` that `neighbourhood-view.ts` maps are byte-identical before and after, so the hero repaints into exactly what it repainted into before. The two PRs can merge in either order.

No file under `features/landing/**` is touched by this branch.

## Validation

```
bun run lint       ✓ exit 0 (10 pre-existing warnings, unchanged from baseline)
bun run typecheck  ✓ exit 0
bun run test:web   ✓ 716 tests, 62 files   (baseline 689 / 57)
```

**No existing assertion had to be loosened.** +27 tests across 5 new files:

- `features/shell/components/theme-migration.spec.tsx` (11) — the storage-key migration, described in §5 above, plus a guard that the key the script writes is the key `layout.tsx` configures. Two literals of one name in two files is the same drift class as a colour, and here it fails *silently*: change the provider's key alone and the migration keeps populating a key nothing reads. Mutation-checked.
- `features/shell/components/theme-tokens.spec.tsx` — both palettes against `cc-theme.css` value for value and in both directions; the shadcn tokens are aliases, not literals; `.dark` restates only `--cc-*`. Mutation-checked.
- `features/shell/components/theme-toggle.spec.tsx` — both glyphs in the first payload; the server render names itself without claiming a theme (the hydration regression above).
- `features/collections/components/collection-chip.spec.tsx` / `collection-tile.spec.tsx` — Delete paints the danger-tint family and contains no `color-mix`; deleting closes the menu so the mutation cannot re-fire.
- `feedback-form.spec.tsx` — the sent panel and the failure line assert their tint tokens.

Class assertions rather than computed colours, matching `review-card.spec.tsx`'s existing pattern: jsdom runs no Tailwind, so a colour assertion there would only ever observe the absence of a stylesheet. What regressed is the token that was asked for.

**Verified in the running app**, `/about` at 1568×772 in both themes:

- Light: cream page, white surfaces, brand-blue rail, correct moon glyph on first paint.
- Dark: `--cc-pg` navy page, `--cc-surface` cards, the darker rail still reading clearly against it.
- Computed values sampled from `document.documentElement` in both themes confirm every alias resolves: light `--card` `#fff` / `--primary` `#1751a6` / `--border` `#e5e0d2`; dark `--card` `#0b254c` / `--primary` `#8bb3ef` / `--border` `rgba(244,238,226,.22)`.
- A live probe of `bg-popover text-popover-foreground border-border` under `.dark` returns `rgb(11,37,76)` / `rgb(230,234,239)` / `rgba(244,238,226,0.22)` — i.e. a shadcn popover now lands on the design's dark surface instead of `#0f172a`.

Refs #127 §1, §2, §4 · #134 · #68

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017EAUKDDo2BkQTFELyvV3v8




