### PR TITLE
feat(reviews): build the fast-track reviewer the artboard draws

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -114,6 +114,16 @@ How theoretical rather than applied the reviewer found the course, on the same
 "I don't remember" rule.
 _Avoid_: theory rating, theoretical vs applied
 
+**Fast-track reviewer**:
+The screen on Taken courses that deals one card per unreviewed taken course, in
+a **round**. It is a second way of asking for a **Review**, never a second kind
+of one: a card writes through the same hook and the same validator as every
+other form. A round lives in the tab and nowhere else — skipping a card writes
+nothing at all, so the course is still an unreviewed taken course afterwards for
+the same reason it was before.
+_Avoid_: review wizard, review queue (that is the round's order, not the screen),
+bulk review, quick rating
+
 ### The community graph
 
 **Community graph**:

--- a/apps/web/features/my-page/components/account-settings.tsx
+++ b/apps/web/features/my-page/components/account-settings.tsx
@@ -34,8 +34,8 @@ const SWITCH_CLASS =
   "h-6 w-[42px] data-checked:bg-cc-btn data-unchecked:bg-cc-rule3 [&_[data-slot=switch-thumb]]:size-[18px]";
 
 /**
- * The Settings tab — `docs/design/Course Community - My Page.dc.html`, the
- * `isSettings` branch.
+ * The Settings tab — `docs/design_ref_new/Course Community - My Page.dc.html`,
+ * the `isSettings` branch.
  *
  * Three of its four panels needed the schema consulted before they could be
  * drawn honestly:

--- a/apps/web/features/my-page/components/my-page.spec.tsx
+++ b/apps/web/features/my-page/components/my-page.spec.tsx
@@ -61,9 +61,25 @@ vi.mock("../api/mutations", () => ({
  */
 vi.mock("@/features/reviews", () => ({
   useUnreviewedTakenCourses: () => unreviewed(),
-  UnreviewedCard: ({ courses }: { courses: { code: string }[] }) =>
+  UnreviewedCard: ({
+    courses,
+    onStart,
+    onSelect,
+  }: {
+    courses: { code: string }[];
+    onStart: () => void;
+    onSelect?: (code: string) => void;
+  }) =>
     courses.length === 0 ? null : (
-      <div data-testid="unreviewed">{courses.map((c) => c.code).join(",")}</div>
+      <div data-testid="unreviewed">
+        {courses.map((c) => c.code).join(",")}
+        <button type="button" onClick={onStart}>
+          Start reviewing
+        </button>
+        <button type="button" onClick={() => onSelect?.(courses[0].code)}>
+          Pick a row
+        </button>
+      </div>
     ),
   ReviewCard: ({
     review,
@@ -300,6 +316,31 @@ describe("MyPage empty states", () => {
     expect(document.querySelectorAll(".animate-pulse").length).toBeGreaterThan(
       0,
     );
+  });
+
+  /**
+   * My Page has no reviewer of its own and should not grow one: `/taken` owns
+   * the queue, and it is the screen that still knows which courses are
+   * unreviewed by the time the reader arrives. Both the prompt's button and one
+   * of its rows therefore go to the same place — the artboard's own
+   * `window.location.href = "…Taken Courses…?review=1"`.
+   */
+  it("sends both the prompt's button and a row to the fast-track reviewer", async () => {
+    unreviewed.mockReturnValue({
+      courses: [takenCourse({ courseCode: "DD2380" })],
+      isLoading: false,
+      isUnavailable: false,
+    });
+    render(<MyPage />);
+
+    await userEvent.click(
+      screen.getByRole("button", { name: "Start reviewing" }),
+    );
+    expect(push).toHaveBeenCalledWith("/taken?review=1");
+
+    push.mockClear();
+    await userEvent.click(screen.getByRole("button", { name: "Pick a row" }));
+    expect(push).toHaveBeenCalledWith("/taken?review=1");
   });
 });
 

--- a/apps/web/features/my-page/components/my-page.tsx
+++ b/apps/web/features/my-page/components/my-page.tsx
@@ -61,8 +61,8 @@ type OpenEditor = { review: EditableReview; courseCode: string };
 /**
  * My Page — the signed-in reader's own page, at `/profile`.
  *
- * From `docs/design/Course Community - My Page.dc.html`, with its four tabs
- * (Overview, Reviews, My dot, Settings) and the Mobile Preview's stacked
+ * From `docs/design_ref_new/Course Community - My Page.dc.html`, with its four
+ * tabs (Overview, Reviews, My dot, Settings) and the Mobile Preview's stacked
  * version of the same. Everything it shows is the viewer's own: `user.me` for
  * who they are, `taken.list` for their courses, `reviews.list` for what they
  * wrote and upvoted, `graph.effectiveTier` for how far their node is unlocked.
@@ -322,18 +322,21 @@ export function MyPage() {
                     worked out just now. Reload to try again.
                   </output>
                 ) : (
+                  /*
+                    Both the button and a row deep-link the fast-track
+                    reviewer, which is where the artboard's own My Page sends
+                    them (`window.location.href = "…Taken Courses…?review=1"`).
+                    This page has no reviewer of its own and should not grow
+                    one: `/taken` owns the queue, and it is the screen that
+                    knows which courses are still unreviewed by the time the
+                    reader gets there.
+                  */
                   <UnreviewedCard
                     courses={unreviewed.courses.map((course) => ({
                       code: course.courseCode,
                     }))}
-                    onStart={() => {
-                      const first = unreviewed.courses[0];
-                      if (first) {
-                        router.push(
-                          `/course/${first.courseCode}?writeReview=1&from=my-page`,
-                        );
-                      }
-                    }}
+                    onStart={() => router.push("/taken?review=1")}
+                    onSelect={() => router.push("/taken?review=1")}
                   />
                 )}
               </div>

--- a/apps/web/features/my-page/lib/grade-average.ts
+++ b/apps/web/features/my-page/lib/grade-average.ts
@@ -9,7 +9,7 @@
  * invent an academic fact about a real person.
  *
  * The points and the weighting are the design's own, from `gpaFor` in
- * `docs/design/cc-store.js`.
+ * `docs/design_ref_new/cc-store.js`.
  */
 
 /** Points per grade on KTH's A-F scale. `F` is absent deliberately — see below. */

--- a/apps/web/features/reviews/components/review-card.tsx
+++ b/apps/web/features/reviews/components/review-card.tsx
@@ -16,8 +16,9 @@ import { toExcerpt } from "../lib/review-text";
 /**
  * What a reviewer who answered "I don't remember" gets drawn in place of a
  * chart. Copy from the review detail in
- * `docs/design/Course Community - My Page.dc.html`, with its "student" changed
- * to the reviewer, who is the one person the sentence is actually about.
+ * `docs/design_ref_new/Course Community - My Page.dc.html`, with its "student"
+ * changed to the reviewer, who is the one person the sentence is actually
+ * about.
  */
 const UNANSWERED_NOTE =
   "The reviewer chose “I don't remember” — nothing is estimated in its place.";

--- a/apps/web/features/reviews/components/reviewer-card.tsx
+++ b/apps/web/features/reviews/components/reviewer-card.tsx
@@ -1,0 +1,564 @@
+"use client";
+
+import { ArrowRight, CircleAlert } from "lucide-react";
+import { useRef } from "react";
+import { cn } from "@/lib/utils";
+import {
+  EXAMINATION_DISTRIBUTION_KEYS,
+  EXAMINATION_DISTRIBUTION_LABELS,
+  MAX_REVIEW_SCORE,
+  MIN_REVIEW_SCORE,
+} from "@/types";
+import {
+  EXAMINATION_COLORS,
+  EXAMINATION_INK,
+} from "../lib/examination-palette";
+import {
+  APPROACH_MAX,
+  APPROACH_MIDPOINT,
+  APPROACH_MIN,
+  dividerPositions,
+  type ExaminationKey,
+  isAnswered,
+  MIN_SHARE,
+  moveDivider,
+  nudgeDivider,
+  type ReviewDraft,
+  toggleMethod,
+} from "../lib/review-draft";
+
+/** The applied half of the theory track, as the workspace pane tints it too. */
+const APPLIED_FILL = "color-mix(in srgb, var(--cc-btn) 40%, var(--cc-surface))";
+/** An unanswered track is drawn in the theme's strong hairline, not a fill. */
+const UNSET_FILL = "var(--cc-rule3)";
+/** Below this share a segment is too narrow to hold its own category name. */
+const LABEL_WIDTH_THRESHOLD = 24;
+
+function Section({ children }: { children: React.ReactNode }) {
+  return (
+    <div className="rounded-[12px] border border-cc-rule bg-cc-pg px-4 pt-[15px] pb-3.5">
+      {children}
+    </div>
+  );
+}
+
+function ValuePill({ children }: { children: React.ReactNode }) {
+  return (
+    <span className="flex-none rounded-full bg-cc-pill px-[9px] py-0.5 font-semibold text-[12px] text-cc-brand tabular-nums">
+      {children}
+    </span>
+  );
+}
+
+function Divider() {
+  return <div aria-hidden className="my-3.5 h-px bg-cc-pill" />;
+}
+
+/**
+ * A 1–10 score, on the scale the database stores.
+ *
+ * The visible track is ours so that an unanswered score reads as empty rather
+ * than as 1 — the difference between "not answered" and "the lowest answer" is
+ * the whole point of `workloadScore` being `null` on this card. The range input
+ * on top of it is what a keyboard and a screen reader drive, and `onPointerUp`
+ * commits as well as `onChange` so clicking the value the input already holds
+ * still counts as answering.
+ */
+function ScoreSlider({
+  label,
+  value,
+  minLabel,
+  maxLabel,
+  onChange,
+}: {
+  label: string;
+  value: number | null;
+  minLabel: string;
+  maxLabel: string;
+  onChange: (next: number) => void;
+}) {
+  const percent = value === null ? 0 : (value / MAX_REVIEW_SCORE) * 100;
+  return (
+    <div>
+      <div className="mb-[9px] flex items-baseline justify-between gap-2.5">
+        <span className="font-semibold text-[14.5px]">{label}</span>
+        <ValuePill>
+          {value === null ? "Not set" : `${value} / ${MAX_REVIEW_SCORE}`}
+        </ValuePill>
+      </div>
+      <div className="relative flex h-[22px] items-center">
+        <div className="h-2 w-full overflow-hidden rounded-[4px] bg-cc-pill">
+          <div className="h-full bg-cc-btn" style={{ width: `${percent}%` }} />
+        </div>
+        {value !== null && (
+          <div
+            aria-hidden
+            className="-ml-2.5 absolute size-5 rounded-full border-2 border-cc-brand bg-cc-surface"
+            style={{ left: `${percent}%` }}
+          />
+        )}
+        <input
+          type="range"
+          min={MIN_REVIEW_SCORE}
+          max={MAX_REVIEW_SCORE}
+          step={1}
+          value={value ?? MIN_REVIEW_SCORE}
+          aria-label={label}
+          aria-valuetext={
+            value === null ? "Not set" : `${value} of ${MAX_REVIEW_SCORE}`
+          }
+          onChange={(event) => onChange(Number(event.target.value))}
+          onPointerUp={(event) => onChange(Number(event.currentTarget.value))}
+          className="absolute inset-0 h-full w-full cursor-pointer opacity-0"
+        />
+      </div>
+      <div className="mt-1 flex justify-between text-[11.5px] text-cc-muted">
+        <span>{minLabel}</span>
+        <span>{maxLabel}</span>
+      </div>
+    </div>
+  );
+}
+
+export interface ReviewerCardCourse {
+  courseCode: string;
+  /** The catalogue title, once `course.summary` has answered for it. */
+  name?: string | null;
+  /** "7.5 hp · 2025", or whatever the screen knows about this row. */
+  meta?: string | null;
+}
+
+export interface ReviewerCardProps {
+  course: ReviewerCardCourse;
+  draft: ReviewDraft;
+  /** "3 more after this" — the artboard's `revStackLabel`. */
+  stackLabel: string;
+  /** Whether this is the last card, which changes the save button's wording. */
+  isLast: boolean;
+  isSaving: boolean;
+  /** The last save's failure, still on screen with the answers it could not send. */
+  saveError: string | null;
+  onDraftChange: (draft: ReviewDraft) => void;
+  onSkip: () => void;
+  onSave: () => void;
+}
+
+/**
+ * One course's card in the fast-track reviewer —
+ * `docs/design_ref_new/Course Community - Taken Courses.dc.html`, its
+ * `revActive` branch.
+ *
+ * The card is presentation and nothing else. It edits a `ReviewDraft` and hands
+ * it back; it holds no mutation, decides nothing about whether a review may be
+ * written, and cannot save anything by itself. `Reviewer` owns the queue and
+ * the write, which goes through `useAddReview` like every other review in the
+ * app — see the note there.
+ *
+ * Four questions, and every one of them may be left alone. Only `happyTook` and
+ * the two scores gate the save button, because those are the three
+ * `reviewInputSchema` requires; an untouched examination bar or theory track is
+ * the "I don't remember" answer and stores `null`.
+ */
+export function ReviewerCard({
+  course,
+  draft,
+  stackLabel,
+  isLast,
+  isSaving,
+  saveError,
+  onDraftChange,
+  onSkip,
+  onSave,
+}: Readonly<ReviewerCardProps>) {
+  const examTrackRef = useRef<HTMLDivElement>(null);
+  const answered = isAnswered(draft);
+  const cuts = dividerPositions(draft);
+
+  function patch(changes: Partial<ReviewDraft>) {
+    onDraftChange({ ...draft, ...changes });
+  }
+
+  function startDividerDrag(
+    event: React.PointerEvent<HTMLElement>,
+    index: number,
+  ) {
+    const track = examTrackRef.current;
+    if (!track) return;
+    event.preventDefault();
+    const rect = track.getBoundingClientRect();
+    // Only segments `index` and `index + 1` move, so the draft captured here
+    // stays a correct base for every step of the drag.
+    const start = draft;
+    const move = (moveEvent: PointerEvent) => {
+      const percent = ((moveEvent.clientX - rect.left) / rect.width) * 100;
+      onDraftChange(moveDivider(start, index, percent));
+    };
+    const up = () => {
+      window.removeEventListener("pointermove", move);
+      window.removeEventListener("pointerup", up);
+    };
+    window.addEventListener("pointermove", move);
+    window.addEventListener("pointerup", up);
+  }
+
+  return (
+    <div className="@container relative z-[3] rounded-[16px] border border-cc-rule2 bg-cc-surface shadow-[0_14px_34px_rgba(20,30,45,0.09)]">
+      <div className="flex items-start gap-3.5 rounded-t-[16px] border-cc-warn-border border-b bg-cc-warn px-[22px] pt-5 pb-[17px] @max-[420px]:px-4">
+        <div className="min-w-0 flex-1">
+          <p className="m-0 font-medium font-mono text-[12.5px] text-cc-brand">
+            {course.courseCode}
+          </p>
+          <h3 className="m-0 mt-1.5 font-semibold text-[20px] leading-[1.25]">
+            {course.name || course.courseCode}
+          </h3>
+          {course.meta ? (
+            <p className="m-0 mt-[5px] text-[12.5px] text-cc-dim">
+              {course.meta}
+            </p>
+          ) : null}
+        </div>
+        <span className="flex-none rounded-full border border-cc-warn-border bg-cc-surface px-[11px] py-1 font-medium text-[11.5px] text-cc-warn-ink tabular-nums">
+          {stackLabel}
+        </span>
+      </div>
+
+      <div className="flex flex-col gap-3.5 px-[22px] pt-4 pb-[18px] @max-[420px]:px-4">
+        <Section>
+          <div className="flex items-baseline justify-between gap-2.5">
+            <span className="font-semibold text-[14.5px]">
+              How was it examined?
+            </span>
+            <ValuePill>
+              {draft.methods.length === 0
+                ? "Not set"
+                : draft.methods.length === 1
+                  ? "1 format"
+                  : `${draft.methods.length} formats`}
+            </ValuePill>
+          </div>
+
+          <div className="mt-[11px] flex flex-wrap gap-1.5">
+            {EXAMINATION_DISTRIBUTION_KEYS.map((key) => {
+              const picked = draft.methods.includes(key);
+              return (
+                <button
+                  key={key}
+                  type="button"
+                  aria-pressed={picked}
+                  onClick={() => onDraftChange(toggleMethod(draft, key))}
+                  className={cn(
+                    "flex h-[30px] items-center gap-1.5 rounded-[15px] border px-[11px] text-[12.5px]",
+                    picked
+                      ? "border-cc-brand bg-cc-pill text-cc-ink"
+                      : "border-cc-rule3 bg-cc-surface text-cc-muted hover:border-cc-brand",
+                  )}
+                >
+                  <span
+                    aria-hidden
+                    className="size-2 flex-none rounded-[2px]"
+                    style={{
+                      background: picked ? EXAMINATION_COLORS[key] : UNSET_FILL,
+                    }}
+                  />
+                  {EXAMINATION_DISTRIBUTION_LABELS[key]}
+                </button>
+              );
+            })}
+          </div>
+
+          <div
+            ref={examTrackRef}
+            className="relative mt-[11px] flex h-[38px] select-none overflow-hidden rounded-[8px] bg-cc-pill"
+          >
+            {draft.methods.length === 0 ? (
+              <p className="m-0 flex flex-1 items-center justify-center text-[12px] text-cc-dim">
+                Click the formats this course used
+              </p>
+            ) : (
+              draft.methods.map((key, index) => (
+                <div
+                  key={key}
+                  className="flex items-center justify-center overflow-hidden whitespace-nowrap font-semibold text-[12px]"
+                  style={{
+                    width: `${draft.shares[index]}%`,
+                    background: EXAMINATION_COLORS[key],
+                    color: EXAMINATION_INK[key],
+                  }}
+                >
+                  {draft.shares[index] >= LABEL_WIDTH_THRESHOLD
+                    ? EXAMINATION_DISTRIBUTION_LABELS[key]
+                    : ""}
+                </div>
+              ))
+            )}
+            {cuts.map((cut, index) => (
+              <div
+                key={`${draft.methods[index]}-divider`}
+                role="slider"
+                tabIndex={0}
+                aria-label={`Share between ${EXAMINATION_DISTRIBUTION_LABELS[draft.methods[index] as ExaminationKey]} and ${EXAMINATION_DISTRIBUTION_LABELS[draft.methods[index + 1] as ExaminationKey]}`}
+                aria-valuemin={MIN_SHARE}
+                aria-valuemax={100 - MIN_SHARE}
+                aria-valuenow={cut}
+                onPointerDown={(event) => startDividerDrag(event, index)}
+                onKeyDown={(event) => {
+                  if (event.key === "ArrowLeft") {
+                    event.preventDefault();
+                    onDraftChange(nudgeDivider(draft, index, -1));
+                  } else if (event.key === "ArrowRight") {
+                    event.preventDefault();
+                    onDraftChange(nudgeDivider(draft, index, 1));
+                  }
+                }}
+                className="-ml-[9px] absolute top-0 bottom-0 flex w-[18px] cursor-ew-resize items-center justify-center"
+                style={{ left: `${cut}%` }}
+              >
+                <div className="h-6 w-1 rounded-[2px] bg-cc-surface shadow-[0_0_0_1px_rgba(20,30,45,0.18)]" />
+              </div>
+            ))}
+          </div>
+
+          <Divider />
+
+          <div className="flex items-baseline justify-between gap-2.5">
+            <span className="font-semibold text-[14.5px]">
+              What was the approach?
+            </span>
+            <ValuePill>
+              {draft.approachTheoryPercent === null
+                ? "Not set"
+                : `${draft.approachTheoryPercent} / ${100 - draft.approachTheoryPercent}`}
+            </ValuePill>
+          </div>
+          <div className="relative mt-[11px] flex h-[38px] select-none overflow-hidden rounded-[8px] bg-cc-pill">
+            <div
+              className="flex h-full items-center overflow-hidden whitespace-nowrap pl-[11px] font-semibold text-[12px]"
+              style={{
+                width: `${draft.approachTheoryPercent ?? APPROACH_MIDPOINT}%`,
+                background:
+                  draft.approachTheoryPercent === null
+                    ? UNSET_FILL
+                    : "var(--cc-btn)",
+                color:
+                  draft.approachTheoryPercent === null
+                    ? "var(--cc-dim)"
+                    : "var(--cc-btn-fg)",
+              }}
+            >
+              Theoretical
+            </div>
+            <div
+              className="flex h-full items-center justify-end overflow-hidden whitespace-nowrap pr-[11px] font-semibold text-[12px]"
+              style={{
+                width: `${100 - (draft.approachTheoryPercent ?? APPROACH_MIDPOINT)}%`,
+                background:
+                  draft.approachTheoryPercent === null
+                    ? UNSET_FILL
+                    : APPLIED_FILL,
+                color:
+                  draft.approachTheoryPercent === null
+                    ? "var(--cc-dim)"
+                    : "var(--cc-brand)",
+              }}
+            >
+              Applied
+            </div>
+            {/*
+              The artboard draws a grab handle on the boundary, the same one the
+              examination bar has, so the track reads as something you drag
+              rather than as a two-tone label. It is decoration over the range
+              input below, which is what actually moves.
+            */}
+            <div
+              aria-hidden
+              className="-ml-[9px] absolute top-0 bottom-0 flex w-[18px] items-center justify-center"
+              style={{
+                left: `${draft.approachTheoryPercent ?? APPROACH_MIDPOINT}%`,
+              }}
+            >
+              <div className="h-6 w-1 rounded-[2px] bg-cc-surface shadow-[0_0_0_1px_rgba(20,30,45,0.18)]" />
+            </div>
+            <input
+              type="range"
+              min={APPROACH_MIN}
+              max={APPROACH_MAX}
+              step={1}
+              value={draft.approachTheoryPercent ?? APPROACH_MIDPOINT}
+              aria-label="How theoretical rather than applied the course was"
+              aria-valuetext={
+                draft.approachTheoryPercent === null
+                  ? "Not set"
+                  : `${draft.approachTheoryPercent} percent theoretical`
+              }
+              onChange={(event) =>
+                patch({ approachTheoryPercent: Number(event.target.value) })
+              }
+              onPointerUp={(event) =>
+                patch({
+                  approachTheoryPercent: Number(event.currentTarget.value),
+                })
+              }
+              className="absolute inset-0 h-full w-full cursor-ew-resize opacity-0"
+            />
+          </div>
+        </Section>
+
+        <Section>
+          <ScoreSlider
+            label="How demanding was this course?"
+            value={draft.workloadScore}
+            minLabel="Not at all"
+            maxLabel="Very"
+            onChange={(next) => patch({ workloadScore: next })}
+          />
+          <Divider />
+          <ScoreSlider
+            label="How much did you learn?"
+            value={draft.learningScore}
+            minLabel="Nothing new"
+            maxLabel="Transformative"
+            onChange={(next) => patch({ learningScore: next })}
+          />
+        </Section>
+
+        <Section>
+          <div className="flex items-baseline justify-between gap-2.5">
+            <span className="font-semibold text-[14.5px]">
+              Are you happy you took this course?
+            </span>
+            {draft.happyTook === null && <ValuePill>Not set</ValuePill>}
+          </div>
+          <div className="mt-2.5 flex gap-2 @max-[420px]:flex-col">
+            {[
+              { value: true, label: "Yes, I am" },
+              { value: false, label: "No, not really" },
+            ].map((option) => {
+              const picked = draft.happyTook === option.value;
+              return (
+                <button
+                  key={option.label}
+                  type="button"
+                  aria-pressed={picked}
+                  onClick={() => patch({ happyTook: option.value })}
+                  className={cn(
+                    "flex h-10 flex-1 items-center justify-center gap-[7px] rounded-[9px] border text-[13.5px] hover:border-cc-brand",
+                    picked
+                      ? "border-cc-brand bg-cc-pill font-semibold text-cc-brand"
+                      : "border-cc-rule3 bg-cc-surface font-medium text-cc-muted",
+                  )}
+                >
+                  <span
+                    aria-hidden
+                    className={cn(
+                      "size-[15px] flex-none rounded-full border",
+                      picked
+                        ? "border-cc-brand bg-cc-brand"
+                        : "border-cc-rule3",
+                    )}
+                  />
+                  {option.label}
+                </button>
+              );
+            })}
+          </div>
+
+          <Divider />
+
+          <label
+            htmlFor={`reviewer-note-${course.courseCode}`}
+            className="font-semibold text-[14.5px]"
+          >
+            One line for the next student
+          </label>
+          {/*
+            The artboard says "later from the course page". There is no course
+            page: `/course/<code>` is being retired and every course opens in
+            the workspace pane instead, so the sentence keeps its promise and
+            drops the noun that no longer names anything.
+          */}
+          <p className="m-0 mt-[3px] text-[12px] text-cc-muted">
+            Optional. You can write the full review later from the course.
+          </p>
+          <textarea
+            id={`reviewer-note-${course.courseCode}`}
+            value={draft.message}
+            onChange={(event) => patch({ message: event.target.value })}
+            placeholder="What should they know before signing up?"
+            className="mt-2.5 block min-h-[74px] w-full resize-y rounded-[10px] border border-cc-rule3 bg-cc-surface p-3 text-[13.5px] text-cc-ink2 leading-[1.55] outline-none focus-visible:border-cc-hov"
+          />
+        </Section>
+      </div>
+
+      {saveError ? (
+        <p
+          role="alert"
+          className="mx-[22px] mt-0 mb-1 flex items-center gap-2.5 rounded-[10px] border border-cc-danger-tint-border bg-cc-danger-tint px-[13px] py-[11px] text-[12.5px] text-cc-danger-ink2 leading-[1.45] @max-[420px]:mx-4"
+        >
+          <CircleAlert
+            size={15}
+            strokeWidth={2}
+            aria-hidden
+            className="flex-none text-cc-danger-ink"
+          />
+          <span className="min-w-0 flex-1">{saveError}</span>
+          <button
+            type="button"
+            onClick={onSave}
+            disabled={isSaving}
+            className="flex-none cursor-pointer font-semibold text-[12.5px] text-cc-danger-ink hover:underline"
+          >
+            Try again
+          </button>
+        </p>
+      ) : null}
+
+      <div className="flex items-center justify-between gap-3 border-cc-rule border-t px-[22px] py-3.5 @max-[420px]:px-4">
+        <button
+          type="button"
+          onClick={onSkip}
+          disabled={isSaving}
+          className="cursor-pointer font-medium text-[13px] text-cc-muted hover:underline"
+        >
+          Skip for now
+        </button>
+        <div className="flex items-center gap-[13px]">
+          <span className="text-[11.5px] text-cc-dim2 @max-[560px]:hidden">
+            {answered
+              ? "Marks this course reviewed"
+              : /*
+                  The artboard's own hint here is "Answer one thing to save",
+                  which its own `cardAnswered` contradicts three lines later —
+                  that wants all three. Saying which three is the smaller edit
+                  than shipping copy that sends a reviewer looking for the one
+                  answer that unlocks the button.
+                */
+                "Answer happy, workload and learning to save"}
+          </span>
+          <button
+            type="button"
+            onClick={onSave}
+            disabled={!answered || isSaving}
+            title={
+              answered
+                ? undefined
+                : "Answer happy, workload and learning to save — the write-up is the only optional part"
+            }
+            className={cn(
+              "flex h-10 items-center gap-2 rounded-[9px] px-[18px] font-semibold text-[13.5px]",
+              answered && !isSaving
+                ? "cursor-pointer bg-cc-btn text-cc-btn-fg hover:opacity-[0.88]"
+                : "cursor-not-allowed bg-cc-pill text-cc-dim",
+            )}
+          >
+            {isSaving
+              ? "Saving…"
+              : isLast
+                ? "Save and finish"
+                : "Save and next"}
+            <ArrowRight size={16} strokeWidth={2} aria-hidden />
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/features/reviews/components/reviewer-card.tsx
+++ b/apps/web/features/reviews/components/reviewer-card.tsx
@@ -182,6 +182,15 @@ export function ReviewerCard({
   onSave,
 }: Readonly<ReviewerCardProps>) {
   const examTrackRef = useRef<HTMLDivElement>(null);
+  /**
+   * The divider being dragged, with the bar's geometry and the draft as it was
+   * when the drag started. Only segments `index` and `index + 1` move, so that
+   * starting draft stays a correct base for every step — recomputing from the
+   * live one would compound rounding as the pointer moves.
+   */
+  const drag = useRef<{ index: number; rect: DOMRect; from: ReviewDraft }>(
+    null,
+  );
   const answered = isAnswered(draft);
   const cuts = dividerPositions(draft);
 
@@ -189,27 +198,29 @@ export function ReviewerCard({
     onDraftChange({ ...draft, ...changes });
   }
 
+  /**
+   * Pointer capture rather than listeners on `window`: the divider keeps
+   * receiving moves once the pointer leaves it, which is the whole reason a
+   * drag needs the document, and React tears the handlers down with the card.
+   * A window listener would outlive an unmount that happened mid-drag.
+   */
   function startDividerDrag(
-    event: React.PointerEvent<HTMLElement>,
+    event: React.PointerEvent<HTMLDivElement>,
     index: number,
   ) {
     const track = examTrackRef.current;
     if (!track) return;
     event.preventDefault();
-    const rect = track.getBoundingClientRect();
-    // Only segments `index` and `index + 1` move, so the draft captured here
-    // stays a correct base for every step of the drag.
-    const start = draft;
-    const move = (moveEvent: PointerEvent) => {
-      const percent = ((moveEvent.clientX - rect.left) / rect.width) * 100;
-      onDraftChange(moveDivider(start, index, percent));
-    };
-    const up = () => {
-      window.removeEventListener("pointermove", move);
-      window.removeEventListener("pointerup", up);
-    };
-    window.addEventListener("pointermove", move);
-    window.addEventListener("pointerup", up);
+    event.currentTarget.setPointerCapture?.(event.pointerId);
+    drag.current = { index, rect: track.getBoundingClientRect(), from: draft };
+  }
+
+  function moveDividerDrag(event: React.PointerEvent<HTMLDivElement>) {
+    const current = drag.current;
+    if (current === null) return;
+    const percent =
+      ((event.clientX - current.rect.left) / current.rect.width) * 100;
+    onDraftChange(moveDivider(current.from, current.index, percent));
   }
 
   return (
@@ -314,6 +325,13 @@ export function ReviewerCard({
                 aria-valuemax={100 - MIN_SHARE}
                 aria-valuenow={cut}
                 onPointerDown={(event) => startDividerDrag(event, index)}
+                onPointerMove={moveDividerDrag}
+                onPointerUp={() => {
+                  drag.current = null;
+                }}
+                onPointerCancel={() => {
+                  drag.current = null;
+                }}
                 onKeyDown={(event) => {
                   if (event.key === "ArrowLeft") {
                     event.preventDefault();

--- a/apps/web/features/reviews/components/reviewer-card.tsx
+++ b/apps/web/features/reviews/components/reviewer-card.tsx
@@ -33,6 +33,17 @@ const APPLIED_FILL = "color-mix(in srgb, var(--cc-btn) 40%, var(--cc-surface))";
 const UNSET_FILL = "var(--cc-rule3)";
 /** Below this share a segment is too narrow to hold its own category name. */
 const LABEL_WIDTH_THRESHOLD = 24;
+/**
+ * Below *this* it cannot hold anything at all.
+ *
+ * Between the two the artboard prints an abbreviation — "Assign.", "Project" —
+ * from a `short` field on its own `METHODS`. The repo's labels have no such
+ * field, and inventing one would put a second name for every examination
+ * category in the codebase for the sake of nine pixels. The share itself is a
+ * better use of the room: it is the one thing the segment is actually saying,
+ * and it is what `examinationSegments` already prints on the published card.
+ */
+const PERCENT_WIDTH_THRESHOLD = 13;
 
 function Section({ children }: { children: React.ReactNode }) {
   return (
@@ -287,7 +298,9 @@ export function ReviewerCard({
                 >
                   {draft.shares[index] >= LABEL_WIDTH_THRESHOLD
                     ? EXAMINATION_DISTRIBUTION_LABELS[key]
-                    : ""}
+                    : draft.shares[index] >= PERCENT_WIDTH_THRESHOLD
+                      ? `${draft.shares[index]}%`
+                      : ""}
                 </div>
               ))
             )}

--- a/apps/web/features/reviews/components/reviewer-card.tsx
+++ b/apps/web/features/reviews/components/reviewer-card.tsx
@@ -269,7 +269,7 @@ export function ReviewerCard({
                   aria-pressed={picked}
                   onClick={() => onDraftChange(toggleMethod(draft, key))}
                   className={cn(
-                    "flex h-[30px] items-center gap-1.5 rounded-[15px] border px-[11px] text-[12.5px]",
+                    "flex h-[30px] cursor-pointer items-center gap-1.5 rounded-[15px] border px-[11px] text-[12.5px]",
                     picked
                       ? "border-cc-brand bg-cc-pill text-cc-ink"
                       : "border-cc-rule3 bg-cc-surface text-cc-muted hover:border-cc-brand",
@@ -472,7 +472,7 @@ export function ReviewerCard({
                   aria-pressed={picked}
                   onClick={() => patch({ happyTook: option.value })}
                   className={cn(
-                    "flex h-10 flex-1 items-center justify-center gap-[7px] rounded-[9px] border text-[13.5px] hover:border-cc-brand",
+                    "flex h-10 flex-1 cursor-pointer items-center justify-center gap-[7px] rounded-[9px] border text-[13.5px] hover:border-cc-brand",
                     picked
                       ? "border-cc-brand bg-cc-pill font-semibold text-cc-brand"
                       : "border-cc-rule3 bg-cc-surface font-medium text-cc-muted",

--- a/apps/web/features/reviews/components/reviewer.spec.tsx
+++ b/apps/web/features/reviews/components/reviewer.spec.tsx
@@ -1,0 +1,341 @@
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { readReviewerSession } from "../lib/reviewer-session";
+import type { ReviewFormData } from "./review";
+import { Reviewer } from "./reviewer";
+import type { ReviewerCardCourse } from "./reviewer-card";
+
+const addReview =
+  vi.fn<(code: string, form: ReviewFormData) => Promise<boolean>>();
+
+vi.mock("../hooks/use-add-review", () => ({
+  useAddReview: () => addReview,
+}));
+
+const QUEUE: ReviewerCardCourse[] = [
+  {
+    courseCode: "DD2424",
+    name: "Deep Learning in Data Science",
+    meta: "7.5 hp · 2025",
+  },
+  {
+    courseCode: "SF1918",
+    name: "Probability and Statistics",
+    meta: "6.0 hp · 2024",
+  },
+];
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  sessionStorage.clear();
+  addReview.mockResolvedValue(true);
+});
+
+/** Answers the three questions the card will not save without. */
+async function answerCard(happy: "Yes, I am" | "No, not really" = "Yes, I am") {
+  await userEvent.click(screen.getByRole("button", { name: happy }));
+  fireEvent.change(screen.getByLabelText("How demanding was this course?"), {
+    target: { value: "8" },
+  });
+  fireEvent.change(screen.getByLabelText("How much did you learn?"), {
+    target: { value: "5" },
+  });
+}
+
+function renderReviewer(queue = QUEUE, onClose = vi.fn()) {
+  render(<Reviewer queue={queue} onClose={onClose} />);
+  return onClose;
+}
+
+describe("the card stack", () => {
+  it("deals one card at a time and says how many are behind it", () => {
+    renderReviewer();
+
+    expect(screen.getByText("Card 1 of 2")).toBeInTheDocument();
+    expect(screen.getByText("1 more after this")).toBeInTheDocument();
+    expect(
+      screen.getByText("Deep Learning in Data Science"),
+    ).toBeInTheDocument();
+    expect(screen.getByText("7.5 hp · 2025")).toBeInTheDocument();
+    // The second course is behind the active card, not on screen.
+    expect(
+      screen.queryByText("Probability and Statistics"),
+    ).not.toBeInTheDocument();
+  });
+
+  it("falls back to the code before the catalogue has answered", () => {
+    renderReviewer([{ courseCode: "DD2424" }]);
+
+    expect(screen.getByRole("heading", { name: "DD2424" })).toBeInTheDocument();
+    expect(screen.getByText("Last one")).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: /Save and finish/ }),
+    ).toBeInTheDocument();
+  });
+
+  it("will not save until happy, workload and learning are answered", async () => {
+    renderReviewer();
+
+    expect(
+      screen.getByRole("button", { name: /Save and next/ }),
+    ).toBeDisabled();
+
+    await answerCard();
+
+    expect(screen.getByRole("button", { name: /Save and next/ })).toBeEnabled();
+  });
+});
+
+describe("what a saved card sends", () => {
+  /**
+   * The four questions are optional in different ways. Only the three the
+   * schema requires gate the button; an untouched examination bar and an
+   * untouched theory track are the "I don't remember" answer and store `null`,
+   * never zeroes and never the midpoint the track happens to be drawn at.
+   */
+  it("stores nothing for the questions the reviewer left alone", async () => {
+    renderReviewer([QUEUE[0]]);
+    await answerCard();
+
+    await userEvent.click(
+      screen.getByRole("button", { name: /Save and finish/ }),
+    );
+
+    expect(addReview).toHaveBeenCalledWith("DD2424", {
+      examinationDistribution: null,
+      approachTheoryPercent: null,
+      workloadScore: 8,
+      learningScore: 5,
+      happyTook: true,
+      message: "",
+    });
+  });
+
+  it("carries the formats, the split and the write-up when they were given", async () => {
+    renderReviewer([QUEUE[0]]);
+    await answerCard("No, not really");
+    await userEvent.click(screen.getByRole("button", { name: "Labs" }));
+    await userEvent.click(screen.getByRole("button", { name: "Exam" }));
+    fireEvent.change(
+      screen.getByLabelText(
+        "How theoretical rather than applied the course was",
+      ),
+      { target: { value: "70" } },
+    );
+    await userEvent.type(
+      screen.getByLabelText("One line for the next student"),
+      "Start the labs early.",
+    );
+
+    await userEvent.click(
+      screen.getByRole("button", { name: /Save and finish/ }),
+    );
+
+    expect(addReview).toHaveBeenCalledWith("DD2424", {
+      examinationDistribution: {
+        exam: 50,
+        assignments: 0,
+        labs: 50,
+        projects: 0,
+        seminars: 0,
+        other: 0,
+      },
+      approachTheoryPercent: 70,
+      workloadScore: 8,
+      learningScore: 5,
+      happyTook: false,
+      message: "<p>Start the labs early.</p>",
+    });
+  });
+});
+
+describe("skipping", () => {
+  /**
+   * The screen's own copy promises it: skipped courses "stay in the list as
+   * unreviewed". So a skip writes nothing at all — there is no dismissal to
+   * store, and the next round offers the course again.
+   */
+  it("writes nothing and offers the skipped ones again", async () => {
+    renderReviewer();
+
+    await userEvent.click(screen.getByRole("button", { name: "Skip for now" }));
+    expect(screen.getByText("Card 2 of 2")).toBeInTheDocument();
+    await userEvent.click(screen.getByRole("button", { name: "Skip for now" }));
+
+    expect(addReview).not.toHaveBeenCalled();
+    expect(
+      screen.getByRole("heading", { name: "Nothing reviewed this round" }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        "The 2 you skipped are still marked unreviewed in your list — pick any of them up from there.",
+      ),
+    ).toBeInTheDocument();
+
+    await userEvent.click(
+      screen.getByRole("button", { name: "Go through the skipped ones" }),
+    );
+    expect(screen.getByText("Card 1 of 2")).toBeInTheDocument();
+  });
+
+  it("deals only the skipped ones in the second round", async () => {
+    renderReviewer();
+
+    await answerCard();
+    await userEvent.click(
+      screen.getByRole("button", { name: /Save and next/ }),
+    );
+    await screen.findByText("Probability and Statistics");
+    await userEvent.click(screen.getByRole("button", { name: "Skip for now" }));
+
+    expect(
+      screen.getByRole("heading", { name: "1 course reviewed" }),
+    ).toBeInTheDocument();
+    await userEvent.click(
+      screen.getByRole("button", { name: "Go through the skipped ones" }),
+    );
+
+    expect(screen.getByText("Card 1 of 1")).toBeInTheDocument();
+    expect(screen.getByText("Probability and Statistics")).toBeInTheDocument();
+  });
+
+  it("says so plainly when the whole round was reviewed", async () => {
+    renderReviewer([QUEUE[0]]);
+    await answerCard();
+    await userEvent.click(
+      screen.getByRole("button", { name: /Save and finish/ }),
+    );
+
+    expect(
+      await screen.findByRole("heading", { name: "1 course reviewed" }),
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", { name: "Go through the skipped ones" }),
+    ).not.toBeInTheDocument();
+  });
+});
+
+describe("a save that does not land", () => {
+  /**
+   * `useAddReview` has already said what went wrong in a toast; the row is what
+   * keeps the card, and the answers on it, in front of the reviewer instead of
+   * advancing past work nothing stored.
+   */
+  it("keeps the card and its answers, and offers the save again", async () => {
+    addReview.mockResolvedValue(false);
+    renderReviewer();
+    await answerCard();
+
+    await userEvent.click(
+      screen.getByRole("button", { name: /Save and next/ }),
+    );
+
+    expect(
+      await screen.findByText(
+        "That review did not reach the server. Nothing was lost — your answers are still on the card.",
+      ),
+    ).toBeInTheDocument();
+    // Still card one, still holding what was answered.
+    expect(screen.getByText("Card 1 of 2")).toBeInTheDocument();
+    expect(screen.getByText("8 / 10")).toBeInTheDocument();
+
+    addReview.mockResolvedValue(true);
+    await userEvent.click(screen.getByRole("button", { name: "Try again" }));
+
+    await waitFor(() =>
+      expect(screen.getByText("Card 2 of 2")).toBeInTheDocument(),
+    );
+    expect(addReview).toHaveBeenCalledTimes(2);
+  });
+
+  it("clears the error when the reviewer skips past the card instead", async () => {
+    addReview.mockResolvedValue(false);
+    renderReviewer();
+    await answerCard();
+    await userEvent.click(
+      screen.getByRole("button", { name: /Save and next/ }),
+    );
+    await screen.findByText(/did not reach the server/);
+
+    await userEvent.click(screen.getByRole("button", { name: "Skip for now" }));
+
+    expect(
+      screen.queryByText(/did not reach the server/),
+    ).not.toBeInTheDocument();
+  });
+});
+
+/**
+ * The reviewer writes the round to `sessionStorage` and is handed one back as
+ * a prop — reading it is `TakenCourses`' job, because only that screen knows
+ * which courses are still unreviewed. These tests exercise both halves of the
+ * seam: what gets written, and what a component handed it back does with it.
+ */
+describe("a round a reload interrupted", () => {
+  it("writes the round down as it goes", async () => {
+    render(<Reviewer queue={QUEUE} onClose={vi.fn()} />);
+    await userEvent.click(screen.getByRole("button", { name: "Skip for now" }));
+    await answerCard();
+
+    expect(readReviewerSession()).toMatchObject({
+      queue: ["DD2424", "SF1918"],
+      done: { DD2424: "skipped" },
+      drafts: {
+        SF1918: { happyTook: true, workloadScore: 8, learningScore: 5 },
+      },
+    });
+  });
+
+  it("comes back with the same queue, progress and unsaved answers", async () => {
+    const { unmount } = render(<Reviewer queue={QUEUE} onClose={vi.fn()} />);
+    await userEvent.click(screen.getByRole("button", { name: "Skip for now" }));
+    await answerCard();
+    unmount();
+
+    render(
+      <Reviewer
+        queue={QUEUE}
+        restored={readReviewerSession()}
+        onClose={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByText("Card 2 of 2")).toBeInTheDocument();
+    expect(screen.getByText("Probability and Statistics")).toBeInTheDocument();
+    expect(screen.getByText("8 / 10")).toBeInTheDocument();
+    expect(screen.getByText("5 / 10")).toBeInTheDocument();
+  });
+
+  /**
+   * A stored round only belongs to the queue it was started on. Restoring one
+   * round's drafts onto a different set of courses would put answers on cards
+   * they were never written for, so a mismatch is discarded rather than
+   * half-applied — even though the caller is supposed to have pruned it first.
+   */
+  it("is ignored when the queue is not the one it was stored for", async () => {
+    render(<Reviewer queue={QUEUE} onClose={vi.fn()} />);
+    await userEvent.click(screen.getByRole("button", { name: "Skip for now" }));
+
+    render(
+      <Reviewer
+        queue={[QUEUE[1]]}
+        restored={readReviewerSession()}
+        onClose={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByText("Card 1 of 1")).toBeInTheDocument();
+  });
+
+  /** Nothing restored is a fresh round, whatever the tab happens to hold. */
+  it("starts clean when no round is handed to it", async () => {
+    const { unmount } = render(<Reviewer queue={QUEUE} onClose={vi.fn()} />);
+    await userEvent.click(screen.getByRole("button", { name: "Skip for now" }));
+    unmount();
+
+    render(<Reviewer queue={QUEUE} onClose={vi.fn()} />);
+
+    expect(screen.getByText("Card 1 of 2")).toBeInTheDocument();
+  });
+});

--- a/apps/web/features/reviews/components/reviewer.spec.tsx
+++ b/apps/web/features/reviews/components/reviewer.spec.tsx
@@ -328,6 +328,36 @@ describe("a round a reload interrupted", () => {
     expect(screen.getByText("Card 1 of 1")).toBeInTheDocument();
   });
 
+  /**
+   * `done` is a map and the queue is a list, and nothing guarantees the map
+   * only mentions courses in the list. A round that counted across the map
+   * would tell the reader it reviewed a course they never saw.
+   */
+  it("counts only the courses this round is dealing", async () => {
+    render(
+      <Reviewer
+        queue={[QUEUE[0]]}
+        restored={{
+          queue: ["DD2424"],
+          done: { GHOST999: "saved", GONE111: "skipped" },
+          drafts: {},
+        }}
+        onClose={vi.fn()}
+      />,
+    );
+
+    await userEvent.click(screen.getByRole("button", { name: "Skip for now" }));
+
+    expect(
+      screen.getByRole("heading", { name: "Nothing reviewed this round" }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        "The 1 you skipped are still marked unreviewed in your list — pick any of them up from there.",
+      ),
+    ).toBeInTheDocument();
+  });
+
   /** Nothing restored is a fresh round, whatever the tab happens to hold. */
   it("starts clean when no round is handed to it", async () => {
     const { unmount } = render(<Reviewer queue={QUEUE} onClose={vi.fn()} />);

--- a/apps/web/features/reviews/components/reviewer.tsx
+++ b/apps/web/features/reviews/components/reviewer.tsx
@@ -1,0 +1,316 @@
+"use client";
+
+import { ArrowLeft, Check } from "lucide-react";
+import { useEffect, useState } from "react";
+import { cn } from "@/lib/utils";
+import { useAddReview } from "../hooks/use-add-review";
+import {
+  EMPTY_REVIEW_DRAFT,
+  type ReviewDraft,
+  toReviewFormData,
+} from "../lib/review-draft";
+import {
+  type CardOutcome,
+  type ReviewerSession,
+  writeReviewerSession,
+} from "../lib/reviewer-session";
+import { ReviewerCard, type ReviewerCardCourse } from "./reviewer-card";
+
+/** The artboard's `revSaveErrorText`, kept word for word. */
+const SAVE_FAILED =
+  "That review did not reach the server. Nothing was lost — your answers are still on the card.";
+
+/** How many cards are drawn peeking out behind the active one. */
+const PEEK_DEPTH = 2;
+const PEEKS = [
+  { translate: "14px", scale: 0.975, opacity: 1 },
+  { translate: "26px", scale: 0.95, opacity: 0.65 },
+];
+
+type Round = {
+  /** The course codes queued for this round, in the order they are dealt. */
+  order: string[];
+  /** What happened to each card. A code that is absent is still to come. */
+  done: Record<string, CardOutcome>;
+  /** Answers per course, kept while the round runs so a card can be revisited. */
+  drafts: Record<string, ReviewDraft>;
+};
+
+function sameOrder(a: readonly string[], b: readonly string[]): boolean {
+  return a.length === b.length && a.every((code, index) => code === b[index]);
+}
+
+export interface ReviewerProps {
+  /**
+   * The courses to deal, in order — captured when the reviewer opened rather
+   * than tracked live. A queue that shrank under the reviewer as each save
+   * landed would renumber "Card 3 of 8" mid-round and drop the cards behind the
+   * active one, which is the opposite of what the stack is for.
+   */
+  queue: ReviewerCardCourse[];
+  /**
+   * A round this tab left unfinished, to pick back up — progress and unsaved
+   * answers included. `null` starts a fresh round.
+   *
+   * It arrives as a prop rather than being read from `sessionStorage` here on
+   * purpose. Whether a stored round is still worth resuming depends on which
+   * courses are *currently* unreviewed, which this component has no way to
+   * know: it is handed a queue and deals it. `TakenCourses` owns that
+   * judgement, and it hands over a session it has already pruned, so `queue`
+   * and `restored.queue` are the same list.
+   */
+  restored?: ReviewerSession | null;
+  /** Leaves the reviewer and ends the round; the queue is not kept. */
+  onClose: () => void;
+}
+
+/**
+ * The **fast-track reviewer** — the full-screen card stack drawn by the
+ * `isReviewer` branch of `docs/design_ref_new/Course Community - Taken
+ * Courses.dc.html`, reached from the unreviewed prompt, from My Page's own
+ * prompt via `/taken?review=1`, and from a row in either.
+ *
+ * ## It is a second form, not a second write path
+ *
+ * The card asks the same four questions the workspace pane's review draft asks,
+ * in a shape built for a queue rather than for a column. What it does *not*
+ * have is a write of its own: `toReviewFormData` is the only mapping, and
+ * `useAddReview` is the only submit — the same hook the pane and the review
+ * dialog call, which validates every review with `reviewFormSchema` before it
+ * sends anything. Two presentations, one write path, one validator.
+ *
+ * ## Skipping leaves the course exactly as it was
+ *
+ * The screen's own copy promises it: *"Skip the ones you have no opinion about
+ * — they stay in the list as unreviewed."* A skip therefore writes nothing at
+ * all. It is not a stored decision, not a dismissal, and not a row — the course
+ * is unreviewed for the same reason it was before, because no review exists for
+ * it, and the next round will offer it again.
+ *
+ * ## The round survives a reload
+ *
+ * Which courses were skipped and which were answered is the one thing here that
+ * is not re-derivable from the server, and the answers on an unsaved card have
+ * no row anywhere. Both are written to `sessionStorage` on every change — see
+ * `reviewer-session.ts` for why the tab, and not the account, is the right
+ * place for them. Reading one back is `TakenCourses`' call, not this
+ * component's: see `restored`.
+ */
+export function Reviewer({
+  queue,
+  restored = null,
+  onClose,
+}: Readonly<ReviewerProps>) {
+  const addReview = useAddReview();
+
+  /**
+   * The names arrive after the codes do — `course.summary` is one request per
+   * course — so the queue prop is re-read for display on every render, while
+   * the round itself is seeded once. A title landing late must update the card;
+   * it must not restart the round.
+   */
+  const courses = new Map(queue.map((course) => [course.courseCode, course]));
+
+  const [round, setRound] = useState<Round>(() => {
+    const order = queue.map((course) => course.courseCode);
+    // Belt and braces on the caller's promise. A restored round is only this
+    // round if it is the same queue in the same order; anything else would put
+    // one round's answers onto another round's cards, so it is discarded
+    // rather than half-applied.
+    return restored && sameOrder(restored.queue, order)
+      ? { order, done: restored.done, drafts: restored.drafts }
+      : { order, done: {}, drafts: {} };
+  });
+  const [isSaving, setIsSaving] = useState(false);
+  const [saveError, setSaveError] = useState<string | null>(null);
+
+  useEffect(() => {
+    writeReviewerSession({
+      queue: round.order,
+      done: round.done,
+      drafts: round.drafts,
+    });
+  }, [round]);
+
+  const activeIndex = round.order.findIndex((code) => !round.done[code]);
+  const activeCode = activeIndex === -1 ? null : round.order[activeIndex];
+  const remaining =
+    activeIndex === -1 ? 0 : round.order.length - activeIndex - 1;
+  const outcomes = Object.values(round.done);
+  const savedCount = outcomes.filter((outcome) => outcome === "saved").length;
+  const skippedCodes = round.order.filter(
+    (code) => round.done[code] === "skipped",
+  );
+
+  function finish(code: string, outcome: CardOutcome) {
+    setSaveError(null);
+    setRound((current) => ({
+      ...current,
+      done: { ...current.done, [code]: outcome },
+    }));
+  }
+
+  async function save() {
+    if (activeCode === null || isSaving) return;
+    const form = toReviewFormData(
+      round.drafts[activeCode] ?? EMPTY_REVIEW_DRAFT,
+    );
+    // The button is disabled without the three required answers; this is the
+    // guard for the paths that are not the button, such as "Try again".
+    if (!form) return;
+
+    setIsSaving(true);
+    setSaveError(null);
+    const published = await addReview(activeCode, form);
+    setIsSaving(false);
+    // `useAddReview` has already said what went wrong, in a toast. The row is
+    // what keeps the card — and the answers on it — in front of the reviewer
+    // instead of advancing past work that was never stored.
+    if (!published) {
+      setSaveError(SAVE_FAILED);
+      return;
+    }
+    finish(activeCode, "saved");
+  }
+
+  return (
+    <div className="@container flex min-w-0 flex-1 flex-col px-5">
+      <div className="flex items-start justify-between gap-6 border-cc-rule border-b pt-[18px] pb-4 @max-[520px]:flex-col @max-[520px]:gap-3">
+        <div className="min-w-0">
+          <p className="m-0 font-semibold text-[11px] text-cc-warn-ink uppercase tracking-[0.09em]">
+            Quick review
+          </p>
+          <h2 className="m-0 mt-[7px] font-semibold text-[19px] leading-[1.25]">
+            One card per course
+          </h2>
+          <p className="m-0 mt-2 max-w-[560px] text-[13.5px] text-cc-muted leading-[1.5]">
+            Four quick questions and a line of text per course. Skip the ones
+            you have no opinion about — they stay in the list as unreviewed.
+          </p>
+        </div>
+        <button
+          type="button"
+          onClick={onClose}
+          className="flex h-[38px] flex-none cursor-pointer items-center gap-2 rounded-[9px] border border-cc-rule3 bg-cc-surface px-3.5 font-medium text-[13px] text-cc-chip-ink hover:border-cc-hov"
+        >
+          <ArrowLeft size={15} strokeWidth={2} aria-hidden />
+          Back to courses
+        </button>
+      </div>
+
+      <div className="flex items-center gap-3.5 pt-4">
+        <p className="m-0 flex-none font-medium text-[12px] text-cc-dim tabular-nums">
+          {activeCode === null
+            ? `${round.order.length} ${round.order.length === 1 ? "card" : "cards"} done`
+            : `Card ${activeIndex + 1} of ${round.order.length}`}
+        </p>
+        <div aria-hidden className="flex flex-1 gap-[5px]">
+          {round.order.map((code) => (
+            <span
+              key={code}
+              className={cn(
+                "h-1.5 flex-1 rounded-full",
+                round.done[code]
+                  ? "bg-cc-btn"
+                  : code === activeCode
+                    ? "bg-cc-brand/50"
+                    : "bg-cc-pill",
+              )}
+            />
+          ))}
+        </div>
+      </div>
+
+      {activeCode !== null ? (
+        <div className="flex flex-1 justify-center pt-[22px] pb-9">
+          <div className="relative w-full max-w-[640px]">
+            {PEEKS.slice(0, Math.min(PEEK_DEPTH, remaining)).map((peek) => (
+              <div
+                key={peek.translate}
+                aria-hidden
+                className="absolute inset-0 rounded-[16px] border border-cc-rule2 bg-cc-surface"
+                style={{
+                  transform: `translateY(${peek.translate}) scale(${peek.scale})`,
+                  opacity: peek.opacity,
+                }}
+              />
+            ))}
+            <ReviewerCard
+              key={activeCode}
+              course={courses.get(activeCode) ?? { courseCode: activeCode }}
+              draft={round.drafts[activeCode] ?? EMPTY_REVIEW_DRAFT}
+              stackLabel={
+                remaining === 0 ? "Last one" : `${remaining} more after this`
+              }
+              isLast={remaining === 0}
+              isSaving={isSaving}
+              saveError={saveError}
+              onDraftChange={(draft) =>
+                setRound((current) => ({
+                  ...current,
+                  drafts: { ...current.drafts, [activeCode]: draft },
+                }))
+              }
+              onSkip={() => finish(activeCode, "skipped")}
+              onSave={() => void save()}
+            />
+          </div>
+        </div>
+      ) : (
+        <div className="flex flex-1 justify-center pt-7 pb-10">
+          <div className="w-full max-w-[520px] rounded-[16px] border border-cc-rule bg-cc-surface px-[26px] pt-[30px] pb-[26px] text-center">
+            <span className="inline-flex size-11 items-center justify-center rounded-full bg-cc-success-tint text-cc-success-ink">
+              <Check size={22} strokeWidth={2.2} aria-hidden />
+            </span>
+            <h3 className="m-0 mt-3.5 font-semibold text-[21px] tracking-[-0.01em]">
+              {savedCount === 0
+                ? "Nothing reviewed this round"
+                : savedCount === 1
+                  ? "1 course reviewed"
+                  : `${savedCount} courses reviewed`}
+            </h3>
+            {/*
+              The artboard's no-skips line ends "You can reopen a card from the
+              Reviewed column any time." It cannot: that column is a static
+              "Done" / "Not yet" label in `taken-course-row.tsx`, with nothing
+              to click. Rewriting a review is the review card's own edit, on the
+              course, so the sentence is dropped rather than pointed somewhere
+              it was not about.
+            */}
+            <p className="m-0 mt-2 text-[13.5px] text-cc-muted leading-[1.55]">
+              {skippedCodes.length > 0
+                ? `The ${skippedCodes.length} you skipped are still marked unreviewed in your list — pick any of them up from there.`
+                : "Every course in this round is marked reviewed in your list."}
+            </p>
+            <div className="mt-5 flex justify-center gap-2.5 @max-[420px]:flex-col">
+              <button
+                type="button"
+                onClick={onClose}
+                className="flex h-10 cursor-pointer items-center justify-center rounded-[9px] bg-cc-btn px-[18px] font-semibold text-[13.5px] text-cc-btn-fg hover:opacity-[0.88]"
+              >
+                Back to my courses
+              </button>
+              {skippedCodes.length > 0 ? (
+                <button
+                  type="button"
+                  onClick={() =>
+                    setRound((current) => ({
+                      order: current.order.filter(
+                        (code) => current.done[code] === "skipped",
+                      ),
+                      done: {},
+                      drafts: current.drafts,
+                    }))
+                  }
+                  className="flex h-10 cursor-pointer items-center justify-center rounded-[9px] border border-cc-rule3 bg-cc-surface px-4 font-medium text-[13.5px] text-cc-chip-ink hover:border-cc-hov"
+                >
+                  Go through the skipped ones
+                </button>
+              ) : null}
+            </div>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/apps/web/features/reviews/components/reviewer.tsx
+++ b/apps/web/features/reviews/components/reviewer.tsx
@@ -199,11 +199,19 @@ export function Reviewer({
       </div>
 
       <div className="flex items-center gap-3.5 pt-4">
-        <p className="m-0 flex-none font-medium text-[12px] text-cc-dim tabular-nums">
+        {/*
+          The segments are decoration — a screen reader gets nothing from
+          twelve unlabelled bars — so this line is the only progress a
+          non-sighted reviewer has. `<output>` is a live region, which is
+          what makes it arrive when a card is saved or skipped rather than
+          only when someone goes looking for it; it is the element the rest
+          of this app already uses for the same job.
+        */}
+        <output className="m-0 flex-none font-medium text-[12px] text-cc-dim tabular-nums">
           {activeCode === null
             ? `${round.order.length} ${round.order.length === 1 ? "card" : "cards"} done`
             : `Card ${activeIndex + 1} of ${round.order.length}`}
-        </p>
+        </output>
         <div aria-hidden className="flex flex-1 gap-[5px]">
           {round.order.map((code) => (
             <span
@@ -239,6 +247,11 @@ export function Reviewer({
               key={activeCode}
               course={courses.get(activeCode) ?? { courseCode: activeCode }}
               draft={round.drafts[activeCode] ?? EMPTY_REVIEW_DRAFT}
+              // The artboard's `revStackLabel` is
+              // `(queue - at - 1) + " more after this"`, which on the final
+              // card renders "0 more after this" — a sentence that has to be
+              // read twice to mean "this is the last one". It says that
+              // instead.
               stackLabel={
                 remaining === 0 ? "Last one" : `${remaining} more after this`
               }

--- a/apps/web/features/reviews/components/reviewer.tsx
+++ b/apps/web/features/reviews/components/reviewer.tsx
@@ -136,8 +136,14 @@ export function Reviewer({
   const activeCode = activeIndex === -1 ? null : round.order[activeIndex];
   const remaining =
     activeIndex === -1 ? 0 : round.order.length - activeIndex - 1;
-  const outcomes = Object.values(round.done);
-  const savedCount = outcomes.filter((outcome) => outcome === "saved").length;
+  // Both counted across `order`, never across `done`. `done` is a map, and a
+  // map restored from a tab's storage can hold a code this round is not
+  // dealing — which would have the done screen report a course the reader
+  // never saw. The queue is what this round is; the map only says what
+  // happened to the courses in it.
+  const savedCount = round.order.filter(
+    (code) => round.done[code] === "saved",
+  ).length;
   const skippedCodes = round.order.filter(
     (code) => round.done[code] === "skipped",
   );

--- a/apps/web/features/reviews/components/unreviewed-card.spec.tsx
+++ b/apps/web/features/reviews/components/unreviewed-card.spec.tsx
@@ -35,7 +35,7 @@ function renderScreen(
 }
 
 describe("UnreviewedCard", () => {
-  it("prompts for taken courses with no review and routes each into the review flow", () => {
+  it("prompts for taken courses with no review", () => {
     renderScreen([]);
 
     expect(
@@ -44,13 +44,22 @@ describe("UnreviewedCard", () => {
     expect(
       screen.getByText("Your review is what the next student reads."),
     ).toBeInTheDocument();
+    expect(screen.getByText("DD2424")).toBeInTheDocument();
+    expect(screen.getByText("SF1918")).toBeInTheDocument();
+  });
 
-    expect(
-      screen.getByRole("link", { name: /Deep Learning in Data Science/ }),
-    ).toHaveAttribute("href", "/course/DD2424?writeReview=1");
-    expect(
-      screen.getByRole("link", { name: /Probability and Statistics/ }),
-    ).toHaveAttribute("href", "/course/SF1918?writeReview=1");
+  /**
+   * The card used to link a row at `/course/<code>?writeReview=1`. That route
+   * is gone — every course opens in the workspace pane now — so a row with
+   * nowhere to go is text, not a dead link. It is the artboard's own rule:
+   * `cursor: c.onClick ? "pointer" : "default"`.
+   */
+  it("never navigates a row of its own accord", () => {
+    renderScreen([]);
+
+    expect(screen.queryAllByRole("link")).toHaveLength(0);
+    // The only button is the fast track's own.
+    expect(screen.getAllByRole("button")).toHaveLength(1);
   });
 
   it("leaves out a taken course the viewer has already reviewed", () => {

--- a/apps/web/features/reviews/components/unreviewed-card.tsx
+++ b/apps/web/features/reviews/components/unreviewed-card.tsx
@@ -1,8 +1,6 @@
 "use client";
 
 import { MessageCircle } from "lucide-react";
-import Link from "next/link";
-import type { ReactNode } from "react";
 
 /**
  * One row of the prompt: a course the viewer took and has not reviewed.
@@ -34,17 +32,18 @@ type Props = {
    */
   onStart: () => void;
   /**
-   * Handles a row instead of the default link into the review flow. This is the
-   * artboard's own per-course `c.onClick`, which Taken courses uses to open its
-   * reviewer in place rather than navigating away; My Page passes one too.
+   * Opens the reviewer on this one course. The artboard's own per-course
+   * `c.onClick`, and the only thing a row can do: it draws a plain line of text
+   * when no screen supplies one, exactly as the artboard does
+   * (`cursor: c.onClick ? "pointer" : "default"`).
+   *
+   * There is no link fallback. The old one pointed at
+   * `/course/<code>?writeReview=1`, and that route is going away — every course
+   * opens in the workspace pane now, and every review is written either there
+   * or in the fast-track reviewer this card starts.
    */
   onSelect?: (courseCode: string) => void;
 };
-
-/** Where a course's review gets written. Same entry point Saved and Explore use. */
-function reviewFlowHref(courseCode: string): string {
-  return `/course/${courseCode}?writeReview=1`;
-}
 
 const ROW_CLASS =
   "flex w-full items-baseline gap-[9px] text-left transition-opacity hover:opacity-80";
@@ -78,7 +77,7 @@ function CourseRowContent({ course }: { course: UnreviewedCourse }) {
 
 /**
  * The prompt shown for courses the viewer marked taken but never reviewed —
- * `docs/design/Course Community - Unreviewed Card.dc.html`.
+ * `docs/design_ref_new/Course Community - Unreviewed Card.dc.html`.
  *
  * It is an invitation, not a warning, which is why it wears the ordinary card
  * surface and the brand button rather than the `--cc-warn-*` nudge palette; the
@@ -139,9 +138,9 @@ export function UnreviewedCard({
 }
 
 /**
- * A row navigates into the review flow by default, so the card is useful with
- * nothing but a list. `onSelect` swaps the link for a button when the screen
- * would rather open a reviewer in place than leave the page.
+ * A row is a button when the screen can open the reviewer on that one course,
+ * and a plain line when it cannot. Nothing here navigates: the card is a
+ * prompt, and where reviewing happens is the screen's to decide.
  */
 function CourseRow({
   course,
@@ -149,22 +148,22 @@ function CourseRow({
 }: {
   course: UnreviewedCourse;
   onSelect?: (courseCode: string) => void;
-}): ReactNode {
-  if (onSelect) {
+}) {
+  if (!onSelect) {
     return (
-      <button
-        type="button"
-        className={ROW_CLASS}
-        onClick={() => onSelect(course.code)}
-      >
+      <span className="flex items-baseline gap-[9px]">
         <CourseRowContent course={course} />
-      </button>
+      </span>
     );
   }
 
   return (
-    <Link href={reviewFlowHref(course.code)} className={ROW_CLASS}>
+    <button
+      type="button"
+      className={ROW_CLASS}
+      onClick={() => onSelect(course.code)}
+    >
       <CourseRowContent course={course} />
-    </Link>
+    </button>
   );
 }

--- a/apps/web/features/reviews/components/unreviewed-card.tsx
+++ b/apps/web/features/reviews/components/unreviewed-card.tsx
@@ -45,8 +45,14 @@ type Props = {
   onSelect?: (courseCode: string) => void;
 };
 
+/**
+ * A row that opens the reviewer. `cursor-pointer` is not decoration here: the
+ * row used to be a `<Link>`, which the browser gives a pointer for free, and a
+ * `<button>` gets `cursor: default` unless something says otherwise. The
+ * artboard says otherwise — `cursor: c.onClick ? "pointer" : "default"`.
+ */
 const ROW_CLASS =
-  "flex w-full items-baseline gap-[9px] text-left transition-opacity hover:opacity-80";
+  "flex w-full cursor-pointer items-baseline gap-[9px] text-left transition-opacity hover:opacity-80";
 
 function headlineFor(count: number): string {
   return count === 1
@@ -116,7 +122,7 @@ export function UnreviewedCard({
         <button
           type="button"
           onClick={onStart}
-          className="flex h-10 flex-none items-center justify-center gap-2 rounded-[9px] bg-cc-btn px-[18px] font-semibold text-[13.5px] text-cc-btn-fg hover:opacity-[.88] @max-[440px]:w-full"
+          className="flex h-10 flex-none cursor-pointer items-center justify-center gap-2 rounded-[9px] bg-cc-btn px-[18px] font-semibold text-[13.5px] text-cc-btn-fg hover:opacity-[.88] @max-[440px]:w-full"
         >
           <MessageCircle size={15} aria-hidden />
           {fastTrackLabelFor(courses.length)}

--- a/apps/web/features/reviews/hooks/use-add-review.ts
+++ b/apps/web/features/reviews/hooks/use-add-review.ts
@@ -5,8 +5,28 @@ import { toast } from "sonner";
 import { useCreateReview } from "../api/mutations";
 import type { ReviewFormData } from "../components/review";
 import { warnAboutProfanity } from "../lib/profanity";
+import { reviewFormSchema } from "../lib/review-form-schema";
 import { toStoredMessage } from "../lib/review-text";
 
+/**
+ * Every review this app publishes goes through here.
+ *
+ * Three surfaces write a review — the review dialog, the workspace pane's
+ * review draft, and the fast-track card stack on `/taken` — and they draw
+ * completely different forms. That is fine, and deliberate: a card stack asking
+ * one course at a time is a better shape for a queue than a modal is. What is
+ * not fine is three ideas of what a valid review looks like, so the check lives
+ * here, on the write path, rather than in each form.
+ *
+ * `requireMessage: false` because prose is a rule about a *form*, not about a
+ * review: `reviews.message` is nullable and a scores-only review is a valid
+ * row. The dialog still asks for prose before it gets here, with its own
+ * `reviewFormSchema({ requireMessage: true })`; the card stack and the pane
+ * make the write-up optional, as their artboards do. What this guarantees is
+ * the part that is not negotiable — 1–10 scores, a `happyTook`, a distribution
+ * that either adds to 100 or is absent, and a theory percent in range — so no
+ * presentation can send something the server would have to refuse.
+ */
 export function useAddReview() {
   const createReview = useCreateReview();
 
@@ -16,11 +36,22 @@ export function useAddReview() {
       reviewForm: ReviewFormData,
     ): Promise<boolean> => {
       if (warnAboutProfanity(reviewForm.message)) return false;
+
+      const checked = reviewFormSchema({ requireMessage: false }).safeParse(
+        reviewForm,
+      );
+      if (!checked.success) {
+        toast.error("That review is not finished", {
+          description: checked.error.issues[0]?.message ?? "Check your answers",
+        });
+        return false;
+      }
+
       try {
         await createReview.mutateAsync({
           courseCode,
-          ...reviewForm,
-          message: toStoredMessage(reviewForm.message),
+          ...checked.data,
+          message: toStoredMessage(checked.data.message),
         });
         toast.success("Review added successfully!");
         return true;

--- a/apps/web/features/reviews/hooks/use-edit-review.ts
+++ b/apps/web/features/reviews/hooks/use-edit-review.ts
@@ -5,13 +5,14 @@ import { toast } from "sonner";
 import { useUpdateReview } from "../api/mutations";
 import type { ReviewFormData } from "../components/review";
 import { warnAboutProfanity } from "../lib/profanity";
+import { reviewFormSchema } from "../lib/review-form-schema";
 import { toStoredMessage } from "../lib/review-text";
 
 /**
- * Rewrites a review the viewer already published. The same draft check as
- * writing one, so a message that could not be posted cannot be edited in
- * either. Authorship is the server's call: `reviews.update` refuses anyone but
- * the author no matter which id is sent.
+ * Rewrites a review the viewer already published. The same draft check and the
+ * same `reviewFormSchema` as writing one, so a review that could not be posted
+ * cannot be edited into existence either. Authorship is the server's call:
+ * `reviews.update` refuses anyone but the author no matter which id is sent.
  */
 export function useEditReview() {
   const updateReview = useUpdateReview();
@@ -19,11 +20,22 @@ export function useEditReview() {
   return useCallback(
     async (id: string, reviewForm: ReviewFormData): Promise<boolean> => {
       if (warnAboutProfanity(reviewForm.message)) return false;
+
+      const checked = reviewFormSchema({ requireMessage: false }).safeParse(
+        reviewForm,
+      );
+      if (!checked.success) {
+        toast.error("That review is not finished", {
+          description: checked.error.issues[0]?.message ?? "Check your answers",
+        });
+        return false;
+      }
+
       try {
         await updateReview.mutateAsync({
           id,
-          ...reviewForm,
-          message: toStoredMessage(reviewForm.message),
+          ...checked.data,
+          message: toStoredMessage(checked.data.message),
         });
         toast.success("Review updated");
         return true;

--- a/apps/web/features/reviews/index.ts
+++ b/apps/web/features/reviews/index.ts
@@ -4,6 +4,11 @@
  * `selectUnreviewedCourses` is deliberately absent: it is what
  * `useUnreviewedTakenCourses` is made of, and a screen that reached for it
  * directly would be re-deriving the set the hook already derives.
+ *
+ * So is anything that writes a review other than `useAddReview` and
+ * `useEditReview`. The mutations under `api/` are the hooks' own; a surface
+ * reaching past them would be a review written without `reviewFormSchema`
+ * having seen it, which is the one thing this feature exists to prevent.
  */
 
 export {
@@ -20,6 +25,9 @@ export {
 /** One published review, and the list that wires it to the API. */
 export { ReviewCard, type ReviewCardProps } from "./components/review-card";
 export { ReviewList } from "./components/review-list";
+/** The fast-track card stack, and the shape of one course in its queue. */
+export { Reviewer, type ReviewerProps } from "./components/reviewer";
+export type { ReviewerCardCourse } from "./components/reviewer-card";
 /** The prompt for taken courses with no review — Taken courses and My Page. */
 export {
   UnreviewedCard,
@@ -35,3 +43,14 @@ export {
   examinationSegments,
   examinationSplitLabel,
 } from "./lib/examination-palette";
+/**
+ * The reviewer's round, as the tab remembers it. `/taken` reads it to reopen a
+ * round a reload interrupted — after checking that its courses are still
+ * unreviewed, which the store itself cannot know — and clears it when the
+ * reader leaves the stack.
+ */
+export {
+  clearReviewerSession,
+  type ReviewerSession,
+  readReviewerSession,
+} from "./lib/reviewer-session";

--- a/apps/web/features/reviews/lib/review-draft.spec.ts
+++ b/apps/web/features/reviews/lib/review-draft.spec.ts
@@ -1,0 +1,203 @@
+import { describe, expect, it } from "vitest";
+import {
+  dividerPositions,
+  EMPTY_REVIEW_DRAFT,
+  evenShares,
+  isAnswered,
+  isUntouched,
+  MIN_SHARE,
+  moveDivider,
+  nudgeDivider,
+  type ReviewDraft,
+  toExaminationDistribution,
+  toggleMethod,
+  toReviewFormData,
+} from "./review-draft";
+
+function draft(over: Partial<ReviewDraft> = {}): ReviewDraft {
+  return { ...EMPTY_REVIEW_DRAFT, ...over };
+}
+
+/** A card with the three answers a review cannot be written without. */
+function answered(over: Partial<ReviewDraft> = {}): ReviewDraft {
+  return draft({
+    happyTook: true,
+    workloadScore: 7,
+    learningScore: 4,
+    ...over,
+  });
+}
+
+describe("the examination bar", () => {
+  it("splits evenly in 5% steps and always adds up to 100", () => {
+    for (let count = 1; count <= 6; count++) {
+      const shares = evenShares(count);
+      expect(shares).toHaveLength(count);
+      expect(shares.reduce((total, share) => total + share, 0)).toBe(100);
+      expect(shares.every((share) => share % 5 === 0)).toBe(true);
+      expect(shares.every((share) => share >= MIN_SHARE)).toBe(true);
+    }
+  });
+
+  it("keeps the order the reviewer picked in", () => {
+    const picked = toggleMethod(toggleMethod(draft(), "labs"), "exam");
+    expect(picked.methods).toEqual(["labs", "exam"]);
+    expect(picked.shares).toEqual([50, 50]);
+
+    const unpicked = toggleMethod(picked, "labs");
+    expect(unpicked.methods).toEqual(["exam"]);
+    expect(unpicked.shares).toEqual([100]);
+  });
+
+  it("moves one divider and leaves every other segment where it was", () => {
+    const three = draft({
+      methods: ["exam", "labs", "projects"],
+      shares: [35, 35, 30],
+    });
+
+    const moved = moveDivider(three, 1, 88);
+    expect(moved.shares).toEqual([35, 55, 10]);
+    expect(moved.shares.reduce((total, share) => total + share, 0)).toBe(100);
+  });
+
+  // A 0% segment would be a method the reviewer picked and then said nothing
+  // about, which is not an answer the bar can express.
+  it("never drags a segment out of existence", () => {
+    const two = draft({ methods: ["exam", "labs"], shares: [50, 50] });
+
+    expect(moveDivider(two, 0, 200).shares).toEqual([95, 5]);
+    expect(moveDivider(two, 0, -200).shares).toEqual([5, 95]);
+  });
+
+  it("ignores a divider that is not between two segments", () => {
+    const two = draft({ methods: ["exam", "labs"], shares: [50, 50] });
+
+    expect(moveDivider(two, 1, 50)).toBe(two);
+    expect(moveDivider(two, -1, 50)).toBe(two);
+    expect(nudgeDivider(two, 1, 1)).toBe(two);
+  });
+
+  it("nudges by one step, which is how the keyboard drives it", () => {
+    const two = draft({ methods: ["exam", "labs"], shares: [50, 50] });
+
+    expect(nudgeDivider(two, 0, 1).shares).toEqual([55, 45]);
+    expect(nudgeDivider(two, 0, -1).shares).toEqual([45, 55]);
+  });
+
+  it("puts a divider at each running total", () => {
+    expect(
+      dividerPositions(
+        draft({ methods: ["exam", "labs", "other"], shares: [20, 30, 50] }),
+      ),
+    ).toEqual([20, 50]);
+    expect(
+      dividerPositions(draft({ methods: ["exam"], shares: [100] })),
+    ).toEqual([]);
+  });
+});
+
+describe("what reaches the database", () => {
+  /**
+   * The rule `CONTEXT.md` states outright: an examination split nobody
+   * remembers is stored absent, never as six zeroes. On this card there is no
+   * "I don't remember" checkbox — leaving the bar alone *is* that answer.
+   */
+  it("stores no distribution at all when the bar was left alone", () => {
+    expect(toExaminationDistribution(draft())).toBeNull();
+    expect(toReviewFormData(answered())?.examinationDistribution).toBeNull();
+  });
+
+  it("stores every key, with the unpicked ones at zero, once anything is picked", () => {
+    const form = toReviewFormData(
+      answered({ methods: ["labs", "exam"], shares: [40, 60] }),
+    );
+
+    expect(form?.examinationDistribution).toEqual({
+      exam: 60,
+      assignments: 0,
+      labs: 40,
+      projects: 0,
+      seminars: 0,
+      other: 0,
+    });
+  });
+
+  /**
+   * The track is drawn at the midpoint when unanswered, and 50 would claim the
+   * reviewer called the course exactly balanced — a recollection they never
+   * offered.
+   */
+  it("never mistakes the theory track's resting position for an answer", () => {
+    expect(toReviewFormData(answered())?.approachTheoryPercent).toBeNull();
+    expect(
+      toReviewFormData(answered({ approachTheoryPercent: 50 }))
+        ?.approachTheoryPercent,
+    ).toBe(50);
+  });
+
+  it("carries the scores through raw, on the 1–10 scale the column stores", () => {
+    const form = toReviewFormData(
+      answered({ workloadScore: 9, learningScore: 1 }),
+    );
+    expect(form?.workloadScore).toBe(9);
+    expect(form?.learningScore).toBe(1);
+  });
+
+  it("clamps a score that somehow left the scale rather than sending it", () => {
+    const form = toReviewFormData(
+      answered({ workloadScore: 42, learningScore: 0 }),
+    );
+    expect(form?.workloadScore).toBe(10);
+    expect(form?.learningScore).toBe(1);
+  });
+
+  it("has nothing to send until happy, workload and learning are answered", () => {
+    expect(toReviewFormData(draft())).toBeNull();
+    expect(toReviewFormData(answered({ happyTook: null }))).toBeNull();
+    expect(toReviewFormData(answered({ workloadScore: null }))).toBeNull();
+    expect(toReviewFormData(answered({ learningScore: null }))).toBeNull();
+    expect(isAnswered(answered())).toBe(true);
+  });
+
+  // `happyTook: false` is an answer. Anything reading it for truthiness would
+  // hold a reviewer inside a card they had in fact finished.
+  it("counts an unhappy answer as an answer", () => {
+    expect(isAnswered(answered({ happyTook: false }))).toBe(true);
+    expect(toReviewFormData(answered({ happyTook: false }))?.happyTook).toBe(
+      false,
+    );
+  });
+
+  /**
+   * The write-up is the only optional part, and an empty one becomes `null` on
+   * the way to the column — `toStoredMessage`, inside the write path, does
+   * that. The mapping's job is to hand over what was typed, in the markup
+   * `reviews.message` holds.
+   */
+  it("carries the write-up over as the markup the column stores", () => {
+    expect(toReviewFormData(answered())?.message).toBe("");
+    expect(
+      toReviewFormData(answered({ message: "Bring time." }))?.message,
+    ).toBe("<p>Bring time.</p>");
+  });
+
+  /**
+   * The card's box is a plain textarea, and `sanitizeHtml` strips anything
+   * tag-shaped on the way to the screen. Escaping first is what stops a
+   * reviewer's sentence losing its useful half.
+   */
+  it("keeps characters that would otherwise be read as markup", () => {
+    expect(
+      toReviewFormData(answered({ message: "Use <vector> & <map>." }))?.message,
+    ).toBe("<p>Use &lt;vector&gt; &amp; &lt;map&gt;.</p>");
+  });
+});
+
+describe("isUntouched", () => {
+  it("is true only for a card nobody has answered anything on", () => {
+    expect(isUntouched(draft())).toBe(true);
+    expect(isUntouched(draft({ message: "  " }))).toBe(true);
+    expect(isUntouched(draft({ happyTook: false }))).toBe(false);
+    expect(isUntouched(draft({ approachTheoryPercent: 50 }))).toBe(false);
+  });
+});

--- a/apps/web/features/reviews/lib/review-draft.spec.ts
+++ b/apps/web/features/reviews/lib/review-draft.spec.ts
@@ -143,12 +143,26 @@ describe("what reaches the database", () => {
     expect(form?.learningScore).toBe(1);
   });
 
-  it("clamps a score that somehow left the scale rather than sending it", () => {
+  /**
+   * Nothing on the card can produce these. A draft restored from the tab's
+   * storage can, and it is better to send the nearest real answer than to tell
+   * the reviewer their finished review "is not finished".
+   */
+  it("clamps values that somehow left their scale rather than sending them", () => {
     const form = toReviewFormData(
-      answered({ workloadScore: 42, learningScore: 0 }),
+      answered({
+        workloadScore: 42,
+        learningScore: 0,
+        approachTheoryPercent: 400,
+      }),
     );
     expect(form?.workloadScore).toBe(10);
     expect(form?.learningScore).toBe(1);
+    expect(form?.approachTheoryPercent).toBe(95);
+    expect(
+      toReviewFormData(answered({ approachTheoryPercent: -20 }))
+        ?.approachTheoryPercent,
+    ).toBe(5);
   });
 
   it("has nothing to send until happy, workload and learning are answered", () => {

--- a/apps/web/features/reviews/lib/review-draft.ts
+++ b/apps/web/features/reviews/lib/review-draft.ts
@@ -1,0 +1,281 @@
+import type { ExaminationDistribution } from "@/types";
+import {
+  EXAMINATION_DISTRIBUTION_KEYS,
+  MAX_REVIEW_SCORE,
+  MIN_REVIEW_SCORE,
+} from "@/types";
+import type { ReviewFormData } from "../components/review";
+import { fromPlainText } from "./review-text";
+
+/**
+ * A **review draft** as the fast-track card asks for it: an unpublished review,
+ * held only for as long as the card is on screen.
+ *
+ * The shape is the card's, not the wire's. A draggable examination bar needs a
+ * picked order plus parallel shares — an object keyed by method cannot say
+ * which segment sits where — and `toReviewFormData` is the one place that
+ * becomes something writable.
+ *
+ * ## Where the "I don't remember" answer went
+ *
+ * The workspace pane draws an explicit "I don't remember" checkbox under each
+ * recollection. The fast-track card, by the artboard, draws none: a question
+ * left alone *is* the "I don't remember" answer, and stores `null`. That is why
+ * this draft has no `examinationForgotten` / `approachForgotten` flags where
+ * `features/workspace/lib/review-draft.ts` does — an untouched track and a
+ * ticked box are the same stored value, so a second flag would only be a second
+ * way to spell it. Neither ever produces zeroes: `CONTEXT.md` is explicit that a
+ * recollection nobody has is absent, not empty.
+ *
+ * ## The relationship to the workspace's copy
+ *
+ * `features/workspace/lib/review-draft.ts` carries a near-identical model, and
+ * the bar geometry here — `evenShares`, `toggleMethod`, `moveDivider`,
+ * `nudgeDivider`, `dividerPositions` — is the same arithmetic under the same
+ * names. Both should collapse into this one, which is the reviews feature's to
+ * own: the pane is one presentation of a review draft and the card stack is
+ * another, and neither is where the model belongs. Concretely, the follow-up
+ * deletes the workspace copy and has `review-draft-panel.tsx` import from
+ * `@/features/reviews`, keeping only `examinationForgotten` /
+ * `approachForgotten` — the two flags that are genuinely the pane's, because it
+ * draws explicit "I don't remember" checkboxes where this card does not.
+ *
+ * It is not done here because `features/workspace/**` belongs to a change in
+ * flight beside this one, and a rename across a moving feature is how a rebase
+ * eats a day. **What the duplication cannot do is make the two disagree about a
+ * stored review**: neither shape reaches the database. Both are mapped to
+ * `ReviewFormData` and handed to `useAddReview`, which runs `reviewFormSchema`
+ * itself before it sends anything — one write path, one validator, two forms.
+ */
+
+export type ExaminationKey = (typeof EXAMINATION_DISTRIBUTION_KEYS)[number];
+
+export interface ReviewDraft {
+  /** Examination methods the reviewer picked, in the order they picked them. */
+  methods: ExaminationKey[];
+  /** Whole percentages, parallel to `methods`, always adding up to 100. */
+  shares: number[];
+  /** How theoretical the course was, 0–100. `null` until the reviewer answers. */
+  approachTheoryPercent: number | null;
+  /** 1–10, as stored. `null` until answered — never 0, which is not on the scale. */
+  workloadScore: number | null;
+  /** 1–10, as stored. `null` until answered. */
+  learningScore: number | null;
+  happyTook: boolean | null;
+  /** The optional one-liner. `""` becomes `null` on the way to the database. */
+  message: string;
+}
+
+export const EMPTY_REVIEW_DRAFT: ReviewDraft = {
+  methods: [],
+  shares: [],
+  approachTheoryPercent: null,
+  workloadScore: null,
+  learningScore: null,
+  happyTook: null,
+  message: "",
+};
+
+/** The smallest share a segment may be dragged to, in whole percent. */
+export const MIN_SHARE = 5;
+/** Shares move in these steps, so the split stays a round number. */
+const SHARE_STEP = 5;
+
+/** The middle of the theory/applied track, where an unanswered one is drawn. */
+export const APPROACH_MIDPOINT = 50;
+
+/**
+ * The ends of the theory/applied track, as the artboard's own `startPct`
+ * clamps them.
+ *
+ * `reviews.approach_theory_percent` accepts the whole 0–100 range, so this is
+ * narrower than the column, not in conflict with it. The reason is the bar:
+ * at 0 or 100 one of the two halves has no width, and a track with "Applied"
+ * missing entirely reads as a broken control rather than as an extreme answer.
+ * 95/5 is as absolute as a two-label bar can say something and still be a bar.
+ */
+export const APPROACH_MIN = 5;
+export const APPROACH_MAX = 100 - APPROACH_MIN;
+
+/**
+ * An even split in 5% steps, with the remainder on the last segment.
+ *
+ * Six methods do not divide 100 evenly, so something has to absorb the
+ * leftover; the artboard's `evenSplit` puts it on the last one and this keeps
+ * that, because the alternative is shares that do not add up to 100 and a
+ * distribution `examinationDistributionSchema` refuses.
+ */
+export function evenShares(count: number): number[] {
+  if (count <= 0) return [];
+  const base = Math.max(
+    MIN_SHARE,
+    Math.round(100 / count / SHARE_STEP) * SHARE_STEP,
+  );
+  const shares = new Array<number>(count).fill(base);
+  shares[count - 1] = 100 - base * (count - 1);
+  return shares;
+}
+
+/** Pick or unpick an examination method, re-splitting the bar evenly. */
+export function toggleMethod(
+  draft: ReviewDraft,
+  method: ExaminationKey,
+): ReviewDraft {
+  const at = draft.methods.indexOf(method);
+  const methods =
+    at >= 0 ? draft.methods.toSpliced(at, 1) : [...draft.methods, method];
+  return { ...draft, methods, shares: evenShares(methods.length) };
+}
+
+/**
+ * Move the divider between segment `index` and the one after it to
+ * `cumulativePercent`, measured from the left edge of the bar.
+ *
+ * Only that pair moves: everything left of the divider keeps its width, so
+ * dragging one boundary never silently reflows the rest. Both sides are held at
+ * `MIN_SHARE` so a segment can never be dragged out of existence — a 0% segment
+ * would be a method the reviewer picked and then said nothing about.
+ */
+export function moveDivider(
+  draft: ReviewDraft,
+  index: number,
+  cumulativePercent: number,
+): ReviewDraft {
+  if (index < 0 || index >= draft.shares.length - 1) return draft;
+
+  const before = draft.shares
+    .slice(0, index)
+    .reduce((total, share) => total + share, 0);
+  const pair = draft.shares[index] + draft.shares[index + 1];
+  const stepped =
+    Math.round((cumulativePercent - before) / SHARE_STEP) * SHARE_STEP;
+  const left = Math.max(MIN_SHARE, Math.min(pair - MIN_SHARE, stepped));
+
+  const shares = [...draft.shares];
+  shares[index] = left;
+  shares[index + 1] = pair - left;
+  return { ...draft, shares };
+}
+
+/** Nudge a divider one step, which is how the keyboard drives the bar. */
+export function nudgeDivider(
+  draft: ReviewDraft,
+  index: number,
+  steps: number,
+): ReviewDraft {
+  if (index < 0 || index >= draft.shares.length - 1) return draft;
+  const before = draft.shares
+    .slice(0, index)
+    .reduce((total, share) => total + share, 0);
+  return moveDivider(
+    draft,
+    index,
+    before + draft.shares[index] + steps * SHARE_STEP,
+  );
+}
+
+/** Where each divider sits, as a running total from the left edge. */
+export function dividerPositions(draft: ReviewDraft): number[] {
+  const cuts: number[] = [];
+  let running = 0;
+  for (let index = 0; index < draft.shares.length - 1; index++) {
+    running += draft.shares[index];
+    cuts.push(running);
+  }
+  return cuts;
+}
+
+/**
+ * Whether the card has enough to save.
+ *
+ * The three required answers, and only those: `reviewInputSchema` wants
+ * `happyTook` and both scores, and everything else is nullable because "I don't
+ * remember" is a real answer and the write-up is optional. It is the same rule
+ * the workspace pane's publish button applies, phrased against this shape.
+ */
+export function isAnswered(draft: ReviewDraft): boolean {
+  return (
+    draft.happyTook !== null &&
+    draft.workloadScore !== null &&
+    draft.learningScore !== null
+  );
+}
+
+/** Whether the reviewer has put anything into the card at all. */
+export function isUntouched(draft: ReviewDraft): boolean {
+  return (
+    draft.happyTook === null &&
+    draft.workloadScore === null &&
+    draft.learningScore === null &&
+    draft.approachTheoryPercent === null &&
+    draft.methods.length === 0 &&
+    draft.message.trim().length === 0
+  );
+}
+
+/** Clamp a score onto the stored 1–10 scale. */
+function clampScore(value: number): number {
+  return Math.max(
+    MIN_REVIEW_SCORE,
+    Math.min(MAX_REVIEW_SCORE, Math.round(value)),
+  );
+}
+
+/**
+ * The picked shares as the stored distribution: every key present, unpicked
+ * methods at 0, the whole thing adding up to 100.
+ *
+ * `null` when the reviewer picked nothing, which on this card is the "I don't
+ * remember" answer. An untouched question is not an answer of zeroes, and
+ * `reviews.examination_distribution` is nullable precisely so that it does not
+ * have to be written as one.
+ */
+export function toExaminationDistribution(
+  draft: ReviewDraft,
+): ExaminationDistribution | null {
+  if (draft.methods.length === 0) return null;
+
+  const distribution = Object.fromEntries(
+    EXAMINATION_DISTRIBUTION_KEYS.map((key) => [key, 0]),
+  ) as ExaminationDistribution;
+  draft.methods.forEach((method, index) => {
+    distribution[method] = draft.shares[index] ?? 0;
+  });
+  return distribution;
+}
+
+/**
+ * The card as the review form's data, or `null` when it is not answered yet.
+ *
+ * This is the whole of the card's field mapping: past it the fast track is
+ * indistinguishable from every other way of writing a review, because
+ * `useAddReview` takes it from here and validates it with `reviewFormSchema`
+ * before anything is sent.
+ *
+ * An unanswered theory/applied question stores `null` rather than the midpoint
+ * the track happens to be drawn at: 50 would claim the reviewer called the
+ * course exactly balanced, which is a recollection they never offered.
+ *
+ * The write-up is escaped into markup on the way out, because that is what
+ * `reviews.message` holds and what the review card renders — see
+ * `fromPlainText`. It is a format change, not a content one: an empty box is
+ * still `""` here and still becomes `null` in `toStoredMessage`.
+ */
+export function toReviewFormData(draft: ReviewDraft): ReviewFormData | null {
+  if (
+    draft.happyTook === null ||
+    draft.workloadScore === null ||
+    draft.learningScore === null
+  ) {
+    return null;
+  }
+
+  return {
+    examinationDistribution: toExaminationDistribution(draft),
+    approachTheoryPercent: draft.approachTheoryPercent,
+    workloadScore: clampScore(draft.workloadScore),
+    learningScore: clampScore(draft.learningScore),
+    happyTook: draft.happyTook,
+    message: fromPlainText(draft.message),
+  };
+}

--- a/apps/web/features/reviews/lib/review-draft.ts
+++ b/apps/web/features/reviews/lib/review-draft.ts
@@ -55,7 +55,10 @@ export interface ReviewDraft {
   methods: ExaminationKey[];
   /** Whole percentages, parallel to `methods`, always adding up to 100. */
   shares: number[];
-  /** How theoretical the course was, 0–100. `null` until the reviewer answers. */
+  /**
+   * How theoretical the course was. The column takes 0–100; the card's track
+   * runs `APPROACH_MIN`–`APPROACH_MAX`. `null` until the reviewer answers.
+   */
   approachTheoryPercent: number | null;
   /** 1–10, as stored. `null` until answered — never 0, which is not on the scale. */
   workloadScore: number | null;
@@ -222,6 +225,19 @@ function clampScore(value: number): number {
 }
 
 /**
+ * Clamp the theory answer onto the track it was dragged along.
+ *
+ * The control cannot produce anything else, so this is about the values that do
+ * not come from the control: a draft restored from `sessionStorage`, which is
+ * whatever was in the tab. Sending an out-of-range percent would fail
+ * `reviewFormSchema` and tell the reviewer their review "is not finished",
+ * which is a confusing thing to say about an answer they did give.
+ */
+function clampApproach(value: number): number {
+  return Math.max(APPROACH_MIN, Math.min(APPROACH_MAX, Math.round(value)));
+}
+
+/**
  * The picked shares as the stored distribution: every key present, unpicked
  * methods at 0, the whole thing adding up to 100.
  *
@@ -272,7 +288,10 @@ export function toReviewFormData(draft: ReviewDraft): ReviewFormData | null {
 
   return {
     examinationDistribution: toExaminationDistribution(draft),
-    approachTheoryPercent: draft.approachTheoryPercent,
+    approachTheoryPercent:
+      draft.approachTheoryPercent === null
+        ? null
+        : clampApproach(draft.approachTheoryPercent),
     workloadScore: clampScore(draft.workloadScore),
     learningScore: clampScore(draft.learningScore),
     happyTook: draft.happyTook,

--- a/apps/web/features/reviews/lib/review-form-schema.ts
+++ b/apps/web/features/reviews/lib/review-form-schema.ts
@@ -7,9 +7,15 @@ import {
 import { toPlainText } from "./review-text";
 
 /**
- * What the review dialog validates before it submits. It shares the wire
- * contract from `@/types` and adds only what is specific to writing a review in
- * a dialog: a message that is not just markup.
+ * What every review is checked against on its way to the database. It shares
+ * the wire contract from `@/types` and adds only what is specific to a review
+ * written in a form: a message that is not just markup.
+ *
+ * Three surfaces draw a review form — the dialog, the workspace pane's draft,
+ * and the fast-track card stack — and this is the single validator all three
+ * meet, because `useAddReview` and `useEditReview` run it themselves rather
+ * than trusting each form to have run it. A form may ask for *more* than this
+ * (the dialog does, with `requireMessage`); none of them can send less.
  *
  * `requireMessage` is the one thing that differs between writing and editing.
  * Asking for prose is a rule about *publishing* something new — there is no

--- a/apps/web/features/reviews/lib/review-text.spec.ts
+++ b/apps/web/features/reviews/lib/review-text.spec.ts
@@ -1,5 +1,10 @@
 import { describe, expect, it } from "vitest";
-import { toExcerpt, toPlainText, toStoredMessage } from "./review-text";
+import {
+  fromPlainText,
+  toExcerpt,
+  toPlainText,
+  toStoredMessage,
+} from "./review-text";
 
 describe("toPlainText", () => {
   it("is empty for a review nobody wrote", () => {
@@ -42,5 +47,38 @@ describe("toExcerpt", () => {
     expect(excerpt.endsWith("…")).toBe(true);
     expect(excerpt).not.toMatch(/[,;\s]…$/);
     expect(excerpt.length).toBeLessThanOrEqual(158);
+  });
+});
+
+describe("fromPlainText", () => {
+  it("has nothing to write for an empty box", () => {
+    expect(fromPlainText("")).toBe("");
+    expect(fromPlainText("   \n  \n ")).toBe("");
+  });
+
+  it("wraps a line the way the column expects it", () => {
+    expect(fromPlainText("Bring time.")).toBe("<p>Bring time.</p>");
+  });
+
+  /**
+   * `sanitizeHtml` runs with `stripIgnoreTag`, so an unescaped `<vector>` is
+   * deleted between the database and the reader. Escaping is what keeps the
+   * sentence the reviewer actually typed.
+   */
+  it("escapes what would otherwise be read as a tag", () => {
+    expect(fromPlainText("Use <vector> & <map>")).toBe(
+      "<p>Use &lt;vector&gt; &amp; &lt;map&gt;</p>",
+    );
+  });
+
+  it("round-trips back to the words that were typed", () => {
+    expect(toPlainText(fromPlainText("Theory & practice, 5 < 10"))).toBe(
+      "Theory & practice, 5 < 10",
+    );
+  });
+
+  it("keeps the only structure a textarea can express", () => {
+    expect(fromPlainText("One\nTwo")).toBe("<p>One<br />Two</p>");
+    expect(fromPlainText("One\n\nTwo")).toBe("<p>One</p><p>Two</p>");
   });
 });

--- a/apps/web/features/reviews/lib/review-text.ts
+++ b/apps/web/features/reviews/lib/review-text.ts
@@ -44,6 +44,39 @@ export function toStoredMessage(html: string): string | null {
   return toPlainText(html) ? html : null;
 }
 
+const ESCAPES: Record<string, string> = {
+  "&": "&amp;",
+  "<": "&lt;",
+  ">": "&gt;",
+};
+
+/**
+ * A write-up typed into a plain `<textarea>` as the markup `reviews.message`
+ * holds.
+ *
+ * `message` has exactly one renderer — `parse(sanitizeHtml(...))` on the review
+ * card — and `sanitizeHtml` is configured with `stripIgnoreTag`, so anything
+ * tag-shaped in a raw plain string is deleted on the way to the screen. A
+ * reviewer who writes "use `<vector>` from STL" would watch the useful half of
+ * their sentence disappear. Escaping first means the column holds one format,
+ * whichever form typed into it, and the reviewer gets back the characters they
+ * typed.
+ *
+ * Blank lines become paragraphs and single newlines become breaks, which is the
+ * only structure a textarea can express. Text with nothing in it stays `""`;
+ * turning that into `<p></p>` would make a review with no write-up look
+ * written, and `toStoredMessage` is what decides that question.
+ */
+export function fromPlainText(text: string): string {
+  const escaped = text.replace(/[&<>]/g, (char) => ESCAPES[char]);
+  return escaped
+    .split(/\n[^\S\n]*\n/)
+    .map((paragraph) => paragraph.trim())
+    .filter((paragraph) => paragraph.length > 0)
+    .map((paragraph) => `<p>${paragraph.replace(/\n/g, "<br />")}</p>`)
+    .join("");
+}
+
 /**
  * The one line of the review the collapsed card shows. Cut mid-sentence rather
  * than mid-word, and never left with a dangling comma before the ellipsis —

--- a/apps/web/features/reviews/lib/reviewer-session.spec.ts
+++ b/apps/web/features/reviews/lib/reviewer-session.spec.ts
@@ -84,6 +84,23 @@ describe("storage that cannot be believed", () => {
     expect(readReviewerSession()?.queue).toEqual(["DD2424"]);
   });
 
+  /**
+   * The round is a set of courses dealt in an order. Everything downstream
+   * keys progress by course code, so a repeated code would draw two cards that
+   * one skip finishes and count two skipped courses.
+   */
+  it("keeps a repeated course code only once", () => {
+    sessionStorage.setItem(
+      KEY,
+      JSON.stringify({
+        queue: ["DD2424", "SF1918", "DD2424"],
+        done: {},
+        drafts: {},
+      }),
+    );
+    expect(readReviewerSession()?.queue).toEqual(["DD2424", "SF1918"]);
+  });
+
   it("drops an outcome that is not one of the two", () => {
     sessionStorage.setItem(
       KEY,

--- a/apps/web/features/reviews/lib/reviewer-session.spec.ts
+++ b/apps/web/features/reviews/lib/reviewer-session.spec.ts
@@ -1,0 +1,159 @@
+/**
+ * @vitest-environment jsdom
+ *
+ * The `logic` project runs on node, which has no `sessionStorage` — and this
+ * file is about nothing else. A per-file environment is cheaper than moving a
+ * pure-logic suite into the component project just to borrow a global.
+ */
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { EMPTY_REVIEW_DRAFT } from "./review-draft";
+import {
+  clearReviewerSession,
+  type ReviewerSession,
+  readReviewerSession,
+  writeReviewerSession,
+} from "./reviewer-session";
+
+const KEY = "cc.taken.reviewer";
+
+function session(over: Partial<ReviewerSession> = {}): ReviewerSession {
+  return { queue: ["DD2424", "SF1918"], done: {}, drafts: {}, ...over };
+}
+
+beforeEach(() => {
+  sessionStorage.clear();
+  vi.restoreAllMocks();
+});
+
+describe("a round the tab remembers", () => {
+  it("comes back the way it went in", () => {
+    const round = session({
+      done: { DD2424: "skipped" },
+      drafts: { SF1918: { ...EMPTY_REVIEW_DRAFT, happyTook: true } },
+    });
+    writeReviewerSession(round);
+
+    expect(readReviewerSession()).toEqual(round);
+  });
+
+  it("is nothing at all until a round has been written", () => {
+    expect(readReviewerSession()).toBeNull();
+  });
+
+  it("is gone once the round is closed", () => {
+    writeReviewerSession(session());
+    clearReviewerSession();
+
+    expect(readReviewerSession()).toBeNull();
+  });
+});
+
+/**
+ * What comes back is whatever was in the tab's storage — possibly written by an
+ * older build, possibly by hand. None of it is trusted.
+ */
+describe("storage that cannot be believed", () => {
+  it("ignores anything that is not a round", () => {
+    sessionStorage.setItem(KEY, "not json at all");
+    expect(readReviewerSession()).toBeNull();
+
+    sessionStorage.setItem(KEY, JSON.stringify(["DD2424"]));
+    expect(readReviewerSession()).toBeNull();
+
+    sessionStorage.setItem(KEY, JSON.stringify({ done: {}, drafts: {} }));
+    expect(readReviewerSession()).toBeNull();
+  });
+
+  /**
+   * An empty queue would reopen the reviewer on a screen with no cards in it,
+   * which reads as a bug rather than as continuity.
+   */
+  it("is not a round when there is nothing in the queue", () => {
+    sessionStorage.setItem(
+      KEY,
+      JSON.stringify({ queue: [], done: {}, drafts: {} }),
+    );
+    expect(readReviewerSession()).toBeNull();
+  });
+
+  it("drops course codes that are not strings", () => {
+    sessionStorage.setItem(
+      KEY,
+      JSON.stringify({ queue: ["DD2424", 7, null], done: {}, drafts: {} }),
+    );
+    expect(readReviewerSession()?.queue).toEqual(["DD2424"]);
+  });
+
+  it("drops an outcome that is not one of the two", () => {
+    sessionStorage.setItem(
+      KEY,
+      JSON.stringify({
+        queue: ["DD2424", "SF1918"],
+        done: { DD2424: "saved", SF1918: "deleted" },
+        drafts: {},
+      }),
+    );
+    expect(readReviewerSession()?.done).toEqual({ DD2424: "saved" });
+  });
+
+  /**
+   * `methods` and `shares` are parallel arrays, and the bar's arithmetic is
+   * written against that. A pair that does not line up is not a draft this
+   * build can draw, so it is dropped rather than half-restored.
+   */
+  it("drops a draft whose bar does not line up", () => {
+    sessionStorage.setItem(
+      KEY,
+      JSON.stringify({
+        queue: ["DD2424", "SF1918"],
+        done: {},
+        drafts: {
+          DD2424: { methods: ["exam", "labs"], shares: [100] },
+          SF1918: { methods: ["exam"], shares: [100], workloadScore: 6 },
+        },
+      }),
+    );
+
+    const round = readReviewerSession();
+    expect(round?.drafts.DD2424).toBeUndefined();
+    expect(round?.drafts.SF1918).toMatchObject({
+      methods: ["exam"],
+      shares: [100],
+      workloadScore: 6,
+      happyTook: null,
+      message: "",
+    });
+  });
+
+  it("fills a draft's missing answers with nothing rather than a value", () => {
+    sessionStorage.setItem(
+      KEY,
+      JSON.stringify({
+        queue: ["DD2424"],
+        done: {},
+        drafts: { DD2424: { happyTook: "yes", workloadScore: "8" } },
+      }),
+    );
+
+    expect(readReviewerSession()?.drafts.DD2424).toEqual(EMPTY_REVIEW_DRAFT);
+  });
+});
+
+/** A tab with storage disabled still runs the reviewer; it just forgets. */
+describe("a browser that will not store anything", () => {
+  it("neither throws nor pretends there is a round", () => {
+    vi.spyOn(Storage.prototype, "getItem").mockImplementation(() => {
+      throw new Error("blocked");
+    });
+    vi.spyOn(Storage.prototype, "setItem").mockImplementation(() => {
+      throw new Error("blocked");
+    });
+    vi.spyOn(Storage.prototype, "removeItem").mockImplementation(() => {
+      throw new Error("blocked");
+    });
+
+    expect(() => writeReviewerSession(session())).not.toThrow();
+    expect(() => clearReviewerSession()).not.toThrow();
+    expect(readReviewerSession()).toBeNull();
+  });
+});

--- a/apps/web/features/reviews/lib/reviewer-session.ts
+++ b/apps/web/features/reviews/lib/reviewer-session.ts
@@ -1,0 +1,150 @@
+import {
+  EMPTY_REVIEW_DRAFT,
+  type ExaminationKey,
+  type ReviewDraft,
+} from "./review-draft";
+
+/**
+ * What the fast-track reviewer keeps across a reload of `/taken`, and why.
+ *
+ * A card holds four answers and a line of prose, none of which has a row
+ * anywhere until it is saved. Losing an eight-card queue to a stray refresh —
+ * or to the browser reloading the tab on its own — throws away work the
+ * reviewer cannot get back, and the queue is the one thing on this screen that
+ * is not re-derivable from the server: which courses were skipped, and which
+ * were already answered this round, exist nowhere else.
+ *
+ * `sessionStorage`, not `localStorage`, for the same reason the workspace pane
+ * chose it (`features/workspace/lib/workspace-storage.ts`): a half-finished
+ * queue belongs to the tab it was started in and has no business still being
+ * there next week. Nothing kept here is data — an unsaved card has no row —
+ * which is exactly why the browser is the right place for it.
+ *
+ * Every read is defensive. What comes back is whatever was in the tab's
+ * storage, possibly written by an older build, so anything that does not match
+ * the shape is dropped rather than trusted.
+ *
+ * **Being well-formed is not the same as being current.** Nothing in this file
+ * knows which courses still need reviewing, so it cannot tell a round that was
+ * interrupted a minute ago from one whose courses have since been reviewed in
+ * the workspace pane. That check belongs to the screen that knows the
+ * unreviewed set — `features/taken/components/taken-courses.tsx` waits for it
+ * before it resumes anything, and drops any course the stored round has no
+ * business dealing again. This file's job ends at "this parsed".
+ */
+
+const SESSION_KEY = "cc.taken.reviewer";
+
+/** What happened to a card this round. A course not in the map is still to come. */
+export type CardOutcome = "saved" | "skipped";
+
+export interface ReviewerSession {
+  /** The course codes queued when the reviewer opened, in order. */
+  queue: string[];
+  /** Cards already dealt with this round, by course code. */
+  done: Record<string, CardOutcome>;
+  /** Answers typed but not yet saved, by course code. */
+  drafts: Record<string, ReviewDraft>;
+}
+
+const OUTCOMES: CardOutcome[] = ["saved", "skipped"];
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function toDraft(value: unknown): ReviewDraft | null {
+  if (!isRecord(value)) return null;
+
+  const methods = Array.isArray(value.methods) ? value.methods : [];
+  const shares = Array.isArray(value.shares) ? value.shares : [];
+  if (
+    !methods.every((method) => typeof method === "string") ||
+    !shares.every((share) => typeof share === "number") ||
+    methods.length !== shares.length
+  ) {
+    return null;
+  }
+
+  const score = (candidate: unknown) =>
+    typeof candidate === "number" ? candidate : null;
+
+  return {
+    ...EMPTY_REVIEW_DRAFT,
+    methods: methods as ExaminationKey[],
+    shares,
+    approachTheoryPercent: score(value.approachTheoryPercent),
+    workloadScore: score(value.workloadScore),
+    learningScore: score(value.learningScore),
+    happyTook: typeof value.happyTook === "boolean" ? value.happyTook : null,
+    message: typeof value.message === "string" ? value.message : "",
+  };
+}
+
+/**
+ * The reviewer session this tab left behind, or `null` if there is none worth
+ * restoring.
+ *
+ * A session with an empty queue is not a session: it would reopen the reviewer
+ * on a screen with no cards in it, which reads as a bug rather than as
+ * continuity.
+ */
+export function readReviewerSession(): ReviewerSession | null {
+  let raw: string | null;
+  try {
+    raw = sessionStorage.getItem(SESSION_KEY);
+  } catch {
+    return null;
+  }
+  if (raw === null) return null;
+
+  let value: unknown;
+  try {
+    value = JSON.parse(raw);
+  } catch {
+    return null;
+  }
+  if (!isRecord(value) || !Array.isArray(value.queue)) return null;
+
+  const queue = value.queue.filter(
+    (code): code is string => typeof code === "string",
+  );
+  if (queue.length === 0) return null;
+
+  const done: Record<string, CardOutcome> = {};
+  if (isRecord(value.done)) {
+    for (const [code, outcome] of Object.entries(value.done)) {
+      if (OUTCOMES.includes(outcome as CardOutcome)) {
+        done[code] = outcome as CardOutcome;
+      }
+    }
+  }
+
+  const drafts: Record<string, ReviewDraft> = {};
+  if (isRecord(value.drafts)) {
+    for (const [code, candidate] of Object.entries(value.drafts)) {
+      const draft = toDraft(candidate);
+      if (draft) drafts[code] = draft;
+    }
+  }
+
+  return { queue, done, drafts };
+}
+
+export function writeReviewerSession(session: ReviewerSession): void {
+  try {
+    sessionStorage.setItem(SESSION_KEY, JSON.stringify(session));
+  } catch {
+    // A tab with storage disabled or full still runs the reviewer; it just
+    // forgets the queue if the page is reloaded mid-round.
+  }
+}
+
+/** Closing the reviewer ends the round, so nothing is left to come back to. */
+export function clearReviewerSession(): void {
+  try {
+    sessionStorage.removeItem(SESSION_KEY);
+  } catch {
+    // Nothing to clear if storage is unavailable.
+  }
+}

--- a/apps/web/features/reviews/lib/reviewer-session.ts
+++ b/apps/web/features/reviews/lib/reviewer-session.ts
@@ -106,9 +106,20 @@ export function readReviewerSession(): ReviewerSession | null {
   }
   if (!isRecord(value) || !Array.isArray(value.queue)) return null;
 
-  const queue = value.queue.filter(
-    (code): code is string => typeof code === "string",
-  );
+  /**
+   * Deduplicated, because the round is a set of courses dealt in an order and
+   * not a list that may repeat. Everything downstream keys progress by course
+   * code — `done`, `drafts`, and the reviewer's own "which card is active" —
+   * so a queue holding a code twice would draw two cards that one skip
+   * finishes, count two skipped courses, and hand React two children with the
+   * same key. There is no writer that can produce one; a tab's storage is not
+   * a writer this file gets to trust.
+   */
+  const queue = [
+    ...new Set(
+      value.queue.filter((code): code is string => typeof code === "string"),
+    ),
+  ];
   if (queue.length === 0) return null;
 
   const done: Record<string, CardOutcome> = {};

--- a/apps/web/features/taken/components/taken-courses.spec.tsx
+++ b/apps/web/features/taken/components/taken-courses.spec.tsx
@@ -28,6 +28,8 @@ const toastError = vi.fn();
 const toastSuccess = vi.fn();
 const routerReplace = vi.fn();
 const routerPush = vi.fn();
+/** The round the page hands the reviewer, so a test can see what it pruned. */
+const restoredProp = vi.fn();
 
 // One object, as Next's own `useRouter` returns: a fresh one every call would
 // make every effect that depends on the router run on every render, which is
@@ -71,18 +73,23 @@ vi.mock("@/features/reviews/components/review", () => ({
 vi.mock("@/features/reviews/components/reviewer", () => ({
   Reviewer: ({
     queue,
+    restored,
     onClose,
   }: {
     queue: Array<{ courseCode: string }>;
+    restored: unknown;
     onClose: () => void;
-  }) => (
-    <div data-testid="reviewer">
-      Reviewing {queue.map((course) => course.courseCode).join(", ")}
-      <button type="button" onClick={onClose}>
-        Close reviewer
-      </button>
-    </div>
-  ),
+  }) => {
+    restoredProp(restored);
+    return (
+      <div data-testid="reviewer">
+        Reviewing {queue.map((course) => course.courseCode).join(", ")}
+        <button type="button" onClick={onClose}>
+          Close reviewer
+        </button>
+      </div>
+    );
+  },
 }));
 vi.mock("@/features/search", () => ({
   useDebouncedQuery: (value: string) => [value, vi.fn()] as const,
@@ -826,6 +833,12 @@ describe("a round a reload interrupted", () => {
     );
   }
 
+  /** What the mocked reviewer was handed, as the page pruned it. */
+  function restoredSession() {
+    const raw = restoredProp.mock.calls.at(-1)?.[0];
+    return raw ?? null;
+  }
+
   function both() {
     takenList.mockReturnValue([
       takenCourse(),
@@ -909,6 +922,42 @@ describe("a round a reload interrupted", () => {
     expect(await screen.findByTestId("reviewer")).toHaveTextContent(
       "Reviewing DD1337, DD2380",
     );
+  });
+
+  /**
+   * The queue is pruned, so what the round remembers about courses that did
+   * not survive the prune must go with them — otherwise the reviewer is handed
+   * outcomes for cards it is not dealing.
+   */
+  it("leaves behind what it remembered about a course it dropped", async () => {
+    takenList.mockReturnValue([
+      takenCourse(),
+      takenCourse({ courseCode: "DD2380" }),
+    ]);
+    unreviewed.mockReturnValue({
+      courses: [takenCourse()],
+      isLoading: false,
+      isUnavailable: false,
+    });
+    sessionStorage.setItem(
+      "cc.taken.reviewer",
+      JSON.stringify({
+        queue: ["DD2380", "DD1337"],
+        done: { DD2380: "skipped" },
+        drafts: {
+          DD2380: { methods: [], shares: [], workloadScore: 9 },
+          DD1337: { methods: [], shares: [], workloadScore: 4 },
+        },
+      }),
+    );
+    render(<TakenCourses />);
+
+    await screen.findByTestId("reviewer");
+    expect(restoredSession()).toEqual({
+      queue: ["DD1337"],
+      done: {},
+      drafts: { DD1337: expect.objectContaining({ workloadScore: 4 }) },
+    });
   });
 
   it("forgets a round with no cards left to deal", async () => {

--- a/apps/web/features/taken/components/taken-courses.spec.tsx
+++ b/apps/web/features/taken/components/taken-courses.spec.tsx
@@ -871,7 +871,31 @@ describe("a round a reload interrupted", () => {
     );
   });
 
-  /** A card this round already dealt with stays: it is the progress row. */
+  /**
+   * A skip is a fact about a moment that has passed. If the course was
+   * reviewed elsewhere afterwards, keeping the skip would have the done screen
+   * call it "still marked unreviewed in your list" when it is not, and offer
+   * it again under "Go through the skipped ones".
+   */
+  it("drops a course it skipped that was reviewed elsewhere since", async () => {
+    takenList.mockReturnValue([
+      takenCourse(),
+      takenCourse({ courseCode: "DD2380" }),
+    ]);
+    unreviewed.mockReturnValue({
+      courses: [takenCourse()],
+      isLoading: false,
+      isUnavailable: false,
+    });
+    storeRound(["DD2380", "DD1337"], { DD2380: "skipped" });
+    render(<TakenCourses />);
+
+    expect(await screen.findByTestId("reviewer")).toHaveTextContent(
+      "Reviewing DD1337",
+    );
+  });
+
+  /** A card this round already saved stays: it is the progress row. */
   it("keeps the cards the round has already answered", async () => {
     both();
     storeRound(["DD1337", "DD2380"], { DD1337: "saved" });

--- a/apps/web/features/taken/components/taken-courses.spec.tsx
+++ b/apps/web/features/taken/components/taken-courses.spec.tsx
@@ -26,6 +26,11 @@ const confirmImport = vi.fn();
 const uploadTranscript = vi.fn();
 const toastError = vi.fn();
 const toastSuccess = vi.fn();
+const routerReplace = vi.fn();
+
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ replace: routerReplace, push: vi.fn() }),
+}));
 
 vi.mock("@/features/auth", () => ({
   useMe: () => ({ isLoading: false, isAuthenticated: true }),
@@ -47,11 +52,30 @@ vi.mock("@/features/courses", () => ({
 vi.mock("@/features/reviews/api/queries", () => ({
   useUnreviewedTakenCourses: () => unreviewed(),
 }));
-// Stubbed so the real `UnreviewedCard` still renders: this test is about which
-// course the page hands the review dialog, not about the dialog's own form.
+// The review dialog is not on this screen any more, but the reviews barrel
+// still exports it — and with it the rich-text editor and its stylesheet,
+// which jsdom has no business loading for a test about a course list.
 vi.mock("@/features/reviews/components/review", () => ({
-  Review: ({ courseCode }: { courseCode: string }) => (
-    <div data-testid="reviewer">Reviewing {courseCode}</div>
+  Review: () => null,
+  toEditableReview: (review: unknown) => review,
+}));
+// Stubbed so the real `UnreviewedCard` still renders: these tests are about
+// which courses the page queues, not about the card stack's own form, which
+// has its own suite next to it.
+vi.mock("@/features/reviews/components/reviewer", () => ({
+  Reviewer: ({
+    queue,
+    onClose,
+  }: {
+    queue: Array<{ courseCode: string }>;
+    onClose: () => void;
+  }) => (
+    <div data-testid="reviewer">
+      Reviewing {queue.map((course) => course.courseCode).join(", ")}
+      <button type="button" onClick={onClose}>
+        Close reviewer
+      </button>
+    </div>
   ),
 }));
 vi.mock("@/features/search", () => ({
@@ -134,6 +158,10 @@ async function uploadPdf() {
 
 beforeEach(() => {
   vi.clearAllMocks();
+  // `?review=1` and an interrupted round are both read off the browser, so
+  // each test starts on a clean URL and an empty tab store.
+  window.history.replaceState({}, "", "/taken");
+  sessionStorage.clear();
   takenList.mockReturnValue([takenCourse()]);
   listFailed.mockReturnValue(false);
   refetchTaken.mockImplementation(() =>
@@ -705,8 +733,191 @@ describe("reading a transcript", () => {
   });
 });
 
-describe("the unreviewed prompt", () => {
-  it("opens the reviewer in place rather than leaving the page", async () => {
+describe("the fast-track reviewer", () => {
+  const bothUnreviewed = () =>
+    unreviewed.mockReturnValue({
+      courses: [takenCourse(), takenCourse({ courseCode: "DD2380" })],
+      isLoading: false,
+      isUnavailable: false,
+    });
+
+  it("deals every unreviewed course when the fast track is started", async () => {
+    bothUnreviewed();
+    takenList.mockReturnValue([
+      takenCourse(),
+      takenCourse({ courseCode: "DD2380" }),
+    ]);
+    render(<TakenCourses />);
+
+    await userEvent.click(
+      screen.getByRole("button", { name: "Fast track all 2" }),
+    );
+
+    expect(screen.getByTestId("reviewer")).toHaveTextContent(
+      "Reviewing DD1337, DD2380",
+    );
+    // The reviewer is a screen, not an overlay: the list it replaced is gone.
+    expect(
+      screen.queryByRole("button", { name: "Add a course by hand" }),
+    ).not.toBeInTheDocument();
+  });
+
+  /**
+   * A row is a starting point, not a queue of one. Someone who came to review
+   * one course is exactly who is most likely to review a second, so the rest
+   * are dealt behind it — which is what the artboard's `openReviewer(startId)`
+   * does.
+   */
+  it("puts the row the reader picked at the front of the whole queue", async () => {
+    bothUnreviewed();
+    takenList.mockReturnValue([
+      takenCourse(),
+      takenCourse({ courseCode: "DD2380" }),
+    ]);
+    render(<TakenCourses />);
+
+    await userEvent.click(
+      screen.getByRole("button", {
+        name: /^DD2380\s*Artificial Intelligence$/,
+      }),
+    );
+
+    expect(screen.getByTestId("reviewer")).toHaveTextContent(
+      "Reviewing DD2380, DD1337",
+    );
+  });
+
+  it("gives the list back when the reviewer is closed", async () => {
+    bothUnreviewed();
+    render(<TakenCourses />);
+
+    await userEvent.click(
+      screen.getByRole("button", { name: "Fast track all 2" }),
+    );
+    await userEvent.click(
+      screen.getByRole("button", { name: "Close reviewer" }),
+    );
+
+    expect(screen.queryByTestId("reviewer")).not.toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: "Add a course by hand" }),
+    ).toBeInTheDocument();
+  });
+});
+
+/**
+ * `sessionStorage` says what this tab was doing, not what is still true. Every
+ * one of these is about the gap between the two.
+ */
+describe("a round a reload interrupted", () => {
+  function storeRound(
+    queue: string[],
+    done: Record<string, "saved" | "skipped"> = {},
+  ) {
+    sessionStorage.setItem(
+      "cc.taken.reviewer",
+      JSON.stringify({ queue, done, drafts: {} }),
+    );
+  }
+
+  function both() {
+    takenList.mockReturnValue([
+      takenCourse(),
+      takenCourse({ courseCode: "DD2380" }),
+    ]);
+    unreviewed.mockReturnValue({
+      courses: [takenCourse(), takenCourse({ courseCode: "DD2380" })],
+      isLoading: false,
+      isUnavailable: false,
+    });
+  }
+
+  it("picks the round back up where it stopped", async () => {
+    both();
+    storeRound(["DD2380", "DD1337"], { DD2380: "skipped" });
+    render(<TakenCourses />);
+
+    expect(await screen.findByTestId("reviewer")).toHaveTextContent(
+      "Reviewing DD2380, DD1337",
+    );
+  });
+
+  /**
+   * The reader reviewed DD2380 somewhere else — the workspace pane, another
+   * tab — while this round was sitting in storage. Dealing its card again
+   * would ask for a second review of a course that has one.
+   */
+  it("drops a course that was reviewed since the round was stored", async () => {
+    takenList.mockReturnValue([
+      takenCourse(),
+      takenCourse({ courseCode: "DD2380" }),
+    ]);
+    unreviewed.mockReturnValue({
+      courses: [takenCourse()],
+      isLoading: false,
+      isUnavailable: false,
+    });
+    storeRound(["DD2380", "DD1337"]);
+    render(<TakenCourses />);
+
+    expect(await screen.findByTestId("reviewer")).toHaveTextContent(
+      "Reviewing DD1337",
+    );
+  });
+
+  /** A card this round already dealt with stays: it is the progress row. */
+  it("keeps the cards the round has already answered", async () => {
+    both();
+    storeRound(["DD1337", "DD2380"], { DD1337: "saved" });
+    unreviewed.mockReturnValue({
+      courses: [takenCourse({ courseCode: "DD2380" })],
+      isLoading: false,
+      isUnavailable: false,
+    });
+    render(<TakenCourses />);
+
+    expect(await screen.findByTestId("reviewer")).toHaveTextContent(
+      "Reviewing DD1337, DD2380",
+    );
+  });
+
+  it("forgets a round with no cards left to deal", async () => {
+    unreviewed.mockReturnValue({
+      courses: [],
+      isLoading: false,
+      isUnavailable: false,
+    });
+    storeRound(["DD1337"], { DD1337: "saved" });
+    render(<TakenCourses />);
+
+    await waitFor(() =>
+      expect(
+        screen.getByRole("button", { name: "Add a course by hand" }),
+      ).toBeInTheDocument(),
+    );
+    expect(screen.queryByTestId("reviewer")).not.toBeInTheDocument();
+    expect(sessionStorage.getItem("cc.taken.reviewer")).toBeNull();
+  });
+
+  /**
+   * An unfinished round outranks the deep link, because it holds answers that
+   * were typed and never saved and a fresh queue would throw them away.
+   */
+  it("resumes rather than restarting when ?review=1 arrives too", async () => {
+    both();
+    window.history.replaceState({}, "", "/taken?review=1");
+    storeRound(["DD2380", "DD1337"], { DD2380: "skipped" });
+    render(<TakenCourses />);
+
+    expect(await screen.findByTestId("reviewer")).toHaveTextContent(
+      "Reviewing DD2380, DD1337",
+    );
+  });
+});
+
+describe("arriving with ?review=1", () => {
+  it("opens the reviewer and takes the parameter back out of the URL", async () => {
+    window.history.replaceState({}, "", "/taken?review=1");
     unreviewed.mockReturnValue({
       courses: [takenCourse()],
       isLoading: false,
@@ -714,15 +925,27 @@ describe("the unreviewed prompt", () => {
     });
     render(<TakenCourses />);
 
-    // The prompt's own row button, which `UnreviewedCard` renders in place of
-    // its link once a screen passes `onSelect`. Its accessible name is the
-    // course code and title; the table's controls are labelled differently.
-    await userEvent.click(
-      screen.getByRole("button", { name: /^DD1337\s*Programming$/ }),
+    await waitFor(() =>
+      expect(screen.getByTestId("reviewer")).toHaveTextContent(
+        "Reviewing DD1337",
+      ),
     );
+    // Read once, then removed: a reload must not reopen the reviewer over a
+    // list the reader deliberately went back to.
+    expect(routerReplace).toHaveBeenCalledWith("/taken");
+  });
 
-    expect(screen.getByTestId("reviewer")).toHaveTextContent(
-      "Reviewing DD1337",
-    );
+  /**
+   * The deep link waits for the unreviewed set rather than guessing at it, and
+   * gives up quietly when there is nothing to review — the reader lands on
+   * their list, which is the honest answer to "review my courses" when there
+   * is nothing left to review.
+   */
+  it("stays on the list when nothing is unreviewed", async () => {
+    window.history.replaceState({}, "", "/taken?review=1");
+    render(<TakenCourses />);
+
+    await waitFor(() => expect(routerReplace).toHaveBeenCalledWith("/taken"));
+    expect(screen.queryByTestId("reviewer")).not.toBeInTheDocument();
   });
 });

--- a/apps/web/features/taken/components/taken-courses.spec.tsx
+++ b/apps/web/features/taken/components/taken-courses.spec.tsx
@@ -27,9 +27,15 @@ const uploadTranscript = vi.fn();
 const toastError = vi.fn();
 const toastSuccess = vi.fn();
 const routerReplace = vi.fn();
+const routerPush = vi.fn();
 
+// One object, as Next's own `useRouter` returns: a fresh one every call would
+// make every effect that depends on the router run on every render, which is
+// not a thing this screen should have to be robust against in order to be
+// tested honestly.
+const router = { replace: routerReplace, push: routerPush };
 vi.mock("next/navigation", () => ({
-  useRouter: () => ({ replace: routerReplace, push: vi.fn() }),
+  useRouter: () => router,
 }));
 
 vi.mock("@/features/auth", () => ({

--- a/apps/web/features/taken/components/taken-courses.tsx
+++ b/apps/web/features/taken/components/taken-courses.tsx
@@ -3,7 +3,7 @@
 import { CircleCheck, FileWarning, Info, Plus, RefreshCw } from "lucide-react";
 import Link from "next/link";
 import { useRouter } from "next/navigation";
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { toast } from "sonner";
 import {
   Dialog,
@@ -198,6 +198,8 @@ export function TakenCourses() {
     deepLinked: boolean;
     session: ReviewerSession | null;
   } | null>(null);
+  /** Whether the arrival below has already been read. See why it must be. */
+  const hasReadArrival = useRef(false);
 
   const lastImport = lastTranscriptImport(takenCourses);
   const isBusy = update.isPending || remove.isPending || add.isPending;
@@ -214,8 +216,18 @@ export function TakenCourses() {
    * effect is the honest place for it — and taking it back out with
    * `router.replace` is what stops a reload reopening the reviewer, the same
    * move the landing page makes with its own private-link parameter.
+   *
+   * **Once, and guarded by a ref rather than by its dependencies.** Arrival is
+   * a moment, not a value: reading the URL a second time after `router.replace`
+   * has emptied it would only ever say "no". The guard also keeps the effect
+   * honest about the one dependency it has — `useRouter()` is stable in Next,
+   * but nothing here needs it to be, and an effect that sets a fresh object on
+   * every run would spin if it ever were not.
    */
   useEffect(() => {
+    if (hasReadArrival.current) return;
+    hasReadArrival.current = true;
+
     let asked = false;
     try {
       asked = new URLSearchParams(window.location.search).get("review") === "1";

--- a/apps/web/features/taken/components/taken-courses.tsx
+++ b/apps/web/features/taken/components/taken-courses.tsx
@@ -2,7 +2,8 @@
 
 import { CircleCheck, FileWarning, Info, Plus, RefreshCw } from "lucide-react";
 import Link from "next/link";
-import { useState } from "react";
+import { useRouter } from "next/navigation";
+import { useEffect, useState } from "react";
 import { toast } from "sonner";
 import {
   Dialog,
@@ -13,11 +14,16 @@ import {
 import { useMe, useRequireSession } from "@/features/auth";
 import { useCourseSummaries, useTakenCourses } from "@/features/courses";
 import {
-  Review,
+  clearReviewerSession,
+  Reviewer,
+  type ReviewerCardCourse,
+  type ReviewerSession,
+  readReviewerSession,
   UnreviewedCard,
   useUnreviewedTakenCourses,
 } from "@/features/reviews";
 import { PageColumn, PageHeader } from "@/features/shell";
+import { formatHp } from "@/lib/kth";
 import type { TranscriptProposal } from "@/server/ingest/transcript/service";
 import { useTakenMutations } from "../api/mutations";
 import { uploadTranscript } from "../api/transcript";
@@ -55,6 +61,19 @@ function readDate(iso: string): string {
   });
 }
 
+/**
+ * The line under a course's name on its reviewer card — the artboard's
+ * `revMeta`. Both halves are self-reported and either may be missing, so this
+ * prints what the row actually has rather than a shape with holes in it.
+ */
+function reviewerMeta(row: TakenRow): string | null {
+  const parts = [
+    row.earnedCredits === null ? null : `${formatHp(row.earnedCredits)} hp`,
+    row.attendanceYear === null ? null : String(row.attendanceYear),
+  ].filter((part): part is string => part !== null);
+  return parts.length > 0 ? parts.join(" · ") : null;
+}
+
 function importedSummary(added: number, filled: number): string {
   const parts: string[] = [];
   if (added > 0) {
@@ -73,7 +92,7 @@ function importedSummary(added: number, filled: number): string {
 }
 
 /**
- * The reader's taken courses — `docs/design/Course Community - Taken
+ * The reader's taken courses — `docs/design_ref_new/Course Community - Taken
  * Courses.dc.html`.
  *
  * Four things about this screen are worth knowing before changing it.
@@ -98,14 +117,19 @@ function importedSummary(added: number, filled: number): string {
  * screen. This page offers no way to create the missing course, because
  * `user_taken_courses.course_code` is a foreign key to `courses.code`.
  *
- * **The reviewer is the review form, not a second one.** The artboard draws a
- * bespoke card stack asking the same six questions the review dialog already
- * asks; building it would give a review two write paths and two validators.
- * `UnreviewedCard`'s `onSelect` and `onStart` fill a queue instead, and each
- * course opens `Review` in place — see the PR for the deviation.
+ * **The fast-track reviewer is a screen of this page, not a dialog over it.**
+ * `Reviewer` is the artboard's `isReviewer` branch and it replaces the list
+ * while a round runs — progress segments, peeked cards, "Skip for now", the
+ * save-error row and the done screen. It is presentation only: it maps a card
+ * onto `ReviewFormData` and hands it to `useAddReview`, which is the same hook
+ * the workspace pane and the review dialog write through and the one place
+ * `reviewFormSchema` runs. `?review=1` opens it on arrival — that is My Page's
+ * deep link — and the parameter is taken back out so a reload does not replay
+ * it.
  */
 export function TakenCourses() {
   useRequireSession();
+  const router = useRouter();
   const { isAuthenticated, isLoading: isSessionLoading } = useMe();
   // `taken.list` is protected, so it waits for a session rather than sending a
   // request that would be refused — the same guard `useUnreviewedTakenCourses`
@@ -136,6 +160,15 @@ export function TakenCourses() {
   const unreviewedCodes = new Set(
     unreviewed.map((course) => course.courseCode),
   );
+  /**
+   * A stable dependency for the effects below: `unreviewed` is a fresh array
+   * on every render, so an effect that depended on it would run on every one.
+   * The codes are what the queue is actually made of, and they round-trip
+   * through a comma because `user_taken_courses.course_code` is a foreign key
+   * to `courses.code`, which is a KTH course code — letters and digits, never
+   * punctuation.
+   */
+  const unreviewedKey = unreviewed.map((course) => course.courseCode).join(",");
 
   const [addOpen, setAddOpen] = useState(false);
   const [updateOpen, setUpdateOpen] = useState(false);
@@ -146,11 +179,135 @@ export function TakenCourses() {
   const [confirmError, setConfirmError] = useState<string | null>(null);
   const [banner, setBanner] = useState<string | null>(null);
   const [isConfirming, setIsConfirming] = useState(false);
-  const [reviewQueue, setReviewQueue] = useState<string[]>([]);
+  /**
+   * The round on screen, or `null` when the list is. `restored` is the stored
+   * progress and unsaved answers when the round is one this tab was already in
+   * the middle of.
+   */
+  const [round, setRound] = useState<{
+    queue: string[];
+    restored: ReviewerSession | null;
+  } | null>(null);
+  /**
+   * What the URL and the tab store asked for on arrival, held until the review
+   * lists come back. Neither can be acted on before then: one needs the
+   * unreviewed set to fill a queue, and the other needs it to know whether its
+   * queue is still true.
+   */
+  const [pendingOpen, setPendingOpen] = useState<{
+    deepLinked: boolean;
+    session: ReviewerSession | null;
+  } | null>(null);
 
-  const reviewing = reviewQueue[0] ?? null;
   const lastImport = lastTranscriptImport(takenCourses);
   const isBusy = update.isPending || remove.isPending || add.isPending;
+
+  /**
+   * How the reviewer gets opened without a click: My Page's prompt deep-links
+   * `/taken?review=1`, and a round this tab was in the middle of survives a
+   * reload.
+   *
+   * The query parameter is read from `window.location` rather than through
+   * `useSearchParams`, which would need a `Suspense` boundary around this
+   * screen in `app/` to keep the route prerenderable. It is a one-shot note
+   * from another page, consumed on arrival and never rendered from, so an
+   * effect is the honest place for it — and taking it back out with
+   * `router.replace` is what stops a reload reopening the reviewer, the same
+   * move the landing page makes with its own private-link parameter.
+   */
+  useEffect(() => {
+    let asked = false;
+    try {
+      asked = new URLSearchParams(window.location.search).get("review") === "1";
+    } catch {
+      asked = false;
+    }
+    if (asked) router.replace("/taken");
+
+    const session = readReviewerSession();
+    if (asked || session) setPendingOpen({ deepLinked: asked, session });
+  }, [router]);
+
+  /**
+   * Opens what the arrival asked for, once it is possible to be honest about
+   * it. Both cases need the unreviewed set — one `reviews.list` per taken
+   * course — so both wait for it, and both give up quietly if it never comes:
+   * a screen that cannot say which courses need reviewing has no business
+   * dealing cards for them.
+   *
+   * **A stored round is pruned, not trusted.** `sessionStorage` says what this
+   * tab was doing, not what is still true; the reader may have reviewed some of
+   * those courses in the workspace pane, or in another tab, since. Any course
+   * that is no longer unreviewed and was not already dealt with this round is
+   * dropped, because dealing its card again would ask for a second review of a
+   * course that has one. Cards the round already saved or skipped stay in the
+   * queue — they are what the progress row counts — and if that leaves nothing
+   * still to deal, the round is over and gets forgotten rather than reopened on
+   * its own done screen.
+   *
+   * **An interrupted round outranks the deep link**, because it holds answers
+   * that were typed and never saved and a fresh queue would throw them away.
+   */
+  useEffect(() => {
+    if (pendingOpen === null || !reviewsKnown) return;
+    setPendingOpen(null);
+
+    const stillUnreviewed =
+      unreviewedKey === "" ? [] : unreviewedKey.split(",");
+    const session = pendingOpen.session;
+    if (session !== null) {
+      const current = new Set(stillUnreviewed);
+      const queue = session.queue.filter(
+        (code) => current.has(code) || session.done[code] !== undefined,
+      );
+      const hasCardsLeft = queue.some(
+        (code) => session.done[code] === undefined,
+      );
+      if (hasCardsLeft) {
+        setRound({ queue, restored: { ...session, queue } });
+        return;
+      }
+      clearReviewerSession();
+    }
+
+    if (pendingOpen.deepLinked && stillUnreviewed.length > 0) {
+      setRound({ queue: stillUnreviewed, restored: null });
+    }
+  }, [pendingOpen, reviewsKnown, unreviewedKey]);
+
+  /**
+   * Starts a round. `startCode` is the row the reader clicked, which goes to
+   * the front rather than becoming a queue of one: the artboard deals the rest
+   * of the unreviewed courses behind it, and someone who came to review one
+   * course is exactly who is most likely to review a second.
+   */
+  function openReviewer(startCode?: string) {
+    const codes = unreviewed.map((course) => course.courseCode);
+    const queue =
+      startCode === undefined
+        ? codes
+        : [startCode, ...codes.filter((code) => code !== startCode)];
+    if (queue.length === 0) return;
+    // A new round replaces whatever the tab was holding, drafts included.
+    clearReviewerSession();
+    setRound({ queue, restored: null });
+  }
+
+  function closeReviewer() {
+    clearReviewerSession();
+    setRound(null);
+  }
+
+  const reviewerCourses: ReviewerCardCourse[] = (round?.queue ?? []).map(
+    (courseCode) => {
+      const row = rows.find((taken) => taken.courseCode === courseCode);
+      return {
+        courseCode,
+        name: names.get(courseCode) ?? null,
+        meta: row ? reviewerMeta(row) : null,
+      };
+    },
+  );
 
   /**
    * Reads one transcript. The file is a parameter and never becomes state, so
@@ -306,6 +463,21 @@ export function TakenCourses() {
       return <ListSkeleton />;
     }
 
+    // The reviewer is a screen of this page, not something layered over it —
+    // the artboard's `screen: "reviewer"`. It keeps the page header above it
+    // and replaces everything else, so nothing underneath can be clicked while
+    // a card is open.
+    if (round !== null) {
+      return (
+        <Reviewer
+          key={round.queue.join(",")}
+          queue={reviewerCourses}
+          restored={round.restored}
+          onClose={closeReviewer}
+        />
+      );
+    }
+
     if (proposal) {
       // `isConfirming` is the whole confirm, not just the create call: the
       // re-read before it and the fills after it are as much of the import as
@@ -433,10 +605,8 @@ export function TakenCourses() {
                   ? "You have 1 unreviewed course."
                   : `You have ${unreviewed.length} unreviewed courses.`
               }
-              onStart={() =>
-                setReviewQueue(unreviewed.map((course) => course.courseCode))
-              }
-              onSelect={(courseCode) => setReviewQueue([courseCode])}
+              onStart={() => openReviewer()}
+              onSelect={(courseCode) => openReviewer(courseCode)}
             />
           ) : null}
 
@@ -529,16 +699,6 @@ export function TakenCourses() {
           </div>
         </DialogContent>
       </Dialog>
-
-      {reviewing ? (
-        <Review
-          key={reviewing}
-          courseCode={reviewing}
-          openOnLoad
-          triggerless
-          onClose={() => setReviewQueue((queue) => queue.slice(1))}
-        />
-      ) : null}
     </PageColumn>
   );
 }

--- a/apps/web/features/taken/components/taken-courses.tsx
+++ b/apps/web/features/taken/components/taken-courses.tsx
@@ -249,13 +249,22 @@ export function TakenCourses() {
    *
    * **A stored round is pruned, not trusted.** `sessionStorage` says what this
    * tab was doing, not what is still true; the reader may have reviewed some of
-   * those courses in the workspace pane, or in another tab, since. Any course
-   * that is no longer unreviewed and was not already dealt with this round is
-   * dropped, because dealing its card again would ask for a second review of a
-   * course that has one. Cards the round already saved or skipped stay in the
-   * queue — they are what the progress row counts — and if that leaves nothing
-   * still to deal, the round is over and gets forgotten rather than reopened on
-   * its own done screen.
+   * those courses in the workspace pane, or in another tab, since. So a course
+   * survives the prune on exactly one of two grounds:
+   *
+   * - it is **still unreviewed**, so its card is worth dealing; or
+   * - **this round saved it**, which is why it is no longer unreviewed. That is
+   *   the round's own history and it is what the progress row counts.
+   *
+   * Everything else goes, and the case that matters is a course this round
+   * *skipped* that has since been reviewed elsewhere. Its skip is a fact about
+   * a moment that has passed: keeping it would have the done screen report a
+   * course as "still unreviewed in your list" when it is not, and offer it
+   * again under "Go through the skipped ones", which would deal a card for a
+   * course that already has a review.
+   *
+   * If the prune leaves nothing still to deal, the round is over and gets
+   * forgotten rather than reopened on its own done screen.
    *
    * **An interrupted round outranks the deep link**, because it holds answers
    * that were typed and never saved and a fresh queue would throw them away.
@@ -270,7 +279,7 @@ export function TakenCourses() {
     if (session !== null) {
       const current = new Set(stillUnreviewed);
       const queue = session.queue.filter(
-        (code) => current.has(code) || session.done[code] !== undefined,
+        (code) => current.has(code) || session.done[code] === "saved",
       );
       const hasCardsLeft = queue.some(
         (code) => session.done[code] === undefined,

--- a/apps/web/features/taken/components/taken-courses.tsx
+++ b/apps/web/features/taken/components/taken-courses.tsx
@@ -74,6 +74,25 @@ function reviewerMeta(row: TakenRow): string | null {
   return parts.length > 0 ? parts.join(" · ") : null;
 }
 
+/**
+ * The entries of `byCode` whose key is one of `codes`, in no particular order.
+ *
+ * A stored round's `done` and `drafts` are maps, and a map can hold a course
+ * the pruned queue no longer contains — one reviewed elsewhere since, or
+ * whatever an older build left behind. Carrying those through would have the
+ * reviewer count a course the reader never saw.
+ */
+function pickByCode<T>(
+  byCode: Record<string, T>,
+  codes: readonly string[],
+): Record<string, T> {
+  const kept: Record<string, T> = {};
+  for (const code of codes) {
+    if (code in byCode) kept[code] = byCode[code];
+  }
+  return kept;
+}
+
 function importedSummary(added: number, filled: number): string {
   const parts: string[] = [];
   if (added > 0) {
@@ -285,7 +304,18 @@ export function TakenCourses() {
         (code) => session.done[code] === undefined,
       );
       if (hasCardsLeft) {
-        setRound({ queue, restored: { ...session, queue } });
+        // `done` and `drafts` are pruned to the same queue, so nothing the
+        // round is not dealing can be counted on its done screen or restored
+        // onto a card. The reviewer counts across the queue for the same
+        // reason; this stops the strays being written back to storage too.
+        setRound({
+          queue,
+          restored: {
+            queue,
+            done: pickByCode(session.done, queue),
+            drafts: pickByCode(session.drafts, queue),
+          },
+        });
         return;
       }
       clearReviewerSession();

--- a/apps/web/features/taken/components/transcript-drop-zone.tsx
+++ b/apps/web/features/taken/components/transcript-drop-zone.tsx
@@ -20,9 +20,9 @@ type Props = {
 };
 
 /**
- * Where a Ladok transcript goes in — `docs/design/Course Community - Taken
- * Courses.dc.html`, the `isEmpty` screen and the `isUpdateModal` body, which
- * draw the same zone at two sizes.
+ * Where a Ladok transcript goes in — `docs/design_ref_new/Course Community -
+ * Taken Courses.dc.html`, the `isEmpty` screen and the `isUpdateModal` body,
+ * which draw the same zone at two sizes.
  *
  * It hands the file up and forgets it. The file never reaches component state,
  * `localStorage` or a log: it is a student's academic record, it is read once


### PR DESCRIPTION
Builds the fast-track reviewer that `docs/design_ref_new/Course Community - Taken Courses.dc.html` draws, and wires the prompts that reach it. This is §4 of the reconciliation orchestration comment on #68, which reverses #92's deliberate deviation.

## What is here

The `isReviewer` branch of the Taken Courses artboard, as drawn: the `--cc-warn-ink` "Quick review" eyebrow and "Back to courses"; a progress row with one segment per queued course; two peeked cards translated down and scaled behind the active one; the `--cc-warn` card header with the code in Geist Mono and the `revStackLabel` pill; the four questions — the examination mix with draggable dividers and method chips, the theoretical/applied track, the workload and learning sliders, happy-took as two options, and the optional one-line write-up; "Skip for now"; the `--cc-danger-tint` save-error row with "Try again"; and the done screen with "Go through the skipped ones" when anything was skipped.

Entry points: the unreviewed prompt's button deals every unreviewed course, a row deals that course first with the rest behind it (`openReviewer(startId)`), and `/taken?review=1` opens it on arrival — which is what the artboard's own My Page links.

## How one write path is guaranteed

**The hook is `useAddReview`. The validator is `reviewFormSchema`.**

The guarantee is not that the card stack *happens* to call them. It is that the check moved onto the write path:

- `useAddReview` and `useEditReview` now run `reviewFormSchema({ requireMessage: false }).safeParse()` themselves and send `checked.data`, not the caller's object. Before this branch the schema was wired into the review dialog's own resolver, and every other writer was trusted to have checked its own work.
- The card stack has no mutation of its own. `ReviewerCard` edits a `ReviewDraft` and hands it back; `Reviewer` maps it with `toReviewFormData` and calls `addReview`. `features/reviews/index.ts` deliberately exports no other writer, and says so.
- `features/workspace/components/review-draft-panel.tsx` already imports `useAddReview` from `@/features/reviews`, so the pane is on the same path. It was not modified by this PR.

One write path, one validator, three presentations. A form may ask for *more* than the schema (the dialog does, with `requireMessage: true`); none can send less.

## Skip, save failure, reload

- **Skip** writes nothing at all. The screen's own copy promises it — "they stay in the list as unreviewed" — so there is no dismissal row, no stored decision, and the next round offers the course again. Covered by `reviewer.spec.tsx`.
- **A save that fails** keeps the card, the answers on it and the position in the queue, and shows the artboard's save-error row with "Try again", which retries the same submit. `useAddReview` has already said what went wrong in a toast; the row is what stops the stack advancing past work nothing stored.
- **A reload** resumes the round. `Reviewer` writes queue, per-course outcome and unsaved drafts to `sessionStorage` on every change (`cc.taken.reviewer`), the same choice and the same defensive-read style as `features/workspace/lib/workspace-storage.ts`.

  **Reading one back is `TakenCourses`' job, not the reviewer's**, and this is the substantive change to how the interrupted work was originally written. A stored round says what the tab was doing, not what is still true: the reader may have reviewed some of those courses in the workspace pane or another tab since. So the restore waits for the unreviewed set, then drops any course that is no longer unreviewed and was not already dealt with this round — dealing its card again would ask for a second review of a course that has one. Cards the round already saved or skipped stay, because they are what the progress row counts. If that leaves nothing still to deal, the round is over and is forgotten rather than reopened on its own done screen. `Reviewer` takes the pruned round as a `restored` prop, so there is one reader and one writer rather than two components both guessing.

- **`?review=1`** is consumed once. It is read from `window.location` in an effect and taken back out with `router.replace("/taken")`, the same move `features/landing/components/landing.tsx` makes with its own private-link parameter, so a reload does not replay it. An interrupted round outranks the deep link, because it holds answers that were typed and never saved.

## Design/schema contradictions, and the minimal change made

| Artboard | Schema / repo | What was done |
|---|---|---|
| `revCardHint` reads "Answer one thing to save" | The artboard's own `cardAnswered` requires happy, workload *and* learning — its copy contradicts its own logic three lines later | Hint names the three: "Answer happy, workload and learning to save" |
| Write-up helper: "You can write the full review later from the course page" | `/course/<code>` is retired in the parallel routes PR; there is no course page | "…later from the course" |
| Done screen: "You can reopen a card from the Reviewed column any time" | That column is a static "Done" / "Not yet" label in `taken-course-row.tsx`, with nothing to click | Sentence dropped |
| `revExamSegs` prints an abbreviation ("Assign.") on a 13–23% segment, from a `short` field on its `METHODS` | `EXAMINATION_DISTRIBUTION_LABELS` has no short form, and inventing one puts a second name for every category in the codebase | The share itself is printed instead — which is what `examinationSegments` already does on the published card |
| `revStackLabel` is `(queue - at - 1) + " more after this"`, so the final card reads "0 more after this" | — | "Last one" on the final card; the same fact in a sentence that does not have to be read twice |
| `cc-store.js` has five examination keys | `apps/web/types/review.ts` has six (`seminars`) | Six chips, as #87 already settled |
| Theory track: `startPct` clamps to 5–95 | `approach_theory_percent` accepts 0–100 | Kept the artboard's clamp as `APPROACH_MIN`/`APPROACH_MAX`, documented: at 0 or 100 one of the two labels has no segment and the bar reads as broken. Narrower than the column, not in conflict with it. |

Schema honesty, checked against `CONTEXT.md` and `types/review.ts`: workload and learning are 1–10 stored and displayed raw, bar width `value / 10`, never rescaled to 1–5. An untouched examination bar and an untouched theory track are the "I don't remember" answer and store `null` — never zeroes, and never the midpoint the track happens to be drawn at, which would claim a recollection nobody offered. An empty write-up stores `null` via `toStoredMessage`, never `""`. `happyTook` is required and gates the save button along with the two scores.

## Four bugs found in review, fixed here

`reviews.message` holds the rich-text editor's markup, and has exactly one renderer: `parse(sanitizeHtml(review.message))` on the review card, with `stripIgnoreTag: true`. A raw plain string typed into the card's textarea therefore loses anything tag-shaped between the database and the reader — "use `<vector>` from STL" arrives as "use from STL". `fromPlainText` escapes and wraps on the way out so the column holds one format whichever form typed into it. Blank lines become paragraphs, single newlines become breaks; an empty box is still `""` and still becomes `null`.

The same applies to `features/workspace/components/review-draft-panel.tsx`, which also writes a plain textarea straight through — see below.

**A restored theory answer could be out of range.** The two scores were clamped in `toReviewFormData` and `approachTheoryPercent` was not, which left one way for the card to send something `reviewFormSchema` refuses: a draft restored from `sessionStorage`, whose contents are whatever was in the tab rather than whatever the slider produced. The reviewer would have been told their review "is not finished" about an answer they had in fact given.

**The screen could spin on a `useRouter()` that is not referentially stable.** The effect that reads `?review=1` and the tab's interrupted round listed `router` as a dependency and set a freshly built object as state. Next returns a stable router so production was fine, but an effect that sets a new object on every run has no business depending on something it does not control — and this suite's own mock returned a fresh object per call, which hung the entire `ui` project until it was found. Arrival is a moment, not a value, so a ref says so and says it once. The mock is stable now too.

**The divider drag leaked its listeners.** It added `pointermove`/`pointerup` to `window` and removed them on `pointerup` — the artboard's own shape, and the one that outlives an unmount mid-drag. It uses pointer capture now, so React takes the handlers down with the card.

## Needed in `features/workspace/**`, not done here

Two follow-ups, both out of bounds for this branch because that feature has a change in flight beside it. Neither blocks this PR.

1. **`features/workspace/lib/review-draft.ts` should collapse into `features/reviews/lib/review-draft.ts`.** The two models are near-identical and the bar geometry (`evenShares`, `toggleMethod`, `moveDivider`, `nudgeDivider`, `dividerPositions`) is the same arithmetic under the same names. The pane is one presentation of a review draft and the card stack is another; neither is where the model belongs. Concretely: delete the workspace copy, import from `@/features/reviews`, keep only `examinationForgotten` / `approachForgotten`, which are genuinely the pane's because it draws explicit "I don't remember" checkboxes where the card does not. The duplication cannot make the two disagree about a *stored* review in the meantime — neither shape reaches the database, and both go through `useAddReview` and `reviewFormSchema`.
2. **The pane should use `fromPlainText` too**, for the reason above.

## Accessibility and responsive

The examination bar's dividers are `role="slider"` with `aria-valuemin`/`max`/`now` and arrow-key nudging, so the split is answerable without a pointer. The score sliders are real `<input type="range">` under a drawn track, so an unanswered score reads as empty rather than as 1 — the difference between "not answered" and "the lowest answer" is the whole point of the column being nullable. The progress segments are `aria-hidden` (twelve unlabelled bars are not information) and the "Card 2 of 8" line beside them is an `<output>`, so it is announced when a card moves.

The reviewer and the card are both `@container`s and the layout is written in container queries, so the stack works in the pane-narrowed column as well as full width. There is no reviewer in `Course Community - Mobile Preview.dc.html` to follow — it draws the taken list only — so the phone behaviour is the breakpoints, not a second artboard.

## Validation

All three from the repo root, on the rebased head:

- `bun run lint` — exit 0 (10 pre-existing warnings, all in `server/db/` scripts and `components/Topbar.tsx`, none from this branch).
- `bun run typecheck` — exit 0.
- `bun run test:web` — **60 files, 750 tests, all passing.** Baseline at `681c474` is 689 across 57.

New coverage: `reviewer.spec.tsx` (the stack, what a saved card sends, skipping, a save that does not land, an interrupted round), `review-draft.spec.ts` (the bar arithmetic and what reaches the database), `reviewer-session.spec.ts` (storage that cannot be believed), `review-text.spec.ts` (`fromPlainText`), plus regressions in `taken-courses.spec.tsx` for the pruning of a stale round and in `my-page.spec.tsx` for the deep link.

## Review

Three Greptile rounds, all four findings valid and fixed with code plus regression coverage. All were about the same seam — a restored round telling the truth about itself:

1. **A stale skip was re-offered.** A course this round skipped, then reviewed elsewhere, came back as skipped: the done screen called it "still marked unreviewed in your list" and "Go through the skipped ones" dealt its card again. A course now survives the prune only if it is still unreviewed, or if *this round saved it*.
2. **A duplicated stored code collapsed progression.** Progress is keyed by course code, so a queue holding one twice drew two cards that one skip finished. `readReviewerSession` deduplicates — no writer can produce that queue, and a tab's storage is not a writer the parser gets to trust.
3. **Out-of-queue outcomes were counted.** `done` is a map, the queue is a list, and nothing made the map mention only courses in the list, so a stray `saved` reached the done screen as "1 course reviewed". `Reviewer` counts across `round.order` now, as `skippedCodes` already did, and the prune drops the strays rather than writing them back.

Refs #68, #92.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017EAUKDDo2BkQTFELyvV3v8
