### PR TITLE
fix(collections): one meaning for unsave, and one review-draft model (#132)

### DIFF
--- a/apps/web/features/collections/components/collections.spec.tsx
+++ b/apps/web/features/collections/components/collections.spec.tsx
@@ -444,3 +444,22 @@ describe("a visitor", () => {
     expect(screen.queryByText(/AI/)).not.toBeInTheDocument();
   });
 });
+
+/*
+ * The artboard heads this page "Group courses you want to compare." and draws a
+ * "New collection" tile promising a side-by-side view. #68's settled decision 1
+ * is that neither exists, so the promise is gone from both — a collection is a
+ * named, ordered group of saved courses and nothing in the app puts two of them
+ * beside each other.
+ */
+describe("what the page promises", () => {
+  it("never offers to compare anything, as a page or as a section", () => {
+    setup();
+    const page = render(<Collections />);
+    expect(page.container.textContent).not.toMatch(/compar/i);
+    page.unmount();
+
+    const section = render(<Collections compact />);
+    expect(section.container.textContent).not.toMatch(/compar/i);
+  });
+});

--- a/apps/web/features/collections/components/collections.tsx
+++ b/apps/web/features/collections/components/collections.tsx
@@ -27,6 +27,25 @@ import { NewCollectionDialog } from "./new-collection-dialog";
 /** Names the compact variant's section by its own heading. */
 const COMPACT_HEADING_ID = "collections-section-heading";
 
+/**
+ * The line under the heading, in both variants.
+ *
+ * `Course Community - Collections.dc.html` reads "Group courses you want to
+ * compare." — and the "New collection" tile beside it reads "Group specific
+ * courses and compare them side by side." Neither is true: there is no
+ * comparison surface anywhere in the app, and #68's settled decision 1 is that
+ * there is no AI-comparison feature to build one for. #91 already dropped the
+ * promise from the tile; this is the same substitution finished, so the page
+ * does not head itself with a promise its own tile has stopped making. The
+ * wording is the tile's, so the two agree.
+ *
+ * It is a copy change against the visual authority, which is the narrow case
+ * `CLAUDE.md` allows: the design loses to the schema on what exists, and it is
+ * the smallest edit that leaves the artboard otherwise intact — same slot, same
+ * length, same voice.
+ */
+const SUBTITLE = "Group the courses you are considering together.";
+
 /** How long the artboard's confirmation strip stays up, in milliseconds. */
 const NOTE_LIFETIME = 3000;
 
@@ -518,9 +537,7 @@ export function Collections({
         >
           Collections
         </h2>
-        <div className="mt-1 text-[12.5px] text-cc-muted">
-          Group courses you want to compare.
-        </div>
+        <div className="mt-1 text-[12.5px] text-cc-muted">{SUBTITLE}</div>
         {body}
       </section>
     );
@@ -528,10 +545,7 @@ export function Collections({
 
   return (
     <PageColumn>
-      <PageHeader
-        title="Collections"
-        subtitle="Group courses you want to compare."
-      />
+      <PageHeader title="Collections" subtitle={SUBTITLE} />
       {body}
     </PageColumn>
   );

--- a/apps/web/features/reviews/index.ts
+++ b/apps/web/features/reviews/index.ts
@@ -44,6 +44,35 @@ export {
   examinationSplitLabel,
 } from "./lib/examination-palette";
 /**
+ * The review draft: the shape a review has while it is still being written,
+ * and the arithmetic behind the draggable examination bar.
+ *
+ * Two surfaces write a review through this — the fast-track card stack here,
+ * and the workspace pane's review-draft panel, whose draft is this shape plus
+ * its two "I don't remember" flags. It is exported for that second one: the
+ * pane used to carry its own copy of the model and every bar transform, and a
+ * second copy is a second thing to keep in step with the column it writes to.
+ * `toReviewFormData` is the only way either of them becomes something writable,
+ * and it is what escapes a plain-text write-up into the markup
+ * `reviews.message` holds.
+ */
+export {
+  APPROACH_MAX,
+  APPROACH_MIDPOINT,
+  APPROACH_MIN,
+  dividerPositions,
+  EMPTY_REVIEW_DRAFT,
+  type ExaminationKey,
+  isAnswered,
+  isUntouched,
+  MIN_SHARE,
+  moveDivider,
+  nudgeDivider,
+  type ReviewDraft,
+  toggleMethod,
+  toReviewFormData,
+} from "./lib/review-draft";
+/**
  * The reviewer's round, as the tab remembers it. `/taken` reads it to reopen a
  * round a reload interrupted — after checking that its courses are still
  * unreviewed, which the store itself cannot know — and clears it when the

--- a/apps/web/features/reviews/lib/review-draft.ts
+++ b/apps/web/features/reviews/lib/review-draft.ts
@@ -27,25 +27,26 @@ import { fromPlainText } from "./review-text";
  * way to spell it. Neither ever produces zeroes: `CONTEXT.md` is explicit that a
  * recollection nobody has is absent, not empty.
  *
- * ## The relationship to the workspace's copy
+ * ## The workspace pane writes through this model too
  *
- * `features/workspace/lib/review-draft.ts` carries a near-identical model, and
- * the bar geometry here — `evenShares`, `toggleMethod`, `moveDivider`,
- * `nudgeDivider`, `dividerPositions` — is the same arithmetic under the same
- * names. Both should collapse into this one, which is the reviews feature's to
- * own: the pane is one presentation of a review draft and the card stack is
- * another, and neither is where the model belongs. Concretely, the follow-up
- * deletes the workspace copy and has `review-draft-panel.tsx` import from
- * `@/features/reviews`, keeping only `examinationForgotten` /
- * `approachForgotten` — the two flags that are genuinely the pane's, because it
- * draws explicit "I don't remember" checkboxes where this card does not.
+ * `features/workspace/lib/review-draft.ts` used to carry a near-identical copy
+ * of everything below — the same shape, the same bar arithmetic under the same
+ * names. It no longer does: it now holds only the two flags that are genuinely
+ * the pane's, `examinationForgotten` and `approachForgotten`, and extends this
+ * shape with them. The pane draws explicit "I don't remember" checkboxes where
+ * this card leaves the question alone, which is the one real difference between
+ * the two surfaces.
  *
- * It is not done here because `features/workspace/**` belongs to a change in
- * flight beside this one, and a rename across a moving feature is how a rebase
- * eats a day. **What the duplication cannot do is make the two disagree about a
- * stored review**: neither shape reaches the database. Both are mapped to
- * `ReviewFormData` and handed to `useAddReview`, which runs `reviewFormSchema`
- * itself before it sends anything — one write path, one validator, two forms.
+ * That is why `toggleMethod`, `moveDivider` and `nudgeDivider` are generic over
+ * the draft rather than typed to this exact shape. Each of them replaces
+ * `methods` and `shares` and copies everything else through untouched, so a
+ * caller with a wider draft gets its own type back instead of having its extra
+ * fields erased at the type level while surviving at runtime.
+ *
+ * What the split cannot do is make the two disagree about a stored review.
+ * Neither shape reaches the database: both are mapped to `ReviewFormData` and
+ * handed to `useAddReview`, which runs `reviewFormSchema` itself before it
+ * sends anything — one write path, one validator, two forms.
  */
 
 export type ExaminationKey = (typeof EXAMINATION_DISTRIBUTION_KEYS)[number];
@@ -119,15 +120,25 @@ export function evenShares(count: number): number[] {
   return shares;
 }
 
-/** Pick or unpick an examination method, re-splitting the bar evenly. */
-export function toggleMethod(
-  draft: ReviewDraft,
+/**
+ * Pick or unpick an examination method, re-splitting the bar evenly.
+ *
+ * Generic over the draft because the workspace pane's draft is this one plus
+ * its two "I don't remember" flags, and it has to get its own type back. The
+ * cast is sound for exactly the reason the generic is safe: `methods` and
+ * `shares` are both declared on `ReviewDraft`, they are the only fields
+ * replaced, and everything else is spread through unchanged. TypeScript cannot
+ * see that a spread of `D` with two of `D`'s own fields overwritten is still a
+ * `D`, so it is asserted here rather than pushed onto three call sites.
+ */
+export function toggleMethod<D extends ReviewDraft>(
+  draft: D,
   method: ExaminationKey,
-): ReviewDraft {
+): D {
   const at = draft.methods.indexOf(method);
   const methods =
     at >= 0 ? draft.methods.toSpliced(at, 1) : [...draft.methods, method];
-  return { ...draft, methods, shares: evenShares(methods.length) };
+  return { ...draft, methods, shares: evenShares(methods.length) } as D;
 }
 
 /**
@@ -139,11 +150,11 @@ export function toggleMethod(
  * `MIN_SHARE` so a segment can never be dragged out of existence — a 0% segment
  * would be a method the reviewer picked and then said nothing about.
  */
-export function moveDivider(
-  draft: ReviewDraft,
+export function moveDivider<D extends ReviewDraft>(
+  draft: D,
   index: number,
   cumulativePercent: number,
-): ReviewDraft {
+): D {
   if (index < 0 || index >= draft.shares.length - 1) return draft;
 
   const before = draft.shares
@@ -157,15 +168,17 @@ export function moveDivider(
   const shares = [...draft.shares];
   shares[index] = left;
   shares[index + 1] = pair - left;
-  return { ...draft, shares };
+  // Same assertion as `toggleMethod`, for the same reason: only `shares`,
+  // already a field of `ReviewDraft`, is replaced.
+  return { ...draft, shares } as D;
 }
 
 /** Nudge a divider one step, which is how the keyboard drives the bar. */
-export function nudgeDivider(
-  draft: ReviewDraft,
+export function nudgeDivider<D extends ReviewDraft>(
+  draft: D,
   index: number,
   steps: number,
-): ReviewDraft {
+): D {
   if (index < 0 || index >= draft.shares.length - 1) return draft;
   const before = draft.shares
     .slice(0, index)

--- a/apps/web/features/saved/api/mutations.spec.tsx
+++ b/apps/web/features/saved/api/mutations.spec.tsx
@@ -1,0 +1,153 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { renderHook, waitFor } from "@testing-library/react";
+import type { ReactNode } from "react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { useSetCourseSaved } from "./mutations";
+
+/**
+ * Unsaving is also a collections write, and the cache has to hear about it.
+ *
+ * `collection_courses` has a composite foreign key onto `user_saved_courses`
+ * with `on delete cascade`, because a course may only be in a collection its
+ * owner has also saved. So `saved.unsave` empties the course out of every
+ * collection it was in without `collections.removeCourse` ever being called,
+ * and nothing on the client can see that happen unless `collections.list` is
+ * refetched too.
+ *
+ * The three surfaces that unsave — Explore's Save button, the Saved page's
+ * trash, and the trash on a card inside a collection — all go through this one
+ * hook, so this is the only place the invalidation can be got right once.
+ */
+
+const ME_KEY = ["user", "me"];
+const COLLECTIONS_KEY = ["collections", "list"];
+
+const saveMutation = vi.fn();
+const unsaveMutation = vi.fn();
+
+vi.mock("@/trpc/client", () => ({
+  useTRPC: () => ({
+    user: { me: { queryKey: () => ME_KEY } },
+    collections: { list: { queryKey: () => COLLECTIONS_KEY } },
+    saved: {
+      save: {
+        mutationOptions: () => ({
+          mutationFn: (input: unknown) => saveMutation(input),
+        }),
+      },
+      unsave: {
+        mutationOptions: () => ({
+          mutationFn: (input: unknown) => unsaveMutation(input),
+        }),
+      },
+    },
+  }),
+}));
+
+const ME = {
+  id: "u1",
+  name: "Elsa",
+  savedCourseCodes: ["DD2380", "DD1337"],
+};
+
+function setup() {
+  const queryClient = new QueryClient({
+    defaultOptions: {
+      queries: { retry: false },
+      mutations: { retry: false },
+    },
+  });
+  queryClient.setQueryData(ME_KEY, ME);
+  queryClient.setQueryData(COLLECTIONS_KEY, []);
+
+  const invalidated: unknown[] = [];
+  const invalidateQueries = queryClient.invalidateQueries.bind(queryClient);
+  vi.spyOn(queryClient, "invalidateQueries").mockImplementation((filters) => {
+    invalidated.push(filters?.queryKey);
+    return invalidateQueries(filters);
+  });
+
+  function Wrapper({ children }: { children: ReactNode }) {
+    return (
+      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    );
+  }
+
+  const { result } = renderHook(() => useSetCourseSaved(), {
+    wrapper: Wrapper,
+  });
+  return { result, invalidated };
+}
+
+beforeEach(() => {
+  saveMutation.mockReset().mockResolvedValue(undefined);
+  unsaveMutation.mockReset().mockResolvedValue(undefined);
+});
+
+describe("unsaving a course", () => {
+  it("refetches the collections it was silently removed from", async () => {
+    const { result, invalidated } = setup();
+
+    await result.current.setSaved("DD2380", false);
+
+    await waitFor(() => {
+      expect(unsaveMutation).toHaveBeenCalledWith({ courseCode: "DD2380" });
+    });
+    expect(invalidated).toContainEqual(ME_KEY);
+    expect(invalidated).toContainEqual(COLLECTIONS_KEY);
+  });
+
+  // Only the last write for a course refetches, so a burst of clicks does not
+  // pull server state back over a move that is still in flight.
+  it("refetches once for a burst of clicks on the same course", async () => {
+    const { result, invalidated } = setup();
+
+    await Promise.all([
+      result.current.setSaved("DD2380", false),
+      result.current.setSaved("DD2380", true),
+      result.current.setSaved("DD2380", false),
+    ]);
+
+    await waitFor(() => {
+      expect(invalidated.filter((key) => key === COLLECTIONS_KEY)).toHaveLength(
+        1,
+      );
+    });
+  });
+});
+
+describe("saving a course", () => {
+  /*
+   * Saving adds a row to `user_saved_courses`. That makes the course *eligible*
+   * for a collection; it never puts it in one, so there is nothing about the
+   * viewer's collections that has changed and nothing to refetch.
+   */
+  it("leaves the collections alone", async () => {
+    const { result, invalidated } = setup();
+
+    await result.current.setSaved("SF1626", true);
+
+    await waitFor(() => {
+      expect(saveMutation).toHaveBeenCalledWith({ courseCode: "SF1626" });
+    });
+    expect(invalidated).toContainEqual(ME_KEY);
+    expect(invalidated).not.toContainEqual(COLLECTIONS_KEY);
+  });
+});
+
+describe("an unsave that fails", () => {
+  /*
+   * The optimistic edit is rolled back and the caller is told, which is what
+   * raises the toast. The refetch still happens: the write may have reached the
+   * database before the response was lost, and a refetch is the only thing that
+   * can tell.
+   */
+  it("puts the course back and still asks the server who is right", async () => {
+    const { result, invalidated } = setup();
+    unsaveMutation.mockRejectedValue(new Error("offline"));
+
+    await expect(result.current.setSaved("DD2380", false)).rejects.toThrow();
+
+    expect(invalidated).toContainEqual(COLLECTIONS_KEY);
+  });
+});

--- a/apps/web/features/saved/api/mutations.spec.tsx
+++ b/apps/web/features/saved/api/mutations.spec.tsx
@@ -116,6 +116,47 @@ describe("unsaving a course", () => {
   });
 });
 
+/*
+ * The cascade happens when the unsave runs, and nothing later undoes it: the
+ * course can come back saved while every collection it used to be in has lost
+ * it. Only the last write in a sequence cleans up, so asking *that* call whether
+ * it was a save would skip the refetch on exactly the flow that needs it — a
+ * reader who unsaves and immediately re-saves ends on a save, and their chips
+ * would go on counting a course the database has already dropped.
+ */
+describe("an unsave that a later save overtakes", () => {
+  it("still refetches the collections the unsave emptied", async () => {
+    const { result, invalidated } = setup();
+
+    await Promise.all([
+      result.current.setSaved("DD2380", false),
+      result.current.setSaved("DD2380", true),
+    ]);
+
+    await waitFor(() => {
+      expect(unsaveMutation).toHaveBeenCalledWith({ courseCode: "DD2380" });
+      expect(saveMutation).toHaveBeenCalledWith({ courseCode: "DD2380" });
+    });
+    expect(invalidated.filter((key) => key === COLLECTIONS_KEY)).toHaveLength(
+      1,
+    );
+  });
+
+  // The mark is cleared when the sequence it belongs to finishes, so a plain
+  // save afterwards is a plain save again.
+  it("does not keep refetching for every later save of that course", async () => {
+    const { result, invalidated } = setup();
+
+    await result.current.setSaved("DD2380", false);
+    await result.current.setSaved("DD2380", true);
+    await result.current.setSaved("DD2380", true);
+
+    expect(invalidated.filter((key) => key === COLLECTIONS_KEY)).toHaveLength(
+      1,
+    );
+  });
+});
+
 describe("saving a course", () => {
   /*
    * Saving adds a row to `user_saved_courses`. That makes the course *eligible*

--- a/apps/web/features/saved/api/mutations.ts
+++ b/apps/web/features/saved/api/mutations.ts
@@ -13,11 +13,32 @@ import { useTRPC } from "@/trpc/client";
  * Writes to one course are queued, so the last click decides the stored state
  * even when a user clicks faster than the network answers. Two different
  * courses still go in parallel.
+ *
+ * ## Unsaving is also a collections write, and the cache has to know
+ *
+ * `collection_courses` carries a composite foreign key onto `user_saved_courses`
+ * with `on delete cascade` (`collection_courses_saved_course_fk`), because a
+ * course may only be in a collection its owner has also saved. So `saved.unsave`
+ * removes the course from *every* collection it was in, on the server, without
+ * `collections.removeCourse` ever being called.
+ *
+ * Nothing on the client can see that happen. Refetching `user.me` alone leaves
+ * the card's picker still ticking a collection the course has just left, the
+ * Saved page's chips still counting it, and an open collection's detail still
+ * listing it — three surfaces disagreeing with the database after one click,
+ * and the disagreement lasts until something else happens to invalidate the
+ * list. `collections.list` is therefore refetched alongside `user.me`, so the
+ * unsave means the same thing wherever it was pressed: Explore's Save button,
+ * the Saved page's trash, or the trash on a card inside a collection.
+ *
+ * Saving does not need it. Adding a row to `user_saved_courses` makes a course
+ * *eligible* for a collection; it never puts it in one.
  */
 export function useSetCourseSaved() {
   const trpc = useTRPC();
   const queryClient = useQueryClient();
   const meKey = trpc.user.me.queryKey();
+  const collectionsKey = trpc.collections.list.queryKey();
 
   const save = useMutation(trpc.saved.save.mutationOptions());
   const unsave = useMutation(trpc.saved.unsave.mutationOptions());
@@ -61,6 +82,9 @@ export function useSetCourseSaved() {
       if (queue.get(courseCode) === write) {
         queue.delete(courseCode);
         queryClient.invalidateQueries({ queryKey: meKey });
+        if (!saved) {
+          queryClient.invalidateQueries({ queryKey: collectionsKey });
+        }
       }
     }
   }

--- a/apps/web/features/saved/api/mutations.ts
+++ b/apps/web/features/saved/api/mutations.ts
@@ -33,6 +33,14 @@ import { useTRPC } from "@/trpc/client";
  *
  * Saving does not need it. Adding a row to `user_saved_courses` makes a course
  * *eligible* for a collection; it never puts it in one.
+ *
+ * What decides the refetch is therefore the *sequence*, not the last call in it.
+ * Only the last write for a course cleans up, so a reader who unsaves and then
+ * re-saves before the first request answers ends on a save — and the cascade
+ * has already happened, whatever the course's saved state ends up being. Asking
+ * the final call whether it was a save would skip the refetch on exactly the
+ * flow that needs it most: the course comes back saved, but every collection it
+ * used to be in has lost it, and the chips would go on counting it.
  */
 export function useSetCourseSaved() {
   const trpc = useTRPC();
@@ -46,8 +54,23 @@ export function useSetCourseSaved() {
   // The write currently in flight per course code, so the next one can wait for
   // it instead of racing it.
   const inFlight = useRef(new Map<string, Promise<unknown>>());
+  /**
+   * Courses whose queued sequence has run an unsave, and therefore owes
+   * `collections.list` a refetch when that sequence finishes.
+   *
+   * Marked before the request rather than after it answers. A response that
+   * never arrives says nothing about whether the row was deleted, and a refetch
+   * is the only thing that can tell — the same reason the queue refetches
+   * `user.me` after a failure.
+   */
+  const cascadedCourses = useRef(new Set<string>());
 
   async function setSaved(courseCode: string, saved: boolean) {
+    // An unsave cascades collection membership away on the server, and it has
+    // done so whether or not a later write in this sequence puts the course
+    // back. The mark is on the course, not on this call.
+    if (!saved) cascadedCourses.current.add(courseCode);
+
     // Written before the first await so a second click in the same tick reads
     // the state this one is heading for, not the state it started from.
     const previous = queryClient.getQueryData<Me | null>(meKey);
@@ -82,7 +105,9 @@ export function useSetCourseSaved() {
       if (queue.get(courseCode) === write) {
         queue.delete(courseCode);
         queryClient.invalidateQueries({ queryKey: meKey });
-        if (!saved) {
+        // `Set.delete` answers "was it marked?" and clears the mark in one
+        // step, so the next sequence for this course starts clean.
+        if (cascadedCourses.current.delete(courseCode)) {
           queryClient.invalidateQueries({ queryKey: collectionsKey });
         }
       }

--- a/apps/web/features/saved/components/saved.spec.tsx
+++ b/apps/web/features/saved/components/saved.spec.tsx
@@ -169,12 +169,15 @@ describe("Saved", { timeout: 20_000 }, () => {
     });
 
     // #68's settled decision 1: there is no AI-comparison feature, so the word
-    // is gone from the copy as well as from the identifiers.
-    it("never says comparison", () => {
+    // is gone from the copy as well as from the identifiers. The whole page is
+    // checked, embedded collections strip included — that strip is the last
+    // place the substitution was half-finished, and it renders here rather than
+    // on a route of its own.
+    it("never offers to compare anything", () => {
       saved("DD2380");
       const { container } = render(<Saved />);
 
-      expect(container.textContent).not.toMatch(/comparison/i);
+      expect(container.textContent).not.toMatch(/compar/i);
     });
 
     it("shows placeholders rather than an empty list while loading", () => {

--- a/apps/web/features/workspace/components/review-draft-panel.tsx
+++ b/apps/web/features/workspace/components/review-draft-panel.tsx
@@ -4,8 +4,18 @@ import { useEffect, useRef, useState } from "react";
 import { type AuthReason, AuthReasonDialog, useMe } from "@/features/auth";
 import { useCourseDetails } from "@/features/courses";
 import {
+  APPROACH_MAX,
+  APPROACH_MIDPOINT,
+  APPROACH_MIN,
+  dividerPositions,
   EXAMINATION_COLORS,
   EXAMINATION_INK,
+  type ExaminationKey,
+  isAnswered,
+  MIN_SHARE,
+  moveDivider,
+  nudgeDivider,
+  toggleMethod,
   useAddReview,
   useReviewList,
 } from "@/features/reviews";
@@ -18,20 +28,12 @@ import {
   MIN_REVIEW_SCORE,
 } from "@/types";
 import {
-  APPROACH_MIDPOINT,
-  canPublish,
-  dividerPositions,
   EMPTY_REVIEW_DRAFT,
-  type ExaminationKey,
   isUntouched,
-  MIN_SHARE,
-  moveDivider,
-  nudgeDivider,
   REVIEW_DRAFT_SECTIONS,
   type ReviewDraft,
   sectionsDone,
-  toggleMethod,
-  toReviewInput,
+  toReviewFormData,
 } from "../lib/review-draft";
 import {
   claimAwaitingSignIn,
@@ -49,6 +51,14 @@ const PROMPTS = [
 
 /** Unanswered tracks are drawn in the theme's strong hairline, not a fill. */
 const UNSET_FILL = "var(--cc-rule3)";
+
+/**
+ * The theory/applied track moves in whole five-point steps, as the artboard's
+ * does. It is its own constant rather than the examination bar's `MIN_SHARE`,
+ * which is the same number and answers a different question — the smallest a
+ * *segment* may be dragged to.
+ */
+const APPROACH_STEP = 5;
 
 function Card({ children }: { children: React.ReactNode }) {
   return (
@@ -252,7 +262,7 @@ export function ReviewDraftPanel({
     (courseReviews.data ?? []).some((review) => review.userId === userId);
   const alreadyReviewed =
     justPublished || reviewedInList || publishedAt !== null;
-  const publishable = canPublish(draft) && !alreadyReviewed;
+  const publishable = isAnswered(draft) && !alreadyReviewed;
 
   /**
    * The workspace's note that it published covers one window: between the
@@ -331,18 +341,24 @@ export function ReviewDraftPanel({
   }
 
   async function publish() {
-    const input = toReviewInput(draft);
-    if (!input || alreadyReviewed) return;
+    /*
+     * The write-up leaves the textarea as plain text and `reviews.message`
+     * holds markup — it has exactly one renderer, `parse(sanitizeHtml(...))`
+     * with `stripIgnoreTag` — so anything tag-shaped in a raw plain string is
+     * deleted on the way to the screen and "use `<vector>` from STL" arrives as
+     * "use from STL". `toReviewFormData` escapes it first, which is why
+     * publishing goes through the reviews feature's mapper rather than handing
+     * `draft.message` straight to `addReview`.
+     */
+    const form = toReviewFormData(draft);
+    if (!form || alreadyReviewed) return;
     if (!isAuthenticated) {
       markAwaitingSignIn(courseCode);
       setAuthReason("post-review");
       return;
     }
     setPublishing(true);
-    const ok = await addReview(courseCode, {
-      ...input,
-      message: input.message ?? "",
-    });
+    const ok = await addReview(courseCode, form);
     setPublishing(false);
     if (!ok) return;
     setPublishedDraft(draft);
@@ -554,11 +570,16 @@ export function ReviewDraftPanel({
             >
               Applied
             </div>
+            {/* The track's ends are the approach question's own, not the
+                examination bar's minimum share — the two happen to be the same
+                number today and mean different things. `toReviewFormData`
+                clamps to exactly these, so a control bounded by anything else
+                would let the writer set a value the mapper then quietly moved. */}
             <input
               type="range"
-              min={MIN_SHARE}
-              max={100 - MIN_SHARE}
-              step={MIN_SHARE}
+              min={APPROACH_MIN}
+              max={APPROACH_MAX}
+              step={APPROACH_STEP}
               value={draft.approachTheoryPercent ?? APPROACH_MIDPOINT}
               aria-label="How theoretical rather than applied the course was"
               aria-valuetext={

--- a/apps/web/features/workspace/components/workspace-pane.spec.tsx
+++ b/apps/web/features/workspace/components/workspace-pane.spec.tsx
@@ -7,6 +7,7 @@ import {
 } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import { sanitizeHtml } from "@/lib/sanitize-html";
 import type { CourseDetails, CourseStats } from "@/types";
 import type { OpenCourse } from "../lib/open-courses";
 import { WorkspacePane } from "./workspace-pane";
@@ -33,11 +34,15 @@ vi.mock("@/features/courses", () => ({
 // `ReviewList` is the reviews feature's own list of designed Review Cards
 // (#87). The pane's job is to hand it the course and its reviews, which is
 // what this asserts; how a card draws itself is that feature's test.
-// The palette is the real one — the pane draws the same examination bar the
-// Review Card does. The barrel itself is not imported: it reaches the rich
-// text editor, whose stylesheet needs a PostCSS pass Vitest does not run.
+// The palette and the review-draft model are the real ones — the pane draws
+// the same examination bar the Review Card does, and since the pane's draft
+// stopped carrying its own copy of the model, `toReviewFormData` is what turns
+// what the writer typed into what is sent. Faking either would test a fake.
+// The barrel itself is not imported: it reaches the rich text editor, whose
+// stylesheet needs a PostCSS pass Vitest does not run.
 vi.mock("@/features/reviews", async () => ({
   ...(await import("@/features/reviews/lib/examination-palette")),
+  ...(await import("@/features/reviews/lib/review-draft")),
   useReviewList: (code: string | undefined) => useReviewList(code),
   useAddReview: () => addReview,
   ReviewList: ({
@@ -443,9 +448,37 @@ describe("the review draft tab", () => {
       workloadScore: 8,
       learningScore: 6,
       happyTook: true,
-      message: "Hard but worth it.",
+      message: "<p>Hard but worth it.</p>",
     });
     expect(await screen.findByText(/Published. Thanks/)).toBeInTheDocument();
+  });
+
+  /*
+   * The write-up leaves a plain `<textarea>` and lands in `reviews.message`,
+   * which has exactly one renderer: `parse(sanitizeHtml(...))` on the Review
+   * Card, configured with `stripIgnoreTag`. A raw plain string therefore loses
+   * everything tag-shaped *on the way to the screen*, after it was stored and
+   * with nothing to show the reviewer it happened — "use <vector> from STL"
+   * arrives as "use from STL". The pane escapes it first, through the reviews
+   * feature's own `toReviewFormData`.
+   */
+  it("keeps a write-up that mentions something tag-shaped", async () => {
+    const user = userEvent.setup({ delay: null });
+    renderPane([openCourse("review")]);
+
+    await user.click(screen.getByRole("button", { name: "Yes, I am" }));
+    setScore("How demanding was this course?", 8);
+    setScore("How much did you learn in this course?", 6);
+    await user.type(
+      screen.getByRole("textbox", { name: "Write your review" }),
+      "use <vector> from STL",
+    );
+    await user.click(screen.getByRole("button", { name: "Post review" }));
+
+    const sent = addReview.mock.calls.at(-1)?.[1].message as string;
+    expect(sent).toBe("<p>use &lt;vector&gt; from STL</p>");
+    // The renderer that used to eat it, run for real.
+    expect(sanitizeHtml(sent)).toContain("&lt;vector&gt;");
   });
 
   it("asks a visitor to sign in instead of publishing", async () => {

--- a/apps/web/features/workspace/components/workspace-pane.tsx
+++ b/apps/web/features/workspace/components/workspace-pane.tsx
@@ -43,8 +43,16 @@ export interface WorkspacePaneProps {
   /** Opening a review draft from the course being read, and vice versa. */
   onOpen: (courseCode: string, kind: OpenCourseKind) => void;
   /**
-   * Drop the tab strip. The mobile layout shows the pane as a full-screen
-   * sheet with one course in it, and puts the switcher in its own chrome.
+   * Drop the tab strip.
+   *
+   * Mobile sets it, and there is no switcher on that side to replace it: the
+   * Mobile Preview artboard stacks sheets and says so in its own note — "Sheets
+   * stack — open several, dismiss each with the × or by dragging it all the way
+   * down" — and every sheet it draws imports this pane with `hide-tabs`. So the
+   * open list is still the same list; only the top of the stack is on screen,
+   * and dismissing it reveals the one under it. `MobileWorkspaceSheetHost`
+   * passes a single entry for that reason, and `onActivate` has nothing to
+   * activate.
    */
   hideTabs?: boolean;
   className?: string;

--- a/apps/web/features/workspace/lib/review-draft.spec.ts
+++ b/apps/web/features/workspace/lib/review-draft.spec.ts
@@ -1,92 +1,37 @@
 import { describe, expect, it } from "vitest";
+import { sanitizeHtml } from "@/lib/sanitize-html";
 import { examinationDistributionSchema } from "@/types";
 import {
-  canPublish,
-  dividerPositions,
   EMPTY_REVIEW_DRAFT,
-  evenShares,
-  moveDivider,
-  nudgeDivider,
+  isUntouched,
   type ReviewDraft,
   sectionsDone,
-  toExaminationDistribution,
-  toggleMethod,
-  toReviewInput,
+  toReviewFormData,
 } from "./review-draft";
 
+/**
+ * Only what the pane adds to the reviews feature's draft.
+ *
+ * The model itself and every bar transform now live in
+ * `features/reviews/lib/review-draft.ts`, and `features/reviews/lib/
+ * review-draft.spec.ts` is where they are tested. Re-testing `evenShares` or
+ * `moveDivider` here would be testing the same function twice under two names,
+ * which is what the duplication this file used to sit on top of felt like from
+ * the inside.
+ */
 function draft(over: Partial<ReviewDraft> = {}): ReviewDraft {
   return { ...EMPTY_REVIEW_DRAFT, ...over };
 }
 
-describe("evenShares", () => {
-  it.each([1, 2, 3, 4, 5, 6])("adds up to 100 for %i methods", (count) => {
-    const shares = evenShares(count);
-    expect(shares).toHaveLength(count);
-    expect(shares.reduce((total, share) => total + share, 0)).toBe(100);
+/** A publishable draft, so a test can vary one thing at a time. */
+function answered(over: Partial<ReviewDraft> = {}): ReviewDraft {
+  return draft({
+    happyTook: true,
+    workloadScore: 7,
+    learningScore: 8,
+    ...over,
   });
-
-  it("has nothing to split when nothing is picked", () => {
-    expect(evenShares(0)).toEqual([]);
-  });
-});
-
-describe("toggleMethod", () => {
-  it("picks a method and splits the bar evenly", () => {
-    const picked = toggleMethod(toggleMethod(draft(), "exam"), "labs");
-
-    expect(picked.methods).toEqual(["exam", "labs"]);
-    expect(picked.shares).toEqual([50, 50]);
-  });
-
-  it("unpicking re-splits what is left", () => {
-    const three = ["exam", "labs", "projects"].reduce(
-      (current, method) =>
-        toggleMethod(current, method as "exam" | "labs" | "projects"),
-      draft(),
-    );
-    const two = toggleMethod(three, "labs");
-
-    expect(two.methods).toEqual(["exam", "projects"]);
-    expect(two.shares).toEqual([50, 50]);
-  });
-});
-
-describe("moveDivider", () => {
-  const three = draft({
-    methods: ["exam", "labs", "projects"],
-    shares: [35, 35, 30],
-  });
-
-  it("moves only the pair either side of the divider", () => {
-    const moved = moveDivider(three, 0, 20);
-
-    expect(moved.shares).toEqual([20, 50, 30]);
-    expect(moved.shares.reduce((total, share) => total + share, 0)).toBe(100);
-  });
-
-  it("snaps to five-point steps", () => {
-    expect(moveDivider(three, 0, 22).shares[0]).toBe(20);
-    expect(moveDivider(three, 0, 23).shares[0]).toBe(25);
-  });
-
-  it("never drags a segment out of existence", () => {
-    expect(moveDivider(three, 0, 0).shares).toEqual([5, 65, 30]);
-    expect(moveDivider(three, 0, 100).shares).toEqual([65, 5, 30]);
-  });
-
-  it("ignores a divider that is not there", () => {
-    expect(moveDivider(three, 2, 50)).toBe(three);
-  });
-
-  it("nudges one step at a time from the keyboard", () => {
-    expect(nudgeDivider(three, 0, -1).shares).toEqual([30, 40, 30]);
-    expect(nudgeDivider(three, 1, 1).shares).toEqual([35, 40, 25]);
-  });
-
-  it("reports each divider as a running total", () => {
-    expect(dividerPositions(three)).toEqual([35, 70]);
-  });
-});
+}
 
 describe("sectionsDone", () => {
   it("counts nothing on an untouched draft", () => {
@@ -116,12 +61,9 @@ describe("sectionsDone", () => {
   it("counts all three when the write-up is there too", () => {
     expect(
       sectionsDone(
-        draft({
+        answered({
           examinationForgotten: true,
           approachForgotten: true,
-          workloadScore: 7,
-          learningScore: 8,
-          happyTook: true,
           message: "Worth it.",
         }),
       ),
@@ -129,84 +71,109 @@ describe("sectionsDone", () => {
   });
 });
 
-describe("canPublish", () => {
-  it("needs happy took and both scores, and nothing else", () => {
-    const ready = draft({
-      happyTook: false,
-      workloadScore: 3,
-      learningScore: 9,
-    });
+describe("isUntouched", () => {
+  it("is true for a draft nobody has answered anything on", () => {
+    expect(isUntouched(draft())).toBe(true);
+  });
 
-    expect(canPublish(ready)).toBe(true);
-    expect(canPublish({ ...ready, happyTook: null })).toBe(false);
-    expect(canPublish({ ...ready, workloadScore: null })).toBe(false);
-    expect(canPublish({ ...ready, learningScore: null })).toBe(false);
+  // The header reads "Not saved yet" off this, and ticking a box is an answer
+  // the pane has to keep — the shared check cannot see either flag.
+  it("is false once a checkbox says the writer does not remember", () => {
+    expect(isUntouched(draft({ examinationForgotten: true }))).toBe(false);
+    expect(isUntouched(draft({ approachForgotten: true }))).toBe(false);
+  });
+
+  it("is false once anything else is answered", () => {
+    expect(isUntouched(draft({ workloadScore: 3 }))).toBe(false);
+    expect(isUntouched(draft({ message: "Good." }))).toBe(false);
   });
 });
 
-describe("toExaminationDistribution", () => {
-  it("fills every key and passes the wire contract", () => {
-    const distribution = toExaminationDistribution(
-      draft({ methods: ["labs", "exam"], shares: [60, 40] }),
+describe("what the pane sends", () => {
+  it("has nothing to send until happy, workload and learning are answered", () => {
+    expect(toReviewFormData(draft())).toBeNull();
+    expect(toReviewFormData(draft({ happyTook: true }))).toBeNull();
+    expect(
+      toReviewFormData(draft({ happyTook: true, workloadScore: 5 })),
+    ).toBeNull();
+  });
+
+  it("keeps the scores on the stored 1-10 scale", () => {
+    const form = toReviewFormData(answered());
+
+    expect(form?.workloadScore).toBe(7);
+    expect(form?.learningScore).toBe(8);
+  });
+
+  it("fills every examination key and passes the wire contract", () => {
+    const form = toReviewFormData(
+      answered({ methods: ["exam", "labs"], shares: [60, 40] }),
     );
 
-    expect(distribution).toEqual({
-      exam: 40,
+    expect(
+      examinationDistributionSchema.safeParse(form?.examinationDistribution)
+        .success,
+    ).toBe(true);
+    expect(form?.examinationDistribution).toMatchObject({
+      exam: 60,
+      labs: 40,
       assignments: 0,
-      labs: 60,
       projects: 0,
       seminars: 0,
       other: 0,
     });
-    expect(examinationDistributionSchema.safeParse(distribution).success).toBe(
-      true,
-    );
-  });
-
-  it("is absent, not zeroes, when the writer does not remember", () => {
-    expect(
-      toExaminationDistribution(
-        draft({ methods: ["exam"], shares: [100], examinationForgotten: true }),
-      ),
-    ).toBeNull();
-  });
-
-  it("is absent when the question was never touched", () => {
-    expect(toExaminationDistribution(draft())).toBeNull();
-  });
-});
-
-describe("toReviewInput", () => {
-  it("refuses a draft that is not publishable", () => {
-    expect(toReviewInput(draft({ happyTook: true }))).toBeNull();
-  });
-
-  it("keeps the scores on the stored 1-10 scale", () => {
-    const input = toReviewInput(
-      draft({ happyTook: true, workloadScore: 8, learningScore: 6 }),
-    );
-
-    expect(input).toMatchObject({ workloadScore: 8, learningScore: 6 });
   });
 
   it("stores an unanswered approach as absent rather than the midpoint", () => {
-    const input = toReviewInput(
-      draft({ happyTook: true, workloadScore: 5, learningScore: 5 }),
-    );
-
-    expect(input?.approachTheoryPercent).toBeNull();
+    expect(toReviewFormData(answered())?.approachTheoryPercent).toBeNull();
   });
 
-  it("stores a remembered approach as the writer left it", () => {
-    const input = toReviewInput(
-      draft({
-        happyTook: true,
-        workloadScore: 5,
-        learningScore: 5,
-        approachTheoryPercent: 70,
+  // "I don't remember" is a stored `null`, never zeroes, and it has to win over
+  // whatever the cleared control happened to leave behind — a draft restored
+  // from `sessionStorage` is read field by field, so both can be present at once.
+  it("drops answers the writer said they do not remember", () => {
+    const form = toReviewFormData(
+      answered({
+        examinationForgotten: true,
+        methods: ["exam"],
+        shares: [100],
+        approachForgotten: true,
+        approachTheoryPercent: 80,
       }),
     );
 
-    expect(input?.approachTheoryPercent).toBe(70);
+    expect(form?.examinationDistribution).toBeNull();
+    expect(form?.approachTheoryPercent).toBeNull();
+  });
+
+  /*
+   * The data-loss regression.
+   *
+   * `reviews.message` is only ever rendered through `parse(sanitizeHtml(...))`,
+   * and `sanitizeHtml` runs with `stripIgnoreTag` — so a raw plain-text
+   * write-up loses everything tag-shaped on its way to the screen, silently and
+   * after it was stored. The pane's box is a plain `<textarea>`, so escaping on
+   * the way out is the only thing standing between a reviewer and a sentence
+   * with a hole in it.
+   */
+  it("keeps characters a renderer would otherwise eat as markup", () => {
+    const form = toReviewFormData(
+      answered({ message: "use <vector> from STL & <algorithm> too" }),
+    );
+
+    expect(form?.message).toBe(
+      "<p>use &lt;vector&gt; from STL &amp; &lt;algorithm&gt; too</p>",
+    );
+    // And what the review card actually renders: `sanitizeHtml` with
+    // `stripIgnoreTag` is the step that used to delete the useful half of the
+    // sentence, so it is run here rather than described.
+    expect(sanitizeHtml(form?.message ?? "")).toContain("&lt;vector&gt;");
+    expect(sanitizeHtml(form?.message ?? "")).not.toBe(
+      "<p>use  from STL & </p>",
+    );
+  });
+
+  it("leaves a write-up nobody typed empty rather than inventing a paragraph", () => {
+    expect(toReviewFormData(answered({ message: "   " }))?.message).toBe("");
   });
 });

--- a/apps/web/features/workspace/lib/review-draft.ts
+++ b/apps/web/features/workspace/lib/review-draft.ts
@@ -1,150 +1,76 @@
-import type { ExaminationDistribution, ReviewInput } from "@/types";
+import type { ReviewFormData } from "@/features/reviews";
+/*
+ * The one place in this repo that reaches past a feature barrel, and the reason
+ * is weight rather than taste.
+ *
+ * `@/features/reviews` is the reviews feature's cross-feature API and it is
+ * what `review-draft-panel.tsx` imports, correctly — a component may pull in
+ * components. But the barrel exports `Review`, the review dialog, which imports
+ * `RichTextEditor`, which imports a Lexical theme and its stylesheet. Importing
+ * it from here would drag all of that into a module that is arithmetic, and
+ * into the `logic` vitest project, whose whole point is a node environment with
+ * no DOM and no CSS pipeline. `lib/review-draft.ts` is the same pure module on
+ * both sides of this import, so it is named directly.
+ *
+ * The type above still comes through the barrel: types are erased, so they cost
+ * nothing at runtime and the convention is free to hold there.
+ */
 import {
-  EXAMINATION_DISTRIBUTION_KEYS,
-  MAX_REVIEW_SCORE,
-  MIN_REVIEW_SCORE,
-} from "@/types";
+  EMPTY_REVIEW_DRAFT as EMPTY_REVIEW_ANSWERS,
+  isUntouched as noAnswersGiven,
+  type ReviewDraft as ReviewAnswers,
+  toReviewFormData as toAnsweredFormData,
+} from "@/features/reviews/lib/review-draft";
 
 /**
- * A **review draft**: an unpublished review being written in the workspace
- * pane.
+ * What the workspace pane's review draft has that the reviews feature's model
+ * does not, and nothing else.
  *
- * It has no row anywhere. The pane holds it for as long as it is open, keyed
- * by course code so switching tabs does not lose it, and it becomes a Review
- * only when the writer publishes. Nothing in `server/` stores a draft, so the
- * design's "Save draft" has nothing behind it — see the PR for that.
+ * The model itself — the picked methods, the parallel shares, the scores, the
+ * write-up — and every piece of the examination bar's arithmetic live in
+ * `features/reviews/lib/review-draft.ts`. This file used to carry a second copy
+ * of all of it. It no longer does, because there is nothing about the pane that
+ * makes a divider move differently: a review draft is one concept with two
+ * presentations, and the model belongs to the feature that owns reviews rather
+ * than to whichever screen was built first.
  *
- * The shape is the form's, not the wire's: the examination split is a picked
- * order plus parallel shares, which is what a draggable bar needs, and
- * `toReviewInput` is the one place it becomes the contract in `@/types`.
+ * ## What is genuinely the pane's
+ *
+ * Two flags. The pane draws an explicit "I don't remember" checkbox under the
+ * examination bar and under the theory/applied track; the fast-track card, by
+ * its artboard, draws neither and treats a question left alone as that same
+ * answer. So the flags exist here and only here, and everything below is about
+ * them: the progress bar counts a ticked box as a finished section, and
+ * "Not saved yet" has to stop saying that once one is ticked.
+ *
+ * Both spell the same stored value — `null`, never zeroes — which is why they
+ * cannot leak into what is written. `toReviewFormData` folds them away before
+ * the reviews feature's own mapper ever sees the draft.
  */
-
-export type ExaminationKey = (typeof EXAMINATION_DISTRIBUTION_KEYS)[number];
-
-export interface ReviewDraft {
-  /** Examination methods the writer picked, in the order they picked them. */
-  methods: ExaminationKey[];
-  /** Whole percentages, parallel to `methods`, always adding up to 100. */
-  shares: number[];
+export interface ReviewDraft extends ReviewAnswers {
   /** "I don't remember" for the examination split. Stores `null`, not zeroes. */
   examinationForgotten: boolean;
-  /** How theoretical the course was, 0–100. `null` until the writer answers. */
-  approachTheoryPercent: number | null;
   /** "I don't remember" for the theory/applied question. */
   approachForgotten: boolean;
-  workloadScore: number | null;
-  learningScore: number | null;
-  happyTook: boolean | null;
-  message: string;
 }
 
 export const EMPTY_REVIEW_DRAFT: ReviewDraft = {
-  methods: [],
-  shares: [],
+  ...EMPTY_REVIEW_ANSWERS,
   examinationForgotten: false,
-  approachTheoryPercent: null,
   approachForgotten: false,
-  workloadScore: null,
-  learningScore: null,
-  happyTook: null,
-  message: "",
 };
 
-/** The smallest share a segment may be dragged to, in whole percent. */
-export const MIN_SHARE = 5;
-/** Shares move in these steps, so the split stays a round number. */
-const SHARE_STEP = 5;
-
-/** The middle of the theory/applied track, where an untouched drag starts. */
-export const APPROACH_MIDPOINT = 50;
+/** The three sections the progress bar counts. */
+export const REVIEW_DRAFT_SECTIONS = 3;
 
 /**
- * An even split in 5% steps, with the remainder on the last segment.
+ * How many of the form's three sections the writer has finished, 0–3.
  *
- * Six methods do not divide 100 evenly, so something has to absorb the
- * leftover; the design puts it on the last one and this keeps that, because
- * the alternative is shares that do not add up to 100 and a distribution the
- * server rejects.
+ * The pane's own, because a ticked "I don't remember" finishes a section here
+ * and there is no such box on the card. The write-up counts towards the third
+ * section even though publishing does not require it: the bar reports how much
+ * of the form has been filled in, not how much of it is compulsory.
  */
-export function evenShares(count: number): number[] {
-  if (count <= 0) return [];
-  const base = Math.max(
-    MIN_SHARE,
-    Math.round(100 / count / SHARE_STEP) * SHARE_STEP,
-  );
-  const shares = new Array<number>(count).fill(base);
-  shares[count - 1] = 100 - base * (count - 1);
-  return shares;
-}
-
-/** Pick or unpick an examination method, re-splitting the bar evenly. */
-export function toggleMethod(
-  draft: ReviewDraft,
-  method: ExaminationKey,
-): ReviewDraft {
-  const at = draft.methods.indexOf(method);
-  const methods =
-    at >= 0 ? draft.methods.toSpliced(at, 1) : [...draft.methods, method];
-  return { ...draft, methods, shares: evenShares(methods.length) };
-}
-
-/**
- * Move the divider between segment `index` and the one after it to
- * `cumulativePercent` measured from the left edge of the bar.
- *
- * Only that pair moves: everything left of the divider keeps its width, so
- * dragging one boundary never silently reflows the rest. Both sides are held
- * at `MIN_SHARE` so a segment can never be dragged out of existence.
- */
-export function moveDivider(
-  draft: ReviewDraft,
-  index: number,
-  cumulativePercent: number,
-): ReviewDraft {
-  if (index < 0 || index >= draft.shares.length - 1) return draft;
-
-  const before = draft.shares
-    .slice(0, index)
-    .reduce((total, share) => total + share, 0);
-  const pair = draft.shares[index] + draft.shares[index + 1];
-  const stepped =
-    Math.round((cumulativePercent - before) / SHARE_STEP) * SHARE_STEP;
-  const left = Math.max(MIN_SHARE, Math.min(pair - MIN_SHARE, stepped));
-
-  const shares = [...draft.shares];
-  shares[index] = left;
-  shares[index + 1] = pair - left;
-  return { ...draft, shares };
-}
-
-/** Nudge a divider one step, which is how the keyboard drives the bar. */
-export function nudgeDivider(
-  draft: ReviewDraft,
-  index: number,
-  steps: number,
-): ReviewDraft {
-  const before = draft.shares
-    .slice(0, index)
-    .reduce((total, share) => total + share, 0);
-  return moveDivider(
-    draft,
-    index,
-    before + draft.shares[index] + steps * SHARE_STEP,
-  );
-}
-
-/** Where each divider sits, as a running total from the left edge. */
-export function dividerPositions(draft: ReviewDraft): number[] {
-  const cuts: number[] = [];
-  let running = 0;
-  for (let i = 0; i < draft.shares.length - 1; i++) {
-    running += draft.shares[i];
-    cuts.push(running);
-  }
-  return cuts;
-}
-
-/** How many of the form's three sections the writer has finished, 0–3. */
 export function sectionsDone(draft: ReviewDraft): number {
   const format =
     (draft.methods.length > 0 || draft.examinationForgotten) &&
@@ -154,98 +80,45 @@ export function sectionsDone(draft: ReviewDraft): number {
   return [format, profile, take].filter(Boolean).length;
 }
 
-/** The three sections the progress bar counts. */
-export const REVIEW_DRAFT_SECTIONS = 3;
-
 /**
  * Whether the writer has put anything into the draft at all.
  *
- * It is what the header's "Not saved yet" reads off: there is nothing to have
- * kept until a question is answered or a word is typed.
+ * It is what the header's "Not saved yet" reads off. Ticking "I don't remember"
+ * is putting something in — it is the answer to a question — so the shared
+ * check is not enough on its own and the two flags are added to it here.
  */
 export function isUntouched(draft: ReviewDraft): boolean {
   return (
-    sectionsDone(draft) === 0 &&
-    draft.happyTook === null &&
-    draft.workloadScore === null &&
-    draft.learningScore === null &&
-    draft.methods.length === 0 &&
+    noAnswersGiven(draft) &&
     !draft.examinationForgotten &&
-    !draft.approachForgotten &&
-    draft.approachTheoryPercent === null &&
-    draft.message.trim().length === 0
+    !draft.approachForgotten
   );
 }
 
 /**
- * Whether the draft can be published.
+ * The pane's draft as the review form's data, or `null` when it is not
+ * publishable yet.
  *
- * The write-up is the only optional part: `reviewInputSchema` requires the two
- * scores and `happyTook`, and everything else is nullable because "I don't
- * remember" is a real answer.
- */
-export function canPublish(draft: ReviewDraft): boolean {
-  return (
-    draft.happyTook !== null &&
-    draft.workloadScore !== null &&
-    draft.learningScore !== null
-  );
-}
-
-/** Clamp a score onto the stored 1–10 scale. */
-function clampScore(value: number): number {
-  return Math.max(
-    MIN_REVIEW_SCORE,
-    Math.min(MAX_REVIEW_SCORE, Math.round(value)),
-  );
-}
-
-/**
- * The picked shares as the stored distribution: every key present, unpicked
- * methods at 0, the whole thing adding up to 100.
+ * The flags are folded away first, and explicitly rather than by relying on the
+ * checkboxes having cleared the answers they cover. A draft comes back out of
+ * `sessionStorage`, where it may have been written by an older build or by a
+ * tab that never finished a keystroke, and `toDraft` reads each field on its
+ * own — so a stored draft carrying both a ticked box and the methods it was
+ * meant to clear is a shape this has to survive. "I don't remember" wins,
+ * because that is the answer the writer gave last.
  *
- * `null` when the writer said they do not remember, and equally when they
- * picked nothing — an untouched question is not an answer of zeroes.
+ * Past this point the pane is indistinguishable from every other way of writing
+ * a review: `toReviewFormData` escapes the write-up into the markup
+ * `reviews.message` holds, and `useAddReview` validates the result with
+ * `reviewFormSchema` before anything is sent.
  */
-export function toExaminationDistribution(
-  draft: ReviewDraft,
-): ExaminationDistribution | null {
-  if (draft.examinationForgotten || draft.methods.length === 0) return null;
-
-  const distribution = Object.fromEntries(
-    EXAMINATION_DISTRIBUTION_KEYS.map((key) => [key, 0]),
-  ) as ExaminationDistribution;
-  draft.methods.forEach((method, index) => {
-    distribution[method] = draft.shares[index] ?? 0;
-  });
-  return distribution;
-}
-
-/**
- * The draft as the wire contract, or `null` when it is not publishable yet.
- *
- * An unanswered theory/applied question stores `null` rather than the
- * midpoint the track happens to be drawn at: 50 would claim the writer called
- * the course exactly balanced, and `CONTEXT.md` holds that an unanswered
- * recollection is stored absent, never invented.
- */
-export function toReviewInput(draft: ReviewDraft): ReviewInput | null {
-  if (
-    draft.happyTook === null ||
-    draft.workloadScore === null ||
-    draft.learningScore === null
-  ) {
-    return null;
-  }
-
-  return {
-    examinationDistribution: toExaminationDistribution(draft),
+export function toReviewFormData(draft: ReviewDraft): ReviewFormData | null {
+  return toAnsweredFormData({
+    ...draft,
+    methods: draft.examinationForgotten ? [] : draft.methods,
+    shares: draft.examinationForgotten ? [] : draft.shares,
     approachTheoryPercent: draft.approachForgotten
       ? null
       : draft.approachTheoryPercent,
-    workloadScore: clampScore(draft.workloadScore),
-    learningScore: clampScore(draft.learningScore),
-    happyTook: draft.happyTook,
-    message: draft.message,
-  };
+  });
 }


### PR DESCRIPTION
Closes #132.

Wave 2. Cross-consumer reconciliation of every collection control, plus the two
workspace-pane defects wave 1 surfaced but could not fix because
`features/workspace/**` belonged to another agent at the time.

---

## 1. The desktop/mobile parity matrix

There is no separate mobile tree for any collection surface. The course card, the
Collections strip and the collection detail are one component each at every width,
and responsiveness is a **container query** — `@max-[440px]` on the card's own
`@container`, matching `Course Community - Mobile Preview.dc.html`. The only real
breakpoint fork in this area is the workspace pane
(`useWorkspacePresentation`, 768px → column | sheet), and the pane draws no
collection control on either side; `Course Community - Workspace Pane.dc.html`
draws none either.

So every row below reads the same on both sides by construction. What differed was
**invalidation**, and that is the row in bold.

| Control | Surfaces | Desktop | Mobile | Hook → mutation | Invalidates | Auth gate |
|---|---|---|---|---|---|---|
| Picker trigger — `▾` half of the split Save button | Explore (`action="save"`) | yes | yes; label hidden by `@max-[440px]`, `aria-label`/`title` = `addLabel` retained | `useCourseCard.onPicker` → `useCollectionPicker.toggle` | — (opens a panel) | `useMe()`; a visitor gets the artboard's inline sign-up prompt inside the panel |
| Picker trigger — standalone "Add to collection" | Saved, collection detail (`action="add"`) | yes | yes, same container query | same | — | same |
| Collection row toggle (tick on/off) | all three | yes | yes | `useCollectionPicker.rows[].onClick` → `collections.addCourse` / `collections.removeCourse`, preceded by `setSaved(code, true)` when the course is not saved | `collections.list`, plus `user.me` when it had to save first | `protectedProcedure`; the rows only render for `signedIn` |
| "Create new collection" row + inline name field | all three | yes | yes | `onNewCollection` → `startNew` → `onDraftCommit` → `collections.create` then `addCourse` | `collections.list` (both writes) | as above |
| **Save / unsave** | Explore's Save button; Saved's trash; the trash on a card inside a collection | yes | yes | `useSetCourseSaved.setSaved` → `saved.save` / `saved.unsave` | **was `user.me` only — now `user.me` + `collections.list` whenever the queued sequence for that course contained an unsave** | `protectedProcedure`; a visitor is handed to `AuthReasonDialog` with reason `save-course` |
| Remove from *this collection* (card trash inside a detail) | collection detail | yes | yes | `Collections.onRemoveCourse` → `collections.removeCourse` | `collections.list` | protected |
| "New collection" chip | Saved (compact strip) | yes | yes — `flex-wrap`, no width gate | `NewCollectionDialog` → `onCreate` → `create` + one `addCourse` per picked course | `collections.list` per write | `useMe()`; the guest panel replaces the strip |
| "New collection" tile | `/collections` (unlinked route) | yes | yes | same | same | same |
| Chip / tile `⋯` → Rename | Saved strip, `/collections` | yes | yes | `useRenameDraft` → `collections.rename` | `collections.list` | protected |
| Chip / tile `⋯` → Delete | Saved strip, `/collections` | yes | yes | `collections.delete` | `collections.list` | protected |
| Open a collection | chip and tile (whole surface is one stretched button) | yes | yes | `openCollection` → `router.replace(?collection=)` | — | protected |
| Detail: Rename / Add course / Delete | detail header | yes | yes — `flex-wrap items-start` | `rename` / `addCourse` / `delete` | `collections.list` | protected |
| Detail: reorder ▲ ▼ | detail rows | yes | yes | `moveCourse` → `collections.reorder` (optimistic, no rollback — see the hook) | `collections.list` once the last reorder settles | protected |
| Open / review a course from a collection | detail cards | yes | yes | `router.push('/saved?collection=…&open=…&kind=…')` | — | the pane's own gate |

### The one-breakpoint control, and why it stays

`WorkspacePane`'s tab strip and its "All open panes" dropdown are desktop-only:
`MobileWorkspaceSheetHost` passes `hideTabs` and a single entry. **This is
deliberate and the artboard supports it.** `Course Community - Mobile Preview.dc.html`
states it outright — *"Sheets stack — open several, dismiss each with the × or by
dragging it all the way down"* — and every sheet it draws imports the pane with
`hide-tabs`. The open list is unchanged; only the top of the stack is on screen and
dismissing it reveals the one beneath.

What was wrong was the **documentation**: `WorkspacePaneProps.hideTabs` claimed
mobile "puts the switcher in its own chrome", which nothing does. Per CLAUDE.md
("prefer documenting real behavior from code"), the comment now says what actually
happens and cites the artboard note.

---

## 2. Inert controls

**None removed, because none were found.** Every collection control on every
surface reaches a real mutation. Two things worth naming, neither of which is an
inert control today:

- `CourseCard`'s "Write a review" button renders unconditionally while
  `c.onReview` is optional. All three consumers (Explore, Saved, `CollectionDetail`)
  pass one, so it is latent rather than live. Tightening it means changing the
  card's public prop shape, which Explore also consumes — reported rather than done.
- `CourseCardModel.notCreating` is computed by the mapper and read by nothing; it is
  the artboard's `sc-if` complement of `creating`, which JSX does not need. Dead
  data, not a control, and it lives in `types/course-card.ts`, which is not mine.

Wave 1 had already removed the real ones — the artboard's "Save draft" button in the
pane (no draft table behind it) and Explore's pager (`search.courses` ignores `page`).

---

## 3. Terminology

The product-wide shift was already almost complete: identifiers, `addLabel`,
`onNewCollection`, the picker heading and every guest prompt already said
Collection, and `compare courses with AI` survives only in the artboards, never in
`apps/web`. One reader-facing straggler was left:

- `features/collections/components/collections.tsx` headed both variants with the
  artboard's **"Group courses you want to compare."** — now
  **"Group the courses you are considering together."**

Rationale in the file. In short: the artboard's own "New collection" tile reads
"Group specific courses and compare them side by side", and #91 had already dropped
that promise from the tile because there is no side-by-side view; the header was the
same promise in fewer words, so the page headed itself with something its own tile
had stopped saying. Locked in by two new tests asserting `/compar/i` appears nowhere
on the page, in either variant, and nowhere on Saved (which embeds the compact strip)
— the previous Saved test only checked the noun "comparison", which "compare" slipped
past.

---

## 4. Pane defect (a) — a live data-loss bug

`reviews.message` has exactly one renderer: `parse(sanitizeHtml(review.message))`
in `features/reviews/components/review-card.tsx:317`, and `sanitizeHtml` runs with
`stripIgnoreTag`. The pane's review-draft panel wrote a plain `<textarea>` straight
into that column via `toReviewInput`, so anything tag-shaped was deleted **on the
way to the screen** — after it was stored, with nothing to tell the reviewer.
*"use `<vector>` from STL"* arrived as *"use from STL"*.

`publish()` now maps through the reviews feature's own `toReviewFormData`, which
applies `fromPlainText` — the same helper the fast-track card stack uses, not a
second one.

**Evidence.** Two regression tests, both confirmed to fail on the old code path
(verified by temporarily restoring `message: draft.message` and re-running):

- `features/workspace/lib/review-draft.spec.ts` → *"keeps characters a renderer
  would otherwise eat as markup"*. Asserts the exact stored markup for
  `use <vector> from STL & <algorithm> too`, then runs the **real**
  `sanitizeHtml` over it rather than describing what it would do.
- `features/workspace/components/workspace-pane.spec.tsx` → *"keeps a write-up that
  mentions something tag-shaped"*. Drives the panel end to end with `userEvent`,
  asserts what `addReview` was actually handed, and runs the real sanitizer over that.

The existing *"publishes the draft as the wire contract"* test now expects
`<p>Hard but worth it.</p>` — the format change is deliberate and is what the column
holds. `toStoredMessage` still turns an untouched box into `null`, so a scores-only
review is unchanged.

The write path is untouched: `useAddReview` still runs `reviewFormSchema` itself and
sends `checked.data`.

## 5. Pane defect (b) — the duplicated seam

`features/workspace/lib/review-draft.ts` went from 251 lines to 108. Deleted: the
duplicate `ReviewDraft`, `EMPTY_REVIEW_DRAFT`, `MIN_SHARE`, `APPROACH_MIDPOINT`,
`evenShares`, `toggleMethod`, `moveDivider`, `nudgeDivider`, `dividerPositions`,
`toExaminationDistribution`, `canPublish` and `toReviewInput`. Kept, because they
are genuinely the pane's: `examinationForgotten` / `approachForgotten`, and
`sectionsDone` / `REVIEW_DRAFT_SECTIONS` / `isUntouched` / `toReviewFormData`, all
four of which exist only because those flags do. `ReviewDraft` now `extends` the
reviews feature's shape.

**I verified the fast-track agent's analysis rather than trusting it**, and it holds
with three corrections worth recording:

1. The workspace copy's `nudgeDivider` was **missing the bounds guard** the reviews
   copy has. It could not crash — `moveDivider` guards and returns the draft — but it
   read `draft.shares[index]` out of range first. Gone with the duplicate.
2. The workspace copy's `toReviewInput` **did not clamp the approach percent**;
   `toReviewFormData` does, to `APPROACH_MIN`/`APPROACH_MAX`. A draft restored from
   `sessionStorage` with an out-of-range value would have failed `reviewFormSchema`
   and told the reviewer their review "is not finished".
3. The two `isUntouched` implementations were **not** interchangeable: the shared one
   cannot see the flags, so ticking "I don't remember" would have left the header
   saying "Not saved yet". The pane keeps its own, built on the shared one.

`toggleMethod`, `moveDivider` and `nudgeDivider` are now **generic over the draft**
(`<D extends ReviewDraft>`). Each replaces `methods` and/or `shares` and copies
everything else through, so a caller with a wider draft gets its own type back
instead of having its extra fields erased at the type level while surviving at
runtime. There is one `as D` per function, commented, because TypeScript cannot see
that a spread of `D` with two of `D`'s own fields overwritten is still a `D`.

The pane's `toReviewFormData` folds the flags away **explicitly** rather than relying
on the checkboxes having cleared what they cover: `workspace-storage.ts`'s `toDraft`
reads each field independently, so a stored draft carrying both a ticked box and the
methods it was meant to clear is a shape that has to survive. "I don't remember"
wins. Covered by *"drops answers the writer said they do not remember"*.

`features/workspace/lib/review-draft.spec.ts` lost the tests that were verbatim
duplicates of `features/reviews/lib/review-draft.spec.ts` (`evenShares`,
`toggleMethod`, `moveDivider`, `nudgeDivider`, `dividerPositions`) and kept/added
those covering the pane's own delta. Net test count 804 → 797 for that reason;
nothing lost coverage.

---

## 6. Design and schema contradictions

| # | Contradiction | Minimal change |
|---|---|---|
| 1 | `collection_courses_saved_course_fk` cascades on unsave, so the server changes collection membership through a procedure the client thinks is only about saving. No artboard shows this. | Refetch `collections.list` on an unsave. Schema wins; nothing visual changed. |
| 2 | `Collections.dc.html` heads the page "Group courses you want to compare." and its tile promises a side-by-side view. No comparison surface exists (#68 decision 1). | Copy only, same slot, same length. #91 had already made the same edit to the tile. |
| 3 | `Collections.dc.html` guest panel: "…create collections, compare courses with AI, and sync across devices." | Already gone from `apps/web` before this PR (`course-card.tsx`, `collections.tsx`). Verified, no change needed. |
| 4 | `Mobile Preview.dc.html`'s Saved screen draws collection chips and a "+ New" chip as **static divs with no handler**. | Not followed. The real compact strip is fully interactive at every width; a mock's inertness is not a design decision. |
| 5 | `Workspace Pane.dc.html` draws a "Save draft" button; no draft table exists. | Already omitted by wave 1. Confirmed still absent. |
| 6 | The pane's approach slider was bounded by `MIN_SHARE` (the examination bar's smallest *segment*) rather than by `APPROACH_MIN`/`APPROACH_MAX` (what the mapper clamps to). Same number today, different questions. | Bounded by its own constants; `APPROACH_STEP` is now local and named. |

---

## 7. Things needing a file I do not own

- **`types/course-card.ts`** — `CourseCardModel.notCreating` is written by the mapper
  and read by nothing. Removing it touches `types/`, `data/course-card-sample.ts` and
  `features/courses/lib/course-card-model.ts`. Cosmetic; left alone.
- **`features/search/components/explore.tsx`** (the parallel wave-2 agent's) —
  **no change needed**. The card's props and internals are unchanged by this PR, so
  Explore's use of `CourseCardItem` is unaffected. Flagged only because the overlap
  was called out in the brief.
- Nothing in `app/**`, `server/**`, `features/taken/**` or `features/my-page/**` was
  touched or needs to be.

## 8. Follow-ups that want their own issue

1. **`CollectionDetail` pins its cards to `EXPANDED_CARD_GEOMETRY`.** Inside `/saved`
   the detail sits in the column the workspace pane narrows, and Saved's own list
   ramps with `courseCardGeometry(resultsWidth)` while the detail's does not — so the
   same card behaves differently depending on which list it is in, with a pane open.
   The container query still catches it below 440px, so this is chunky rather than
   broken. The fix is threading `geo` through `Collections` → `CollectionDetail`,
   which needs a decision about `/collections`, where there is no pane to yield to.
2. **The reviews barrel drags a Lexical editor.** `@/features/reviews` exports
   `Review`, which imports `RichTextEditor` and its stylesheet, so any pure-logic
   module importing the barrel pulls a CSS pipeline into the node-environment `logic`
   vitest project. `features/workspace/lib/review-draft.ts` therefore names
   `@/features/reviews/lib/review-draft` directly, with the reason in the file — the
   only deep cross-feature import here, and the panel component still goes through
   the barrel as CLAUDE.md asks. `workspace-pane.spec.tsx` already carried a comment
   noting the same problem before this PR. Splitting the reviews barrel is the real
   fix and is out of scope.

---

## Validation

From the repo root, base `origin/feat/frontend` at `c33c3e4`:

```
bun run lint       Checked 396 files. No fixes applied. 8 warnings (all pre-existing)
bun run typecheck  exit 0
bun run test:web   68 files, 797 tests passed   (baseline: 67 files, 804 tests)
```

Run time 28–31s against a 28.7s baseline — no runaway effect. Nothing here adds an
effect; the one invalidation added runs inside a mutation's `finally`, not in a
`useEffect`.

Both new regressions were confirmed to **fail** against the code they protect:

```
# with the collections invalidation removed
x refetches the collections it was silently removed from
x refetches once for a burst of clicks on the same course
x puts the course back and still asks the server who is right

# with publish() sending draft.message raw again
x publishes the draft as the wire contract, absent answers and all
x keeps a write-up that mentions something tag-shaped
```

---

## Round 2 — Greptile P1, and it was right

Greptile came back 4/5 with one finding, reproduced by its own runner, and it
was a real hole in the round-1 fix.

Only the last write for a course cleans up its queue, and the fix asked *that
call* whether it was a save. So a reader who unsaves and re-saves before the
first request answers ends on a save, and the refetch was skipped — on exactly
the flow that needs it most. The cascade already happened when the unsave ran:
the course comes back saved while every collection it was in has lost it.

My own "burst of clicks" test missed it because its last call was an unsave.

The mark is now on the **course**, not on the call — a `Set` of course codes
whose queued sequence has run an unsave. Set before the request, because a
response that never arrives says nothing about whether the row was deleted; read
and cleared in one step by the `Set.delete` in the queue's cleanup, so the next
sequence for that course starts clean.

Two tests added, the first confirmed to fail against the round-1 branch:

```
# with the round-1 `if (!saved)` restored
x still refetches the collections the unsave emptied
```

- *"still refetches the collections the unsave emptied"* — `[unsave, save]`
  concurrently, asserts both mutations ran and `collections.list` was
  invalidated exactly once.
- *"does not keep refetching for every later save of that course"* — the mark
  does not survive its own sequence.

Final: **Greptile 5/5, zero unresolved threads, 2 rounds.** Gates re-run green at
`e6458e1` — 68 files, 799 tests, 29.0s.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017EAUKDDo2BkQTFELyvV3v8
