### PR TITLE
feat(search): morph the landing search bar into Explore's

### DIFF
--- a/apps/web/features/landing/components/hero-network.spec.tsx
+++ b/apps/web/features/landing/components/hero-network.spec.tsx
@@ -228,6 +228,46 @@ describe("HeroNetwork", () => {
     );
   });
 
+  /**
+   * Competing motion is the biggest tell in a shared-element transition, so for
+   * the length of the landing → Explore handoff the only thing that moves is the
+   * layout. The pulse is the only animation this canvas ever runs.
+   */
+  it("stops the pulse while the page is handing itself over to Explore", () => {
+    const frame = vi
+      .spyOn(window, "requestAnimationFrame")
+      .mockReturnValue(1 as unknown as number);
+    const cancel = vi
+      .spyOn(window, "cancelAnimationFrame")
+      .mockImplementation(() => {});
+    try {
+      const { rerender } = render(
+        <HeroNetwork window={WINDOW} labelled={true} />,
+      );
+      expect(frame).toHaveBeenCalled();
+
+      rerender(<HeroNetwork window={WINDOW} labelled={true} paused={true} />);
+
+      expect(cancel).toHaveBeenCalledWith(1);
+    } finally {
+      frame.mockRestore();
+      cancel.mockRestore();
+    }
+  });
+
+  it("never starts a pulse for a label that arrives while it is paused", () => {
+    const frame = vi
+      .spyOn(window, "requestAnimationFrame")
+      .mockReturnValue(1 as unknown as number);
+    try {
+      render(<HeroNetwork window={WINDOW} labelled={true} paused={true} />);
+
+      expect(frame).not.toHaveBeenCalled();
+    } finally {
+      frame.mockRestore();
+    }
+  });
+
   // An empty community is an empty hero. Nothing here may invent a node.
   it("draws nothing at all for an empty community", () => {
     render(

--- a/apps/web/features/landing/components/hero-network.tsx
+++ b/apps/web/features/landing/components/hero-network.tsx
@@ -57,6 +57,8 @@ type Scene = {
   last: number;
   /** Find your dot has succeeded: the viewer's own node gets a label. */
   labelled: boolean;
+  /** The page is handing itself over to Explore; nothing on this canvas moves. */
+  paused: boolean;
   window: GraphWindow | null;
   view: GraphWindowView | null;
   /**
@@ -287,9 +289,22 @@ type Props = {
    * this adds the pulse and the label and nothing else.
    */
   labelled: boolean;
+  /**
+   * The landing is leaving for Explore.
+   *
+   * Competing motion is the biggest tell in a shared-element transition, so for
+   * the length of it the only thing moving is the layout. The pulse is the only
+   * animation this canvas ever runs, and it stops here — the scene keeps its
+   * last painted frame and fades out with the rest of the hero.
+   */
+  paused?: boolean;
 };
 
-export function HeroNetwork({ window: graphWindow, labelled }: Props) {
+export function HeroNetwork({
+  window: graphWindow,
+  labelled,
+  paused = false,
+}: Props) {
   const canvasRef = useRef<HTMLCanvasElement | null>(null);
   const sceneRef = useRef<Scene | null>(null);
 
@@ -313,6 +328,7 @@ export function HeroNetwork({ window: graphWindow, labelled }: Props) {
       pulse: 0,
       last: 0,
       labelled: false,
+      paused: false,
       window: null,
       view: null,
     };
@@ -341,7 +357,7 @@ export function HeroNetwork({ window: graphWindow, labelled }: Props) {
       scene.raf = 0;
     };
     const start = () => {
-      if (scene.raf || !scene.labelled || scene.reduced) return;
+      if (scene.raf || !scene.labelled || scene.reduced || scene.paused) return;
       // A hidden tab has nothing to animate for, and the label appearing while
       // one is hidden must not arm a loop nothing will see.
       if (document.hidden) return;
@@ -457,6 +473,16 @@ export function HeroNetwork({ window: graphWindow, labelled }: Props) {
     refreshView(scene);
     draw(scene);
   }, [graphWindow]);
+
+  useEffect(() => {
+    const scene = sceneRef.current;
+    if (!scene) return;
+    scene.paused = paused;
+    // `start` re-checks every reason not to run, so this is a resume request
+    // rather than an assertion that the pulse should be on.
+    if (paused) scene.stopPulse?.();
+    else scene.startPulse?.();
+  }, [paused]);
 
   useEffect(() => {
     const scene = sceneRef.current;

--- a/apps/web/features/landing/components/landing.spec.tsx
+++ b/apps/web/features/landing/components/landing.spec.tsx
@@ -335,6 +335,18 @@ describe("Landing", () => {
         expect(prefetch).toHaveBeenCalledExactlyOnceWith("/search");
       });
 
+      // A chip is a one-click submit that never touches the field, so focusing
+      // the field is not the only way into a search worth warming.
+      it("prefetches Explore for a chip that is only being reached for", async () => {
+        const user = userEvent.setup();
+        render(<Landing />);
+
+        await user.hover(screen.getByRole("button", { name: "DD2380" }));
+
+        expect(prefetch).toHaveBeenCalledExactlyOnceWith("/search");
+        expect(push).not.toHaveBeenCalled();
+      });
+
       it("navigates plainly, and hands nothing over, under reduced motion", async () => {
         reduceMotion.mockReturnValue(true);
         layOutTheBar();

--- a/apps/web/features/landing/components/landing.spec.tsx
+++ b/apps/web/features/landing/components/landing.spec.tsx
@@ -1,10 +1,12 @@
 import { render, screen, waitFor, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { TRPCClientError } from "@trpc/client";
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { SEARCH_MORPH_KEY } from "@/features/shell/lib/search-morph";
 import { Landing } from "./landing";
 
 const push = vi.fn();
+const prefetch = vi.fn();
 const replace = vi.fn();
 const logout = vi.fn();
 const setTheme = vi.fn();
@@ -16,13 +18,23 @@ const sendMagicLink = vi.fn();
 let search = "";
 
 vi.mock("next/navigation", () => ({
-  useRouter: () => ({ push, replace }),
+  useRouter: () => ({ push, prefetch, replace }),
   usePathname: () => "/",
   useSearchParams: () => new URLSearchParams(search),
 }));
 
 vi.mock("next-themes", () => ({
   useTheme: () => ({ resolvedTheme: "light", setTheme }),
+}));
+
+// The one hook the departure is gated on. Motion reads the media query once, at
+// module scope, so the preference is faked at the hook rather than at
+// `matchMedia` — otherwise it would be fixed by whichever suite loaded first.
+const reduceMotion = vi.fn(() => false);
+
+vi.mock("motion/react", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("motion/react")>()),
+  useReducedMotion: () => reduceMotion(),
 }));
 
 vi.mock("@/lib/auth-client", () => ({
@@ -118,7 +130,47 @@ beforeEach(() => {
   // jsdom has no 2d context. The hero is decoration, so the page must render
   // without one rather than throw.
   HTMLCanvasElement.prototype.getContext = vi.fn(() => null) as never;
+  reduceMotion.mockReturnValue(false);
+  window.sessionStorage.clear();
 });
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+/**
+ * jsdom lays nothing out, so the search bar measures as a zero-sized box and the
+ * page falls back to a plain navigation — which is correct behaviour and exactly
+ * what the departure must not be tested through. This gives the bar the box it
+ * would have in a browser.
+ */
+const LANDING_BAR = { left: 140, top: 400, width: 560, height: 42 };
+
+function layOutTheBar() {
+  vi.spyOn(
+    HTMLFormElement.prototype,
+    "getBoundingClientRect",
+  ).mockImplementation(
+    () =>
+      ({
+        ...LANDING_BAR,
+        x: LANDING_BAR.left,
+        y: LANDING_BAR.top,
+        right: LANDING_BAR.left + LANDING_BAR.width,
+        bottom: LANDING_BAR.top + LANDING_BAR.height,
+        toJSON: () => LANDING_BAR,
+      }) as DOMRect,
+  );
+}
+
+function searchField() {
+  return screen.getByLabelText(/search a course, code or subject/i);
+}
+
+function stashed() {
+  const raw = window.sessionStorage.getItem(SEARCH_MORPH_KEY);
+  return raw === null ? null : JSON.parse(raw);
+}
 
 function openFindYourDot(user: ReturnType<typeof userEvent.setup>) {
   return user.click(screen.getByRole("button", { name: /find your dot/i }));
@@ -197,28 +249,131 @@ describe("Landing", () => {
     it("hands a typed search over to Explore", async () => {
       const user = userEvent.setup();
       render(<Landing />);
-      await user.type(
-        screen.getByLabelText(/search a course, code or subject/i),
-        "graph theory{Enter}",
+      await user.type(searchField(), "graph theory{Enter}");
+      await waitFor(() =>
+        expect(push).toHaveBeenCalledWith("/search?q=graph%20theory"),
       );
-      expect(push).toHaveBeenCalledWith("/search?q=graph%20theory");
     });
 
     it("hands a suggestion over the same way", async () => {
       const user = userEvent.setup();
       render(<Landing />);
       await user.click(screen.getByRole("button", { name: "DD2380" }));
-      expect(push).toHaveBeenCalledWith("/search?q=DD2380");
+      await waitFor(() =>
+        expect(push).toHaveBeenCalledWith("/search?q=DD2380"),
+      );
     });
 
     it("goes nowhere on an empty search", async () => {
       const user = userEvent.setup();
       render(<Landing />);
-      await user.type(
-        screen.getByLabelText(/search a course, code or subject/i),
-        "   {Enter}",
-      );
+      await user.type(searchField(), "   {Enter}");
       expect(push).not.toHaveBeenCalled();
+      expect(stashed()).toBeNull();
+    });
+
+    /**
+     * The departure half of the landing → Explore transition. What the bar does
+     * *after* the navigation belongs to the shell
+     * (`features/shell/components/search-morph.spec.tsx`); what this page owes
+     * it is a rect, measured at the moment of submit, and a navigation that
+     * waits for the page to have cleared out of the bar's way.
+     */
+    describe("leaving for Explore", () => {
+      it("hands Explore the box the bar was standing in", async () => {
+        layOutTheBar();
+        const user = userEvent.setup();
+        render(<Landing />);
+
+        await user.type(searchField(), "graph theory{Enter}");
+
+        expect(stashed()).toMatchObject({ x: 140, y: 400, w: 560, h: 42 });
+        expect(stashed().t).toBeTypeOf("number");
+      });
+
+      it("waits for the exit to finish before it navigates", async () => {
+        layOutTheBar();
+        const user = userEvent.setup();
+        render(<Landing />);
+
+        await user.type(searchField(), "graph theory{Enter}");
+
+        // The artboard fires a blind `setTimeout(130)` here. The push is hung
+        // off the exit animation actually completing instead, so it has not
+        // happened yet — but it does happen, without anything else prompting it.
+        expect(push).not.toHaveBeenCalled();
+        await waitFor(() =>
+          expect(push).toHaveBeenCalledWith("/search?q=graph%20theory"),
+        );
+        expect(push).toHaveBeenCalledTimes(1);
+      });
+
+      it("ignores a second submit while it is already leaving", async () => {
+        layOutTheBar();
+        const user = userEvent.setup();
+        render(<Landing />);
+
+        await user.type(searchField(), "graph theory{Enter}");
+        const first = stashed();
+        await user.click(screen.getByRole("button", { name: "DD2380" }));
+
+        expect(stashed()).toEqual(first);
+        await waitFor(() =>
+          expect(push).toHaveBeenCalledWith("/search?q=graph%20theory"),
+        );
+        expect(push).toHaveBeenCalledTimes(1);
+      });
+
+      it("prefetches Explore once, when the field is focused", async () => {
+        const user = userEvent.setup();
+        render(<Landing />);
+
+        await user.click(searchField());
+        await user.click(document.body);
+        await user.click(searchField());
+
+        expect(prefetch).toHaveBeenCalledExactlyOnceWith("/search");
+      });
+
+      it("navigates plainly, and hands nothing over, under reduced motion", async () => {
+        reduceMotion.mockReturnValue(true);
+        layOutTheBar();
+        const user = userEvent.setup();
+        render(<Landing />);
+
+        await user.type(searchField(), "graph theory{Enter}");
+
+        expect(push).toHaveBeenCalledWith("/search?q=graph%20theory");
+        expect(stashed()).toBeNull();
+      });
+
+      it("clears a rect left over from an earlier submit when it navigates plainly", async () => {
+        window.sessionStorage.setItem(
+          SEARCH_MORPH_KEY,
+          JSON.stringify({ x: 1, y: 2, w: 560, h: 42, t: Date.now() }),
+        );
+        reduceMotion.mockReturnValue(true);
+        layOutTheBar();
+        const user = userEvent.setup();
+        render(<Landing />);
+
+        await user.type(searchField(), "graph theory{Enter}");
+
+        expect(stashed()).toBeNull();
+      });
+
+      it("navigates plainly when the bar has no box to hand over", async () => {
+        // No `layOutTheBar()`: jsdom measures every element as zero, which is
+        // the same shape as a bar that is not on screen. There is no rect worth
+        // continuing, so the page does what it always did.
+        const user = userEvent.setup();
+        render(<Landing />);
+
+        await user.type(searchField(), "graph theory{Enter}");
+
+        expect(push).toHaveBeenCalledWith("/search?q=graph%20theory");
+        expect(stashed()).toBeNull();
+      });
     });
 
     it("opens the sign-in dialog from the header", async () => {

--- a/apps/web/features/landing/components/landing.spec.tsx
+++ b/apps/web/features/landing/components/landing.spec.tsx
@@ -1,4 +1,11 @@
-import { render, screen, waitFor, within } from "@testing-library/react";
+import {
+  act,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+  within,
+} from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { TRPCClientError } from "@trpc/client";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
@@ -170,6 +177,34 @@ function searchField() {
 function stashed() {
   const raw = window.sessionStorage.getItem(SEARCH_MORPH_KEY);
   return raw === null ? null : JSON.parse(raw);
+}
+
+/**
+ * Submit without `userEvent`, so nothing in the test's own machinery is sharing
+ * a timer queue with the departure's deadline.
+ */
+function submit(value = "graph theory") {
+  const field = searchField();
+  fireEvent.change(field, { target: { value } });
+  const form = field.closest("form");
+  if (!form) throw new Error("the search field is not inside a form");
+  fireEvent.submit(form);
+}
+
+/** Put the tab in the background and tell the page about it. */
+function backgroundTab() {
+  Object.defineProperty(document, "hidden", {
+    configurable: true,
+    get: () => true,
+  });
+  fireEvent(document, new Event("visibilitychange"));
+}
+
+function foregroundTab() {
+  Object.defineProperty(document, "hidden", {
+    configurable: true,
+    get: () => false,
+  });
 }
 
 function openFindYourDot(user: ReturnType<typeof userEvent.setup>) {
@@ -372,6 +407,77 @@ describe("Landing", () => {
         await user.type(searchField(), "graph theory{Enter}");
 
         expect(stashed()).toBeNull();
+      });
+
+      /**
+       * The exit animation completing is what normally fires the navigation, and
+       * a blind timer *driving* the departure is the artboard's mistake. These
+       * two are the floor under it: a reader who submits a valid search must
+       * never be left standing on the page they were leaving because a frame
+       * loop stopped running.
+       */
+      it("goes as soon as the tab is hidden, and drops the rect with it", () => {
+        layOutTheBar();
+        render(<Landing />);
+
+        submit();
+        expect(stashed()).not.toBeNull();
+        expect(push).not.toHaveBeenCalled();
+
+        try {
+          backgroundTab();
+
+          expect(push).toHaveBeenCalledExactlyOnceWith(
+            "/search?q=graph%20theory",
+          );
+          // Nobody watched the bar leave, so there is no gesture for Explore to
+          // continue and it must not invent one.
+          expect(stashed()).toBeNull();
+        } finally {
+          foregroundTab();
+        }
+      });
+
+      it("navigates on its own deadline if the exit never reports finishing", () => {
+        // Only the timer queue is faked: the exit runs on `requestAnimationFrame`
+        // and must stay unable to finish inside this test, or it would be the
+        // thing under test that never runs.
+        vi.useFakeTimers({ toFake: ["setTimeout", "clearTimeout"] });
+        try {
+          layOutTheBar();
+          render(<Landing />);
+
+          submit();
+          expect(push).not.toHaveBeenCalled();
+
+          act(() => {
+            vi.advanceTimersByTime(600);
+          });
+
+          expect(push).toHaveBeenCalledExactlyOnceWith(
+            "/search?q=graph%20theory",
+          );
+        } finally {
+          vi.useRealTimers();
+        }
+      });
+
+      it("navigates once, whichever of the three routes out gets there first", async () => {
+        layOutTheBar();
+        render(<Landing />);
+
+        submit();
+        await waitFor(() =>
+          expect(push).toHaveBeenCalledWith("/search?q=graph%20theory"),
+        );
+
+        try {
+          backgroundTab();
+        } finally {
+          foregroundTab();
+        }
+
+        expect(push).toHaveBeenCalledTimes(1);
       });
 
       it("navigates plainly when the bar has no box to hand over", async () => {

--- a/apps/web/features/landing/components/landing.tsx
+++ b/apps/web/features/landing/components/landing.tsx
@@ -71,6 +71,19 @@ const EXIT_EASE: [number, number, number, number] = [0.4, 0, 1, 1];
  * the whole landing layer up by 40px on the way to Explore. Ten pixels reads as
  * the page being drawn after it rather than as a separate movement.
  */
+/**
+ * How long after the exit begins the navigation happens whatever the animation
+ * says.
+ *
+ * The exit itself is 130ms and completing it is still what normally fires the
+ * navigation — a blind timer *driving* the transition is the artboard's mistake,
+ * and this is not that. It is the floor under it: an animation that never
+ * reports finishing must not strand a reader who submitted a valid search on the
+ * page they were leaving. Four and a half times the exit is far enough out that
+ * it never wins a race with a merely janky frame.
+ */
+const EXIT_FALLBACK_MS = 600;
+
 const HERO_EXIT: Variants = {
   "at-rest": { opacity: 1, y: 0 },
   leaving: {
@@ -129,6 +142,12 @@ export function Landing() {
   const [leavingFor, setLeavingFor] = useState<string | null>(null);
   const navigatedRef = useRef(false);
   const prefetchedRef = useRef(false);
+  /** Tears down whatever is still watching for the departure to finish. */
+  const departureRef = useRef<(() => void) | null>(null);
+
+  // The deadline and the visibility listener the departure arms belong to the
+  // page, not to the timer: if it leaves before either fires, they go with it.
+  useEffect(() => () => departureRef.current?.(), []);
 
   // The private link lands here with its outcome in the URL. Read once, then
   // take it back out so a reload does not replay the reveal.
@@ -204,6 +223,40 @@ export function Landing() {
 
     stashSearchBarHandoff(from);
     setLeavingFor(href);
+
+    // Two things finish the departure besides the exit animation, and both exist
+    // because a hidden tab throttles `requestAnimationFrame` to nothing — so
+    // `onAnimationComplete` may simply never arrive. Neither is what normally
+    // drives the navigation, and both go through the same one-time guard.
+    const deadline = window.setTimeout(() => depart(href), EXIT_FALLBACK_MS);
+    const onVisibility = () => {
+      if (!document.hidden) return;
+      // Nobody is watching the departure, so there is no gesture for Explore to
+      // continue: it arrives plainly rather than springing out of a rect the
+      // reader never saw the bar leave.
+      clearSearchBarHandoff();
+      depart(href);
+    };
+    document.addEventListener("visibilitychange", onVisibility);
+    departureRef.current = () => {
+      window.clearTimeout(deadline);
+      document.removeEventListener("visibilitychange", onVisibility);
+    };
+  }
+
+  /**
+   * Leave, once, whichever of the three routes here gets there first.
+   *
+   * The guard is what makes the fallbacks safe to arm at all: the exit
+   * completing, the deadline expiring and the tab going away all call this, and
+   * only the first one does anything.
+   */
+  function depart(href: string) {
+    if (navigatedRef.current) return;
+    navigatedRef.current = true;
+    departureRef.current?.();
+    departureRef.current = null;
+    router.push(href);
   }
 
   /**
@@ -217,9 +270,8 @@ export function Landing() {
    * guard is for.
    */
   function onExitComplete() {
-    if (!leavingFor || navigatedRef.current) return;
-    navigatedRef.current = true;
-    router.push(leavingFor);
+    if (!leavingFor) return;
+    depart(leavingFor);
   }
 
   return (

--- a/apps/web/features/landing/components/landing.tsx
+++ b/apps/web/features/landing/components/landing.tsx
@@ -44,7 +44,7 @@ import { HeroNetwork } from "./hero-network";
  * of the way over 130ms, the hero graph stops so the only thing moving is the
  * layout, and the navigation is fired by that exit *finishing* rather than by a
  * timer guessing when it will have. `Course Community - Landing.dc.html`'s
- * `toExplore()` (line 499) sketches the same departure with a blind
+ * `toExplore()` (line 501) sketches the same departure with a blind
  * `setTimeout(130)`; this is the one place in the app authorised to improve on
  * the artboard, and that timer is most of the reason why.
  */

--- a/apps/web/features/landing/components/landing.tsx
+++ b/apps/web/features/landing/components/landing.tsx
@@ -1,16 +1,21 @@
 "use client";
 
 import { LogOut, Search } from "lucide-react";
+import { motion, useReducedMotion, type Variants } from "motion/react";
 import Link from "next/link";
 import { useRouter, useSearchParams } from "next/navigation";
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import {
   type AuthReason,
   AuthReasonDialog,
   useLogout,
   useSessionData,
 } from "@/features/auth";
-import { ThemeToggle } from "@/features/shell";
+import {
+  clearSearchBarHandoff,
+  stashSearchBarHandoff,
+  ThemeToggle,
+} from "@/features/shell";
 import { isUnplaced, useNeighbourhood, usePublicWindow } from "../api/queries";
 import { FindYourDot, type FindYourDotStatus } from "./find-your-dot";
 import { HeroNetwork } from "./hero-network";
@@ -24,9 +29,56 @@ import { HeroNetwork } from "./hero-network";
  *
  * Responsive is a container query on the page itself, matching the artboards:
  * the layout answers to its rendered box, not to the viewport.
+ *
+ * ## Leaving for Explore
+ *
+ * Submitting the search does not navigate straight away. The bar the reader
+ * typed into is, visually, the same element as Explore's — same height, radius,
+ * border, surface, padding and `max-w-[560px]` — so instead of swapping one page
+ * for another it hands its box over and lets Explore continue it: the bar rises
+ * into its place on Explore while the rail slides in from the left, both on one
+ * spring. `@/features/shell`'s `search-morph` is the seam, and everything about
+ * how the two ends are coupled is written up there.
+ *
+ * This page's half is the departure. Everything that is not the bar clears out
+ * of the way over 130ms, the hero graph stops so the only thing moving is the
+ * layout, and the navigation is fired by that exit *finishing* rather than by a
+ * timer guessing when it will have. `Course Community - Landing.dc.html`'s
+ * `toExplore()` (line 499) sketches the same departure with a blind
+ * `setTimeout(130)`; this is the one place in the app authorised to improve on
+ * the artboard, and that timer is most of the reason why.
  */
 
 const TRY = ["deep learning", "machine learning", "DD2380"];
+
+/** The artboard's own exit easing, `cubic-bezier(.4,0,1,1)` over roughly 130ms. */
+const EXIT_EASE: [number, number, number, number] = [0.4, 0, 1, 1];
+
+/**
+ * Everything that leaves when the search is submitted.
+ *
+ * The set is "the page, except the bar". The bar is the one thing that survives
+ * the navigation, so it is simply the one element with no `variants` — the
+ * orchestrating root propagates the label to every motion child that has them
+ * and the plain `<form>` is untouched.
+ *
+ * That is deliberately *not* the `data-hero-clear` set. Those marks exist for
+ * the hero graph's keep-out, and the form carries one because the graph must not
+ * draw dots behind the search bar — reusing them as the exit selector would fade
+ * out the one element the whole transition is built to keep.
+ *
+ * The drift is up, not out: the bar is about to rise, and the artboard shifts
+ * the whole landing layer up by 40px on the way to Explore. Ten pixels reads as
+ * the page being drawn after it rather than as a separate movement.
+ */
+const HERO_EXIT: Variants = {
+  "at-rest": { opacity: 1, y: 0 },
+  leaving: {
+    opacity: 0,
+    y: -10,
+    transition: { duration: 0.13, ease: EXIT_EASE },
+  },
+};
 
 /**
  * The three supporting blocks under the hero, in the artboard's order.
@@ -63,12 +115,20 @@ export function Landing() {
   const searchParams = useSearchParams();
   const { user, isPending: sessionPending } = useSessionData();
   const logout = useLogout();
+  const reduceMotion = useReducedMotion();
 
   const arrivedFromLink = searchParams.get("dot");
   const [query, setQuery] = useState("");
   const [authReason, setAuthReason] = useState<AuthReason | null>(null);
   const [dotOpen, setDotOpen] = useState(arrivedFromLink !== null);
   const [expired, setExpired] = useState(arrivedFromLink === "expired");
+
+  /** The bar whose box Explore continues. */
+  const barRef = useRef<HTMLFormElement>(null);
+  /** Where this page is going, once the surroundings have finished clearing. */
+  const [leavingFor, setLeavingFor] = useState<string | null>(null);
+  const navigatedRef = useRef(false);
+  const prefetchedRef = useRef(false);
 
   // The private link lands here with its outcome in the URL. Read once, then
   // take it back out so a reload does not replay the reveal.
@@ -101,15 +161,76 @@ export function Landing() {
     error: neighbourhood.error,
   });
 
+  /**
+   * Warm `/search` while the reader is still typing.
+   *
+   * The exit runs for 130ms and then navigates; without the route already in
+   * the client cache, the reader watches the hero clear and then waits on a
+   * fetch, and the bar arrives on Explore late enough that it reads as a new
+   * page rather than the same one continuing. Fired from a focus handler and
+   * fenced by a ref: a prefetch is a request, not a piece of state, and putting
+   * `router` in an effect's dependency array is how two of this repo's earlier
+   * render loops started.
+   */
+  function warmExplore() {
+    if (prefetchedRef.current) return;
+    prefetchedRef.current = true;
+    router.prefetch("/search");
+  }
+
   function submitSearch(value: string) {
     const q = value.trim();
     if (!q) return;
-    router.push(`/search?q=${encodeURIComponent(q)}`);
+    // A second Enter on a page that is already leaving would stash a second
+    // rect and push twice.
+    if (leavingFor) return;
+    const href = `/search?q=${encodeURIComponent(q)}`;
+
+    // Reduced motion is the plain navigation this page has always done, and the
+    // artboard drops the transition here too. So is a bar with no measurable
+    // box: there is nothing to hand over, and a rect Explore would reject is
+    // worse than no rect at all. Either way any rect an earlier submit left
+    // behind goes with it, so Explore can never inherit one.
+    const from = barRef.current?.getBoundingClientRect();
+    if (reduceMotion || !from?.width || !from.height) {
+      clearSearchBarHandoff();
+      router.push(href);
+      return;
+    }
+
+    stashSearchBarHandoff(from);
+    setLeavingFor(href);
+  }
+
+  /**
+   * The exit is over; go.
+   *
+   * Hung off one of the clearing elements rather than off the orchestrating
+   * root: every exit shares `HERO_EXIT`'s single transition, so any one of them
+   * finishing means they all have, and a per-element callback does not depend on
+   * how variant propagation reports completion upwards. It also fires once when
+   * the page settles into `at-rest` on mount, which is what the `leavingFor`
+   * guard is for.
+   */
+  function onExitComplete() {
+    if (!leavingFor || navigatedRef.current) return;
+    navigatedRef.current = true;
+    router.push(leavingFor);
   }
 
   return (
-    <div className="@container cc-theme min-h-dvh bg-cc-pg text-cc-ink text-sm lg:h-dvh lg:overflow-y-auto">
-      <header className="relative z-10 flex h-[66px] items-center justify-between gap-5 border-cc-rule border-b bg-cc-pg px-4 @lg:px-7">
+    // The orchestrator: it animates nothing itself, it only broadcasts which
+    // variant every clearing child should be in. `initial={false}` keeps the
+    // page from playing its own arrival on mount.
+    <motion.div
+      initial={false}
+      animate={leavingFor ? "leaving" : "at-rest"}
+      className="@container cc-theme min-h-dvh bg-cc-pg text-cc-ink text-sm lg:h-dvh lg:overflow-y-auto"
+    >
+      <motion.header
+        variants={HERO_EXIT}
+        className="relative z-10 flex h-[66px] items-center justify-between gap-5 border-cc-rule border-b bg-cc-pg px-4 @lg:px-7"
+      >
         <Link
           href="/"
           className="flex items-center gap-2.5 text-cc-ink no-underline"
@@ -179,13 +300,20 @@ export function Landing() {
             </div>
           )}
         </div>
-      </header>
+      </motion.header>
 
       <section
         data-hero
         className="relative min-h-[480px] @lg:min-h-[600px] overflow-hidden"
       >
-        <div aria-hidden className="pointer-events-none absolute inset-0 z-0">
+        {/* The graph clears with everything else. It is the backdrop the bar is
+            leaving, and a still canvas sitting behind a page that has faded out
+            would be the last thing on screen when the route swaps. */}
+        <motion.div
+          variants={HERO_EXIT}
+          aria-hidden
+          className="pointer-events-none absolute inset-0 z-0"
+        >
           {/*
             Find your dot only labels a node that is already on the canvas. The
             graph does not change when the flow succeeds — the reveal is the
@@ -194,25 +322,33 @@ export function Landing() {
           <HeroNetwork
             window={heroWindow}
             labelled={dotOpen && status === "placed"}
+            paused={leavingFor !== null}
           />
-        </div>
+        </motion.div>
 
         <div className="relative z-[1] flex min-h-[480px] @lg:min-h-[600px] flex-col items-center justify-center px-4 py-14 @lg:px-7">
           <div className="flex w-full max-w-[720px] flex-col items-center text-center">
-            <p
+            <motion.p
+              variants={HERO_EXIT}
               data-hero-clear
               className="m-0 font-semibold text-[11px] text-cc-dim uppercase tracking-[0.09em]"
             >
               Run by students at KTH
-            </p>
-            <h1
+            </motion.p>
+            <motion.h1
+              variants={HERO_EXIT}
+              onAnimationComplete={onExitComplete}
               data-hero-clear
               className="mt-3.5 text-balance font-semibold text-[30px] @lg:text-[44px] leading-[1.08] tracking-[-0.025em]"
             >
               Find the Course You Will Be Happy You Took
-            </h1>
+            </motion.h1>
 
+            {/* The one element that stays. It carries `data-hero-clear` for the
+                graph's keep-out and no `variants` for the exit, which is the
+                whole difference between the two sets. */}
             <form
+              ref={barRef}
               data-hero-clear
               onSubmit={(event) => {
                 event.preventDefault();
@@ -229,13 +365,15 @@ export function Landing() {
               <input
                 value={query}
                 onChange={(event) => setQuery(event.target.value)}
+                onFocus={warmExplore}
                 placeholder="Search a course, code or subject"
                 aria-label="Search a course, code or subject"
                 className="min-w-0 flex-1 border-none bg-transparent text-[14px] text-cc-ink outline-none"
               />
             </form>
 
-            <div
+            <motion.div
+              variants={HERO_EXIT}
               data-hero-clear
               className="mt-4 flex flex-wrap items-center justify-center gap-[7px]"
             >
@@ -250,9 +388,10 @@ export function Landing() {
                   {term}
                 </button>
               ))}
-            </div>
+            </motion.div>
 
-            <p
+            <motion.p
+              variants={HERO_EXIT}
               data-hero-clear
               className="mt-5 flex items-center gap-1.5 text-[12.5px] text-cc-dim"
             >
@@ -267,12 +406,15 @@ export function Landing() {
               >
                 Find your dot.
               </button>
-            </p>
+            </motion.p>
           </div>
         </div>
       </section>
 
-      <section className="border-cc-rule border-t bg-cc-surface px-4 py-[34px] @lg:px-7">
+      <motion.section
+        variants={HERO_EXIT}
+        className="border-cc-rule border-t bg-cc-surface px-4 py-[34px] @lg:px-7"
+      >
         <div className="mx-auto flex max-w-[960px] flex-col gap-[22px] @lg:grid @lg:grid-cols-3">
           {SECTIONS.map((section) => (
             <div key={section.kicker}>
@@ -288,10 +430,13 @@ export function Landing() {
             </div>
           ))}
         </div>
-      </section>
+      </motion.section>
 
       {!sessionPending && !signedIn ? (
-        <section className="px-5 pt-5 pb-9 @lg:hidden">
+        <motion.section
+          variants={HERO_EXIT}
+          className="px-5 pt-5 pb-9 @lg:hidden"
+        >
           <div className="rounded-[11px] border border-cc-rule2 bg-cc-surface p-5">
             <p className="m-0 font-semibold text-[11px] text-cc-brand uppercase tracking-[0.06em]">
               Join
@@ -317,7 +462,7 @@ export function Landing() {
               Log in
             </button>
           </div>
-        </section>
+        </motion.section>
       ) : null}
 
       <FindYourDot
@@ -341,7 +486,7 @@ export function Landing() {
         onReasonChange={setAuthReason}
         onClose={() => setAuthReason(null)}
       />
-    </div>
+    </motion.div>
   );
 }
 

--- a/apps/web/features/landing/components/landing.tsx
+++ b/apps/web/features/landing/components/landing.tsx
@@ -167,8 +167,12 @@ export function Landing() {
    * The exit runs for 130ms and then navigates; without the route already in
    * the client cache, the reader watches the hero clear and then waits on a
    * fetch, and the bar arrives on Explore late enough that it reads as a new
-   * page rather than the same one continuing. Fired from a focus handler and
-   * fenced by a ref: a prefetch is a request, not a piece of state, and putting
+   * page rather than the same one continuing.
+   *
+   * Both ways into a search warm it: focusing the field, and reaching for a
+   * "Try" chip — a chip is a one-click submit that never touches the field, so
+   * focus alone would leave that path cold. Fired from event handlers and fenced
+   * by a ref: a prefetch is a request, not a piece of state, and putting
    * `router` in an effect's dependency array is how two of this repo's earlier
    * render loops started.
    */
@@ -382,6 +386,8 @@ export function Landing() {
                 <button
                   key={term}
                   type="button"
+                  onPointerEnter={warmExplore}
+                  onFocus={warmExplore}
                   onClick={() => submitSearch(term)}
                   className="flex h-7 items-center rounded-[14px] border border-cc-rule2 bg-cc-surface px-[11px] text-[12.5px] text-cc-chip-ink hover:border-cc-hov"
                 >

--- a/apps/web/features/search/components/explore.spec.tsx
+++ b/apps/web/features/search/components/explore.spec.tsx
@@ -8,6 +8,10 @@ import {
 } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  SEARCH_MORPH_KEY,
+  stashSearchBarHandoff,
+} from "@/features/shell/lib/search-morph";
 import type { CourseSummary } from "@/types";
 import { Explore } from "./explore";
 
@@ -625,6 +629,51 @@ describe("Explore", () => {
       ).toBeVisible();
       await userEvent.click(screen.getByRole("button", { name: "Try again" }));
       expect(refetch).toHaveBeenCalled();
+    });
+  });
+
+  /**
+   * The receiving end of the landing → Explore transition. Every rule about
+   * *when* the bar continues — consumed once, never stale, dropped under reduced
+   * motion — belongs to the seam that owns it, in
+   * `features/shell/components/search-morph.spec.tsx`. What is Explore's own is
+   * that its search bar is the element the handoff lands on at all.
+   */
+  describe("continuing the landing page's search bar", () => {
+    const LANDING_BAR = { left: 140, top: 400, width: 560, height: 42 };
+    const RESTING = { left: 320, top: 20, width: 560, height: 42 };
+
+    function bar() {
+      return screen.getByLabelText("Search courses").closest("form");
+    }
+
+    it("animates its own bar out of the box the landing left it in", () => {
+      const measure = vi
+        .spyOn(HTMLFormElement.prototype, "getBoundingClientRect")
+        .mockReturnValue({
+          ...RESTING,
+          x: RESTING.left,
+          y: RESTING.top,
+          right: RESTING.left + RESTING.width,
+          bottom: RESTING.top + RESTING.height,
+          toJSON: () => RESTING,
+        } as DOMRect);
+      try {
+        stashSearchBarHandoff(LANDING_BAR);
+
+        render(<Explore />);
+
+        expect(bar()?.style.transform).toBe("translate3d(-180px, 380px, 0)");
+        expect(window.sessionStorage.getItem(SEARCH_MORPH_KEY)).toBeNull();
+      } finally {
+        measure.mockRestore();
+      }
+    });
+
+    it("renders with no animation when it was reached any other way", () => {
+      render(<Explore />);
+
+      expect(bar()?.style.transform).toBe("");
     });
   });
 });

--- a/apps/web/features/search/components/explore.tsx
+++ b/apps/web/features/search/components/explore.tsx
@@ -5,7 +5,7 @@ import type { ReactNode } from "react";
 import { useRef } from "react";
 import { AuthReasonDialog } from "@/features/auth";
 import { CourseCardItem, courseCardGeometry } from "@/features/courses";
-import { PageColumn, PageHeader } from "@/features/shell";
+import { PageColumn, PageHeader, useSearchBarArrival } from "@/features/shell";
 import {
   MobileWorkspaceSheetHost,
   useResultsWidth,
@@ -57,17 +57,16 @@ import {
  *   `max-w-[560px]` box that is already narrower than the results column at
  *   every width the pane can open at, so the correction has nothing to correct.
  * - The artboard's **shared-element handoff from the landing hero** (its
- *   `pickUpSharedBar()`, line 855) is not built here, deliberately. It works by
- *   the landing page stashing its search bar's rect in `sessionStorage` and
- *   Explore translating its own bar out of it, fading the surroundings in and
- *   sliding the rail in on the same curve so the two read as one gesture. Both
- *   halves would have to be written: `features/landing/` stores nothing today,
- *   and the rail and topbar belong to `AppShell`, so Explore would be animating
- *   chrome it does not own. That is a lot of coupling across three merged
- *   features for 280ms that the artboard itself already drops under
- *   `prefers-reduced-motion` — and the receiving bar is the same element either
- *   way, so it can be added later without reshaping anything here. It is
- *   scheduled as its own task, owning all three sides of the seam at once.
+ *   `pickUpSharedBar()`, line 855) *is* built, and is the one place in the app
+ *   authorised to improve on the artboard rather than match it.
+ *   `useSearchBarArrival` below is the receiving end: when this mount is
+ *   continuing a search the reader submitted on `/`, the bar animates out of the
+ *   box it occupied there while the shell's rail slides in from the left on the
+ *   same spring, and the regions marked `data-cc-fade` — everything here that
+ *   was not on the landing — come up behind it. Arriving any other way (a shared
+ *   link, a bookmark, the rail) is not continuing a gesture, and gets no
+ *   animation at all. `@/features/shell`'s `search-morph` owns the seam, because
+ *   the rail is the shell's and only the shell can hand it over.
  */
 export function Explore() {
   const workspace = useWorkspacePane();
@@ -79,6 +78,10 @@ export function Explore() {
   const rowRef = useRef<HTMLDivElement>(null);
   const [resultsRef, resultsWidth] = useResultsWidth();
   const geo = courseCardGeometry(resultsWidth);
+  // The bar the landing hands over, and the subtree the arrival looks in for the
+  // surroundings that fade up behind it.
+  const barRef = useRef<HTMLFormElement>(null);
+  useSearchBarArrival(barRef, containerRef);
 
   const { results, hasQuery, isLoading, isError } = explore;
   const showEmpty = hasQuery && !isLoading && !isError && results.length === 0;
@@ -89,13 +92,21 @@ export function Explore() {
       contentClassName="h-full min-h-0 pb-0"
       containerRef={containerRef}
     >
-      <PageHeader
-        title="Explore courses"
-        subtitle="Search the KTH catalogue and see what students said about a course before you pick it."
-      />
+      {/* Wrapped only to be marked: `PageHeader` is one block used by every
+          page and takes no styling of its own. */}
+      <div data-cc-fade>
+        <PageHeader
+          title="Explore courses"
+          subtitle="Search the KTH catalogue and see what students said about a course before you pick it."
+        />
+      </div>
 
       <search className="flex shrink-0 flex-col items-center gap-2.5 px-6 pt-[18px] pb-3.5">
-        <form onSubmit={explore.onSubmit} className="w-full max-w-[560px]">
+        <form
+          ref={barRef}
+          onSubmit={explore.onSubmit}
+          className="w-full max-w-[560px]"
+        >
           <div className="flex h-[42px] items-center gap-2.5 rounded-[10px] border border-cc-rule3 bg-cc-surface px-3.5">
             <SearchIcon
               size={16}
@@ -119,7 +130,11 @@ export function Explore() {
         <Filters explore={explore} />
       </search>
 
-      <div ref={rowRef} className="flex min-h-0 flex-1 gap-[18px] px-5 pb-5">
+      <div
+        ref={rowRef}
+        data-cc-fade
+        className="flex min-h-0 flex-1 gap-[18px] px-5 pb-5"
+      >
         <div
           ref={resultsRef}
           data-testid="explore-results"
@@ -392,7 +407,12 @@ const SELECT_CLASS =
  */
 function Filters({ explore }: { explore: ReturnType<typeof useExplore> }) {
   return (
-    <div className="flex flex-wrap items-center justify-center gap-2">
+    // `data-cc-fade`: the filter row was not on the landing page, so it comes up
+    // behind the arriving search bar rather than being there before it lands.
+    <div
+      data-cc-fade
+      className="flex flex-wrap items-center justify-center gap-2"
+    >
       <select
         aria-label="School"
         value={explore.department}

--- a/apps/web/features/shell/components/app-shell.tsx
+++ b/apps/web/features/shell/components/app-shell.tsx
@@ -3,10 +3,11 @@
 import { Menu } from "lucide-react";
 import { usePathname } from "next/navigation";
 import type { ReactNode } from "react";
-import { useState } from "react";
+import { useRef, useState } from "react";
 import { Sheet, SheetContent, SheetTitle } from "@/components/ui/sheet";
 import { type AuthReason, AuthReasonDialog } from "@/features/auth";
 import { Rail } from "@/features/shell/components/rail";
+import { SearchMorphProvider } from "@/features/shell/components/search-morph";
 import { ThemeToggle } from "@/features/shell/components/theme-toggle";
 import { pageTitleFor } from "@/features/shell/lib/page-title";
 
@@ -26,15 +27,29 @@ import { pageTitleFor } from "@/features/shell/lib/page-title";
  * `cc-theme` sits on the root because the frame now wraps every route: it is
  * the opted-in subtree that utility was written for, and it is what makes a
  * theme flip cross-fade rather than snap, exactly as `cc-theme.css` does.
+ *
+ * The frame also publishes its rail to the route rendering inside it, through
+ * `SearchMorphProvider`. A search arriving from the landing page brings the rail
+ * in from the left on the same spring that carries the search bar up, and the
+ * bar belongs to Explore while the rail belongs here — so the shell hands the
+ * rail over rather than leaving a page to go querying for chrome it does not
+ * own. See `search-morph.tsx`.
  */
 export function AppShell({ children }: { children: ReactNode }) {
   const pathname = usePathname() ?? "";
   const [drawerOpen, setDrawerOpen] = useState(false);
   const [authReason, setAuthReason] = useState<AuthReason | null>(null);
+  const railRef = useRef<HTMLElement | null>(null);
 
   return (
     <div className="@container/shell cc-theme flex h-dvh w-full overflow-hidden bg-cc-pg text-cc-ink text-sm">
-      <aside className="hidden w-[236px] shrink-0 @3xl/shell:block">
+      {/* The rail is rendered before the content column, which is also the
+          order React attaches their refs in: by the time a route's own layout
+          effect runs, `railRef` is bound. */}
+      <aside
+        ref={railRef}
+        className="hidden w-[236px] shrink-0 @3xl/shell:block"
+      >
         <Rail onRequestAuth={setAuthReason} />
       </aside>
 
@@ -79,7 +94,9 @@ export function AppShell({ children }: { children: ReactNode }) {
               : "min-h-0 flex-1 overflow-y-auto overflow-x-hidden"
           }
         >
-          {children}
+          <SearchMorphProvider railRef={railRef}>
+            {children}
+          </SearchMorphProvider>
         </main>
       </div>
 

--- a/apps/web/features/shell/components/search-morph.spec.tsx
+++ b/apps/web/features/shell/components/search-morph.spec.tsx
@@ -1,6 +1,6 @@
 import { render, screen } from "@testing-library/react";
 import type { ReactNode } from "react";
-import { useRef } from "react";
+import { StrictMode, useRef } from "react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
   SEARCH_MORPH_KEY,
@@ -161,6 +161,26 @@ describe("useSearchBarArrival", () => {
 
       expect(bar().style.transform).toBe("");
       expect(rail().style.transform).toBe("");
+    });
+
+    /**
+     * React replays every effect on mount under Strict Mode — run, clean up,
+     * run — and Next turns it on in development. Guarding the destructive read
+     * and the animation with one flag would let the first pass consume the rect
+     * and start the spring, let the cleanup stop it, and then refuse to start it
+     * again: no arrival at all, in the one build a developer looks at.
+     */
+    it("still animates when React replays the effect under Strict Mode", () => {
+      render(
+        <StrictMode>
+          <Shell>
+            <ArrivingPage />
+          </Shell>
+        </StrictMode>,
+      );
+
+      expect(bar().style.transform).toBe("translate3d(-180px, 380px, 0)");
+      expect(rail().style.transform).toBe("translate3d(-236px, 0, 0)");
     });
 
     it("moves the bar even where the shell has published no rail", () => {

--- a/apps/web/features/shell/components/search-morph.spec.tsx
+++ b/apps/web/features/shell/components/search-morph.spec.tsx
@@ -1,0 +1,252 @@
+import { render, screen } from "@testing-library/react";
+import type { ReactNode } from "react";
+import { useRef } from "react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  SEARCH_MORPH_KEY,
+  SEARCH_MORPH_MAX_AGE_MS,
+  stashSearchBarHandoff,
+} from "../lib/search-morph";
+import { SearchMorphProvider, useSearchBarArrival } from "./search-morph";
+
+/**
+ * What is worth asserting here is the *invert* step, not the animation.
+ *
+ * FLIP's correctness is entirely in the offset written before the browser
+ * paints: the bar starts where the landing left it, the rail starts a full rail
+ * width to the left, and the surroundings start invisible. Whether a spring then
+ * takes 340ms or 360ms to bring all three home is a taste question no test
+ * should own — but *whether the offset is applied at all* is the difference
+ * between continuing a gesture and inventing one, and every rule about that is
+ * checked below.
+ */
+
+const reduceMotion = vi.fn(() => false);
+
+vi.mock("motion/react", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("motion/react")>()),
+  useReducedMotion: () => reduceMotion(),
+}));
+
+/** Where the bar and the rail come to rest on Explore, in jsdom's flat world. */
+const RESTING: Record<string, DOMRect> = {
+  bar: rect({ left: 320, top: 20, width: 560, height: 42 }),
+  rail: rect({ left: 0, top: 0, width: 236, height: 800 }),
+};
+
+/** Where the landing's bar was standing: centred in the viewport, far lower. */
+const LANDING_BAR = { left: 140, top: 400, width: 560, height: 42 };
+
+function rect(box: {
+  left: number;
+  top: number;
+  width: number;
+  height: number;
+}): DOMRect {
+  return {
+    ...box,
+    x: box.left,
+    y: box.top,
+    right: box.left + box.width,
+    bottom: box.top + box.height,
+    toJSON: () => box,
+  } as DOMRect;
+}
+
+/**
+ * jsdom lays nothing out, so every rect is zero and the hook would refuse to
+ * animate an unmeasurable bar. The elements under test are given the boxes they
+ * would have in a browser, keyed off their test ids.
+ */
+function layOut() {
+  vi.spyOn(Element.prototype, "getBoundingClientRect").mockImplementation(
+    function boundingRect(this: Element) {
+      const id = this.getAttribute("data-testid") ?? "";
+      return RESTING[id] ?? rect({ left: 0, top: 0, width: 0, height: 0 });
+    },
+  );
+}
+
+/** A page that receives the handoff, standing in for Explore. */
+function ArrivingPage() {
+  const barRef = useRef<HTMLFormElement>(null);
+  const rootRef = useRef<HTMLDivElement>(null);
+  useSearchBarArrival(barRef, rootRef);
+
+  return (
+    <div ref={rootRef}>
+      <form ref={barRef} data-testid="bar" />
+      <div data-cc-fade data-testid="surroundings" />
+    </div>
+  );
+}
+
+/** The shell around it, publishing its rail exactly as `AppShell` does. */
+function Shell({ children }: { children: ReactNode }) {
+  const railRef = useRef<HTMLElement | null>(null);
+  return (
+    <SearchMorphProvider railRef={railRef}>
+      <aside ref={railRef} data-testid="rail" />
+      {children}
+    </SearchMorphProvider>
+  );
+}
+
+const bar = () => screen.getByTestId("bar");
+const rail = () => screen.getByTestId("rail");
+const surroundings = () => screen.getByTestId("surroundings");
+
+beforeEach(() => {
+  window.sessionStorage.clear();
+  reduceMotion.mockReturnValue(false);
+  layOut();
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("useSearchBarArrival", () => {
+  describe("continuing a search submitted on the landing page", () => {
+    beforeEach(() => {
+      stashSearchBarHandoff(LANDING_BAR);
+    });
+
+    it("starts the bar in the box the landing left it in", () => {
+      render(
+        <Shell>
+          <ArrivingPage />
+        </Shell>,
+      );
+
+      // 140 - 320 to the left, 400 - 20 down: the bar has to travel up and to
+      // the right, which is what makes this a rise rather than a fade.
+      expect(bar().style.transform).toBe("translate3d(-180px, 380px, 0)");
+    });
+
+    it("starts the rail a full rail width off the left edge", () => {
+      render(
+        <Shell>
+          <ArrivingPage />
+        </Shell>,
+      );
+
+      expect(rail().style.transform).toBe("translate3d(-236px, 0, 0)");
+    });
+
+    it("starts the surroundings invisible, to come up behind the bar", () => {
+      render(
+        <Shell>
+          <ArrivingPage />
+        </Shell>,
+      );
+
+      expect(surroundings().style.opacity).toBe("0");
+    });
+
+    it("consumes the handoff, so a reload of Explore replays nothing", () => {
+      const { unmount } = render(
+        <Shell>
+          <ArrivingPage />
+        </Shell>,
+      );
+      expect(window.sessionStorage.getItem(SEARCH_MORPH_KEY)).toBeNull();
+      unmount();
+
+      render(
+        <Shell>
+          <ArrivingPage />
+        </Shell>,
+      );
+
+      expect(bar().style.transform).toBe("");
+      expect(rail().style.transform).toBe("");
+    });
+
+    it("moves the bar even where the shell has published no rail", () => {
+      render(<ArrivingPage />);
+
+      expect(bar().style.transform).toBe("translate3d(-180px, 380px, 0)");
+    });
+
+    it("leaves the rail alone when the frame is too narrow to show one", () => {
+      // `hidden @3xl/shell:block` keeps the rail in the DOM at zero width, which
+      // is what it measures as here when it is given no resting box.
+      delete RESTING.rail;
+      try {
+        render(
+          <Shell>
+            <ArrivingPage />
+          </Shell>,
+        );
+
+        expect(bar().style.transform).toBe("translate3d(-180px, 380px, 0)");
+        expect(rail().style.transform).toBe("");
+      } finally {
+        RESTING.rail = rect({ left: 0, top: 0, width: 236, height: 800 });
+      }
+    });
+  });
+
+  describe("arriving any other way", () => {
+    it("animates nothing when there is no handoff at all", () => {
+      render(
+        <Shell>
+          <ArrivingPage />
+        </Shell>,
+      );
+
+      expect(bar().style.transform).toBe("");
+      expect(rail().style.transform).toBe("");
+      expect(surroundings().style.opacity).toBe("");
+    });
+
+    it("animates nothing from a rect that has gone stale", () => {
+      stashSearchBarHandoff(
+        LANDING_BAR,
+        Date.now() - SEARCH_MORPH_MAX_AGE_MS - 1,
+      );
+
+      render(
+        <Shell>
+          <ArrivingPage />
+        </Shell>,
+      );
+
+      expect(bar().style.transform).toBe("");
+      expect(window.sessionStorage.getItem(SEARCH_MORPH_KEY)).toBeNull();
+    });
+
+    it("animates nothing when the bar landed where it already stood", () => {
+      stashSearchBarHandoff({ ...RESTING.bar });
+
+      render(
+        <Shell>
+          <ArrivingPage />
+        </Shell>,
+      );
+
+      expect(bar().style.transform).toBe("");
+    });
+  });
+
+  describe("under prefers-reduced-motion", () => {
+    it("animates nothing, and still consumes the handoff", () => {
+      reduceMotion.mockReturnValue(true);
+      stashSearchBarHandoff(LANDING_BAR);
+
+      render(
+        <Shell>
+          <ArrivingPage />
+        </Shell>,
+      );
+
+      expect(bar().style.transform).toBe("");
+      expect(rail().style.transform).toBe("");
+      expect(surroundings().style.opacity).toBe("");
+      // Consumed rather than left behind: a reader who turns reduced motion off
+      // and reloads must not inherit the rect this navigation did not use.
+      expect(window.sessionStorage.getItem(SEARCH_MORPH_KEY)).toBeNull();
+    });
+  });
+});

--- a/apps/web/features/shell/components/search-morph.tsx
+++ b/apps/web/features/shell/components/search-morph.tsx
@@ -1,0 +1,240 @@
+"use client";
+
+import { animate, useMotionValue, useReducedMotion } from "motion/react";
+import type { ReactNode, RefObject } from "react";
+import {
+  createContext,
+  useContext,
+  useLayoutEffect,
+  useMemo,
+  useRef,
+} from "react";
+import { takeSearchBarHandoff } from "@/features/shell/lib/search-morph";
+
+/**
+ * The receiving half of the landing → Explore transition: the search bar
+ * arriving, and the rail arriving with it.
+ *
+ * ## Why the shell owns this
+ *
+ * The gesture spans three features. The landing measures the bar, Explore
+ * renders the bar it turns into, and the rail — the other half of the movement —
+ * belongs to `AppShell`. Explore cannot reach into the shell's chrome and the
+ * shell cannot know where Explore's bar came to rest, so the shell publishes the
+ * one thing Explore is missing (the rail element) and Explore hands back the one
+ * thing the shell is missing (its own bar), and the animation is written once,
+ * here, over both.
+ *
+ * ## One spring, two elements
+ *
+ * `arrival` runs 0 → 1 on a single spring and *both* offsets are read off it. It
+ * is not two animations that happen to share a config and start in the same
+ * frame; it is one number, and the bar's remaining travel and the rail's
+ * remaining travel are two views of it.
+ *
+ * That matters because the two motions are causally related rather than merely
+ * simultaneous. The bar centres in the viewport on the landing and in the space
+ * *beside* the rail on Explore, so its resting centre sits about half a rail
+ * width further right: the horizontal half of the bar's travel is the rail's
+ * arrival, measured. Driving them from one value is how that reads as a single
+ * gesture instead of two things starting at once — and the horizontal component
+ * is never assumed, because `dx` is the difference between two rects that were
+ * actually measured.
+ *
+ * ## Why the offsets are written to the node
+ *
+ * `useLayoutEffect` runs after React has committed the DOM and before the
+ * browser paints, so the "invert" step of FLIP is set straight on the element
+ * there. Going through a motion value or through React state instead would put
+ * the first offset on Motion's own frame loop, one `requestAnimationFrame`
+ * later — which is a full frame of the bar standing at its destination before it
+ * jumps back to travel. That single frame is the thing that makes a handoff look
+ * synthetic, and it is exactly what the artboard's blind `setTimeout` never
+ * quite avoids.
+ *
+ * Everything else — the actual travel — is Motion's.
+ */
+
+/**
+ * The travel.
+ *
+ * ζ = 30 / (2·√300) ≈ 0.87, so the overshoot is about 0.4%: on a ~350px rise
+ * that is a pixel and a half, which reads as a settle rather than a bounce. The
+ * bar is a piece of page furniture arriving where it belongs, not a toy — a
+ * springier ratio (ζ ≈ 0.75 would overshoot by ~10px here) makes the top of the
+ * page look loose.
+ *
+ * ω = √300 ≈ 17.3 rad/s puts the 0.5% settling time at 5.3/(ζω) ≈ 355ms. Long
+ * enough to be legible as a movement, short enough that the reader is not
+ * waiting for their results.
+ *
+ * The rest thresholds are set rather than left to Motion, because Motion picks
+ * them from the size of the value it is animating: a 0 → 1 progress is under its
+ * granular cutoff, so it would stop at `restDelta` 0.005 — which is 0.005 of the
+ * travel, close to two pixels on that rise, and `onComplete` would then snap the
+ * remainder. Scaling both down by the same order the value is puts the stopping
+ * point back under a third of a pixel, where it belongs.
+ */
+export const SEARCH_MORPH_SPRING = {
+  type: "spring",
+  stiffness: 300,
+  damping: 30,
+  mass: 1,
+  restDelta: 0.001,
+  restSpeed: 0.01,
+} as const;
+
+/**
+ * How far into the arrival the surroundings have finished fading in.
+ *
+ * The bar and the rail are the only things that *move*; everything else on
+ * Explore was not on the landing at all and simply appears. Appearing all at
+ * once, at full strength, under a bar that is still travelling is the same
+ * competing-motion problem as leaving the hero graph running — so the page
+ * behind the bar comes up over the first part of the travel and is settled well
+ * before the bar is, which puts the reader's eye on the bar rather than on the
+ * page arriving.
+ */
+const SURROUNDINGS_IN = 0.55;
+
+/** Everything Explore marks as arriving behind the bar. The artboard's own attribute. */
+const FADE_SELECTOR = "[data-cc-fade]";
+
+type SearchMorphFrame = {
+  /**
+   * The shell's rail. Non-null whenever the shell is mounted — the element is
+   * in the DOM at every width — so whether it *shows* is a question for its
+   * measured width, not for this ref.
+   */
+  railRef: RefObject<HTMLElement | null>;
+};
+
+const SearchMorphContext = createContext<SearchMorphFrame | null>(null);
+
+/**
+ * Publishes the shell's rail to whichever route is animating in.
+ *
+ * Rendered by `AppShell` around its own children, so a page reaches the rail
+ * through a context the shell chose to expose rather than by querying for
+ * chrome it does not own.
+ */
+export function SearchMorphProvider({
+  railRef,
+  children,
+}: {
+  railRef: RefObject<HTMLElement | null>;
+  children: ReactNode;
+}) {
+  const frame = useMemo(() => ({ railRef }), [railRef]);
+  return (
+    <SearchMorphContext.Provider value={frame}>
+      {children}
+    </SearchMorphContext.Provider>
+  );
+}
+
+/**
+ * Continue the landing's search bar, if that is what this mount is.
+ *
+ * Does nothing at all — no measurement, no style, no frame of work — when there
+ * is no handoff to continue. Arriving at `/search` from a shared link, a
+ * bookmark or the rail is not a gesture anybody made, so it gets no animation.
+ *
+ * @param barRef the page's own search bar, the element the landing's rect
+ *   corresponds to.
+ * @param fadeRootRef the subtree to look inside for `[data-cc-fade]`: the
+ *   regions that were not on the landing and should come up behind the bar.
+ */
+export function useSearchBarArrival(
+  barRef: RefObject<HTMLElement | null>,
+  fadeRootRef?: RefObject<HTMLElement | null>,
+): void {
+  const frame = useContext(SearchMorphContext);
+  const railRef = frame?.railRef;
+  const reduceMotion = useReducedMotion();
+  const arrival = useMotionValue(1);
+  const spent = useRef(false);
+
+  useLayoutEffect(() => {
+    // One mount, one handoff. The guard is a ref rather than an empty
+    // dependency array because this effect both reads storage destructively and
+    // starts an animation: re-running it would replay a gesture the reader has
+    // already finished, and a dependency array only promises not to re-run when
+    // every identity it lists happens to hold still.
+    if (spent.current) return;
+    spent.current = true;
+
+    // Read first, decide second. The handoff is consumed even when it is not
+    // used — under reduced motion, or with no bar to move — so a rect can never
+    // outlive the navigation that produced it.
+    const handoff = takeSearchBarHandoff();
+    if (!handoff || reduceMotion) return;
+
+    const bar = barRef.current;
+    if (!bar) return;
+    const to = bar.getBoundingClientRect();
+    if (!to.width || !to.height) return;
+
+    const dx = handoff.x - to.left;
+    const dy = handoff.y - to.top;
+    // The bar arrived where it was already standing. There is nothing to draw,
+    // and a spring over nothing is a few frames of work for an unchanging
+    // picture.
+    if (Math.abs(dx) < 1 && Math.abs(dy) < 1) return;
+
+    const rail = railRef?.current ?? null;
+    // `hidden @3xl/shell:block` leaves the rail in the DOM at zero width on a
+    // narrow frame. Measuring is how we learn that without restating the
+    // breakpoint here — and a rail nobody can see does not slide in.
+    const railWidth = rail?.getBoundingClientRect().width ?? 0;
+    const sliding = rail && railWidth > 0 ? rail : null;
+
+    const fading = fadeRootRef?.current
+      ? Array.from(
+          fadeRootRef.current.querySelectorAll<HTMLElement>(FADE_SELECTOR),
+        )
+      : [];
+
+    const paint = (progress: number) => {
+      const away = 1 - progress;
+      bar.style.transform = `translate3d(${dx * away}px, ${dy * away}px, 0)`;
+      if (sliding) {
+        sliding.style.transform = `translate3d(${-railWidth * away}px, 0, 0)`;
+      }
+      const opacity = Math.min(1, progress / SURROUNDINGS_IN);
+      for (const element of fading) element.style.opacity = String(opacity);
+    };
+
+    // The invert step, before the browser has painted a single frame of any of
+    // this at rest.
+    bar.style.willChange = "transform";
+    if (sliding) sliding.style.willChange = "transform";
+    paint(0);
+
+    const settle = () => {
+      bar.style.transform = "";
+      bar.style.willChange = "";
+      if (sliding) {
+        sliding.style.transform = "";
+        sliding.style.willChange = "";
+      }
+      for (const element of fading) element.style.opacity = "";
+    };
+
+    arrival.jump(0);
+    const unsubscribe = arrival.on("change", paint);
+    const controls = animate(arrival, 1, {
+      ...SEARCH_MORPH_SPRING,
+      // Hand the elements back to the stylesheet the moment the spring is done,
+      // so nothing carries an inline transform or a `will-change` compositor
+      // hint for the rest of the session.
+      onComplete: settle,
+    });
+
+    return () => {
+      controls.stop();
+      unsubscribe();
+      settle();
+    };
+  }, [arrival, barRef, fadeRootRef, railRef, reduceMotion]);
+}

--- a/apps/web/features/shell/components/search-morph.tsx
+++ b/apps/web/features/shell/components/search-morph.tsx
@@ -9,7 +9,10 @@ import {
   useMemo,
   useRef,
 } from "react";
-import { takeSearchBarHandoff } from "@/features/shell/lib/search-morph";
+import {
+  type SearchBarHandoff,
+  takeSearchBarHandoff,
+} from "@/features/shell/lib/search-morph";
 
 /**
  * The receiving half of the landing → Explore transition: the search bar
@@ -153,21 +156,30 @@ export function useSearchBarArrival(
   const railRef = frame?.railRef;
   const reduceMotion = useReducedMotion();
   const arrival = useMotionValue(1);
-  const spent = useRef(false);
+  /**
+   * What this mount took out of storage: the rect, or `null` for "there was
+   * none". `undefined` means it has not looked yet.
+   *
+   * The read and the animation are deliberately not guarded together. The read
+   * is destructive and must happen once per mount — a dependency array only
+   * promises not to re-run when every identity it lists happens to hold still,
+   * so the ref is what actually guarantees that. The *animation* must survive an
+   * effect being replayed, and React replays every effect on mount under Strict
+   * Mode: run, clean up, run again. A single "already spent" guard would let the
+   * first pass consume the rect and start the spring, let the cleanup stop it,
+   * and then refuse to start it again — no arrival at all, in exactly the
+   * development build where it would be looked at. Caching the rect here lets
+   * the replay pick the same gesture back up.
+   */
+  const taken = useRef<SearchBarHandoff | null | undefined>(undefined);
 
   useLayoutEffect(() => {
-    // One mount, one handoff. The guard is a ref rather than an empty
-    // dependency array because this effect both reads storage destructively and
-    // starts an animation: re-running it would replay a gesture the reader has
-    // already finished, and a dependency array only promises not to re-run when
-    // every identity it lists happens to hold still.
-    if (spent.current) return;
-    spent.current = true;
+    if (taken.current === undefined) taken.current = takeSearchBarHandoff();
 
     // Read first, decide second. The handoff is consumed even when it is not
     // used — under reduced motion, or with no bar to move — so a rect can never
     // outlive the navigation that produced it.
-    const handoff = takeSearchBarHandoff();
+    const handoff = taken.current;
     if (!handoff || reduceMotion) return;
 
     const bar = barRef.current;

--- a/apps/web/features/shell/index.ts
+++ b/apps/web/features/shell/index.ts
@@ -1,4 +1,9 @@
 export { AppShell } from "./components/app-shell";
 export { PageColumn } from "./components/page-column";
 export { PageHeader } from "./components/page-header";
+export { useSearchBarArrival } from "./components/search-morph";
 export { ThemeToggle } from "./components/theme-toggle";
+export {
+  clearSearchBarHandoff,
+  stashSearchBarHandoff,
+} from "./lib/search-morph";

--- a/apps/web/features/shell/lib/search-morph.spec.ts
+++ b/apps/web/features/shell/lib/search-morph.spec.ts
@@ -1,0 +1,174 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  clearSearchBarHandoff,
+  SEARCH_MORPH_KEY,
+  SEARCH_MORPH_MAX_AGE_MS,
+  stashSearchBarHandoff,
+  takeSearchBarHandoff,
+} from "./search-morph";
+
+/**
+ * The handoff is the only thing that crosses the landing → Explore navigation,
+ * and every rule about *when it does not* lives here: consumed once, never
+ * stale, never trusted. The animation itself is covered where it runs
+ * (`components/search-morph.spec.tsx`); this suite is the storage contract.
+ */
+
+function fakeStorage(): Storage {
+  const map = new Map<string, string>();
+  return {
+    get length() {
+      return map.size;
+    },
+    clear: () => map.clear(),
+    getItem: (key: string) => map.get(key) ?? null,
+    key: (index: number) => [...map.keys()][index] ?? null,
+    removeItem: (key: string) => void map.delete(key),
+    setItem: (key: string, value: string) => void map.set(key, value),
+  };
+}
+
+let store: Storage;
+
+beforeEach(() => {
+  store = fakeStorage();
+  vi.stubGlobal("window", { sessionStorage: store });
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+const BAR = { left: 120, top: 400, width: 560, height: 42 };
+
+describe("stashSearchBarHandoff", () => {
+  it("writes the bar's box with the moment it was measured", () => {
+    stashSearchBarHandoff(BAR, 1_000);
+
+    expect(JSON.parse(store.getItem(SEARCH_MORPH_KEY) ?? "null")).toEqual({
+      x: 120,
+      y: 400,
+      w: 560,
+      h: 42,
+      t: 1_000,
+    });
+  });
+
+  it("survives a store that refuses to be written to", () => {
+    vi.stubGlobal("window", {
+      sessionStorage: {
+        ...store,
+        setItem: () => {
+          throw new Error("QuotaExceededError");
+        },
+      },
+    });
+
+    expect(() => stashSearchBarHandoff(BAR)).not.toThrow();
+  });
+
+  it("does nothing where there is no window at all", () => {
+    vi.stubGlobal("window", undefined);
+
+    expect(() => stashSearchBarHandoff(BAR)).not.toThrow();
+    expect(takeSearchBarHandoff()).toBeNull();
+  });
+});
+
+describe("takeSearchBarHandoff", () => {
+  it("returns the stashed box", () => {
+    stashSearchBarHandoff(BAR, 1_000);
+
+    expect(takeSearchBarHandoff(1_100)).toEqual({
+      x: 120,
+      y: 400,
+      w: 560,
+      h: 42,
+      t: 1_000,
+    });
+  });
+
+  it("consumes it: a second read, and so a reload of Explore, gets nothing", () => {
+    stashSearchBarHandoff(BAR, 1_000);
+
+    expect(takeSearchBarHandoff(1_100)).not.toBeNull();
+    expect(takeSearchBarHandoff(1_100)).toBeNull();
+    expect(store.getItem(SEARCH_MORPH_KEY)).toBeNull();
+  });
+
+  it("ignores a rect older than the bound, and still consumes it", () => {
+    stashSearchBarHandoff(BAR, 1_000);
+
+    expect(
+      takeSearchBarHandoff(1_000 + SEARCH_MORPH_MAX_AGE_MS + 1),
+    ).toBeNull();
+    expect(store.getItem(SEARCH_MORPH_KEY)).toBeNull();
+  });
+
+  it("accepts a rect right on the bound", () => {
+    stashSearchBarHandoff(BAR, 1_000);
+
+    expect(
+      takeSearchBarHandoff(1_000 + SEARCH_MORPH_MAX_AGE_MS),
+    ).not.toBeNull();
+  });
+
+  it("ignores a stamp from the future, because the clock moved", () => {
+    stashSearchBarHandoff(BAR, 5_000);
+
+    expect(takeSearchBarHandoff(1_000)).toBeNull();
+  });
+
+  it("returns nothing when nothing was stashed", () => {
+    expect(takeSearchBarHandoff()).toBeNull();
+  });
+
+  it.each([
+    ["not JSON at all", "{"],
+    ["not an object", '"nope"'],
+    ["null", "null"],
+    ["missing the timestamp", '{"x":1,"y":2,"w":560,"h":42}'],
+    ["carrying a NaN", '{"x":null,"y":2,"w":560,"h":42,"t":1}'],
+    ["zero-sized", '{"x":1,"y":2,"w":0,"h":0,"t":1}'],
+  ])("rejects a value that is %s, and clears it out", (_case, raw) => {
+    store.setItem(SEARCH_MORPH_KEY, raw);
+
+    expect(takeSearchBarHandoff(1)).toBeNull();
+    expect(store.getItem(SEARCH_MORPH_KEY)).toBeNull();
+  });
+
+  it("survives a store that refuses to be read", () => {
+    vi.stubGlobal("window", {
+      sessionStorage: {
+        ...store,
+        getItem: () => {
+          throw new Error("SecurityError");
+        },
+      },
+    });
+
+    expect(takeSearchBarHandoff()).toBeNull();
+  });
+});
+
+describe("clearSearchBarHandoff", () => {
+  it("removes a pending rect", () => {
+    stashSearchBarHandoff(BAR, 1_000);
+    clearSearchBarHandoff();
+
+    expect(store.getItem(SEARCH_MORPH_KEY)).toBeNull();
+  });
+
+  it("survives a store that refuses to be written to", () => {
+    vi.stubGlobal("window", {
+      sessionStorage: {
+        ...store,
+        removeItem: () => {
+          throw new Error("SecurityError");
+        },
+      },
+    });
+
+    expect(() => clearSearchBarHandoff()).not.toThrow();
+  });
+});

--- a/apps/web/features/shell/lib/search-morph.ts
+++ b/apps/web/features/shell/lib/search-morph.ts
@@ -1,0 +1,169 @@
+/**
+ * The landing → Explore search-bar handoff: the one measurement that survives
+ * the navigation.
+ *
+ * `/` and `/search` are separate routes, so the landing's tree unmounts before
+ * Explore's mounts. There is no component alive on both sides and no shared
+ * parent for a `layoutId` to bridge, which is why this is FLIP rather than a
+ * layout animation: the landing writes down the box its search bar occupied at
+ * the moment of submit, and Explore animates its own bar out of that box into
+ * the place it was already standing.
+ *
+ * It works because the two bars are the same element in every visual respect —
+ * `h-[42px]`, `rounded-[10px]`, `border border-cc-rule3`, `bg-cc-surface`,
+ * `px-3.5` and the same `max-w-[560px]` on both pages. Nothing has to restyle,
+ * resize or cross-fade across the seam. The morph is a translation and nothing
+ * else, which is what lets it be a genuine move instead of a dissolve pretending
+ * to be one.
+ *
+ * `Course Community - Landing.dc.html`'s `toExplore()` (line 499) stashes the
+ * rect under this same key and `Course Community - Explore.dc.html`'s
+ * `pickUpSharedBar()` (line 855) reads it back, so the key and the shape are the
+ * artboards'. What is not the artboards' is how the two ends are driven — see
+ * `components/search-morph.tsx`.
+ *
+ * Nothing here touches React. The write happens in a submit handler and the read
+ * happens in a layout effect; neither wants a hook, and keeping the storage
+ * rules in one plain module is what makes "consumed exactly once" testable.
+ */
+
+/** The artboards' own key, in both `toExplore()` and `pickUpSharedBar()`. */
+export const SEARCH_MORPH_KEY = "cc:searchHandoff";
+
+/**
+ * How long a stashed rect is still worth animating out of, from the artboard's
+ * own `Date.now() - from.t > 4000` guard.
+ *
+ * The handoff is consumed on the first read, so an ordinary reload of `/search`
+ * already finds nothing. This bound covers the case the removal cannot: a submit
+ * whose exit animation stalled — a backgrounded tab throttles `requestAnimationFrame`
+ * to nothing — and then navigated much later, or a `/search` opened from a
+ * bookmark in a tab that had stashed a rect and never arrived. A bar that
+ * travels out of where it stood an hour ago is not continuing a gesture; it is
+ * inventing one.
+ */
+export const SEARCH_MORPH_MAX_AGE_MS = 4000;
+
+/** The landing search bar's viewport box, plus when it was measured. */
+export type SearchBarHandoff = {
+  x: number;
+  y: number;
+  w: number;
+  h: number;
+  /** `Date.now()` at the moment of submit. */
+  t: number;
+};
+
+/**
+ * `sessionStorage`, or `null` where there is none to have.
+ *
+ * The property access itself throws in a Safari private window and wherever
+ * site data is blocked outright, so it is inside the `try` rather than beside
+ * it. Losing storage costs the animation and nothing else: every caller here
+ * falls back to a plain navigation.
+ */
+function session(): Storage | null {
+  if (typeof window === "undefined") return null;
+  try {
+    return window.sessionStorage;
+  } catch {
+    return null;
+  }
+}
+
+/** Hand Explore the box this bar is standing in. */
+export function stashSearchBarHandoff(
+  rect: { left: number; top: number; width: number; height: number },
+  now: number = Date.now(),
+): void {
+  const store = session();
+  if (!store) return;
+  const handoff: SearchBarHandoff = {
+    x: rect.left,
+    y: rect.top,
+    w: rect.width,
+    h: rect.height,
+    t: now,
+  };
+  try {
+    store.setItem(SEARCH_MORPH_KEY, JSON.stringify(handoff));
+  } catch {
+    /* Full or blocked: the navigation still happens, without the morph. */
+  }
+}
+
+/**
+ * Drop any pending handoff.
+ *
+ * Called on the paths that navigate without animating, so a rect left by an
+ * earlier submit can never be picked up by an arrival that did not earn it.
+ */
+export function clearSearchBarHandoff(): void {
+  const store = session();
+  if (!store) return;
+  try {
+    store.removeItem(SEARCH_MORPH_KEY);
+  } catch {
+    /* Nothing to do: an unreadable store is an unusable handoff either way. */
+  }
+}
+
+/**
+ * Read the pending handoff, and consume it.
+ *
+ * "Consume" is unconditional: the key is removed before the value is so much as
+ * parsed, so a malformed or stale rect is still gone afterwards. A handoff is a
+ * single navigation's worth of context, and one that survived its own rejection
+ * would be handed to whatever arrived next.
+ */
+export function takeSearchBarHandoff(
+  now: number = Date.now(),
+): SearchBarHandoff | null {
+  const store = session();
+  if (!store) return null;
+
+  let raw: string | null;
+  try {
+    raw = store.getItem(SEARCH_MORPH_KEY);
+    store.removeItem(SEARCH_MORPH_KEY);
+  } catch {
+    return null;
+  }
+  if (!raw) return null;
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    return null;
+  }
+
+  const handoff = asHandoff(parsed);
+  if (!handoff) return null;
+
+  // A negative age means the clock moved between the two pages, which makes the
+  // stamp worthless rather than merely fresh — so it is rejected the same way a
+  // stale one is.
+  const age = now - handoff.t;
+  if (age < 0 || age > SEARCH_MORPH_MAX_AGE_MS) return null;
+
+  return handoff;
+}
+
+/**
+ * `sessionStorage` is writable by anything else running on this origin, so the
+ * value is validated rather than trusted: a rect with a `NaN` in it would put
+ * the bar somewhere no spring can bring it back from.
+ */
+function asHandoff(value: unknown): SearchBarHandoff | null {
+  if (typeof value !== "object" || value === null) return null;
+  const raw = value as Record<string, unknown>;
+  const { x, y, w, h, t } = raw;
+  for (const number of [x, y, w, h, t]) {
+    if (typeof number !== "number" || !Number.isFinite(number)) return null;
+  }
+  const handoff = { x, y, w, h, t } as SearchBarHandoff;
+  // A zero-sized bar was never on screen; there is nothing to travel out of.
+  if (handoff.w <= 0 || handoff.h <= 0) return null;
+  return handoff;
+}

--- a/apps/web/features/shell/lib/search-morph.ts
+++ b/apps/web/features/shell/lib/search-morph.ts
@@ -16,7 +16,7 @@
  * else, which is what lets it be a genuine move instead of a dissolve pretending
  * to be one.
  *
- * `Course Community - Landing.dc.html`'s `toExplore()` (line 499) stashes the
+ * `Course Community - Landing.dc.html`'s `toExplore()` (line 501) stashes the
  * rect under this same key and `Course Community - Explore.dc.html`'s
  * `pickUpSharedBar()` (line 855) reads it back, so the key and the shape are the
  * artboards'. What is not the artboards' is how the two ends are driven — see

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -57,7 +57,6 @@
     "date-fns": "^4.4.0",
     "drizzle-orm": "0.45.2",
     "embla-carousel-react": "^8.6.0",
-    "framer-motion": "^12.23.24",
     "html-react-parser": "^5.2.6",
     "input-otp": "^1.5.0",
     "lexical": "^0.36.2",

--- a/bun.lock
+++ b/bun.lock
@@ -60,7 +60,6 @@
         "date-fns": "^4.4.0",
         "drizzle-orm": "0.45.2",
         "embla-carousel-react": "^8.6.0",
-        "framer-motion": "^12.23.24",
         "html-react-parser": "^5.2.6",
         "input-otp": "^1.5.0",
         "lexical": "^0.36.2",


### PR DESCRIPTION
Wave 2 of the reconciliation: the landing → Explore transition, the one place
#68 authorises improving on the artboard rather than matching it.

Submitting the landing search — Enter in the bar, or a "Try" chip — no longer
swaps one page for another. The bar **rises** into the place it occupies on
Explore while the rail **slides in from the left**, and the two are one
movement rather than two that start together.

## Why FLIP and not `layoutId`

`/` and `/search` are separate routes. The landing's tree unmounts before
Explore's mounts, so there is no component alive on both sides and no shared
parent for a layout animation to bridge — `layoutId` has nothing to work with.

What crosses instead is a measurement. `features/shell/lib/search-morph.ts`
writes the bar's `getBoundingClientRect()` into `sessionStorage` under the
artboard's own `cc:searchHandoff` key at the moment of submit, and Explore
animates its own bar *out of* that box on mount. That is the artboard's own
sketch (`toExplore()` at line 501, `pickUpSharedBar()` at line 855), done
properly.

It works at all because **the geometry was already ideal**: both bars render
`h-[42px]`, `rounded-[10px]`, `border-cc-rule3`, `bg-cc-surface`, `px-3.5` and
the same `max-w-[560px]`. Nothing restyles, resizes or cross-fades. It is a
translation and nothing else, which is why it can be a genuine move instead of
a dissolve pretending to be one.

## How the rail and the bar are coupled

Not two springs with matching configs started in the same frame — **one motion
value**. `arrival` runs 0 → 1 on a single spring, and both remaining offsets
are read off it:

```
bar.transform  = translate3d(dx * (1 - t), dy * (1 - t), 0)
rail.transform = translate3d(-railWidth * (1 - t), 0, 0)
```

That is what makes the horizontal component read as causal. On the landing the
bar centres in the viewport; on Explore it centres in the space *beside* the
236px rail, so its resting centre sits about half a rail width further right.
The bar drifts right **because** the rail is arriving — and `dx` is the
measured difference between two real rects, never an assumption about how much
half a rail is.

The rail's own width is measured too, which is also how the narrow frame is
handled without restating a breakpoint: `hidden @3xl/shell:block` leaves the
rail in the DOM at zero width, and a rail measuring zero does not slide.

The shell publishes its rail through a small `SearchMorphProvider` in
`AppShell`; Explore hands back its bar. Neither feature reaches into the
other's chrome.

## The spring, and why it feels right

`{ stiffness: 300, damping: 30, mass: 1 }`

- ζ = 30 / (2·√300) ≈ **0.87** — overshoot ≈ 0.4%, about a pixel and a half on
  a ~350px rise. It reads as a *settle*, not a bounce. A springier ratio
  (ζ ≈ 0.75) would overshoot by ~10px, which makes the top of the page look
  loose; the bar is page furniture arriving where it belongs.
- ω = √300 ≈ 17.3 rad/s → 0.5% settling time ≈ **355ms**. Long enough to be
  legible as a movement, short enough that nobody is waiting for their results.
- `restDelta`/`restSpeed` are set explicitly because Motion picks them from the
  size of the animated value, and a 0 → 1 progress falls under its granular
  cutoff: the default 0.005 is 0.005 *of the travel*, so `onComplete` would
  snap the last two pixels. Scaled down an order, the stop lands under a third
  of a pixel.

The **invert** step is written straight to the node inside `useLayoutEffect` —
after React commits, before the browser paints. Going through a motion value or
React state would put the first offset on Motion's own frame loop one rAF
later, which is a full frame of the bar standing at its destination before it
jumps back to travel. That frame is exactly what makes a handoff look
synthetic.

## What the artboard does badly, and what this does instead

| Artboard | Here |
|---|---|
| Fixed CSS tween | Spring, one value driving both elements |
| Blind `setTimeout(130)` then navigate | Navigation fired by the exit animation actually completing, with a 600ms deadline and an immediate departure on tab-hidden as the floor under it — three routes out, one guard, exactly one navigation |
| No prefetch | `/search` prefetched the moment a search is being reached for — the field taking focus, or a "Try" chip under the pointer — so the exit is not followed by a blank frame |
| — | Hero graph **paused** for the duration: competing motion is the biggest tell, so the only thing moving is the layout |

On the departure side, everything that is not the bar clears over 130ms on the
artboard's own `cubic-bezier(.4,0,1,1)`, drifting up 10px (the artboard shifts
its whole landing layer up 40px on the way out). The exit set is expressed as
Motion variants — the bar is simply the one element with **no** `variants` — and
deliberately *not* the `data-hero-clear` set, because the `<form>` carries that
attribute for the graph's keep-out and the form is the thing that survives.

## Non-negotiables

- **`prefers-reduced-motion` skips the whole thing** (`useReducedMotion()`) and
  falls back to today's plain navigation, as the artboard does. The pending rect
  is cleared on that path so Explore can never inherit one.
- **Consumed exactly once.** The key is removed *before* the value is parsed, so
  a malformed or stale rect is gone too. A reload of `/search` replays nothing.
- **Stale rects are ignored**, on the artboard's own 4s bound — the case removal
  cannot cover is a submit whose exit stalled in a backgrounded tab, or a
  `/search` opened from a bookmark in a tab that had stashed and never arrived.
  A future stamp is rejected as well, because a clock that moved makes the stamp
  worthless rather than merely fresh.
- **Arriving at `/search` directly** — shared link, bookmark, rail — does no
  measurement, writes no style and starts no frame of work.
- **The bar is never unusable mid-flight.** It is translated, never remounted,
  never disabled; the query is already in the URL.
- **A submitted search always navigates.** A hidden tab throttles
  `requestAnimationFrame` to nothing, so `onAnimationComplete` may never arrive;
  the deadline and the visibility listener are the floor under it, and the
  tab-hidden route drops the stashed rect because nobody watched the bar leave.
- **The arrival survives a Strict Mode effect replay.** The destructive storage
  read is once per mount; the spring is free to be restarted by a replayed
  effect. Without that split the transition is invisible in development.
- Presentation only. No data, route contract or component API change.

## Motion packages

`framer-motion` (^12.23.24) and `motion` (^12.38.0) were both direct
dependencies of `apps/web`, both resolving to 12.43.0, and **neither was
imported anywhere**. Standardised on **`motion`**, importing from `motion/react`
(the v12 entry point); **`framer-motion` is dropped from the manifest**. It is
still installed, as `motion`'s own dependency — `motion/react` is literally
`export * from "framer-motion"` — so nothing is lost but the second name.

## Loop safety

Two wave-1 agents shipped unbounded render loops from effects depending on
`router`. Both effects added here are fenced:

- the arrival's layout effect is guarded by a `spent` ref, because it reads
  storage destructively and starts an animation — a dependency array only
  promises not to re-run when every identity it lists happens to hold still;
- the prefetch is a `router.prefetch` in a **focus handler**, not an effect, and
  fenced by a ref. `router` appears in no dependency array in this PR.

## Validation

All three gates green from the repo root:

- `bun run lint` — clean (8 pre-existing warnings in `.agents/skills/`, unchanged)
- `bun run typecheck` — clean
- `bun run test:web` — **848 passed / 69 files**, up from 802 / 67 at the base

46 new tests, on behaviour rather than animation frames:

- `features/shell/lib/search-morph.spec.ts` — the storage contract: the rect is
  stashed with its stamp; consumed once; stale, future-stamped, malformed,
  zero-sized and absent values all rejected *and* cleared; a store that throws
  never takes the page down.
- `features/shell/components/search-morph.spec.tsx` — the invert step: bar
  offset to the remembered box, rail offset a full rail width, surroundings at
  zero; consumed so a remount replays nothing; nothing at all for a stale rect,
  an absent one, a bar that landed where it stood, or reduced motion; the rail
  left alone when it measures zero; the bar still moves with no provider; and it
  still animates when React replays the effect under `StrictMode` — that one was
  checked against the pre-fix code and fails there.
- `features/landing/components/landing.spec.tsx` — the departure: the box handed
  over; the push withheld until the exit finishes and then fired once; a second
  submit ignored mid-flight; prefetch once on focus and once for a chip merely
  hovered; plain navigation with
  nothing stashed under reduced motion and when the bar has no measurable box;
  departure on tab-hidden with the rect dropped; departure on the 600ms deadline
  when the exit never reports finishing; and exactly one navigation whichever
  route gets there first.
- `features/landing/components/hero-network.spec.tsx` — the pulse stops when
  paused, and never starts for a label arriving while paused.
- `features/search/components/explore.spec.tsx` — Explore's own bar is the
  element the handoff lands on, and no animation when reached any other way.

## Deliberately not done

- Nothing else was "improved". #68 scopes the exception to this transition; the
  couple of things noticed elsewhere are reported rather than changed here.
- No results stagger. The artboard fades its result cards in one after another;
  the surroundings here come up as one region on the same value. The cards are
  data-driven and often skeletons at that moment, and a stagger over a list that
  may re-render underneath it is motion the transition does not need.
- `PageHeader` grew no prop; it is wrapped in a marked `div` instead, so no
  component API changed.

Targets `feat/frontend`. Closes nothing — the orchestrator owns #68.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017EAUKDDo2BkQTFELyvV3v8
