### PR TITLE
fix(ui): give every scroll container a deliberate scrollbar

### DIFF
--- a/apps/web/app/globals.css
+++ b/apps/web/app/globals.css
@@ -362,7 +362,16 @@
   }
 }
 
-/* Thin, muted scrollbar for internal scroll panes (e.g. search list, sidebar). */
+/* The default for every scroll container in the app: thin and muted, so a pane
+   that scrolls says so without a chunky OS bar cutting across the design.
+
+   The convention is that a scroll container picks one of these two utilities
+   deliberately. Neither is the same as picking nothing: a container with no
+   utility renders the browser's default bar, which is what the artboards do not
+   draw and what this pass corrected across ten surfaces. If you add
+   `overflow-auto` anywhere, add one of these with it.
+
+   `--border` is mapped onto `--cc-rule2`, so this tracks the theme on its own. */
 @utility scrollbar-subtle {
   scrollbar-width: thin;
   scrollbar-color: var(--border) transparent;
@@ -383,9 +392,14 @@
   }
 }
 
-/* Explore owns its list's scroll surface. Hiding its rail keeps that surface
-   visually quiet while retaining wheel, touch, keyboard, and programmatic
-   scrolling. */
+/* The deliberate exception, and the only one. Explore owns its list's scroll
+   surface: hiding the rail keeps that surface visually quiet while retaining
+   wheel, touch, keyboard and programmatic scrolling.
+
+   Reach for this only where something else already tells the reader the region
+   scrolls. Hiding the bar on a list that carries no other affordance takes one
+   away rather than tidying one up, which is why everywhere else takes
+   `scrollbar-subtle`. */
 @utility scrollbar-hidden {
   scrollbar-width: none;
 

--- a/apps/web/features/collections/components/collection-detail.tsx
+++ b/apps/web/features/collections/components/collection-detail.tsx
@@ -155,7 +155,7 @@ export function CollectionDetail({
                   ref={addMenu.panelRef}
                   role="menu"
                   aria-label="Add a saved course"
-                  className="absolute top-9 right-0 z-20 box-border max-h-[260px] w-[250px] overflow-auto rounded-[10px] border border-cc-rule2 bg-cc-surface p-[5px] shadow-[0_8px_24px_rgba(20,30,45,.14)]"
+                  className="scrollbar-subtle absolute top-9 right-0 z-20 box-border max-h-[260px] w-[250px] overflow-auto rounded-[10px] border border-cc-rule2 bg-cc-surface p-[5px] shadow-[0_8px_24px_rgba(20,30,45,.14)]"
                 >
                   {addableCourseCodes.map((courseCode) => (
                     <button

--- a/apps/web/features/collections/components/new-collection-dialog.tsx
+++ b/apps/web/features/collections/components/new-collection-dialog.tsx
@@ -117,7 +117,7 @@ export function NewCollectionDialog({
               aria-label="Filter saved courses"
               className="mt-2 box-border h-[34px] w-full rounded-[9px] border border-cc-rule bg-cc-inset px-3 text-[12.5px] text-cc-ink outline-none focus:border-cc-brand"
             />
-            <div className="mt-2.5 max-h-[210px] overflow-auto rounded-[9px] border border-cc-rule">
+            <div className="scrollbar-subtle mt-2.5 max-h-[210px] overflow-auto rounded-[9px] border border-cc-rule">
               {matches.map((course) => {
                 const checked = picked.includes(course.courseCode);
                 return (

--- a/apps/web/features/landing/components/landing.tsx
+++ b/apps/web/features/landing/components/landing.tsx
@@ -281,7 +281,7 @@ export function Landing() {
     <motion.div
       initial={false}
       animate={leavingFor ? "leaving" : "at-rest"}
-      className="@container cc-theme min-h-dvh bg-cc-pg text-cc-ink text-sm lg:h-dvh lg:overflow-y-auto"
+      className="scrollbar-subtle @container cc-theme min-h-dvh bg-cc-pg text-cc-ink text-sm lg:h-dvh lg:overflow-y-auto"
     >
       <motion.header
         variants={HERO_EXIT}

--- a/apps/web/features/my-page/components/my-page.tsx
+++ b/apps/web/features/my-page/components/my-page.tsx
@@ -206,7 +206,7 @@ export function MyPage() {
       <div
         role="tablist"
         aria-label="My Page sections"
-        className="mt-5 flex gap-1 overflow-x-auto border-cc-rule border-b px-7 @max-[440px]:px-[14px]"
+        className="scrollbar-subtle mt-5 flex gap-1 overflow-x-auto border-cc-rule border-b px-7 @max-[440px]:px-[14px]"
       >
         {VIEWS.map((key) => (
           <button

--- a/apps/web/features/reviews/components/review.tsx
+++ b/apps/web/features/reviews/components/review.tsx
@@ -205,7 +205,7 @@ export function Review({
             </Button>
           </DialogTrigger>
         )}
-        <DialogContent className="max-h-[100vh] max-w-4xl min-w-3xl overflow-y-auto">
+        <DialogContent className="scrollbar-subtle max-h-[100vh] max-w-4xl min-w-3xl overflow-y-auto">
           <DialogHeader>
             <DialogTitle>
               {editing ? "Edit your review" : "Share Your Experience"}

--- a/apps/web/features/shell/components/app-shell.tsx
+++ b/apps/web/features/shell/components/app-shell.tsx
@@ -91,7 +91,7 @@ export function AppShell({ children }: { children: ReactNode }) {
           className={
             pathname === "/search"
               ? "min-h-0 flex-1 overflow-hidden"
-              : "min-h-0 flex-1 overflow-y-auto overflow-x-hidden"
+              : "scrollbar-subtle min-h-0 flex-1 overflow-y-auto overflow-x-hidden"
           }
         >
           <SearchMorphProvider railRef={railRef}>

--- a/apps/web/features/taken/components/add-taken-course-dialog.tsx
+++ b/apps/web/features/taken/components/add-taken-course-dialog.tsx
@@ -185,7 +185,7 @@ export function AddTakenCourseDialog({
                 the catalogue.
               </p>
             ) : (
-              <ul className="m-0 flex max-h-[220px] list-none flex-col overflow-y-auto p-0">
+              <ul className="scrollbar-subtle m-0 flex max-h-[220px] list-none flex-col overflow-y-auto p-0">
                 {results.map((course) => {
                   const isTaken = alreadyTaken.has(course.courseCode);
                   return (

--- a/apps/web/features/taken/components/taken-courses.tsx
+++ b/apps/web/features/taken/components/taken-courses.tsx
@@ -661,7 +661,7 @@ export function TakenCourses() {
             />
           ) : null}
 
-          <div className="overflow-x-auto overflow-y-hidden rounded-[12px] border border-cc-rule bg-cc-surface">
+          <div className="scrollbar-subtle overflow-x-auto overflow-y-hidden rounded-[12px] border border-cc-rule bg-cc-surface">
             <div
               className={`${TAKEN_GRID} border-cc-rule border-b bg-cc-pg px-4 py-3.5 font-semibold text-[11px] text-cc-dim uppercase tracking-[0.06em]`}
             >

--- a/apps/web/features/taken/components/transcript-proposal.tsx
+++ b/apps/web/features/taken/components/transcript-proposal.tsx
@@ -102,7 +102,7 @@ export function TranscriptProposalReview({
         ) : null}
 
         {candidates.length > 0 ? (
-          <ul className="m-0 mt-4 flex max-h-[320px] list-none flex-col overflow-y-auto rounded-[12px] border border-cc-rule bg-cc-surface p-0">
+          <ul className="scrollbar-subtle m-0 mt-4 flex max-h-[320px] list-none flex-col overflow-y-auto rounded-[12px] border border-cc-rule bg-cc-surface p-0">
             {candidates.map((row) => (
               <li
                 key={row.courseCode}

--- a/apps/web/features/workspace/components/workspace-pane.tsx
+++ b/apps/web/features/workspace/components/workspace-pane.tsx
@@ -143,7 +143,7 @@ export function WorkspacePane({
             </DropdownMenuTrigger>
             <DropdownMenuContent
               align="start"
-              className="cc-theme max-h-[222px] w-[262px] overflow-y-auto border-cc-rule2 bg-cc-surface p-[5px] text-cc-ink"
+              className="scrollbar-subtle cc-theme max-h-[222px] w-[262px] overflow-y-auto border-cc-rule2 bg-cc-surface p-[5px] text-cc-ink"
             >
               {openCourses.map((entry) => (
                 <DropdownMenuItem


### PR DESCRIPTION
## What changed

`apps/web/app/globals.css` has carried two scrollbar utilities for a while — `scrollbar-subtle` (thin, muted) and `scrollbar-hidden` (gone entirely). **Ten scroll containers applied neither**, so they rendered the browser's default bar: a chunky OS rail cutting across surfaces the artboards draw without one. The most visible is the Taken courses table, whose horizontal bar sits under the last row.

Picking nothing is not the same as picking one, and that is the actual defect. Each of the ten now takes `scrollbar-subtle`:

| File | Surface |
|---|---|
| `features/taken/components/taken-courses.tsx:664` | the Taken courses table (horizontal) |
| `features/taken/components/transcript-proposal.tsx:105` | transcript proposal list |
| `features/taken/components/add-taken-course-dialog.tsx:188` | add-course search list |
| `features/my-page/components/my-page.tsx:209` | My Page tab strip (horizontal) |
| `features/shell/components/app-shell.tsx:94` | the shell's main scroll column |
| `features/landing/components/landing.tsx:284` | the landing page's own scroll |
| `features/reviews/components/review.tsx:208` | the review dialog |
| `features/collections/components/collection-detail.tsx:158` | collection-detail menu |
| `features/collections/components/new-collection-dialog.tsx:120` | new-collection list |
| `features/workspace/components/workspace-pane.tsx:146` | the pane's open-panes dropdown |

`scrollbar-subtle` resolves through `--border`, which #147 mapped onto `--cc-rule2`, so it follows the theme with no further work.

## The one deliberate exception

Explore keeps `scrollbar-hidden`. It owns its list's scroll surface and something else there already tells the reader the region scrolls. Hiding a bar on a list that carries no other affordance takes an affordance away rather than tidying one up — which is why it stays the exception rather than the pattern.

## The comments were part of the problem

`scrollbar-subtle`'s comment cited "search list, sidebar" as its examples, and the search list had since moved to `scrollbar-hidden`. The single piece of documentation for this convention pointed at a stale example, which is a fair part of why ten containers drifted. Both comments now state the convention plainly, so the next `overflow-auto` gets a scrollbar chosen rather than inherited.

## Validation

- `bun run lint` — clean, 8 pre-existing warnings, unchanged
- `bun run typecheck` — exit 0
- `bun run test:web` — **843 passed / 70 files**, 37.9s, no change from baseline

Presentation only: no data, route contract or component API changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017EAUKDDo2BkQTFELyvV3v8