### PR TITLE
fix(taken,my-page): carry the course through the review deep link, confirm before removing a taken course

### DIFF
--- a/apps/web/features/my-page/components/my-page.spec.tsx
+++ b/apps/web/features/my-page/components/my-page.spec.tsx
@@ -66,13 +66,16 @@ vi.mock("@/features/reviews", () => ({
     onStart,
     onSelect,
   }: {
-    courses: { code: string }[];
+    // The real card falls back to the code when it has no name, so the stub
+    // renders both — a row that renders its code twice is the second half of
+    // #157 and has to be visible to a test.
+    courses: { code: string; name?: string | null }[];
     onStart: () => void;
     onSelect?: (code: string) => void;
   }) =>
     courses.length === 0 ? null : (
       <div data-testid="unreviewed">
-        {courses.map((c) => c.code).join(",")}
+        {courses.map((c) => `${c.code} ${c.name || c.code}`).join(", ")}
         <button type="button" onClick={onStart}>
           Start reviewing
         </button>
@@ -322,10 +325,14 @@ describe("MyPage empty states", () => {
    * My Page has no reviewer of its own and should not grow one: `/taken` owns
    * the queue, and it is the screen that still knows which courses are
    * unreviewed by the time the reader arrives. Both the prompt's button and one
-   * of its rows therefore go to the same place — the artboard's own
+   * of its rows therefore go there — the artboard's own
    * `window.location.href = "…Taken Courses…?review=1"`.
+   *
+   * They do not go to the *same* place. The button names no course and writes
+   * the original flag; a row names one and the URL carries it, which is the
+   * whole point of #157 — the row used to discard the course it named.
    */
-  it("sends both the prompt's button and a row to the fast-track reviewer", async () => {
+  it("sends the prompt's button to a whole round and a row to its own course", async () => {
     unreviewed.mockReturnValue({
       courses: [takenCourse({ courseCode: "DD2380" })],
       isLoading: false,
@@ -340,7 +347,30 @@ describe("MyPage empty states", () => {
 
     push.mockClear();
     await userEvent.click(screen.getByRole("button", { name: "Pick a row" }));
-    expect(push).toHaveBeenCalledWith("/taken?review=1");
+    expect(push).toHaveBeenCalledWith("/taken?review=DD2380");
+  });
+
+  /**
+   * `user_taken_courses` stores only a code, so a row with no name renders the
+   * code twice (#157's second defect). The title now comes back on the course
+   * from `useUnreviewedTakenCourses`, and My Page has only to pass it on.
+   */
+  it("hands the card the catalogue title the hook looked up", async () => {
+    unreviewed.mockReturnValue({
+      courses: [
+        {
+          ...takenCourse({ courseCode: "DD2380" }),
+          name: "Artificial Intelligence",
+        },
+      ],
+      isLoading: false,
+      isUnavailable: false,
+    });
+    render(<MyPage />);
+
+    expect(screen.getByTestId("unreviewed")).toHaveTextContent(
+      "DD2380 Artificial Intelligence",
+    );
   });
 });
 

--- a/apps/web/features/my-page/components/my-page.tsx
+++ b/apps/web/features/my-page/components/my-page.tsx
@@ -13,6 +13,11 @@ import {
   useUnreviewedTakenCourses,
 } from "@/features/reviews";
 import { PageColumn, PageHeader } from "@/features/shell";
+// The module, not `@/features/taken`: the barrel holds that feature's write
+// path, and this page links to the screen rather than writing anything. The
+// route contract is one pure function and this is the half of it that builds
+// a link — `/taken` owns the half that reads one.
+import { reviewHref } from "@/features/taken/lib/review-deep-link";
 import {
   isTierUnavailable,
   useAllReviews,
@@ -330,13 +335,24 @@ export function MyPage() {
                     one: `/taken` owns the queue, and it is the screen that
                     knows which courses are still unreviewed by the time the
                     reader gets there.
+
+                    They do not deep-link to the same place, though. A row names
+                    a course and the URL carries it — `?review=<CODE>` — because
+                    the row's whole contract is "open the reviewer on this one",
+                    and a parameter that could only say "open the reviewer"
+                    discarded the course the reader named (#157). The button,
+                    which names no course, still writes the original
+                    `?review=1`.
                   */
                   <UnreviewedCard
                     courses={unreviewed.courses.map((course) => ({
                       code: course.courseCode,
+                      name: course.name,
                     }))}
-                    onStart={() => router.push("/taken?review=1")}
-                    onSelect={() => router.push("/taken?review=1")}
+                    onStart={() => router.push(reviewHref())}
+                    onSelect={(courseCode) =>
+                      router.push(reviewHref(courseCode))
+                    }
                   />
                 )}
               </div>

--- a/apps/web/features/reviews/api/queries.spec.tsx
+++ b/apps/web/features/reviews/api/queries.spec.tsx
@@ -1,0 +1,156 @@
+import { renderHook } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { useUnreviewedTakenCourses } from "./queries";
+
+/**
+ * The hook is four queries joined into one answer, so the four are the seams
+ * this suite works at: the session, `taken.list`, one `reviews.list` per taken
+ * course, and one `course.summary` per course that survives the difference.
+ * The difference itself is `selectUnreviewedCourses`, which has its own spec —
+ * what is tested here is what the hook does around it.
+ */
+
+type QueryResult<T> = { data?: T; isPending: boolean; isError?: boolean };
+
+const me = vi.fn();
+const takenResult = vi.fn<() => QueryResult<{ courseCode: string }[]>>();
+/** Keyed by course code, so a test can leave one list in flight. */
+const reviewResults =
+  vi.fn<
+    () => Record<string, QueryResult<{ courseCode: string; userId: string }[]>>
+  >();
+const summaryFor = vi.fn<() => Record<string, string>>();
+
+vi.mock("@tanstack/react-query", () => ({
+  useQuery: () => takenResult(),
+  useQueries: ({ queries }: { queries: { input: { courseCode: string } }[] }) =>
+    queries.map(
+      (query) =>
+        reviewResults()[query.input.courseCode] ?? {
+          isPending: false,
+          data: [],
+        },
+    ),
+}));
+
+// The tRPC proxy stands in as the thing that turns an input into query options;
+// the mock above reads the input straight back off them.
+vi.mock("@/trpc/client", () => ({
+  useTRPC: () => ({
+    taken: { list: { queryOptions: () => ({}) } },
+    reviews: {
+      list: { queryOptions: (input: { courseCode: string }) => ({ input }) },
+    },
+  }),
+}));
+
+vi.mock("@/features/auth", () => ({ useMe: () => me() }));
+
+vi.mock("@/features/courses/api/queries", () => ({
+  useCourseSummaries: (codes: string[]) =>
+    codes.map((courseCode) => {
+      const titleEng = summaryFor()[courseCode];
+      return { data: titleEng ? { courseCode, titleEng } : undefined };
+    }),
+}));
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  me.mockReturnValue({
+    userId: "u1",
+    isAuthenticated: true,
+    isLoading: false,
+  });
+  takenResult.mockReturnValue({
+    isPending: false,
+    isError: false,
+    data: [{ courseCode: "DD1337" }, { courseCode: "DD2380" }],
+  });
+  reviewResults.mockReturnValue({});
+  summaryFor.mockReturnValue({
+    DD1337: "Programming",
+    DD2380: "Artificial Intelligence",
+  });
+});
+
+describe("useUnreviewedTakenCourses", () => {
+  it("names every course it returns", () => {
+    const { result } = renderHook(() => useUnreviewedTakenCourses());
+
+    expect(result.current.courses).toEqual([
+      { courseCode: "DD1337", name: "Programming" },
+      { courseCode: "DD2380", name: "Artificial Intelligence" },
+    ]);
+  });
+
+  /**
+   * A missing title is a worse row, not a wrong one — the card falls back to
+   * the code — so nothing waits on `course.summary`. A missing review list is a
+   * wrong row, and that one does hold the whole answer back.
+   */
+  it("returns the course with a null name rather than waiting for its title", () => {
+    summaryFor.mockReturnValue({ DD1337: "Programming" });
+
+    const { result } = renderHook(() => useUnreviewedTakenCourses());
+
+    expect(result.current.courses).toEqual([
+      { courseCode: "DD1337", name: "Programming" },
+      { courseCode: "DD2380", name: null },
+    ]);
+    expect(result.current.isLoading).toBe(false);
+    expect(result.current.isUnavailable).toBe(false);
+  });
+
+  it("drops a course the viewer has already reviewed", () => {
+    reviewResults.mockReturnValue({
+      DD1337: {
+        isPending: false,
+        data: [{ courseCode: "DD1337", userId: "u1" }],
+      },
+    });
+
+    const { result } = renderHook(() => useUnreviewedTakenCourses());
+
+    expect(result.current.courses).toEqual([
+      { courseCode: "DD2380", name: "Artificial Intelligence" },
+    ]);
+  });
+
+  /** Somebody else's review leaves the course unreviewed *by you*. */
+  it("keeps a course only somebody else reviewed", () => {
+    reviewResults.mockReturnValue({
+      DD1337: {
+        isPending: false,
+        data: [{ courseCode: "DD1337", userId: "u2" }],
+      },
+    });
+
+    const { result } = renderHook(() => useUnreviewedTakenCourses());
+
+    expect(result.current.courses.map((course) => course.courseCode)).toEqual([
+      "DD1337",
+      "DD2380",
+    ]);
+  });
+
+  it("reports the set unavailable when a review list did not come back", () => {
+    reviewResults.mockReturnValue({
+      DD1337: { isPending: false, data: undefined },
+    });
+
+    const { result } = renderHook(() => useUnreviewedTakenCourses());
+
+    expect(result.current.courses).toEqual([]);
+    expect(result.current.isUnavailable).toBe(true);
+  });
+
+  it("is still loading while a review list is in flight", () => {
+    reviewResults.mockReturnValue({ DD2380: { isPending: true } });
+
+    const { result } = renderHook(() => useUnreviewedTakenCourses());
+
+    expect(result.current.isLoading).toBe(true);
+    expect(result.current.isUnavailable).toBe(false);
+    expect(result.current.courses).toEqual([]);
+  });
+});

--- a/apps/web/features/reviews/api/queries.ts
+++ b/apps/web/features/reviews/api/queries.ts
@@ -2,6 +2,11 @@
 
 import { useQueries, useQuery } from "@tanstack/react-query";
 import { useMe } from "@/features/auth";
+// The module, not `@/features/courses`. The barrel reaches the course card,
+// which reaches Saved, Collections and the workspace pane — and the pane
+// imports this feature, so going through it would close a cycle back onto this
+// file. `api/queries` imports nothing but the tRPC client.
+import { useCourseSummaries } from "@/features/courses/api/queries";
 import { type RouterOutputs, useTRPC } from "@/trpc/client";
 import {
   reviewsWhenEveryListLoaded,
@@ -12,6 +17,20 @@ export type ReviewList = RouterOutputs["reviews"]["list"];
 
 /** One taken course as `taken.list` returns it: a code and self-reported facts. */
 export type TakenCourse = RouterOutputs["taken"]["list"][number];
+
+/**
+ * A taken course with no review, and the catalogue title to draw it with.
+ *
+ * The title is part of the answer rather than each screen's to fetch:
+ * `user_taken_courses` stores only a code, so a host that forgot the lookup
+ * rendered the code twice — which is exactly what My Page did (#157). There is
+ * one host fewer to remember now, and no second place for the join to diverge.
+ *
+ * `null` while `course.summary` is still in flight, or when it failed. The card
+ * falls back to the code for it, which is why nothing here waits on a title:
+ * a missing name is a worse row, a missing review list is a wrong one.
+ */
+export type UnreviewedTakenCourse = TakenCourse & { name: string | null };
 
 export function useReviewList(courseCode: string | undefined) {
   const trpc = useTRPC();
@@ -41,9 +60,13 @@ export function useReviewList(courseCode: string | undefined) {
  * `isLoading` alone does not gate the difference. Prompting someone to review a
  * course they already reviewed is the one mistake this card must not make, so
  * a list that failed leaves the set unavailable rather than empty.
+ *
+ * The catalogue title comes back with each course for the same reason the
+ * difference does: it is the same join on both screens, and the host that had
+ * to remember it was the host that forgot (#157).
  */
 export function useUnreviewedTakenCourses(): {
-  courses: TakenCourse[];
+  courses: UnreviewedTakenCourse[];
   isLoading: boolean;
   /**
    * A list did not load, so the difference cannot be told. Distinct from an
@@ -76,10 +99,29 @@ export function useUnreviewedTakenCourses(): {
   );
   const isKnown = !isLoading && !takenQuery.isError && reviews !== null;
 
+  const unreviewed = isKnown
+    ? selectUnreviewedCourses(takenCourses, reviews, userId)
+    : [];
+
+  // Titles for the rows the card will actually draw, not for the whole taken
+  // list: on `/taken` these are already in the cache under the same keys that
+  // screen's own `useCourseSummaries` uses, so the join costs nothing there and
+  // costs one request per unreviewed course on My Page, which had none.
+  const summaries = useCourseSummaries(
+    unreviewed.map((course) => course.courseCode),
+    isAuthenticated,
+  );
+  const names = new Map(
+    summaries.flatMap((query) =>
+      query.data ? [[query.data.courseCode, query.data.titleEng] as const] : [],
+    ),
+  );
+
   return {
-    courses: isKnown
-      ? selectUnreviewedCourses(takenCourses, reviews, userId)
-      : [],
+    courses: unreviewed.map((course) => ({
+      ...course,
+      name: names.get(course.courseCode) ?? null,
+    })),
     isLoading,
     isUnavailable: !isLoading && !isKnown,
   };

--- a/apps/web/features/reviews/index.ts
+++ b/apps/web/features/reviews/index.ts
@@ -13,6 +13,7 @@
 
 export {
   type TakenCourse,
+  type UnreviewedTakenCourse,
   useReviewList,
   useUnreviewedTakenCourses,
 } from "./api/queries";

--- a/apps/web/features/taken/components/remove-taken-course-dialog.tsx
+++ b/apps/web/features/taken/components/remove-taken-course-dialog.tsx
@@ -1,0 +1,110 @@
+"use client";
+
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import type { TakenRow } from "../lib/taken-rows";
+
+type Props = {
+  /** The row being removed. Mounted per row, so it can name the course. */
+  row: TakenRow;
+  onCancel: () => void;
+  onConfirm: () => void;
+};
+
+/**
+ * What removing this row actually costs the reader.
+ *
+ * Two answers, because there are two rows. Everything on either is
+ * self-reported — `user_taken_courses` stores a code plus a grade, credits,
+ * periods and year the student typed — but only a hand-entered row can be put
+ * back by the note that follows. Putting an imported row back would go through
+ * `taken.add`, which writes no `transcript_imported_at`, so the course would
+ * return quietly re-labelled as hand-entered and nothing in the API can set
+ * that column again. The dialog says so before the click rather than leaving
+ * the reader to notice the missing Undo afterwards.
+ */
+function bodyFor(row: TakenRow): string {
+  return row.transcriptImportedAt
+    ? `The grade, credits and year on this row are your own entries and go with it. This one was read from a transcript, so there is no putting it back in a tap — you would add ${row.courseCode} by hand, or read the transcript again.`
+    : `The grade, credits and year on this row are your own entries and go with it. Nothing anyone else sees changes, and the note that follows offers one tap to put ${row.courseCode} back.`;
+}
+
+/**
+ * Confirming the removal of a taken course —
+ * `docs/design_ref/2026-09-05/Course Community - My Page.dc.html:426-438`, which
+ * is where this design lives: a 440px panel at 14px radius and 22px padding,
+ * a brand eyebrow over a 19px/600 title, a 13.5px body, and two 38px buttons
+ * ranged right over an `rgba(20,30,45,.34)` scrim.
+ *
+ * Two deliberate departures from that artboard, both recorded on the PR.
+ *
+ * **It confirms before the write, not after.** The artboard removes on the
+ * click and offers a note; #155 settled that destructive actions confirm first,
+ * and of the three that settled a taken course is the one worth the modal —
+ * everything on the row is self-reported and a transcript re-read is the only
+ * cheap way back.
+ *
+ * **The action button is `--cc-danger`, not the artboard's `#c96a4a`.** That
+ * hex has exactly one token in this theme, `--cc-node-ember`, and it is the
+ * community-graph palette — `server/graph/placement.ts` stores a colour *name*
+ * and those six tokens are the client half of that contract. Painting a delete
+ * button from it would make re-skinning the graph re-skin this dialog. The
+ * destructive token is what every other destructive control in the app uses.
+ *
+ * Built on `Dialog` rather than `AlertDialog` because the artboard's scrim is a
+ * flat wash and only `DialogContent` takes an `overlayClassName`; the stock
+ * alert overlay is a blurred `bg-black/10` with no way through to it. The
+ * pattern is the transcript dialog's next door.
+ */
+export function RemoveTakenCourseDialog({ row, onCancel, onConfirm }: Props) {
+  return (
+    <Dialog
+      open
+      onOpenChange={(open) => {
+        if (!open) onCancel();
+      }}
+    >
+      <DialogContent
+        showCloseButton={false}
+        overlayClassName="bg-[rgba(20,30,45,0.34)] supports-backdrop-filter:backdrop-blur-none"
+        className="cc-theme w-[440px] max-w-[calc(100vw-2rem)] gap-0 rounded-[14px] bg-cc-surface p-[22px] text-cc-ink shadow-[0_18px_48px_rgba(20,30,45,0.24)] ring-0 sm:max-w-[440px]"
+      >
+        <p className="m-0 font-semibold text-[11px] text-cc-brand uppercase tracking-[0.06em]">
+          Taken courses
+        </p>
+        <DialogTitle className="mt-2 font-semibold text-[19px] leading-[1.3]">
+          Remove {row.courseCode} from your courses?
+        </DialogTitle>
+        <DialogDescription className="mt-[9px] text-[13.5px] text-cc-muted leading-[1.55]">
+          {bodyFor(row)}
+        </DialogDescription>
+
+        <div className="mt-[18px] flex justify-end gap-[9px]">
+          {/*
+            Ranged right with the safe choice first, which is also the one
+            Radix moves focus to on open: Enter on an unread dialog keeps the
+            course.
+          */}
+          <button
+            type="button"
+            onClick={onCancel}
+            className="flex h-[38px] cursor-pointer items-center rounded-[9px] border border-cc-rule3 bg-cc-surface px-3.5 font-medium text-[13px] text-cc-chip-ink hover:border-cc-hov"
+          >
+            Keep course
+          </button>
+          <button
+            type="button"
+            onClick={onConfirm}
+            className="flex h-[38px] cursor-pointer items-center rounded-[9px] bg-cc-danger px-4 font-semibold text-[13px] text-cc-danger-fg hover:opacity-[0.88]"
+          >
+            Remove course
+          </button>
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/apps/web/features/taken/components/taken-courses.spec.tsx
+++ b/apps/web/features/taken/components/taken-courses.spec.tsx
@@ -1,6 +1,8 @@
 import { act, render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
+import { StrictMode } from "react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { UnreviewedTakenCourse } from "@/features/reviews/api/queries";
 import type { TranscriptProposal } from "@/server/ingest/transcript/service";
 import type { TakenCourse } from "../lib/taken-rows";
 import { TakenCourses } from "./taken-courses";
@@ -13,7 +15,11 @@ const refetchTaken =
   >();
 const unreviewed =
   vi.fn<
-    () => { courses: TakenCourse[]; isLoading: boolean; isUnavailable: boolean }
+    () => {
+      courses: UnreviewedTakenCourse[];
+      isLoading: boolean;
+      isUnavailable: boolean;
+    }
   >();
 const searchResults =
   vi.fn<
@@ -143,6 +149,18 @@ function takenCourse(overrides: Partial<TakenCourse> = {}): TakenCourse {
   };
 }
 
+/**
+ * One unreviewed course as the hook now hands it over: the taken row plus the
+ * catalogue title. The lookup moved into `useUnreviewedTakenCourses` so neither
+ * host has to remember it, and My Page was the host that forgot (#157).
+ */
+function unreviewedCourse(
+  overrides: Partial<TakenCourse> = {},
+): UnreviewedTakenCourse {
+  const course = takenCourse(overrides);
+  return { ...course, name: CATALOGUE[course.courseCode]?.titleEng ?? null };
+}
+
 function proposal(
   overrides: Partial<TranscriptProposal> = {},
 ): TranscriptProposal {
@@ -212,7 +230,7 @@ describe("the list", () => {
 
   it("says a course is not reviewed only once the review lists have arrived", () => {
     unreviewed.mockReturnValue({
-      courses: [takenCourse()],
+      courses: [unreviewedCourse()],
       isLoading: false,
       isUnavailable: false,
     });
@@ -454,13 +472,64 @@ describe("adding by hand", () => {
   });
 });
 
+/**
+ * Everything on a taken row is self-reported — `CONTEXT.md` says so — and a
+ * transcript re-read is the only cheap way back, so the mutation waits behind a
+ * confirmation (#155). The artboard confirms after; the product owner settled
+ * on before for every destructive action.
+ */
 describe("removing", () => {
+  const askToRemove = (code = "DD1337") =>
+    userEvent.click(
+      screen.getByLabelText(`Remove ${code} from your taken courses`),
+    );
+  const confirmRemove = () =>
+    userEvent.click(screen.getByRole("button", { name: "Remove course" }));
+
+  it("asks before it removes anything", async () => {
+    render(<TakenCourses />);
+
+    await askToRemove();
+
+    expect(
+      screen.getByText("Remove DD1337 from your courses?"),
+    ).toBeInTheDocument();
+    expect(removeTaken).not.toHaveBeenCalled();
+  });
+
+  it("keeps the course when the reader backs out", async () => {
+    render(<TakenCourses />);
+
+    await askToRemove();
+    await userEvent.click(screen.getByRole("button", { name: "Keep course" }));
+
+    expect(
+      screen.queryByText("Remove DD1337 from your courses?"),
+    ).not.toBeInTheDocument();
+    expect(removeTaken).not.toHaveBeenCalled();
+  });
+
+  /**
+   * The row came from a transcript, so the note that follows offers no Undo —
+   * the dialog is where that has to be said, before the click rather than by
+   * the reader noticing an absent button afterwards.
+   */
+  it("says an imported row cannot be put back in a tap", async () => {
+    takenList.mockReturnValue([
+      takenCourse({ transcriptImportedAt: "2026-08-24T09:00:00.000Z" }),
+    ]);
+    render(<TakenCourses />);
+
+    await askToRemove();
+
+    expect(screen.getByText(/read from a transcript/i)).toBeInTheDocument();
+  });
+
   it("removes the course and nothing else", async () => {
     render(<TakenCourses />);
 
-    await userEvent.click(
-      screen.getByLabelText("Remove DD1337 from your taken courses"),
-    );
+    await askToRemove();
+    await confirmRemove();
 
     expect(removeTaken).toHaveBeenCalledWith({ courseCode: "DD1337" });
     expect(updateTaken).not.toHaveBeenCalled();
@@ -468,9 +537,8 @@ describe("removing", () => {
 
   it("puts a hand-entered row back exactly as it was, periods included", async () => {
     render(<TakenCourses />);
-    await userEvent.click(
-      screen.getByLabelText("Remove DD1337 from your taken courses"),
-    );
+    await askToRemove();
+    await confirmRemove();
 
     await waitFor(() => expect(toastSuccess).toHaveBeenCalled());
     const [, options] = toastSuccess.mock.calls[0];
@@ -490,9 +558,8 @@ describe("removing", () => {
       takenCourse({ transcriptImportedAt: "2026-08-24T09:00:00.000Z" }),
     ]);
     render(<TakenCourses />);
-    await userEvent.click(
-      screen.getByLabelText("Remove DD1337 from your taken courses"),
-    );
+    await askToRemove();
+    await confirmRemove();
 
     await waitFor(() => expect(toastSuccess).toHaveBeenCalled());
     expect(toastSuccess.mock.calls[0][1].action).toBeUndefined();
@@ -749,7 +816,7 @@ describe("reading a transcript", () => {
 describe("the fast-track reviewer", () => {
   const bothUnreviewed = () =>
     unreviewed.mockReturnValue({
-      courses: [takenCourse(), takenCourse({ courseCode: "DD2380" })],
+      courses: [unreviewedCourse(), unreviewedCourse({ courseCode: "DD2380" })],
       isLoading: false,
       isUnavailable: false,
     });
@@ -845,7 +912,7 @@ describe("a round a reload interrupted", () => {
       takenCourse({ courseCode: "DD2380" }),
     ]);
     unreviewed.mockReturnValue({
-      courses: [takenCourse(), takenCourse({ courseCode: "DD2380" })],
+      courses: [unreviewedCourse(), unreviewedCourse({ courseCode: "DD2380" })],
       isLoading: false,
       isUnavailable: false,
     });
@@ -872,7 +939,7 @@ describe("a round a reload interrupted", () => {
       takenCourse({ courseCode: "DD2380" }),
     ]);
     unreviewed.mockReturnValue({
-      courses: [takenCourse()],
+      courses: [unreviewedCourse()],
       isLoading: false,
       isUnavailable: false,
     });
@@ -896,7 +963,7 @@ describe("a round a reload interrupted", () => {
       takenCourse({ courseCode: "DD2380" }),
     ]);
     unreviewed.mockReturnValue({
-      courses: [takenCourse()],
+      courses: [unreviewedCourse()],
       isLoading: false,
       isUnavailable: false,
     });
@@ -913,7 +980,7 @@ describe("a round a reload interrupted", () => {
     both();
     storeRound(["DD1337", "DD2380"], { DD1337: "saved" });
     unreviewed.mockReturnValue({
-      courses: [takenCourse({ courseCode: "DD2380" })],
+      courses: [unreviewedCourse({ courseCode: "DD2380" })],
       isLoading: false,
       isUnavailable: false,
     });
@@ -935,7 +1002,7 @@ describe("a round a reload interrupted", () => {
       takenCourse({ courseCode: "DD2380" }),
     ]);
     unreviewed.mockReturnValue({
-      courses: [takenCourse()],
+      courses: [unreviewedCourse()],
       isLoading: false,
       isUnavailable: false,
     });
@@ -994,11 +1061,18 @@ describe("a round a reload interrupted", () => {
   });
 });
 
-describe("arriving with ?review=1", () => {
+describe("arriving with ?review=…", () => {
+  const both = () =>
+    unreviewed.mockReturnValue({
+      courses: [unreviewedCourse(), unreviewedCourse({ courseCode: "DD2380" })],
+      isLoading: false,
+      isUnavailable: false,
+    });
+
   it("opens the reviewer and takes the parameter back out of the URL", async () => {
     window.history.replaceState({}, "", "/taken?review=1");
     unreviewed.mockReturnValue({
-      courses: [takenCourse()],
+      courses: [unreviewedCourse()],
       isLoading: false,
       isUnavailable: false,
     });
@@ -1026,5 +1100,63 @@ describe("arriving with ?review=1", () => {
 
     await waitFor(() => expect(routerReplace).toHaveBeenCalledWith("/taken"));
     expect(screen.queryByTestId("reviewer")).not.toBeInTheDocument();
+  });
+
+  /**
+   * The defect this contract was widened for (#157): a row on My Page's prompt
+   * names a course, and the round has to start on it rather than on whatever
+   * the unreviewed set happens to list first.
+   */
+  it("starts on the course the link names, with the rest dealt behind it", async () => {
+    both();
+    window.history.replaceState({}, "", "/taken?review=DD2380");
+    render(<TakenCourses />);
+
+    await waitFor(() =>
+      expect(screen.getByTestId("reviewer")).toHaveTextContent(
+        "Reviewing DD2380, DD1337",
+      ),
+    );
+    expect(routerReplace).toHaveBeenCalledWith("/taken");
+  });
+
+  /** Reviewed elsewhere since, or never taken: there is no card to deal for it. */
+  it("deals the rest when the named course is no longer unreviewed", async () => {
+    unreviewed.mockReturnValue({
+      courses: [unreviewedCourse()],
+      isLoading: false,
+      isUnavailable: false,
+    });
+    window.history.replaceState({}, "", "/taken?review=SF1625");
+    render(<TakenCourses />);
+
+    await waitFor(() =>
+      expect(screen.getByTestId("reviewer")).toHaveTextContent(
+        "Reviewing DD1337",
+      ),
+    );
+  });
+
+  /**
+   * The parameter is a moment, not a value. It is read once, replaced out of
+   * the URL, and never read again — so a second pass over the arrival effect,
+   * which is exactly what Strict Mode's mount replay is, must not open a second
+   * round or replace a second time.
+   */
+  it("reads the arrival once under Strict Mode's mount replay", async () => {
+    both();
+    window.history.replaceState({}, "", "/taken?review=DD2380");
+    render(
+      <StrictMode>
+        <TakenCourses />
+      </StrictMode>,
+    );
+
+    await waitFor(() =>
+      expect(screen.getByTestId("reviewer")).toHaveTextContent(
+        "Reviewing DD2380, DD1337",
+      ),
+    );
+    expect(routerReplace).toHaveBeenCalledTimes(1);
   });
 });

--- a/apps/web/features/taken/components/taken-courses.tsx
+++ b/apps/web/features/taken/components/taken-courses.tsx
@@ -28,6 +28,11 @@ import type { TranscriptProposal } from "@/server/ingest/transcript/service";
 import { useTakenMutations } from "../api/mutations";
 import { uploadTranscript } from "../api/transcript";
 import {
+  parseReviewDeepLink,
+  type ReviewDeepLink,
+  reviewQueue,
+} from "../lib/review-deep-link";
+import {
   lastTranscriptImport,
   planTranscriptImport,
   type TakenEdits,
@@ -36,6 +41,7 @@ import {
   toTakenRows,
 } from "../lib/taken-rows";
 import { AddTakenCourseDialog } from "./add-taken-course-dialog";
+import { RemoveTakenCourseDialog } from "./remove-taken-course-dialog";
 import { TAKEN_GRID, TakenCourseRow } from "./taken-course-row";
 import { TranscriptDropZone } from "./transcript-drop-zone";
 import { TranscriptProposalReview } from "./transcript-proposal";
@@ -142,9 +148,15 @@ function importedSummary(added: number, filled: number): string {
  * save-error row and the done screen. It is presentation only: it maps a card
  * onto `ReviewFormData` and hands it to `useAddReview`, which is the same hook
  * the workspace pane and the review dialog write through and the one place
- * `reviewFormSchema` runs. `?review=1` opens it on arrival — that is My Page's
- * deep link — and the parameter is taken back out so a reload does not replay
- * it.
+ * `reviewFormSchema` runs. `?review=…` opens it on arrival — that is My Page's
+ * deep link, and it carries the course a row named — and the parameter is taken
+ * back out so a reload does not replay it.
+ *
+ * **Removing a row confirms first.** The artboard confirms after, with an
+ * undoable note; #155 settled that destructive actions confirm before, and a
+ * taken course is the most destructive of the three because everything on the
+ * row is self-reported and exists nowhere else. The note and its Undo stay: the
+ * dialog is about the wrong row, the note is about the right one.
  */
 export function TakenCourses() {
   useRequireSession();
@@ -199,6 +211,13 @@ export function TakenCourses() {
   const [banner, setBanner] = useState<string | null>(null);
   const [isConfirming, setIsConfirming] = useState(false);
   /**
+   * The row whose removal is waiting to be confirmed, or `null`. It is the
+   * whole row rather than a code because the dialog names the course and says
+   * which of the two removals this is — a hand-entered row can be put straight
+   * back, an imported one cannot.
+   */
+  const [pendingRemove, setPendingRemove] = useState<TakenRow | null>(null);
+  /**
    * The round on screen, or `null` when the list is. `restored` is the stored
    * progress and unsaved answers when the round is one this tab was already in
    * the middle of.
@@ -214,7 +233,8 @@ export function TakenCourses() {
    * queue is still true.
    */
   const [pendingOpen, setPendingOpen] = useState<{
-    deepLinked: boolean;
+    /** What `?review=…` asked for, or `null` when the URL asked for nothing. */
+    deepLink: ReviewDeepLink | null;
     session: ReviewerSession | null;
   } | null>(null);
   /** Whether the arrival below has already been read. See why it must be. */
@@ -225,8 +245,15 @@ export function TakenCourses() {
 
   /**
    * How the reviewer gets opened without a click: My Page's prompt deep-links
-   * `/taken?review=1`, and a round this tab was in the middle of survives a
+   * `/taken?review=…`, and a round this tab was in the middle of survives a
    * reload.
+   *
+   * **The parameter carries a course.** `?review=<CODE>` starts the round on
+   * that course with the rest dealt behind it, which is what a row on My Page's
+   * prompt means and what it could not say while the parameter was the bare
+   * flag `1` (#157). `1` still means what it always did — open the reviewer, on
+   * no particular course — so links already in the wild keep working;
+   * `parseReviewDeepLink` is the whole contract.
    *
    * The query parameter is read from `window.location` rather than through
    * `useSearchParams`, which would need a `Suspense` boundary around this
@@ -247,16 +274,11 @@ export function TakenCourses() {
     if (hasReadArrival.current) return;
     hasReadArrival.current = true;
 
-    let asked = false;
-    try {
-      asked = new URLSearchParams(window.location.search).get("review") === "1";
-    } catch {
-      asked = false;
-    }
-    if (asked) router.replace("/taken");
+    const deepLink = parseReviewDeepLink(window.location.search);
+    if (deepLink !== null) router.replace("/taken");
 
     const session = readReviewerSession();
-    if (asked || session) setPendingOpen({ deepLinked: asked, session });
+    if (deepLink !== null || session) setPendingOpen({ deepLink, session });
   }, [router]);
 
   /**
@@ -321,8 +343,15 @@ export function TakenCourses() {
       clearReviewerSession();
     }
 
-    if (pendingOpen.deepLinked && stillUnreviewed.length > 0) {
-      setRound({ queue: stillUnreviewed, restored: null });
+    const deepLink = pendingOpen.deepLink;
+    if (deepLink !== null && stillUnreviewed.length > 0) {
+      // A course the link named that is no longer unreviewed is dropped by
+      // `reviewQueue`, and the round opens on the rest — the same quiet
+      // degrading the link already did when nothing at all was unreviewed.
+      setRound({
+        queue: reviewQueue(stillUnreviewed, deepLink.startCode),
+        restored: null,
+      });
     }
   }, [pendingOpen, reviewsKnown, unreviewedKey]);
 
@@ -333,11 +362,10 @@ export function TakenCourses() {
    * course is exactly who is most likely to review a second.
    */
   function openReviewer(startCode?: string) {
-    const codes = unreviewed.map((course) => course.courseCode);
-    const queue =
-      startCode === undefined
-        ? codes
-        : [startCode, ...codes.filter((code) => code !== startCode)];
+    const queue = reviewQueue(
+      unreviewed.map((course) => course.courseCode),
+      startCode ?? null,
+    );
     if (queue.length === 0) return;
     // A new round replaces whatever the tab was holding, drafts included.
     clearReviewerSession();
@@ -489,6 +517,19 @@ export function TakenCourses() {
     }
   }
 
+  /**
+   * Removes a row the reader has confirmed removing.
+   *
+   * The confirmation is not decoration. `CONTEXT.md` holds taken courses to be
+   * **self-reported**: the grade, credits, year and periods on this row exist
+   * nowhere but here, and the only cheap way back is reading a transcript
+   * again — which cannot restore a hand-entered course at all. The artboard
+   * confirms *after*, with a note; the product owner settled on confirming
+   * before for every destructive action, and this is one of them (#155).
+   *
+   * The note stays anyway. Confirming before is about not removing the wrong
+   * row; Undo is about the row it was right to remove and wrong to lose.
+   */
   function removeCourse(row: TakenRow) {
     remove
       .mutateAsync({ courseCode: row.courseCode })
@@ -649,7 +690,7 @@ export function TakenCourses() {
             <UnreviewedCard
               courses={unreviewed.map((course) => ({
                 code: course.courseCode,
-                name: names.get(course.courseCode),
+                name: course.name,
               }))}
               line={
                 unreviewed.length === 1
@@ -695,7 +736,7 @@ export function TakenCourses() {
                 }
                 isBusy={isBusy}
                 onSave={(edits) => saveEdits(row, edits)}
-                onRemove={() => removeCourse(row)}
+                onRemove={() => setPendingRemove(row)}
               />
             ))}
           </div>
@@ -722,6 +763,22 @@ export function TakenCourses() {
         onClose={() => setAddOpen(false)}
         onAdd={addCourse}
       />
+
+      {/*
+        Mounted only while a row is pending, so the confirmation can name the
+        course it is about rather than holding a dialog open over nothing.
+      */}
+      {pendingRemove ? (
+        <RemoveTakenCourseDialog
+          row={pendingRemove}
+          onCancel={() => setPendingRemove(null)}
+          onConfirm={() => {
+            const row = pendingRemove;
+            setPendingRemove(null);
+            removeCourse(row);
+          }}
+        />
+      ) : null}
 
       <Dialog open={updateOpen} onOpenChange={setUpdateOpen}>
         <DialogContent

--- a/apps/web/features/taken/lib/review-deep-link.spec.ts
+++ b/apps/web/features/taken/lib/review-deep-link.spec.ts
@@ -1,0 +1,84 @@
+import { describe, expect, it } from "vitest";
+import {
+  parseReviewDeepLink,
+  reviewHref,
+  reviewQueue,
+} from "./review-deep-link";
+
+describe("parseReviewDeepLink", () => {
+  it("says nothing was asked for when the parameter is absent", () => {
+    expect(parseReviewDeepLink("")).toBeNull();
+    expect(parseReviewDeepLink("?tab=reviews")).toBeNull();
+  });
+
+  /** The original contract. A bookmarked link must keep working. */
+  it("reads ?review=1 as the whole unreviewed set", () => {
+    expect(parseReviewDeepLink("?review=1")).toEqual({ startCode: null });
+  });
+
+  it("reads a course code as the course to start on", () => {
+    expect(parseReviewDeepLink("?review=DD2380")).toEqual({
+      startCode: "DD2380",
+    });
+  });
+
+  it("normalises the code the way course codes are stored", () => {
+    expect(parseReviewDeepLink("?review=%20dd2380%20")).toEqual({
+      startCode: "DD2380",
+    });
+  });
+
+  /**
+   * A value that can match no course is still a request for the reviewer — the
+   * reader clicked something. It degrades to the whole set rather than to
+   * nothing, which is also what stops the parameter being left in the URL.
+   */
+  it("falls back to the whole set for a value no course code could be", () => {
+    expect(parseReviewDeepLink("?review=not+a+code")).toEqual({
+      startCode: null,
+    });
+    expect(parseReviewDeepLink("?review=")).toEqual({ startCode: null });
+  });
+});
+
+describe("reviewHref", () => {
+  it("keeps writing the flag form when no course is named", () => {
+    expect(reviewHref()).toBe("/taken?review=1");
+  });
+
+  it("carries the course when one is", () => {
+    expect(reviewHref("DD2380")).toBe("/taken?review=DD2380");
+  });
+
+  it("round-trips through the parser", () => {
+    const href = reviewHref("SF1625");
+    expect(parseReviewDeepLink(href.slice(href.indexOf("?")))).toEqual({
+      startCode: "SF1625",
+    });
+  });
+});
+
+describe("reviewQueue", () => {
+  it("deals the set as it stands when no course is named", () => {
+    expect(reviewQueue(["DD1337", "DD2380"], null)).toEqual([
+      "DD1337",
+      "DD2380",
+    ]);
+  });
+
+  it("puts the named course first and deals the rest behind it", () => {
+    expect(reviewQueue(["DD1337", "DD2380"], "DD2380")).toEqual([
+      "DD2380",
+      "DD1337",
+    ]);
+  });
+
+  /** Reviewed since, or never taken: there is no card to deal for it. */
+  it("drops a named course the set does not hold", () => {
+    expect(reviewQueue(["DD1337"], "SF1625")).toEqual(["DD1337"]);
+  });
+
+  it("leaves an empty set empty", () => {
+    expect(reviewQueue([], "DD2380")).toEqual([]);
+  });
+});

--- a/apps/web/features/taken/lib/review-deep-link.ts
+++ b/apps/web/features/taken/lib/review-deep-link.ts
@@ -1,0 +1,77 @@
+/**
+ * The `/taken?review=…` contract, and the queue a round starts with.
+ *
+ * My Page has no reviewer of its own — `/taken` owns the queue — so the only
+ * thing it can say about a course the reader picked is what it puts in the URL.
+ * The parameter used to be the bare flag `1`, which could say "open the
+ * reviewer" and nothing else, so a row and the "Fast track all N" button
+ * deep-linked to the very same place and the named course was discarded (#157).
+ */
+
+/**
+ * `review=1` — the original contract. It still means what it always meant: open
+ * the reviewer, on no particular course. Kept so a link somebody bookmarked,
+ * or a tab left open across this deploy, still lands where it used to.
+ */
+export const REVIEW_ALL = "1";
+
+/**
+ * A course code as `courses.code` holds one — letters and digits, never
+ * punctuation. The parameter is a string off the URL bar, so it is checked
+ * rather than trusted; anything else is treated as `1` and the reader gets the
+ * whole unreviewed set instead of a queue built around a code that can match no
+ * course.
+ */
+const COURSE_CODE = /^[A-Z0-9]{2,16}$/;
+
+/** What an arrival asked for. `startCode` of `null` is "no particular course". */
+export type ReviewDeepLink = { startCode: string | null };
+
+/**
+ * What `?review=…` in `search` asks for, or `null` when it asks for nothing.
+ *
+ * `null` and `{ startCode: null }` are different answers and the caller acts on
+ * both: nothing at all leaves the URL alone, while a parameter that named no
+ * usable course still opens the reviewer and still has to be taken back out.
+ */
+export function parseReviewDeepLink(search: string): ReviewDeepLink | null {
+  let value: string | null;
+  try {
+    value = new URLSearchParams(search).get("review");
+  } catch {
+    return null;
+  }
+  if (value === null) return null;
+  if (value === REVIEW_ALL) return { startCode: null };
+
+  const code = value.trim().toUpperCase();
+  return { startCode: COURSE_CODE.test(code) ? code : null };
+}
+
+/** The path My Page links to for a whole round, or for one named course. */
+export function reviewHref(courseCode?: string): string {
+  return courseCode === undefined
+    ? `/taken?review=${REVIEW_ALL}`
+    : `/taken?review=${encodeURIComponent(courseCode)}`;
+}
+
+/**
+ * The round's queue: `startCode` first, then the rest of the unreviewed set
+ * behind it.
+ *
+ * A named course is a starting point and not a queue of one — the artboard
+ * deals the rest behind it, and someone who came to review one course is
+ * exactly who is most likely to review a second.
+ *
+ * A `startCode` the set does not hold is dropped rather than dealt. It is what
+ * a deep link to a course reviewed since, or never taken, arrives as, and
+ * putting it at the front would deal a card for a course that has a review
+ * already or no row at all.
+ */
+export function reviewQueue(
+  codes: readonly string[],
+  startCode: string | null,
+): string[] {
+  if (startCode === null || !codes.includes(startCode)) return [...codes];
+  return [startCode, ...codes.filter((code) => code !== startCode)];
+}


### PR DESCRIPTION
Closes nothing on its own — #157 in full, and the taken-course half of #155.

## 1. The deep link now carries a course (#157)

`UnreviewedCard`'s `onSelect` contract is *"Opens the reviewer on **this one course**"*. Taken courses honoured it; My Page passed a handler taking no parameter and pushed `/taken?review=1` — the same URL its "Fast track all N" button pushed. Clicking a specific course started a round over every unreviewed course and said nothing about it.

The root cause was the route contract, not the handler: `?review=1` was a flag and could carry nothing.

### The route contract, as implemented

| URL | Meaning |
| --- | --- |
| `/taken?review=1` | Open the reviewer on **no particular course** — the whole unreviewed set, in its own order. Unchanged. |
| `/taken?review=<CODE>` | Open the reviewer **starting on `<CODE>`**, with the rest of the unreviewed set dealt behind it. |
| `/taken?review=<anything else>` | Treated as `1`. The reader asked for the reviewer; a value that can match no course degrades to the whole set rather than to nothing. |
| no parameter | Nothing. |

**Backward compatibility.** `1` keeps exactly its old meaning, so a bookmarked link, a tab left open across this deploy, or anything else already in the wild lands where it always did. The parameter is validated (`^[A-Z0-9]{2,16}$` after trim and upcase — `courses.code` is a KTH course code, letters and digits) and a code the unreviewed set no longer holds is **dropped rather than dealt**: reviewed elsewhere since, or never taken, means there is no card for it. That is the same quiet degrading the link already did when nothing at all was unreviewed.

The whole contract is one pure module, `apps/web/features/taken/lib/review-deep-link.ts`: `reviewHref` builds a link, `parseReviewDeepLink` reads one, `reviewQueue` turns a start code into a round. My Page imports only `reviewHref`; `/taken` imports the other two. `openReviewer` and the arrival effect now share `reviewQueue`, so the click path and the link path cannot drift.

Nothing below the arrival effect changed — the queue machinery already took a `startCode`.

### How the parameter is consumed once

Unchanged in shape, because the shape was already right, and this is the third place in this repo where an effect over `router` has shipped an unbounded render loop:

- one `useRef` guard, set on entry, so the effect body runs **once per mounted component** regardless of how many times React runs the effect;
- the value is read straight off `window.location.search` (not `useSearchParams`, which would need a `Suspense` boundary in `app/`), then `router.replace("/taken")` takes it out of the URL — the same idiom `features/landing/components/landing.tsx` uses for its own private-link parameter;
- the effect's only dependency is `router`. `useRouter()` is stable in Next, but the ref guard means nothing here relies on that.

A **Strict Mode** test now pins it: rendering `<StrictMode><TakenCourses /></StrictMode>` with `?review=DD2380` opens exactly one round and calls `router.replace` exactly once. The ref survives the mount replay (run → cleanup → run) because refs persist across it, and the read it guards is non-destructive — `readReviewerSession` only parses, so the `sessionStorage` handoff is not the one-ref-guards-both-a-destructive-read-and-an-action shape that broke before.

### Second defect on the same card: `DD2380   DD2380`

My Page passed `{ code }` and no `name`, so every row fell back to `{course.name || course.code}`.

Fixed where the issue recommended — **in the hook, not in the host**. `useUnreviewedTakenCourses` now does the `course.summary` lookup itself and returns `name` on each course (`UnreviewedTakenCourse`). Both hosts get titles for free and neither can forget. On `/taken` the summaries are already in cache under the same keys that screen's own `useCourseSummaries` uses, so it costs nothing there; on My Page it costs one request per **unreviewed** course, which had none. Titles never gate the answer: a missing name is a worse row, a missing review list is a wrong one, so `isLoading` / `isUnavailable` still turn only on the review lists.

The import is `@/features/courses/api/queries`, not the `@/features/courses` barrel, on purpose: the barrel reaches the course card → Saved → Collections → the workspace pane, and the pane imports `@/features/reviews`, so going through it would close a cycle back onto this file. The module it imports instead pulls in nothing but the tRPC client.

## 2. Removing a taken course confirms before, not after (#155)

**Authorised deviation from the artboard.** `docs/design_ref/2026-09-05/Course Community - My Page.dc.html` confirms *after* the write, with an undoable note. The product owner settled that destructive actions confirm **before** the mutation — for collection deletion, for removing a saved course, and for removing a taken course, which is this PR's half. That overrides the artboard here, deliberately.

It is worth the modal: `CONTEXT.md` holds taken courses to be **self-reported**, so the grade, credits, periods and year on the row exist nowhere else, and a transcript re-read is the only cheap way back — one that cannot restore a hand-entered course at all.

**The Undo note stays.** Confirming before is about not removing the *wrong* row; Undo is about the row it was right to remove and wrong to lose. It is still withheld for an imported row, because `taken.add` writes no `transcript_imported_at` and the course would come back re-labelled — and the dialog now says so *before* the click, rather than leaving the reader to notice an absent button afterwards.

### The dialog, and how it matches the artboard

Built to `Course Community - My Page.dc.html:426-438`, not to stock shadcn defaults (the #134 review found the app's existing delete dialogs are unrestyled `AlertDialog`):

| Artboard | `remove-taken-course-dialog.tsx` |
| --- | --- |
| `width:440px` | `w-[440px] max-w-[calc(100vw-2rem)] sm:max-w-[440px]` |
| `border-radius:14px` | `rounded-[14px]` |
| `padding:22px` | `p-[22px]` |
| `background:var(--surface)` | `bg-cc-surface` |
| `box-shadow:0 18px 48px rgba(20,30,45,.24)` | same, as an arbitrary shadow |
| scrim `rgba(20,30,45,.34)`, no blur | `overlayClassName` sets exactly that and drops the stock blur |
| eyebrow `11px/600`, `.06em`, uppercase, `var(--brand)` | `text-[11px] font-semibold tracking-[0.06em] uppercase text-cc-brand` |
| title `margin-top:8px`, `19px/600`, `line-height:1.3` | `mt-2 text-[19px] font-semibold leading-[1.3]` |
| body `margin-top:9px`, `13.5px`, `1.55`, `var(--muted)` | `mt-[9px] text-[13.5px] leading-[1.55] text-cc-muted` |
| footer `margin-top:18px`, right-ranged, `gap:9px` | `mt-[18px] flex justify-end gap-[9px]` |
| cancel `38px`, `0 14px`, `9px`, `--rule3` / `--chipInk`, hover `--hov` | `h-[38px] px-3.5 rounded-[9px] border-cc-rule3 text-cc-chip-ink hover:border-cc-hov` |
| action `38px`, `0 16px`, `9px`, `13px/600` | `h-[38px] px-4 rounded-[9px] text-[13px] font-semibold` |

Two mechanical departures, both commented in the file:

- **The action button is `--cc-danger`, not the artboard's literal `#c96a4a`.** That hex has exactly one token in this theme — `--cc-node-ember` — and it is the community-graph palette (`server/graph/placement.ts` stores a colour *name*; those six tokens are the client half of that contract). Painting a delete button from it would make re-skinning the graph re-skin this dialog. `--cc-danger` is what every other destructive control in the app already uses. No raw hex was introduced for it.
- **Built on `Dialog`, not `AlertDialog`.** The artboard's scrim is a flat wash and only `DialogContent` exposes an `overlayClassName`; the stock alert overlay is a blurred `bg-black/10` with no way through to it, and `components/ui/` is out of scope for this PR. This is the same pattern as the "Read a newer transcript" dialog next door in the same file. The safe button is first, which is where Radix puts focus on open.

### Not shared with Saved / Collections — on purpose

A parallel agent is building the same-shaped dialog for those two. We did not try to share a component; we would both have been writing one file. **Follow-up issue worth filing:** once both land, extract the artboard's confirm panel into one component (probably `components/ui/` or a shell primitive) and have all three use it.

## Validation

Repo root, all three green:

```
bun run lint       # exit 0 (8 pre-existing warnings, all in .agents/skills/)
bun run typecheck  # exit 0
bun run test:web   # 72 files, 868 tests, 0 failed  (baseline 70 / 843)
```

The run took 34s, in line with the baseline — no sign of the runaway-effect symptom that has bitten this repo before.

New coverage, +25 tests:

- `features/taken/lib/review-deep-link.spec.ts` — the contract: absent, `1`, a code, a normalised code, an unusable value; `reviewHref` round-tripping through the parser; `reviewQueue` fronting a code, dropping one the set does not hold, and leaving an empty set empty.
- `features/reviews/api/queries.spec.tsx` (new file) — the hook: names on every course, a `null` name rather than waiting on a title, the difference against the viewer's own reviews, somebody else's review leaving a course unreviewed by you, unavailable when a list did not come back, loading while one is in flight.
- `features/taken/components/taken-courses.spec.tsx` — starting on the named course with the rest behind it; dealing the rest when the named course is no longer unreviewed; reading the arrival once under Strict Mode; and four around the confirmation (asks before it removes anything, keeps the course on cancel, tells an imported row it cannot be put back in a tap, removes only after confirming). The existing removal tests now go through the dialog.
- `features/my-page/components/my-page.spec.tsx` — the button goes to `?review=1` and a row to `?review=DD2380`; the card is handed the catalogue title the hook looked up.

## Files outside my scope

None were edited. One thing noticed and **not** touched, worth its own issue: `DialogContent`'s base classes include `sm:max-w-sm` (384px), which tailwind-merge does not reconcile against a plain `max-w-*` override — so the existing "Read a newer transcript" dialog's `w-[460px]` is clamped to 384px at `sm` and up. This PR's dialog adds an explicit `sm:max-w-[440px]` for itself; fixing the primitive, or the transcript dialog, belongs to whoever owns `components/ui/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017EAUKDDo2BkQTFELyvV3v8
