### PR TITLE
fix(server): cap the profile-picture upload body, and write the earned personalization tier

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,6 +12,7 @@ Bun workspace monorepo (`workspaces: ["apps/*"]`). The only app is `apps/web`: N
 - Lint / format: `bun run lint` / `bun run format` (Biome)
 - DB: `bun run db:push` / `bun run db:generate`
 - Ingest: `bun run ingest` (optional `--test`)
+- Backfill earned personalization tiers: `bun run backfill:tiers` (idempotent; only ever raises)
 
 Run scripts from the repo root. Env lives in `apps/web/.env.local` (see `apps/web/.env.example`). Path alias `@/*` → `apps/web/*`.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -42,6 +42,7 @@ apps/web/
     ai.ts                   # embeddings (search/ingest)
     ingest/                 # KOPPS → Neon
     email/                  # SES magic-link mail
+    http/                   # request-shaping helpers shared by app/api routes
 ```
 
 ## Conventions
@@ -57,6 +58,7 @@ apps/web/
 - Feature `api/` exposes wrapped `useQuery` / `useMutation` hooks, not raw queryOptions factories.
 - `protectedProcedure` is the real auth gate (`ctx.session.user`). `proxy.ts` (Next 16; not `middleware.ts`) only checks that a session cookie exists for `/profile`, `/saved` and `/taken`. Visitors may browse courses, search, and read reviews.
 - Browser calls same-origin `/api/trpc` and `/api/auth`. Multipart profile pictures POST to `/api/user/profile-picture` (not tRPC).
+- Every multipart route in `app/api/` caps its body with `capRequestBody` from `server/http/body-cap.ts` **before** calling `request.formData()`, which buffers the whole body before anything can read a file's size. `server/http/` is domain-neutral on purpose: this cap lived under `server/ingest/transcript/` and the profile-picture route never found it.
 - Tests colocate as `*.spec.ts` next to server code; mock repositories, not the database.
 - Domain words: `CONTEXT.md`. Decisions: `docs/adr/NNNN-slug.md`.
 - Design: `docs/design_ref/` holds the artboards, in one dated folder per export.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -12,6 +12,7 @@ Bun workspace monorepo (`workspaces: ["apps/*"]`). The only app is `apps/web`: N
 - Lint / format: `bun run lint` / `bun run format` (Biome)
 - DB: `bun run db:push` / `bun run db:generate`
 - Ingest: `bun run ingest` (optional `--test`)
+- Backfill earned personalization tiers: `bun run backfill:tiers` (idempotent; only ever raises)
 
 Run scripts from the repo root. Env lives in `apps/web/.env.local` (see `apps/web/.env.example`). Path alias `@/*` → `apps/web/*`.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -42,6 +42,7 @@ apps/web/
     ai.ts                   # embeddings (search/ingest)
     ingest/                 # KOPPS → Neon
     email/                  # SES magic-link mail
+    http/                   # request-shaping helpers shared by app/api routes
 ```
 
 ## Conventions
@@ -57,6 +58,7 @@ apps/web/
 - Feature `api/` exposes wrapped `useQuery` / `useMutation` hooks, not raw queryOptions factories.
 - `protectedProcedure` is the real auth gate (`ctx.session.user`). `proxy.ts` (Next 16; not `middleware.ts`) only checks that a session cookie exists for `/profile`, `/saved` and `/taken`. Visitors may browse courses, search, and read reviews.
 - Browser calls same-origin `/api/trpc` and `/api/auth`. Multipart profile pictures POST to `/api/user/profile-picture` (not tRPC).
+- Every multipart route in `app/api/` caps its body with `capRequestBody` from `server/http/body-cap.ts` **before** calling `request.formData()`, which buffers the whole body before anything can read a file's size. `server/http/` is domain-neutral on purpose: this cap lived under `server/ingest/transcript/` and the profile-picture route never found it.
 - Tests colocate as `*.spec.ts` next to server code; mock repositories, not the database.
 - Domain words: `CONTEXT.md`. Decisions: `docs/adr/NNNN-slug.md`.
 - Design: `docs/design_ref/` holds the artboards, in one dated folder per export.

--- a/apps/web/app/api/user/profile-picture/route.spec.ts
+++ b/apps/web/app/api/user/profile-picture/route.spec.ts
@@ -1,0 +1,146 @@
+import { put } from "@vercel/blob";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { updateImage } from "@/server/user/service";
+import { POST } from "./route";
+
+const { getSession } = vi.hoisted(() => ({ getSession: vi.fn() }));
+
+vi.mock("@/server/auth", () => ({ getAuth: () => ({ api: { getSession } }) }));
+vi.mock("@vercel/blob", () => ({
+  put: vi.fn(async () => ({ url: "https://blob.test/avatar.png" })),
+}));
+vi.mock("@/server/user/service", () => ({ updateImage: vi.fn() }));
+
+const URL_UNDER_TEST = "https://example.test/api/user/profile-picture";
+const BOUNDARY = "----kthcccontentboundary";
+const MEGABYTE = 1024 * 1024;
+const encoder = new TextEncoder();
+
+function partHeader(filename: string, type: string): Uint8Array {
+  return encoder.encode(
+    `--${BOUNDARY}\r\n` +
+      `Content-Disposition: form-data; name="file"; filename="${filename}"\r\n` +
+      `Content-Type: ${type}\r\n\r\n`,
+  );
+}
+
+const PART_FOOTER = encoder.encode(`\r\n--${BOUNDARY}--\r\n`);
+
+/**
+ * A multipart upload that arrives in chunks and counts what the server pulled.
+ *
+ * The count is the point. A route that buffers first and measures second drains
+ * this source to the end before it can answer; a route that counts the bytes as
+ * they arrive abandons it partway. Only the source can tell those two apart —
+ * the status code is the same either way.
+ */
+function chunkedUpload(chunkCount: number, chunkBytes: number) {
+  let produced = 0;
+  let index = -1;
+
+  const body = new ReadableStream<Uint8Array>({
+    pull(controller) {
+      index += 1;
+      const chunk =
+        index === 0
+          ? partHeader("avatar.png", "image/png")
+          : index <= chunkCount
+            ? new Uint8Array(chunkBytes)
+            : PART_FOOTER;
+      produced += chunk.byteLength;
+      controller.enqueue(chunk);
+      if (index > chunkCount) controller.close();
+    },
+  });
+
+  const request = new Request(URL_UNDER_TEST, {
+    method: "POST",
+    headers: { "content-type": `multipart/form-data; boundary=${BOUNDARY}` },
+    body,
+    // @ts-expect-error `duplex` is required for a stream body and is missing
+    // from the DOM RequestInit types Next ships.
+    duplex: "half",
+  });
+
+  return { request, produced: () => produced, total: chunkCount * chunkBytes };
+}
+
+/** A whole picture in memory, the way a browser actually posts one. */
+function pictureUpload(bytes: number, type = "image/png"): Request {
+  const form = new FormData();
+  form.append(
+    "file",
+    new File([new Uint8Array(bytes)], "avatar.png", { type }),
+  );
+  return new Request(URL_UNDER_TEST, { method: "POST", body: form });
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  getSession.mockResolvedValue({ user: { id: "user-1" } });
+});
+
+describe("POST /api/user/profile-picture", () => {
+  it("abandons an oversized upload instead of buffering it", async () => {
+    // Twenty megabytes offered against a two megabyte limit. Before the cap,
+    // `request.formData()` read all of it into memory and only then compared
+    // `file.size`, so any signed-in caller could spend the server's memory at
+    // will.
+    const upload = chunkedUpload(40, 512 * 1024);
+
+    const response = await POST(upload.request);
+
+    expect(response.status).toBe(413);
+    expect(upload.total).toBe(20 * MEGABYTE);
+    // The cap is 2MB plus a small multipart allowance; a couple of chunks may
+    // already be in flight when it trips. What must not happen is the whole
+    // body being read.
+    expect(upload.produced()).toBeLessThan(4 * MEGABYTE);
+    expect(put).not.toHaveBeenCalled();
+    expect(updateImage).not.toHaveBeenCalled();
+  });
+
+  it("never reads the body of an unauthenticated upload", async () => {
+    getSession.mockResolvedValue(null);
+    const upload = chunkedUpload(40, 512 * 1024);
+
+    const response = await POST(upload.request);
+
+    expect(response.status).toBe(401);
+    // The runtime primes the stream with its first chunk when the request is
+    // constructed, so "untouched" is the part headers and nothing after them.
+    expect(upload.produced()).toBeLessThan(512 * 1024);
+  });
+
+  it("stores a picture that is inside the limit", async () => {
+    const response = await POST(pictureUpload(64 * 1024));
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual({
+      url: "https://blob.test/avatar.png",
+    });
+    expect(updateImage).toHaveBeenCalledWith(
+      "user-1",
+      "https://blob.test/avatar.png",
+    );
+  });
+
+  it("still rejects a picture over 2MB that fits inside the body allowance", async () => {
+    // The stream cap bounds the envelope, so a file a little over the limit
+    // gets through it and is caught by the exact check on `file.size`.
+    const response = await POST(pictureUpload(2 * MEGABYTE + 8 * 1024));
+
+    expect(response.status).toBe(400);
+    expect(await response.json()).toEqual({
+      message: "Image must be less than 2MB",
+    });
+    expect(put).not.toHaveBeenCalled();
+  });
+
+  it("rejects a file whose type is not an allowed image", async () => {
+    const response = await POST(pictureUpload(1024, "application/pdf"));
+
+    expect(response.status).toBe(400);
+    expect(put).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/app/api/user/profile-picture/route.ts
+++ b/apps/web/app/api/user/profile-picture/route.ts
@@ -1,5 +1,6 @@
 import { put } from "@vercel/blob";
 import { getAuth } from "@/server/auth";
+import { capRequestBody, isRequestBodyTooLarge } from "@/server/http/body-cap";
 import { updateImage } from "@/server/user/service";
 
 export const runtime = "nodejs";
@@ -7,13 +8,46 @@ export const runtime = "nodejs";
 const ALLOWED = ["image/jpeg", "image/png", "image/gif", "image/webp"];
 const MAX_BYTES = 2 * 1024 * 1024;
 
+/**
+ * What the whole multipart body may weigh, as opposed to the picture inside it.
+ *
+ * The cap counts bytes off the wire, and those bytes carry the boundary, the
+ * part headers and the filename as well as the image. The allowance is what
+ * keeps a picture of exactly `MAX_BYTES` acceptable — without it the envelope
+ * would push a legal upload over the cap and the route would reject a file it
+ * has always accepted. It is deliberately small: the framing is a few hundred
+ * bytes in practice, and the point of the number is that it is bounded.
+ */
+const MAX_BODY_BYTES = MAX_BYTES + 16 * 1024;
+
+const TOO_LARGE = "Image must be less than 2MB";
+
 export async function POST(request: Request) {
   const session = await getAuth().api.getSession({ headers: request.headers });
   if (!session?.user) {
     return Response.json({ message: "Unauthorized" }, { status: 401 });
   }
 
-  const formData = await request.formData();
+  // Counted as the body arrives, exactly as the transcript upload counts its
+  // own. `formData()` buffers the whole body before anything can look at the
+  // file's size, so checking `file.size` afterwards is a check made after the
+  // damage: any signed-in caller could hand the server an arbitrarily large
+  // upload and have it held in memory first and rejected second. Content-Length
+  // is no substitute — it is absent on a chunked upload and a lie whenever the
+  // client wants it to be.
+  let formData: FormData;
+  try {
+    formData = await capRequestBody(request, MAX_BODY_BYTES).formData();
+  } catch (error) {
+    if (isRequestBodyTooLarge(error)) {
+      return Response.json({ message: TOO_LARGE }, { status: 413 });
+    }
+    return Response.json(
+      { message: "No file provided or invalid image type" },
+      { status: 400 },
+    );
+  }
+
   const file = formData.get("file");
   if (!(file instanceof File) || file.size === 0) {
     return Response.json(
@@ -27,11 +61,11 @@ export async function POST(request: Request) {
       { status: 400 },
     );
   }
+  // The stream cap bounds the envelope; this bounds the picture. Both are
+  // needed: the cap is what stops the memory being spent, and this is what
+  // holds the stated 2MB limit to the byte once the parts are separated.
   if (file.size > MAX_BYTES) {
-    return Response.json(
-      { message: "Image must be less than 2MB" },
-      { status: 400 },
-    );
+    return Response.json({ message: TOO_LARGE }, { status: 400 });
   }
 
   const blob = await put(file.name, file, {

--- a/apps/web/app/api/user/transcript/route.ts
+++ b/apps/web/app/api/user/transcript/route.ts
@@ -1,14 +1,11 @@
 import { getAuth } from "@/server/auth";
+import { capRequestBody, isRequestBodyTooLarge } from "@/server/http/body-cap";
 import { TranscriptParseError } from "@/server/ingest/transcript/parse";
 import {
   extractTranscriptText,
   TranscriptBusyError,
 } from "@/server/ingest/transcript/pdf-text";
 import { buildTranscriptProposal } from "@/server/ingest/transcript/service";
-import {
-  capRequestBody,
-  isTranscriptTooLarge,
-} from "@/server/ingest/transcript/upload";
 
 export const runtime = "nodejs";
 
@@ -38,7 +35,7 @@ export async function POST(request: Request) {
   try {
     formData = await capRequestBody(request, MAX_BYTES).formData();
   } catch (error) {
-    if (isTranscriptTooLarge(error)) {
+    if (isRequestBodyTooLarge(error)) {
       return Response.json({ message: TOO_LARGE }, { status: 413 });
     }
     return Response.json(

--- a/apps/web/features/reviews/lib/unreviewed.ts
+++ b/apps/web/features/reviews/lib/unreviewed.ts
@@ -1,4 +1,15 @@
-import type { Review } from "@/types";
+/**
+ * `selectUnreviewedCourses` moved to `@/server/reviews/unreviewed` when the
+ * personalization tier writer needed the same arithmetic: tier 3 is "every
+ * transcript-imported course has a review by you", which is this function
+ * narrowed to imported rows. Server code cannot import from `features/`, so the
+ * definition had to move to the side both halves can reach, and it is
+ * re-exported here so every existing import path keeps working.
+ *
+ * There is one definition. Do not write a second one — not here, and not in
+ * SQL. See the module it came from for why that matters.
+ */
+export { selectUnreviewedCourses } from "@/server/reviews/unreviewed";
 
 /**
  * Every review across a set of per-course lists, or `null` if any one of them
@@ -10,6 +21,10 @@ import type { Review } from "@/types";
  * empty list would answer "nobody has reviewed it", which is a different claim
  * and the one that puts a review prompt in front of somebody who already wrote
  * theirs.
+ *
+ * This one stays client-side on purpose: "the request has not answered yet" is
+ * a browser cache state and means nothing on the server, which reads the rows
+ * or fails.
  */
 export function reviewsWhenEveryListLoaded<T>(
   lists: readonly (readonly T[] | undefined)[],
@@ -20,39 +35,4 @@ export function reviewsWhenEveryListLoaded<T>(
     reviews.push(...list);
   }
   return reviews;
-}
-
-/**
- * The taken courses this viewer has not reviewed yet.
- *
- * The set arithmetic lives here rather than inside `UnreviewedCard` so the card
- * renders whatever list it is handed and knows nothing about how that list was
- * derived — and so Taken courses and My Page derive it the same way instead of
- * each writing their own filter.
- *
- * `reviews` is every review the caller loaded for the courses in `taken`, not
- * only the viewer's: `reviews.list` takes a course code and has no author
- * filter, so the personal half of the question is answered here. Another
- * student's review of a course leaves that course unreviewed *by you*.
- *
- * Note what is deliberately absent: nothing here reads a satisfaction state.
- * `happyTook` belongs to a published review and does not exist until one is
- * written, so a course in this list has no verdict to render.
- */
-export function selectUnreviewedCourses<T extends { courseCode: string }>(
-  taken: readonly T[],
-  reviews: readonly Pick<Review, "courseCode" | "userId">[],
-  viewerUserId: string,
-): T[] {
-  // With nobody signed in there is no author to compare against, and treating
-  // every taken course as unreviewed would prompt the wrong person.
-  if (!viewerUserId) return [];
-
-  const reviewedCourseCodes = new Set(
-    reviews
-      .filter((review) => review.userId === viewerUserId)
-      .map((review) => review.courseCode),
-  );
-
-  return taken.filter((course) => !reviewedCourseCodes.has(course.courseCode));
 }

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -11,6 +11,7 @@
     "lint": "biome check",
     "format": "biome format --write",
     "ingest": "bun --env-file=.env.local scripts/ingest.ts",
+    "backfill:tiers": "bun --env-file=.env.local scripts/backfill-personalization-tiers.ts",
     "db:generate": "drizzle-kit generate --config server/db/drizzle.config.ts",
     "db:push": "drizzle-kit push --config server/db/drizzle.config.ts",
     "db:migrate": "drizzle-kit migrate --config server/db/drizzle.config.ts",

--- a/apps/web/scripts/backfill-personalization-tiers.ts
+++ b/apps/web/scripts/backfill-personalization-tiers.ts
@@ -1,0 +1,21 @@
+import { backfillEarnedPersonalizationTiers } from "../server/graph/service";
+
+/**
+ * Give app users who contributed before the tier writer existed the tier they
+ * already earned.
+ *
+ * A one-off, but safe to re-run: the recompute is derived and the write only
+ * ever raises, so a second run reports zero raises and changes nothing. Run it
+ * once after the writer ships, and again any time the column looks wrong.
+ */
+async function main() {
+  const { scanned, raised } = await backfillEarnedPersonalizationTiers();
+  console.log(
+    `Recomputed the earned personalization tier for ${scanned} contributors; ${raised} were raised.`,
+  );
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/apps/web/server/graph/placement.ts
+++ b/apps/web/server/graph/placement.ts
@@ -13,11 +13,15 @@
  * migration. This is the one place the list lives.
  *
  * **Nobody is assigned one of these today.** Placement used to hash every app
- * user onto a name here, which gave everyone a colour nobody chose. A node
- * profile is personalisation, and personalisation has no writer: nothing in
- * `server/` raises `users.personalization_tier_earned`, so every account sits
- * at tier 0 and the colour axis is locked for all of them. The palette stays
- * because it is what personalisation will hand out once that writer exists.
+ * user onto a name here, which gave everyone a colour nobody chose, and a node
+ * profile is personalisation: a colour is chosen, never dealt out.
+ *
+ * `users.personalization_tier_earned` does have a writer now —
+ * `recordEarnedPersonalizationTier` raises it from #161's ladder — so accounts
+ * are no longer all at tier 0 and the axis a tier unlocks can genuinely open.
+ * What is still missing is the other half: nothing writes
+ * `users_node_profiles.color`, because no surface yet lets a member pick one.
+ * The palette stays for the moment that surface exists.
  */
 export const NODE_COLORS = [
   "aurora",

--- a/apps/web/server/graph/repository.ts
+++ b/apps/web/server/graph/repository.ts
@@ -1,4 +1,14 @@
-import { and, count, eq, inArray, max, ne, sql } from "drizzle-orm";
+import {
+  and,
+  count,
+  eq,
+  inArray,
+  isNotNull,
+  lt,
+  max,
+  ne,
+  sql,
+} from "drizzle-orm";
 import { db } from "../db";
 import * as schema from "../db/schema";
 import type {
@@ -195,8 +205,11 @@ export async function findTierBasis(
  * repo normally routes service -> service. The exception is deliberate and
  * approved: it is a single read-only aggregate, `reviews_user_id_idx` covers
  * it, and routing it through `server/reviews/service.ts` would couple the graph
- * domain to a review domain that is being rewritten in parallel. Nothing else
- * here may reach into `server/reviews/`.
+ * domain to a review domain that is being rewritten in parallel.
+ *
+ * `findReviewedCourses` below is the same exception for the same reason. Those
+ * two are the whole of it: nothing else here may reach into `server/reviews/`,
+ * and neither of them may grow a write.
  */
 export async function findLastReviewAt(userId: string): Promise<Date | null> {
   const [row] = await db
@@ -204,4 +217,86 @@ export async function findLastReviewAt(userId: string): Promise<Date | null> {
     .from(schema.reviews)
     .where(eq(schema.reviews.userId, userId));
   return row?.lastReviewAt ?? null;
+}
+
+/**
+ * Which courses this app user has reviewed, as review rows rather than bare
+ * codes.
+ *
+ * `userId` comes back on every row even though the query already filtered on
+ * it, so the result is the exact shape `selectUnreviewedCourses` takes. That is
+ * the point: the tier rule runs the same author comparison the browser runs,
+ * through the same function, instead of trusting this `WHERE` to have meant the
+ * same thing. Read-only, and covered by `reviews_user_id_idx`.
+ */
+export function findReviewedCourses(
+  userId: string,
+): Promise<{ courseCode: string; userId: string }[]> {
+  return db
+    .select({
+      courseCode: schema.reviews.courseCode,
+      userId: schema.reviews.userId,
+    })
+    .from(schema.reviews)
+    .where(eq(schema.reviews.userId, userId));
+}
+
+/**
+ * The courses this app user got from a transcript import.
+ *
+ * `transcript_imported_at is not null` is the whole test, and it is the one
+ * #161 names: a course typed in by hand carries no import stamp and cannot earn
+ * tier 2 or 3. The primary key on `(user_id, course_code)` leads with
+ * `user_id`, so this read is indexed.
+ *
+ * It reads `user_taken_courses`, which belongs to the taken domain, and it is
+ * here for the same reason `findLastReviewAt` is: one read-only projection
+ * feeding one derived number, where routing through `taken/service.ts` would
+ * buy nothing but a cycle — `taken` has no business knowing about tiers.
+ */
+export function findTranscriptImportedCourses(
+  userId: string,
+): Promise<{ courseCode: string }[]> {
+  return db
+    .select({ courseCode: schema.userTakenCourses.courseCode })
+    .from(schema.userTakenCourses)
+    .where(
+      and(
+        eq(schema.userTakenCourses.userId, userId),
+        isNotNull(schema.userTakenCourses.transcriptImportedAt),
+      ),
+    );
+}
+
+/**
+ * Raise `personalization_tier_earned` to `tier`, and never lower it.
+ *
+ * The monotonicity is enforced in SQL rather than in the caller. `greatest` is
+ * what makes it hold under concurrency: two contributions landing at once
+ * cannot have the slower one write a stale, smaller number over the faster
+ * one's, and a recompute that answers 2 where the column already says 3 — which
+ * #161's ladder allows, because tier 3's condition stops holding the moment a
+ * further transcript is imported — is a no-op rather than a demotion. The `<`
+ * in the `WHERE` only spares the row a write it does not need; delete it and
+ * the column is still correct.
+ *
+ * Returns whether the column actually rose.
+ */
+export async function raiseEarnedTier(
+  userId: string,
+  tier: number,
+): Promise<boolean> {
+  const raised = await db
+    .update(schema.users)
+    .set({
+      personalizationTierEarned: sql`greatest(${schema.users.personalizationTierEarned}, ${tier})`,
+    })
+    .where(
+      and(
+        eq(schema.users.id, userId),
+        lt(schema.users.personalizationTierEarned, tier),
+      ),
+    )
+    .returning({ userId: schema.users.id });
+  return raised.length > 0;
 }

--- a/apps/web/server/graph/repository.ts
+++ b/apps/web/server/graph/repository.ts
@@ -269,6 +269,40 @@ export function findTranscriptImportedCourses(
 }
 
 /**
+ * A page of the app users whose contributions could earn a tier at all: they
+ * have reviewed something, or they have a transcript-imported course.
+ *
+ * This exists for the backfill, and the narrowing is the whole point of it.
+ * Every other app user is at the column default with nothing to raise them
+ * above it, so walking the entire `users` table would be a recompute per
+ * account to learn what the absence of a row already says.
+ *
+ * Paged on the user id with a cursor rather than an offset, so a page cannot
+ * skip or repeat an app user because a review landed mid-run. `after` is the
+ * last id of the previous page; `null` starts at the beginning.
+ */
+export async function findTierCandidateUserIds(
+  after: string | null,
+  limit: number,
+): Promise<string[]> {
+  const candidates = await db.execute<{ user_id: string }>(sql`
+    select user_id
+    from (
+      select distinct ${schema.reviews.userId} as user_id
+      from ${schema.reviews}
+      union
+      select distinct ${schema.userTakenCourses.userId} as user_id
+      from ${schema.userTakenCourses}
+      where ${schema.userTakenCourses.transcriptImportedAt} is not null
+    ) as tier_candidates
+    where ${after === null ? sql`true` : sql`user_id > ${after}`}
+    order by user_id
+    limit ${limit}
+  `);
+  return candidates.rows.map((row) => row.user_id);
+}
+
+/**
  * Raise `personalization_tier_earned` to `tier`, and never lower it.
  *
  * The monotonicity is enforced in SQL rather than in the caller. `greatest` is

--- a/apps/web/server/graph/service.spec.ts
+++ b/apps/web/server/graph/service.spec.ts
@@ -9,6 +9,7 @@ import {
 import type { BackboneEdge, NeighbourNode, PlacementWrite } from "./repository";
 import * as graphRepo from "./repository";
 import {
+  backfillEarnedPersonalizationTiers,
   COMMUNITY_ORIGIN,
   getEffectiveTier,
   getNeighbourhood,
@@ -577,7 +578,10 @@ describe("recordEarnedPersonalizationTier", () => {
       { courseCode: "SF1625" },
     ]);
 
-    expect(await recordEarnedPersonalizationTier("u1")).toBe(3);
+    expect(await recordEarnedPersonalizationTier("u1")).toEqual({
+      earned: 3,
+      raised: true,
+    });
     expect(graphRepo.raiseEarnedTier).toHaveBeenCalledWith("u1", 3);
   });
 
@@ -589,12 +593,18 @@ describe("recordEarnedPersonalizationTier", () => {
       { courseCode: "SF1625", userId: "u1" },
     ]);
 
-    expect(await recordEarnedPersonalizationTier("u1")).toBe(1);
+    expect(await recordEarnedPersonalizationTier("u1")).toEqual({
+      earned: 1,
+      raised: true,
+    });
     expect(graphRepo.raiseEarnedTier).toHaveBeenCalledWith("u1", 1);
   });
 
   it("writes nothing for an app user who has earned nothing", async () => {
-    expect(await recordEarnedPersonalizationTier("u1")).toBe(0);
+    expect(await recordEarnedPersonalizationTier("u1")).toEqual({
+      earned: 0,
+      raised: false,
+    });
     expect(graphRepo.raiseEarnedTier).not.toHaveBeenCalled();
   });
 
@@ -615,7 +625,10 @@ describe("recordEarnedPersonalizationTier", () => {
     ]);
     vi.mocked(graphRepo.raiseEarnedTier).mockResolvedValue(false);
 
-    expect(await recordEarnedPersonalizationTier("u1")).toBe(2);
+    expect(await recordEarnedPersonalizationTier("u1")).toEqual({
+      earned: 2,
+      raised: false,
+    });
     expect(graphRepo.raiseEarnedTier).toHaveBeenCalledWith("u1", 2);
     expect(graphRepo.findTierBasis).not.toHaveBeenCalled();
   });
@@ -632,5 +645,82 @@ describe("recordEarnedPersonalizationTier", () => {
     expect(logged).toHaveBeenCalled();
 
     logged.mockRestore();
+  });
+});
+
+/**
+ * The writer only fires on a new contribution, so everybody who reviewed or
+ * imported before it shipped needs one pass to be given what they had already
+ * earned. These cover the properties that make that pass safe to run at all:
+ * it visits each contributor once, it pages until the pages run out, and a
+ * second run changes nothing.
+ */
+describe("backfillEarnedPersonalizationTiers", () => {
+  beforeEach(() => {
+    vi.mocked(graphRepo.findReviewedCourses).mockResolvedValue([]);
+    vi.mocked(graphRepo.findTranscriptImportedCourses).mockResolvedValue([]);
+    vi.mocked(graphRepo.raiseEarnedTier).mockResolvedValue(true);
+  });
+
+  /** Candidates served a page at a time, the way the repository serves them. */
+  function candidates(userIds: string[], pageSize: number) {
+    vi.mocked(graphRepo.findTierCandidateUserIds).mockImplementation(
+      async (after, limit) => {
+        const start = after === null ? 0 : userIds.indexOf(after) + 1;
+        return userIds.slice(start, start + Math.min(limit, pageSize));
+      },
+    );
+  }
+
+  it("recomputes every contributor, following the cursor across pages", async () => {
+    const userIds = ["u1", "u2", "u3", "u4", "u5"];
+    candidates(userIds, 2);
+    vi.mocked(graphRepo.findReviewedCourses).mockImplementation(
+      async (userId) => [{ courseCode: "SF1625", userId }],
+    );
+
+    const result = await backfillEarnedPersonalizationTiers(2);
+
+    expect(result).toEqual({ scanned: 5, raised: 5 });
+    for (const userId of userIds) {
+      expect(graphRepo.raiseEarnedTier).toHaveBeenCalledWith(userId, 1);
+    }
+    // Each app user exactly once: paging on the id, never on an offset.
+    expect(vi.mocked(graphRepo.raiseEarnedTier).mock.calls.length).toBe(5);
+  });
+
+  it("does nothing when nobody has contributed", async () => {
+    candidates([], 200);
+
+    expect(await backfillEarnedPersonalizationTiers()).toEqual({
+      scanned: 0,
+      raised: 0,
+    });
+    expect(graphRepo.raiseEarnedTier).not.toHaveBeenCalled();
+  });
+
+  it("reports no raises on a second run, because the write only ever raises", async () => {
+    candidates(["u1", "u2"], 200);
+    vi.mocked(graphRepo.findReviewedCourses).mockImplementation(
+      async (userId) => [{ courseCode: "SF1625", userId }],
+    );
+    // The repository declines a raise that would not move the column.
+    vi.mocked(graphRepo.raiseEarnedTier).mockResolvedValue(false);
+
+    expect(await backfillEarnedPersonalizationTiers()).toEqual({
+      scanned: 2,
+      raised: 0,
+    });
+  });
+
+  it("stops rather than reporting a half-finished run", async () => {
+    candidates(["u1", "u2"], 200);
+    vi.mocked(graphRepo.findReviewedCourses).mockRejectedValue(
+      new Error("neon is having a day"),
+    );
+
+    await expect(backfillEarnedPersonalizationTiers()).rejects.toThrow(
+      "neon is having a day",
+    );
   });
 });

--- a/apps/web/server/graph/service.spec.ts
+++ b/apps/web/server/graph/service.spec.ts
@@ -17,6 +17,8 @@ import {
   joinCommunityGraphOnSignUp,
   MAX_NEIGHBOURHOOD_NODES,
   MAX_PUBLIC_WINDOW_NODES,
+  recordEarnedPersonalizationTier,
+  recordEarnedPersonalizationTierOnContribution,
 } from "./service";
 
 vi.mock("./repository");
@@ -546,13 +548,89 @@ describe("getEffectiveTier", () => {
   it("never writes the earned tier back", async () => {
     await getEffectiveTier("reader", new Date("2044-01-01T00:00:00.000Z"));
 
-    // The only write the graph domain owns is placement; there is deliberately
-    // no repository function that could update personalization_tier_earned.
+    // Decay is derived and thrown away. The graph domain owns exactly two
+    // writes — placement, and the monotonic tier raise — and reading a decayed
+    // tier must touch neither. The name list is the guard against a third
+    // appearing quietly.
     expect(graphRepo.persistPlacement).not.toHaveBeenCalled();
+    expect(graphRepo.raiseEarnedTier).not.toHaveBeenCalled();
     expect(
       Object.keys(graphRepo).filter((name) =>
-        /^(insert|update|upsert|delete|save|persist|set)/.test(name),
+        /^(insert|update|upsert|delete|save|persist|set|raise)/.test(name),
       ),
-    ).toEqual(["persistPlacement"]);
+    ).toEqual(["persistPlacement", "raiseEarnedTier"]);
+  });
+});
+
+describe("recordEarnedPersonalizationTier", () => {
+  beforeEach(() => {
+    vi.mocked(graphRepo.findReviewedCourses).mockResolvedValue([]);
+    vi.mocked(graphRepo.findTranscriptImportedCourses).mockResolvedValue([]);
+    vi.mocked(graphRepo.raiseEarnedTier).mockResolvedValue(true);
+  });
+
+  it("raises the column to what the contributions earn", async () => {
+    vi.mocked(graphRepo.findReviewedCourses).mockResolvedValue([
+      { courseCode: "SF1625", userId: "u1" },
+    ]);
+    vi.mocked(graphRepo.findTranscriptImportedCourses).mockResolvedValue([
+      { courseCode: "SF1625" },
+    ]);
+
+    expect(await recordEarnedPersonalizationTier("u1")).toBe(3);
+    expect(graphRepo.raiseEarnedTier).toHaveBeenCalledWith("u1", 3);
+  });
+
+  it("counts only transcript-imported courses towards tier 2", async () => {
+    // A manually typed course never reaches the service: the repository read
+    // filters on `transcript_imported_at`, so an app user with none is at the
+    // tier their reviews alone earn.
+    vi.mocked(graphRepo.findReviewedCourses).mockResolvedValue([
+      { courseCode: "SF1625", userId: "u1" },
+    ]);
+
+    expect(await recordEarnedPersonalizationTier("u1")).toBe(1);
+    expect(graphRepo.raiseEarnedTier).toHaveBeenCalledWith("u1", 1);
+  });
+
+  it("writes nothing for an app user who has earned nothing", async () => {
+    expect(await recordEarnedPersonalizationTier("u1")).toBe(0);
+    expect(graphRepo.raiseEarnedTier).not.toHaveBeenCalled();
+  });
+
+  /**
+   * The monotonicity itself is `greatest` in SQL, which is the only place it
+   * can be true under concurrency. What the service must not do is talk itself
+   * out of it: a recompute that answers 2 for somebody the column already has
+   * at 3 still asks for 2, and the repository declines. Never a demotion, and
+   * never a read-then-write that could race one in.
+   */
+  it("asks for the recomputed tier and lets the repository refuse to lower it", async () => {
+    vi.mocked(graphRepo.findReviewedCourses).mockResolvedValue([
+      { courseCode: "SF1625", userId: "u1" },
+    ]);
+    vi.mocked(graphRepo.findTranscriptImportedCourses).mockResolvedValue([
+      { courseCode: "SF1625" },
+      { courseCode: "DD1337" },
+    ]);
+    vi.mocked(graphRepo.raiseEarnedTier).mockResolvedValue(false);
+
+    expect(await recordEarnedPersonalizationTier("u1")).toBe(2);
+    expect(graphRepo.raiseEarnedTier).toHaveBeenCalledWith("u1", 2);
+    expect(graphRepo.findTierBasis).not.toHaveBeenCalled();
+  });
+
+  it("swallows its own failure so a contribution is never lost to it", async () => {
+    const logged = vi.spyOn(console, "error").mockImplementation(() => {});
+    vi.mocked(graphRepo.findReviewedCourses).mockRejectedValue(
+      new Error("neon is having a day"),
+    );
+
+    await expect(
+      recordEarnedPersonalizationTierOnContribution("u1"),
+    ).resolves.toBeUndefined();
+    expect(logged).toHaveBeenCalled();
+
+    logged.mockRestore();
   });
 });

--- a/apps/web/server/graph/service.ts
+++ b/apps/web/server/graph/service.ts
@@ -238,11 +238,13 @@ export async function getEffectiveTier(
  * if somebody tries. Decay is the other half of the same policy and is derived
  * at read time by `getEffectiveTier`, which stores nothing.
  *
- * Returns the tier the contributions earn, whether or not the column moved.
+ * Reports the tier the contributions earn and whether the column actually
+ * moved. Those are different answers whenever the recompute is at or below
+ * what is already stored, which is the normal case for a repeat run.
  */
 export async function recordEarnedPersonalizationTier(
   userId: string,
-): Promise<number> {
+): Promise<{ earned: number; raised: boolean }> {
   const [reviews, transcriptImportedCourses] = await Promise.all([
     graphRepo.findReviewedCourses(userId),
     graphRepo.findTranscriptImportedCourses(userId),
@@ -255,8 +257,63 @@ export async function recordEarnedPersonalizationTier(
   });
   // Tier 0 is the column default and cannot raise anything, so the write is
   // skipped rather than issued and thrown away.
-  if (earned > 0) await graphRepo.raiseEarnedTier(userId, earned);
-  return earned;
+  const raised =
+    earned > 0 && (await graphRepo.raiseEarnedTier(userId, earned));
+  return { earned, raised };
+}
+
+/**
+ * How many app users one backfill page recomputes.
+ *
+ * A page is a bound on the work in flight, not on the run: the backfill keeps
+ * asking until a page comes back short. Small, because each app user in it
+ * costs two reads and possibly a write, and nothing is waiting on the result.
+ */
+const TIER_BACKFILL_PAGE = 200;
+
+/**
+ * Give every app user who already contributed the tier they already earned.
+ *
+ * The writer above only fires on a *new* review or a *new* import, so on the
+ * day this ships, everybody who reviewed or imported before it exists is still
+ * at the column default and still sees three locked axes until they contribute
+ * again. This is the one-off that fixes that, and it is safe to run whenever
+ * anybody doubts the column: it derives from the same `deriveEarnedTier`, it
+ * raises through the same `greatest`, so a second run is a no-op and a run
+ * racing a live contribution cannot lower anything.
+ *
+ * It walks only the app users who could earn something —
+ * `findTierCandidateUserIds` — and pages on the user id, so a review published
+ * mid-run cannot make it skip somebody. One app user at a time rather than a
+ * single statement, because the rule that decides a tier is TypeScript and
+ * expressing it again in SQL is exactly the second definition #161 forbids.
+ *
+ * Unlike the per-contribution path this does **not** swallow: a backfill that
+ * half-ran and reported success is worse than one that stops and says where.
+ */
+export async function backfillEarnedPersonalizationTiers(
+  pageSize: number = TIER_BACKFILL_PAGE,
+): Promise<{ scanned: number; raised: number }> {
+  let after: string | null = null;
+  let scanned = 0;
+  let raised = 0;
+
+  for (;;) {
+    const userIds: string[] = await graphRepo.findTierCandidateUserIds(
+      after,
+      pageSize,
+    );
+    if (userIds.length === 0) return { scanned, raised };
+
+    for (const userId of userIds) {
+      const result = await recordEarnedPersonalizationTier(userId);
+      scanned += 1;
+      if (result.raised) raised += 1;
+    }
+
+    if (userIds.length < pageSize) return { scanned, raised };
+    after = userIds[userIds.length - 1] ?? null;
+  }
 }
 
 /**

--- a/apps/web/server/graph/service.ts
+++ b/apps/web/server/graph/service.ts
@@ -9,7 +9,7 @@ import {
 } from "./placement";
 import type { BackboneEdge, GraphNode, NeighbourNode } from "./repository";
 import * as graphRepo from "./repository";
-import { deriveEffectiveTier } from "./tier";
+import { deriveEarnedTier, deriveEffectiveTier } from "./tier";
 
 /**
  * How many nodes one bounded neighbourhood read may return.
@@ -56,7 +56,8 @@ export type WindowNode = {
   /**
    * The stored appearance name. Node appearance is drawn on a public landing
    * page by design, so it is not a disclosure; it is also `"default"` for
-   * everybody until personalisation has a writer.
+   * everybody until a member has some way to choose a colour. The earned tier
+   * has a writer now, but nothing writes `users_node_profiles.color`.
    */
   color: string;
   /** The one node belonging to the caller. Never true in a public window. */
@@ -221,6 +222,84 @@ export async function getEffectiveTier(
     lastReviewAt ?? basis.accountCreatedAt,
     now,
   );
+}
+
+/**
+ * Recompute what this app user's contributions have earned and raise the stored
+ * tier to match.
+ *
+ * **It raises and never lowers.** `personalization_tier_earned` is the highest
+ * value ever reached — `CONTEXT.md`, under **Personalization tier** — while
+ * `deriveEarnedTier`'s answer is a statement about right now and can fall:
+ * importing a second transcript leaves imported courses unreviewed again and
+ * turns tier 3's condition false. The earned tier still stands. Do not "fix"
+ * that asymmetry by writing the computed value straight into the column; the
+ * `greatest` in `raiseEarnedTier` is there to make the mistake impossible even
+ * if somebody tries. Decay is the other half of the same policy and is derived
+ * at read time by `getEffectiveTier`, which stores nothing.
+ *
+ * Returns the tier the contributions earn, whether or not the column moved.
+ */
+export async function recordEarnedPersonalizationTier(
+  userId: string,
+): Promise<number> {
+  const [reviews, transcriptImportedCourses] = await Promise.all([
+    graphRepo.findReviewedCourses(userId),
+    graphRepo.findTranscriptImportedCourses(userId),
+  ]);
+
+  const earned = deriveEarnedTier({
+    userId,
+    reviews,
+    transcriptImportedCourses,
+  });
+  // Tier 0 is the column default and cannot raise anything, so the write is
+  // skipped rather than issued and thrown away.
+  if (earned > 0) await graphRepo.raiseEarnedTier(userId, earned);
+  return earned;
+}
+
+/**
+ * Recompute the earned tier after a contribution that could have raised it.
+ *
+ * **When this runs.** The two moments the inputs change are publishing a review
+ * and confirming a transcript import, and both call this immediately after
+ * their own write commits — `reviews/service.ts` and
+ * `ingest/transcript/service.ts`. A background job would leave a member staring
+ * at a locked axis for however long the job's period is, and computing it at
+ * read time would mean `graph.effectiveTier` wrote to the database, which the
+ * whole tier design says it must not.
+ *
+ * **Why after the write rather than inside its transaction.** Recomputing
+ * inside would mean the reviews repository reading `user_taken_courses` and
+ * writing `users`, which is the layering this repo enforces with Biome, for a
+ * guarantee that is not needed: the recompute reads committed state and the
+ * write is `greatest`, so it is idempotent and order-independent. Two
+ * contributions racing cannot produce a wrong number, and a recompute that is
+ * lost costs a tier that the next contribution recomputes anyway.
+ *
+ * **Why it swallows.** A member who published a review has published it. Losing
+ * their review, or seeing their transcript import fail, because a cosmetic
+ * number could not be updated would be a much worse trade — the same reasoning,
+ * and the same shape, as `joinCommunityGraphOnSignUp`.
+ *
+ * Not called on deletion. Removing a review or an imported course can only make
+ * a lower tier true, and the column does not go down, so there is nothing to
+ * write. Removing an imported course can also complete a transcript and make
+ * tier 3 true; that raise waits for the next contribution rather than putting a
+ * tier write on a delete path, and #161 settles the ladder, not its latency.
+ */
+export async function recordEarnedPersonalizationTierOnContribution(
+  userId: string,
+): Promise<void> {
+  try {
+    await recordEarnedPersonalizationTier(userId);
+  } catch (error) {
+    console.error(
+      `Could not update the earned personalization tier for app user ${userId}:`,
+      error,
+    );
+  }
 }
 
 /**

--- a/apps/web/server/graph/tier.spec.ts
+++ b/apps/web/server/graph/tier.spec.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { deriveEffectiveTier } from "./tier";
+import { deriveEarnedTier, deriveEffectiveTier } from "./tier";
 
 // Fixed dates only: deriveEffectiveTier is pure, so there is no clock to inject
 // beyond its own `now` parameter.
@@ -57,6 +57,159 @@ describe("deriveEffectiveTier", () => {
   it("does not decay when there is no reference date at all", () => {
     expect(
       deriveEffectiveTier(2, null, new Date("2044-01-15T12:00:00.000Z")),
+    ).toBe(2);
+  });
+});
+
+/**
+ * #161's ladder. Every case here is a sentence from that decision, so a change
+ * to the rule has to change a sentence as well as a number.
+ */
+describe("deriveEarnedTier", () => {
+  const reviewOf = (courseCode: string, userId = "u1") => ({
+    courseCode,
+    userId,
+  });
+
+  it("earns nothing from an account that has done nothing", () => {
+    expect(
+      deriveEarnedTier({
+        userId: "u1",
+        reviews: [],
+        transcriptImportedCourses: [],
+      }),
+    ).toBe(0);
+  });
+
+  it("earns tier 1 for a published review", () => {
+    expect(
+      deriveEarnedTier({
+        userId: "u1",
+        reviews: [reviewOf("SF1625")],
+        transcriptImportedCourses: [],
+      }),
+    ).toBe(1);
+  });
+
+  it("does not earn tier 1 from somebody else's review", () => {
+    expect(
+      deriveEarnedTier({
+        userId: "u1",
+        reviews: [reviewOf("SF1625", "u2")],
+        transcriptImportedCourses: [],
+      }),
+    ).toBe(0);
+  });
+
+  it("earns tier 2 for an imported transcript with courses still unreviewed", () => {
+    expect(
+      deriveEarnedTier({
+        userId: "u1",
+        reviews: [reviewOf("SF1625")],
+        transcriptImportedCourses: [
+          { courseCode: "SF1625" },
+          { courseCode: "DD1337" },
+        ],
+      }),
+    ).toBe(2);
+  });
+
+  // The plain reading of "tier 2 is an imported transcript": somebody who hands
+  // over their history before writing anything is at 2, not held at 0.
+  it("earns tier 2 for an import even with no review at all", () => {
+    expect(
+      deriveEarnedTier({
+        userId: "u1",
+        reviews: [],
+        transcriptImportedCourses: [{ courseCode: "SF1625" }],
+      }),
+    ).toBe(2);
+  });
+
+  it("earns tier 3 once every imported course has the app user's review", () => {
+    expect(
+      deriveEarnedTier({
+        userId: "u1",
+        reviews: [reviewOf("SF1625"), reviewOf("DD1337")],
+        transcriptImportedCourses: [
+          { courseCode: "SF1625" },
+          { courseCode: "DD1337" },
+        ],
+      }),
+    ).toBe(3);
+  });
+
+  // "All reviewed" over nothing is true and means nothing. An empty import must
+  // not be a shortcut to the top of the ladder.
+  it("cannot reach tier 3 with no imported courses", () => {
+    expect(
+      deriveEarnedTier({
+        userId: "u1",
+        reviews: [reviewOf("SF1625")],
+        transcriptImportedCourses: [],
+      }),
+    ).toBe(1);
+  });
+
+  it("does not let another student's reviews complete a transcript", () => {
+    expect(
+      deriveEarnedTier({
+        userId: "u1",
+        reviews: [reviewOf("SF1625"), reviewOf("DD1337", "u2")],
+        transcriptImportedCourses: [
+          { courseCode: "SF1625" },
+          { courseCode: "DD1337" },
+        ],
+      }),
+    ).toBe(2);
+  });
+
+  // Manual entries never reach this function; the caller passes imported rows
+  // only. Stated here so the contract is tested rather than assumed: a taken
+  // course that is absent from the imported set cannot hold tier 3 back.
+  it("judges tier 3 over the imported courses it was given and no others", () => {
+    expect(
+      deriveEarnedTier({
+        userId: "u1",
+        reviews: [reviewOf("SF1625")],
+        transcriptImportedCourses: [{ courseCode: "SF1625" }],
+      }),
+    ).toBe(3);
+  });
+
+  // `selectUnreviewedCourses` answers "nothing is unreviewed" for an empty
+  // viewer id, which would read as a completed transcript if the guard went.
+  it("earns nothing without an app user to judge", () => {
+    expect(
+      deriveEarnedTier({
+        userId: "",
+        reviews: [],
+        transcriptImportedCourses: [{ courseCode: "SF1625" }],
+      }),
+    ).toBe(0);
+  });
+
+  // The condition is not monotonic and is not meant to be; the column it feeds
+  // is. This is the fall the writer must refuse to follow.
+  it("falls back to tier 2 when a further import leaves courses unreviewed", () => {
+    const reviews = [reviewOf("SF1625")];
+
+    expect(
+      deriveEarnedTier({
+        userId: "u1",
+        reviews,
+        transcriptImportedCourses: [{ courseCode: "SF1625" }],
+      }),
+    ).toBe(3);
+    expect(
+      deriveEarnedTier({
+        userId: "u1",
+        reviews,
+        transcriptImportedCourses: [
+          { courseCode: "SF1625" },
+          { courseCode: "DD1337" },
+        ],
+      }),
     ).toBe(2);
   });
 });

--- a/apps/web/server/graph/tier.ts
+++ b/apps/web/server/graph/tier.ts
@@ -1,19 +1,109 @@
+import type { Review } from "@/types";
+import { selectUnreviewedCourses } from "../reviews/unreviewed";
+
 /**
- * Effective personalization tier.
+ * Personalization tier: what earns it, and what inactivity does to it.
  *
  * `users.personalization_tier_earned` stores the highest tier an app user has
- * ever reached. Inactivity decay is derived at read time and is never written
- * back — nothing in this file, or any caller of it, may update that column.
+ * ever reached. `deriveEarnedTier` says what that number should be from the
+ * app user's contributions; `deriveEffectiveTier` derives the decayed tier at
+ * read time and is never written back.
  *
- * The formula lives here, alone and pure, so product can swap it without
- * touching a service or a query.
+ * Both formulas live here, alone and pure, so product can swap them without
+ * touching a service or a query. They are one policy seen from two ends —
+ * earning and decay — which is why they share a file rather than a layer.
+ *
+ * The rule itself is #161's settled ladder, and the two halves are deliberately
+ * asymmetric: see `deriveEarnedTier` on why a non-monotonic condition still
+ * produces a column that only ever rises.
  */
 
 /** Complete months of inactivity that cost one tier step. */
 const MONTHS_PER_DECAY_STEP = 6;
 
+/** The highest tier the ladder defines. Matches the column's check constraint. */
+export const MAX_PERSONALIZATION_TIER = 3;
+
+/**
+ * Everything the ladder is decided from, and nothing else.
+ *
+ * `transcriptImportedCourses` is already narrowed to rows whose
+ * `transcript_imported_at` is set. Manual entries are excluded by the caller
+ * rather than filtered here, because "which rows count as imported" is a
+ * question about the `user_taken_courses` column and belongs with whoever
+ * reads it; what belongs here is what the ladder does with them.
+ */
+export type EarnedTierInputs = {
+  /** The app user whose ladder this is. */
+  userId: string;
+  /** Reviews visible to the caller. Only this app user's own are counted. */
+  reviews: readonly Pick<Review, "courseCode" | "userId">[];
+  /** This app user's taken courses that came from a transcript import. */
+  transcriptImportedCourses: readonly { courseCode: string }[];
+};
+
+/**
+ * The tier an app user's contributions have earned, right now.
+ *
+ * The ladder, settled in #161:
+ *
+ * - **1** — they have published a review. The 0→1 step, and the contribution
+ *   the product most wants.
+ * - **2** — they have imported a transcript: at least one `user_taken_courses`
+ *   row with `transcript_imported_at` set. Manual entry does not earn this;
+ *   the tier rewards the upload specifically, because that is the data the
+ *   column can vouch for.
+ * - **3** — every transcript-imported course has a review by them, and there
+ *   is at least one imported course, so an empty import cannot make "all
+ *   reviewed" vacuously true.
+ *
+ * Each rung is tested on its own and the highest one that holds wins, rather
+ * than every lower rung having to hold as well. That matters in one case only:
+ * somebody who imports a transcript before writing anything is at 2, not 0.
+ * Reading it the other way would make the plain statement "tier 2 is an
+ * imported transcript" false, and there is nothing to gain by holding a
+ * member's own history against them.
+ *
+ * **This result may go down. The stored column may not.** Tier 3's condition is
+ * not monotonic: importing a second transcript later leaves imported courses
+ * unreviewed again and this function will answer 2 where it once answered 3.
+ * The earned tier still stands — `CONTEXT.md` defines it as "the highest value
+ * ever reached" under **Personalization tier**. The asymmetry is the design,
+ * not a bug to be tidied away: the writer in `graph/service.ts` raises the
+ * column and never lowers it, and decay is a separate, read-time thing that
+ * `deriveEffectiveTier` computes and nobody stores.
+ */
+export function deriveEarnedTier(inputs: EarnedTierInputs): number {
+  // No viewer, no ladder. Said out loud because `selectUnreviewedCourses`
+  // answers "nothing is unreviewed" for an empty id, which would otherwise
+  // read as a completed transcript and hand out tier 3.
+  if (!inputs.userId) return 0;
+
+  const hasImported = inputs.transcriptImportedCourses.length > 0;
+  // The one definition of "unreviewed", narrowed to imported courses. Tier 3
+  // falls out of the same arithmetic the "Fast track all N" count uses; a
+  // second version of it written in SQL is exactly the duplication #161 forbids.
+  const unreviewedImported = selectUnreviewedCourses(
+    inputs.transcriptImportedCourses,
+    inputs.reviews,
+    inputs.userId,
+  );
+  if (hasImported && unreviewedImported.length === 0) return 3;
+  if (hasImported) return 2;
+
+  const hasPublishedReview = inputs.reviews.some(
+    (review) => review.userId === inputs.userId,
+  );
+  return hasPublishedReview ? 1 : 0;
+}
+
 /**
  * Derive the tier an app user effectively has right now.
+ *
+ * Decay is read-time and disposable: this result is never stored, and no caller
+ * of it may update `personalization_tier_earned`. The only write to that column
+ * is `raiseEarnedPersonalizationTier`, which raises it from `deriveEarnedTier`
+ * and never lowers it.
  *
  * @param earnedTier The highest tier ever reached (`users.personalization_tier_earned`).
  * @param lastReviewAt The date decay is measured from: the app user's most

--- a/apps/web/server/graph/tier.ts
+++ b/apps/web/server/graph/tier.ts
@@ -21,9 +21,6 @@ import { selectUnreviewedCourses } from "../reviews/unreviewed";
 /** Complete months of inactivity that cost one tier step. */
 const MONTHS_PER_DECAY_STEP = 6;
 
-/** The highest tier the ladder defines. Matches the column's check constraint. */
-export const MAX_PERSONALIZATION_TIER = 3;
-
 /**
  * Everything the ladder is decided from, and nothing else.
  *
@@ -102,8 +99,8 @@ export function deriveEarnedTier(inputs: EarnedTierInputs): number {
  *
  * Decay is read-time and disposable: this result is never stored, and no caller
  * of it may update `personalization_tier_earned`. The only write to that column
- * is `raiseEarnedPersonalizationTier`, which raises it from `deriveEarnedTier`
- * and never lowers it.
+ * is `recordEarnedPersonalizationTier` in `graph/service.ts`, which raises it
+ * from `deriveEarnedTier` and never lowers it.
  *
  * @param earnedTier The highest tier ever reached (`users.personalization_tier_earned`).
  * @param lastReviewAt The date decay is measured from: the app user's most

--- a/apps/web/server/http/body-cap.spec.ts
+++ b/apps/web/server/http/body-cap.spec.ts
@@ -1,9 +1,9 @@
 import { describe, expect, it } from "vitest";
 import {
   capRequestBody,
-  isTranscriptTooLarge,
-  TranscriptTooLargeError,
-} from "./upload";
+  isRequestBodyTooLarge,
+  RequestBodyTooLargeError,
+} from "./body-cap";
 
 function streamingRequest(chunks: number[]): Request {
   const body = new ReadableStream<Uint8Array>({
@@ -32,18 +32,18 @@ describe("capRequestBody", () => {
     const capped = capRequestBody(streamingRequest([600, 600, 600]), 1000);
 
     await expect(capped.arrayBuffer()).rejects.toBeInstanceOf(
-      TranscriptTooLargeError,
+      RequestBodyTooLargeError,
     );
   });
 
   it("recognises the cap failure through a wrapping error", () => {
     const wrapped = new TypeError("terminated", {
-      cause: new TranscriptTooLargeError(),
+      cause: new RequestBodyTooLargeError(),
     });
 
-    expect(isTranscriptTooLarge(new TranscriptTooLargeError())).toBe(true);
-    expect(isTranscriptTooLarge(wrapped)).toBe(true);
-    expect(isTranscriptTooLarge(new Error("something else"))).toBe(false);
+    expect(isRequestBodyTooLarge(new RequestBodyTooLargeError())).toBe(true);
+    expect(isRequestBodyTooLarge(wrapped)).toBe(true);
+    expect(isRequestBodyTooLarge(new Error("something else"))).toBe(false);
   });
 
   it("does not trust a Content-Length that undercounts the body", async () => {
@@ -54,5 +54,35 @@ describe("capRequestBody", () => {
     });
 
     await expect(capRequestBody(request, 1000).arrayBuffer()).rejects.toThrow();
+  });
+
+  it("stops pulling from the source once the cap is passed", async () => {
+    // The point of the cap is not the error, it is that the bytes after it are
+    // never asked for. A source that counts what it was pulled shows that: a
+    // 10-chunk body capped at two chunks must not be drained to the end.
+    let pulled = 0;
+    const body = new ReadableStream<Uint8Array>({
+      pull(controller) {
+        pulled += 1;
+        if (pulled > 10) {
+          controller.close();
+          return;
+        }
+        controller.enqueue(new Uint8Array(600));
+      },
+    });
+    const request = new Request("https://example.test/api/user/transcript", {
+      method: "POST",
+      body,
+      // @ts-expect-error `duplex` is required for a stream body.
+      duplex: "half",
+    });
+
+    await expect(
+      capRequestBody(request, 1000).arrayBuffer(),
+    ).rejects.toBeInstanceOf(RequestBodyTooLargeError);
+    // Queueing means a chunk or two may be in flight when the cap trips; what
+    // matters is that the whole 6000-byte body was never read.
+    expect(pulled).toBeLessThan(10);
   });
 });

--- a/apps/web/server/http/body-cap.ts
+++ b/apps/web/server/http/body-cap.ts
@@ -1,9 +1,22 @@
+/**
+ * Size caps for request bodies that arrive as a stream.
+ *
+ * This lived in `server/ingest/transcript/upload.ts` and filed under transcript
+ * machinery, which is why the profile-picture route never found it and buffered
+ * whatever a signed-in caller sent. Nothing here knows what the body contains,
+ * so it belongs to no domain: `server/http/` is the neutral shelf every route
+ * handler can reach without importing another domain's internals.
+ *
+ * Every multipart route in `app/api/` must cap its body here before touching
+ * `formData()`. There is no second way to do it.
+ */
+
 /** Raised while reading a request body that runs past the size cap. */
-export class TranscriptTooLargeError extends Error {
-  readonly code = "TRANSCRIPT_TOO_LARGE" as const;
+export class RequestBodyTooLargeError extends Error {
+  readonly code = "REQUEST_BODY_TOO_LARGE" as const;
   constructor() {
-    super("Transcript upload exceeded the size limit");
-    this.name = "TranscriptTooLargeError";
+    super("Request body exceeded the size limit");
+    this.name = "RequestBodyTooLargeError";
   }
 }
 
@@ -13,10 +26,10 @@ export class TranscriptTooLargeError extends Error {
  * The body readers wrap a mid-stream error in one of their own on some
  * runtimes, so the cause is worth checking as well as the error itself.
  */
-export function isTranscriptTooLarge(error: unknown): boolean {
+export function isRequestBodyTooLarge(error: unknown): boolean {
   return (
-    error instanceof TranscriptTooLargeError ||
-    (error instanceof Error && error.cause instanceof TranscriptTooLargeError)
+    error instanceof RequestBodyTooLargeError ||
+    (error instanceof Error && error.cause instanceof RequestBodyTooLargeError)
   );
 }
 
@@ -38,7 +51,7 @@ export function capRequestBody(request: Request, maxBytes: number): Request {
       transform(chunk, controller) {
         seen += chunk.byteLength;
         if (seen > maxBytes) {
-          controller.error(new TranscriptTooLargeError());
+          controller.error(new RequestBodyTooLargeError());
           return;
         }
         controller.enqueue(chunk);

--- a/apps/web/server/ingest/transcript/service.spec.ts
+++ b/apps/web/server/ingest/transcript/service.spec.ts
@@ -3,10 +3,13 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { CourseSummary } from "@/types";
 import * as courseService from "../../course/service";
 import { NotFoundError } from "../../errors";
+import * as graphService from "../../graph/service";
 import * as takenService from "../../taken/service";
 import { buildTranscriptProposal, confirmTranscriptImport } from "./service";
 
 vi.mock("../../course/service");
+// The tier writer belongs to the graph domain and is reached service -> service.
+vi.mock("../../graph/service");
 vi.mock("../../taken/service");
 
 function fixture(name: string): string {
@@ -223,5 +226,57 @@ describe("confirmTranscriptImport", () => {
     expect(result).toEqual({ inserted: 0, updated: 0 });
     expect(takenService.recordTranscriptCoursesIfAbsent).not.toHaveBeenCalled();
     expect(courseService.getSummariesByCodes).not.toHaveBeenCalled();
+    // Nothing was imported, so nothing about the ladder can have changed.
+    expect(
+      graphService.recordEarnedPersonalizationTierOnContribution,
+    ).not.toHaveBeenCalled();
+  });
+
+  /**
+   * Confirming an import is the second of the two moments #161's ladder can
+   * move: it earns tier 2 outright, and tier 3 for somebody who had already
+   * reviewed everything the transcript names. It runs after the write so the
+   * recompute reads committed rows.
+   */
+  it("recomputes the earned personalization tier after the import lands", async () => {
+    vi.mocked(courseService.getSummariesByCodes).mockResolvedValue(
+      catalogue("SF1625", "DD1337"),
+    );
+    vi.mocked(takenService.recordTranscriptCoursesIfAbsent).mockResolvedValue({
+      inserted: 2,
+      updated: 0,
+    });
+
+    await confirmTranscriptImport("user-1", confirmed, importedAt);
+
+    expect(
+      graphService.recordEarnedPersonalizationTierOnContribution,
+    ).toHaveBeenCalledWith("user-1");
+    expect(
+      vi.mocked(graphService.recordEarnedPersonalizationTierOnContribution).mock
+        .invocationCallOrder[0],
+    ).toBeGreaterThan(
+      vi.mocked(takenService.recordTranscriptCoursesIfAbsent).mock
+        .invocationCallOrder[0] ?? 0,
+    );
+  });
+
+  it("recomputes the tier even when the confirmation only inserted nothing new", async () => {
+    // A repeat confirmation writes no rows, but the stored transcript rows it
+    // re-confirms are still the ones the ladder is judged over, and the
+    // recompute is idempotent — so it runs rather than being guessed about.
+    vi.mocked(courseService.getSummariesByCodes).mockResolvedValue(
+      catalogue("SF1625", "DD1337"),
+    );
+    vi.mocked(takenService.recordTranscriptCoursesIfAbsent).mockResolvedValue({
+      inserted: 0,
+      updated: 0,
+    });
+
+    await confirmTranscriptImport("user-1", confirmed, importedAt);
+
+    expect(
+      graphService.recordEarnedPersonalizationTierOnContribution,
+    ).toHaveBeenCalledWith("user-1");
   });
 });

--- a/apps/web/server/ingest/transcript/service.ts
+++ b/apps/web/server/ingest/transcript/service.ts
@@ -1,5 +1,6 @@
 import { getSummariesByCodes } from "../../course/service";
 import { NotFoundError } from "../../errors";
+import { recordEarnedPersonalizationTierOnContribution } from "../../graph/service";
 import {
   fillTranscriptCourseFields,
   recordTranscriptCoursesIfAbsent,
@@ -135,11 +136,18 @@ export async function confirmTranscriptImport(
     inputs,
     importedAt,
   );
-  return {
-    inserted: created.inserted,
-    updated:
-      fillInputs.length > 0
-        ? await fillTranscriptCourseFields(userId, fillInputs)
-        : 0,
-  };
+  const updated =
+    fillInputs.length > 0
+      ? await fillTranscriptCourseFields(userId, fillInputs)
+      : 0;
+
+  // The other moment #161's ladder can move: an import earns tier 2, and it
+  // earns tier 3 outright for somebody who had already reviewed everything on
+  // it. It runs even when nothing was inserted, because a confirmation that
+  // only filled fields still tells us the stored rows are worth re-reading, and
+  // because the recompute is idempotent. It never lowers the column, so a
+  // second import that leaves courses unreviewed cannot take tier 3 away.
+  await recordEarnedPersonalizationTierOnContribution(userId);
+
+  return { inserted: created.inserted, updated };
 }

--- a/apps/web/server/reviews/service.spec.ts
+++ b/apps/web/server/reviews/service.spec.ts
@@ -1,5 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { ForbiddenError, NotFoundError, ValidationError } from "../errors";
+import * as graphService from "../graph/service";
 import * as reviewsRepo from "./repository";
 import {
   createReview,
@@ -10,6 +11,8 @@ import {
 } from "./service";
 
 vi.mock("./repository");
+// The tier writer belongs to the graph domain and is reached service -> service.
+vi.mock("../graph/service");
 
 const review = {
   id: "review-123",
@@ -120,6 +123,47 @@ describe("reviews", () => {
       downvoteCount: 0,
       userVote: null,
     });
+  });
+
+  /**
+   * Publishing a review is one of the two moments #161's ladder can move, and
+   * the recompute runs here rather than in a job so the member sees the unlock
+   * on the page they earned it from.
+   */
+  it("createReview recomputes the earned personalization tier", async () => {
+    vi.mocked(reviewsRepo.insertReviewIfFirst).mockResolvedValue(review);
+
+    await createReview("SF1625", "user-456", {
+      examinationDistribution: null,
+      approachTheoryPercent: null,
+      workloadScore: 8,
+      learningScore: 9,
+      happyTook: true,
+      message: null,
+    });
+
+    expect(
+      graphService.recordEarnedPersonalizationTierOnContribution,
+    ).toHaveBeenCalledWith("user-456");
+  });
+
+  it("createReview does not recompute the tier when nothing was published", async () => {
+    // A rejected duplicate changes no review and can earn no tier.
+    vi.mocked(reviewsRepo.insertReviewIfFirst).mockResolvedValue(undefined);
+
+    await expect(
+      createReview("SF1625", "user-456", {
+        examinationDistribution: null,
+        approachTheoryPercent: null,
+        workloadScore: 8,
+        learningScore: 9,
+        happyTook: true,
+        message: null,
+      }),
+    ).rejects.toThrow(ValidationError);
+    expect(
+      graphService.recordEarnedPersonalizationTierOnContribution,
+    ).not.toHaveBeenCalled();
   });
 
   it("createReview keeps an unremembered distribution and percent null", async () => {

--- a/apps/web/server/reviews/service.ts
+++ b/apps/web/server/reviews/service.ts
@@ -2,6 +2,7 @@ import { nanoid } from "nanoid";
 import type { Review, ReviewInput, ReviewVoteType } from "@/types";
 import { reviewInputSchema } from "@/types";
 import { ForbiddenError, NotFoundError, ValidationError } from "../errors";
+import { recordEarnedPersonalizationTierOnContribution } from "../graph/service";
 import * as reviewsRepo from "./repository";
 
 export type { ReviewInput };
@@ -102,6 +103,14 @@ export async function createReview(
       `You have already reviewed ${courseCode}. Edit that review instead.`,
     );
   }
+
+  // Publishing a first review is one of the two moments #161's ladder can move:
+  // it earns tier 1 outright, and it is what completes a transcript for tier 3.
+  // The recompute reads the row this call just committed, raises the column and
+  // never lowers it, and swallows its own failures — a review that was
+  // published stays published even if the tier write does not land.
+  await recordEarnedPersonalizationTierOnContribution(userId);
+
   return serializeReview(inserted);
 }
 

--- a/apps/web/server/reviews/unreviewed.spec.ts
+++ b/apps/web/server/reviews/unreviewed.spec.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from "vitest";
+import { selectUnreviewedCourses as clientSide } from "@/features/reviews/lib/unreviewed";
+import { selectUnreviewedCourses } from "./unreviewed";
+
+const TAKEN = [{ courseCode: "DD2424" }, { courseCode: "SF1918" }];
+
+/**
+ * The behaviour itself is covered by `features/reviews/lib/unreviewed.spec.ts`,
+ * which has exercised it since the card was built. What is worth asserting here
+ * is the thing #161 actually asked for: that the browser and the tier rule are
+ * running the *same function*, not two that agree today.
+ *
+ * A spec is the only place in `server/` allowed to import from `features/`, and
+ * this is what it is for — the moment somebody re-implements the client copy,
+ * the identity check fails and says so.
+ */
+describe("one definition of unreviewed", () => {
+  it("is the same function the reviews feature exports", () => {
+    expect(clientSide).toBe(selectUnreviewedCourses);
+  });
+
+  it("still answers the question the tier rule narrows", () => {
+    const unreviewed = selectUnreviewedCourses(
+      TAKEN,
+      [{ courseCode: "SF1918", userId: "u1" }],
+      "u1",
+    );
+
+    expect(unreviewed.map((course) => course.courseCode)).toEqual(["DD2424"]);
+  });
+});

--- a/apps/web/server/reviews/unreviewed.ts
+++ b/apps/web/server/reviews/unreviewed.ts
@@ -1,0 +1,56 @@
+import type { Review } from "@/types";
+
+/**
+ * What "unreviewed" means, for everybody who asks.
+ *
+ * This is the one definition in the repo and it is deliberately pure: no
+ * database, no tRPC, no React. It sits in the reviews domain because "reviewed
+ * by you" is a reviews concept, and it sits in `server/` because that is the
+ * half of the codebase the other half can reach — Biome forbids server code
+ * importing from `features/`, so a shared derivation cannot live there.
+ * `features/reviews/lib/unreviewed.ts` re-exports it, which is why Taken
+ * courses and My Page keep importing exactly what they always did.
+ *
+ * Both callers are worth naming, because they are why a second copy is
+ * dangerous. The client counts what is left to review — the "Fast track all N"
+ * figure. The server asks the same question of transcript-imported courses to
+ * decide personalization tier 3 (`server/graph/tier.ts`). If those two ever
+ * disagreed, a member would be told they had finished while the tier said they
+ * had not. That is the shape of the duplicated `ReviewDraft` decoder the #134
+ * audit found, and one function is how it stays impossible.
+ */
+
+/**
+ * The taken courses this viewer has not reviewed yet.
+ *
+ * The set arithmetic lives here rather than inside `UnreviewedCard` so the card
+ * renders whatever list it is handed and knows nothing about how that list was
+ * derived — and so Taken courses and My Page derive it the same way instead of
+ * each writing their own filter.
+ *
+ * `reviews` is every review the caller loaded for the courses in `taken`, not
+ * only the viewer's: `reviews.list` takes a course code and has no author
+ * filter, so the personal half of the question is answered here. Another
+ * student's review of a course leaves that course unreviewed *by you*.
+ *
+ * Note what is deliberately absent: nothing here reads a satisfaction state.
+ * `happyTook` belongs to a published review and does not exist until one is
+ * written, so a course in this list has no verdict to render.
+ */
+export function selectUnreviewedCourses<T extends { courseCode: string }>(
+  taken: readonly T[],
+  reviews: readonly Pick<Review, "courseCode" | "userId">[],
+  viewerUserId: string,
+): T[] {
+  // With nobody signed in there is no author to compare against, and treating
+  // every taken course as unreviewed would prompt the wrong person.
+  if (!viewerUserId) return [];
+
+  const reviewedCourseCodes = new Set(
+    reviews
+      .filter((review) => review.userId === viewerUserId)
+      .map((review) => review.courseCode),
+  );
+
+  return taken.filter((course) => !reviewedCourseCodes.has(course.courseCode));
+}

--- a/apps/web/vitest.config.ts
+++ b/apps/web/vitest.config.ts
@@ -14,7 +14,10 @@ export default defineConfig({
         test: {
           name: "server",
           environment: "node",
-          include: ["server/**/*.spec.ts"],
+          // `app/api/` holds route handlers, which are server code that happens
+          // to live under `app/` because that is where Next looks for them.
+          // They belong in this project, not in a DOM one.
+          include: ["server/**/*.spec.ts", "app/api/**/*.spec.ts"],
         },
       },
       {

--- a/docs/adr/0005-personalization-tier-earning.md
+++ b/docs/adr/0005-personalization-tier-earning.md
@@ -1,0 +1,135 @@
+# 5. Earning the personalization tier: the ladder, one derivation, and a monotonic column
+
+Date: 2026-09-05
+
+## Status
+
+Accepted. Settles the ladder half of #161; the axis half — which personalization
+axis each tier unlocks — is still open and is **not** decided here.
+
+## Context
+
+`users.personalization_tier_earned` shipped with a default of 0, a
+`between 0 and 3` check constraint, and no writer. Every account therefore sat at
+tier 0 and all three personalization axes rendered locked. That was never an
+oversight in the code: nothing had ever decided what earns a tier, so there was
+nothing for a writer to write.
+
+Two constraints shaped the answer.
+
+**`CONTEXT.md` already defines the column as "the highest value ever reached".**
+Inactivity decay exists, but it is derived at read time by `deriveEffectiveTier`
+and never written back. So whatever the writer computes, the column may only
+rise.
+
+**There must be one definition of "unreviewed".** The #134 cross-route audit
+found a duplicated `ReviewDraft` decoder that silently dropped fields. The
+"courses you have taken but not reviewed" arithmetic already existed as
+`selectUnreviewedCourses`, used by the Taken courses and My Page cards; the top
+tier is the same question asked of transcript-imported courses. A second copy —
+in particular one written as a SQL anti-join — would be the same defect waiting
+to happen, and the two copies would disagree in the worst possible place: the UI
+telling a member they had finished while the tier said they had not.
+
+## Decision
+
+**The ladder.** `deriveEarnedTier` in `apps/web/server/graph/tier.ts`:
+
+| Tier | Earned by |
+| ---: | --- |
+| 1 | The app user has published a review. |
+| 2 | At least one `user_taken_courses` row has `transcript_imported_at` set. |
+| 3 | Every transcript-imported course has a review by them, **and** there is at least one imported course. |
+
+Each rung is tested on its own and the highest that holds wins, rather than
+every lower rung having to hold too. This matters in one case: somebody who
+imports a transcript before writing anything is at 2, not held at 0. Reading it
+the other way would make the plain statement "tier 2 is an imported transcript"
+false.
+
+Manual entry earns neither 2 nor 3. The tier rewards the upload specifically,
+because that is the data `transcript_imported_at` can vouch for. Tier 3 requires
+at least one imported course so that an empty import cannot make "all reviewed"
+vacuously true.
+
+**The rule lives beside the decay formula**, in `graph/tier.ts`, because earning
+and decay are one policy seen from two ends and product should be able to change
+either without touching a service or a query.
+
+**One derivation, reachable from both halves of the codebase.**
+`selectUnreviewedCourses` moved to `apps/web/server/reviews/unreviewed.ts` — the
+reviews domain owns the concept, and `server/` is the side the client can import
+from while Biome forbids the reverse. `features/reviews/lib/unreviewed.ts`
+re-exports it, so every existing client import path is unchanged.
+`server/reviews/unreviewed.spec.ts` asserts the two are the same function
+object, so a re-implementation fails a test rather than drifting quietly.
+
+**The column only ever rises, in SQL.** `raiseEarnedTier` writes
+`greatest(personalization_tier_earned, tier)`. That is where the guarantee has
+to live: two contributions landing at once cannot have the slower one write a
+stale smaller number over the faster one's. It matters because **tier 3's
+condition is not monotonic** — importing a further transcript leaves imported
+courses unreviewed again, and the rule will answer 2 where it once answered 3.
+The earned tier still stands. The asymmetry is deliberate and is written down at
+the rule, the writer and the repository so that nobody later "fixes" it.
+
+**When the writer runs.** In the same request as the write that could raise the
+tier, immediately after it commits: publishing a review
+(`reviews/service.ts`) and confirming a transcript import
+(`ingest/transcript/service.ts`). Not a background job, which would leave a
+member looking at a locked axis for the job's period; not a read-time write,
+which the tier design forbids. Deliberately *not* inside the write's own
+transaction: that would mean the reviews repository reading `user_taken_courses`
+and writing `users`, and the `greatest` already makes the recompute idempotent
+and order-independent, so the atomicity would buy nothing. It swallows and logs
+its own failures, like `joinCommunityGraphOnSignUp` — a published review stays
+published even when a cosmetic number does not land.
+
+Deletion is not a trigger. Removing a review or an imported course can only make
+a *lower* tier true, and the column does not go down.
+
+## Releasing this: the backfill is an operator step
+
+The writer only fires on a **new** contribution, so every app user who reviewed
+or imported before it shipped is still at the column default. `bun run
+backfill:tiers` recomputes them: it walks only the app users who could earn
+anything, pages on the user id, derives through the same `deriveEarnedTier`, and
+raises through the same `greatest`, so it is safe to re-run at any time and a
+second run raises nothing.
+
+**Run it once, from a checkout, immediately after this ships.**
+
+It is an operator step rather than a deployment step because this repo has no
+deployment step to hang it on, and cannot grow one here. `Dockerfile.web`'s
+runtime stage is `node:20-alpine` carrying only the Next standalone output — no
+bun, no `scripts/`, no `drizzle-kit` — and `.github/workflows/docker-build-push.yml`
+builds and pushes an image without ever reaching a database. Every schema change
+this project has shipped, including migration `0014` and the one that created
+this column, was applied by an operator running `bun run db:push` from a
+checkout. The backfill is the same class of operation and takes the same path.
+
+Automating it is worth doing and is a separate decision: it means either putting
+bun and the source into the runtime image, or giving the build workflow a
+production `DATABASE_URL`. Both are release-engineering choices about credentials
+and image size, not personalization ones, and neither belongs in the change that
+introduced the writer.
+
+## Consequences
+
+- Members can now reach tiers 1-3, so **the open half of #161 becomes urgent**:
+  the My Page artboard's rendered list and `cc-store.js`'s `TIER_AXES` disagree
+  about which axis tiers 2 and 3 unlock, and the code follows the rendered list
+  provisionally. That was harmless while every account was at tier 0. Changing
+  the pairing after members hold those tiers would take back a feature somebody
+  had already unlocked, so it should be settled before this is deployed.
+- `graph/repository.ts` now holds three read-only projections that cross a domain
+  boundary — `findLastReviewAt`, `findReviewedCourses` and
+  `findTranscriptImportedCourses` — plus the union read the backfill pages over.
+  They are the documented exception, not a precedent: nothing else in the graph
+  domain may reach into `reviews` or `user_taken_courses`, and none of them may
+  grow a write.
+- A member who publishes a review pays two extra reads and at most one write on
+  that request. Accepted: it is the moment the unlock has to be visible.
+- Until the backfill is run, existing contributors keep seeing locked axes. That
+  is a stale display, not a wrong one — nothing is lost and nothing is granted in
+  error, because the column only rises.

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "rm:web": "bun remove --filter=kth-course-community-web",
     "docker:web:build": "bun run --filter kth-course-community-web build",
     "ingest": "bun run --filter kth-course-community-web ingest",
+    "backfill:tiers": "bun run --filter kth-course-community-web backfill:tiers",
     "db:push": "bun run --filter kth-course-community-web db:push",
     "db:generate": "bun run --filter kth-course-community-web db:generate",
     "db:migrate": "bun run --filter kth-course-community-web db:migrate",


### PR DESCRIPTION
Two server-side fixes from the fix wave: an unbounded upload on the
profile-picture route, and the missing writer for
`users.personalization_tier_earned` (#161).

## 1. The security fix — an upload nobody bounded

`apps/web/app/api/user/profile-picture/route.ts` called
`await request.formData()` at line 16 and compared `file.size` against the
2MB limit at line 30. By the time the check ran the entire body was in
memory, so any signed-in caller could hand the server an arbitrarily large
upload and have it buffered first and rejected second.

**The root cause is where the fix lived, not that it did not exist.**
`capRequestBody` counts bytes as they arrive and errors the stream
mid-body; its docstring already describes exactly this failure mode. It
was filed at `server/ingest/transcript/upload.ts`, which reads as
transcript machinery, so nobody working on an image upload would find it.

### Where `capRequestBody` lives now

`apps/web/server/http/body-cap.ts` — domain-neutral, because nothing in it
knows what the body contains. The error type moved with it and was
renamed, since it was never about transcripts:

| before | after |
| --- | --- |
| `TranscriptTooLargeError` | `RequestBodyTooLargeError` |
| `isTranscriptTooLarge` | `isRequestBodyTooLarge` |

Callers updated:

- `apps/web/app/api/user/transcript/route.ts` — import and predicate name
  only. Its behaviour is byte-for-byte unchanged: same 4MB cap, same 413,
  same messages.
- `apps/web/app/api/user/profile-picture/route.ts` — now caps before
  `formData()`.

`apps/web/server/ingest/transcript/upload.spec.ts` moved to
`apps/web/server/http/body-cap.spec.ts` (renamed in git, so the history
follows).

### What changed in the picture route's behaviour

The cap counts bytes off the wire, and those carry multipart framing as
well as the image, so the envelope is capped at `2MB + 16KB` and the exact
`file.size > 2MB` check is kept afterwards. A picture of exactly 2MB is
still accepted and the stated limit still holds to the byte.

An oversized body now answers **413** rather than 400 (this matches the
transcript route). `apps/web/lib/user.ts` keys on `res.ok` and then on the
message text, both unchanged, so the user-visible copy is identical.

### The test asserts non-buffering, not the status code

`apps/web/app/api/user/profile-picture/route.spec.ts` builds a streaming
multipart upload whose source counts what the server pulled from it. 20MB
is offered against a 2MB cap; the assertion is that fewer than 4MB were
ever read. A route that buffers first and measures second drains the
source to the end and fails this test while still returning the right
status.

Route handlers are server code that happens to live under `app/`, so
`app/api/**/*.spec.ts` joins the node test project in
`apps/web/vitest.config.ts`.

`CLAUDE.md` and `AGENTS.md` now state the rule — every multipart route
caps with `server/http/body-cap.ts` before `formData()` — because the root
cause here was that the rule was findable only by accident.

## 2. The personalization tier writer (#161)

### The rule as implemented

`apps/web/server/graph/tier.ts`, beside `deriveEffectiveTier`, whose
docstring already claimed that address. Earning and decay are one policy
seen from two ends.

- **Tier 1** — the app user has published a review.
- **Tier 2** — at least one `user_taken_courses` row has
  `transcript_imported_at` set. Manual entry earns neither 2 nor 3.
- **Tier 3** — every transcript-imported course has a review by them,
  **and** there is at least one imported course, so an empty import cannot
  make "all reviewed" vacuously true.

Each rung is tested on its own and the highest that holds wins, rather
than every lower rung having to hold too. That matters in exactly one
case: somebody who imports a transcript before writing anything is at 2,
not held at 0. Reading it the other way would make the plain statement
"tier 2 is an imported transcript" false. `deriveEarnedTier` also returns
0 for an empty `userId`, because `selectUnreviewedCourses` answers
"nothing is unreviewed" for an empty viewer and that would otherwise read
as a completed transcript.

### One definition of "unreviewed", and how both callers reach it

Tier 3 *is* `selectUnreviewedCourses` narrowed to imported rows — the same
function, not a second copy, and emphatically not a copy written in SQL.

Server code cannot import from `features/` (Biome), so the pure derivation
moved **down** to `apps/web/server/reviews/unreviewed.ts` — the reviews
domain, because "reviewed by you" is a reviews concept, and `server/`
because that is the half both halves can reach.

- The client reaches it through
  `apps/web/features/reviews/lib/unreviewed.ts`, which now re-exports it.
  Every existing import path in `features/` resolves unchanged; no client
  file outside that one was touched. `reviewsWhenEveryListLoaded` stays
  there, since "the request has not answered yet" is a browser cache state
  and means nothing on the server.
- The server reaches it from `server/graph/tier.ts`.

`apps/web/server/reviews/unreviewed.spec.ts` asserts the two are the
**same function object**. If somebody re-implements the client copy, that
test fails rather than the two silently drifting — which is the shape of
the duplicated `ReviewDraft` decoder the #134 audit found.

### Monotonicity

`graphRepo.raiseEarnedTier` writes
`greatest(personalization_tier_earned, tier)` and never lowers. The
guarantee is in SQL because that is the only place it holds under
concurrency: two contributions landing at once cannot have the slower one
write a stale smaller number over the faster one's.

This matters because **tier 3's condition is not monotonic** — importing a
further transcript leaves imported courses unreviewed again, and
`deriveEarnedTier` will answer 2 where it once answered 3. The earned tier
still stands; `CONTEXT.md` defines the column as the highest value ever
reached. The asymmetry is written down in three places — the rule, the
writer, and the repository — so nobody later "fixes" it into a bug, and
there is a test for the fall (`deriveEarnedTier` drops to 2) next to a
test that the service still asks for the lower number and lets the
repository decline it.

`deriveEffectiveTier` is untouched: decay is still derived at read time
and still writes nothing. `getEffectiveTier`'s "never writes the earned
tier back" test was tightened rather than relaxed — it now also asserts
`raiseEarnedTier` was not called, and its write-name regex was widened to
catch `raise*` so a third write cannot appear quietly.

### When the writer runs, and why there

`recordEarnedPersonalizationTierOnContribution(userId)` is called from the
two moments the inputs change, in the same request as the write that could
raise the tier, immediately after it commits:

- `apps/web/server/reviews/service.ts` → `createReview`, after a
  successful insert (not on the rejected-duplicate path).
- `apps/web/server/ingest/transcript/service.ts` →
  `confirmTranscriptImport`, after the rows land.

Not a background job: a member would sit looking at a locked axis for the
job's period. Not a read-time write: `graph.effectiveTier` writing to the
database is precisely what the tier design forbids.

**Not literally inside the write's transaction.** Doing that would mean
the reviews repository reading `user_taken_courses` and writing `users` —
the layering this repo enforces with Biome — to buy atomicity that is not
needed: the recompute reads committed state and the write is `greatest`,
so it is idempotent and order-independent. A lost recompute costs a tier
that the next contribution recomputes anyway.

It swallows and logs its own failures, the same shape as
`joinCommunityGraphOnSignUp`: a review that was published stays published
even if a cosmetic number fails to update.

### The backfill for existing contributors

The writer only fires on a *new* contribution, so everybody who reviewed or
imported before it ships is still at the column default.
`backfillEarnedPersonalizationTiers` recomputes them: it walks only the app
users who could earn anything (`findTierCandidateUserIds` — the union of
reviewers and transcript importers), pages on the user id with a cursor rather
than an offset so a review published mid-run cannot make it skip somebody, and
is idempotent because the derivation is pure and the write is still `greatest`.

It is a maintenance command — `bun run backfill:tiers` — rather than committed
SQL, because deriving tier 3 in SQL would mean an anti-join expressing "every
imported course reviewed": a second definition of unreviewed, which is the thing
#161 forbids. One app user at a time reuses `deriveEarnedTier` itself.

Unlike the per-contribution path it does **not** swallow. A backfill that
half-ran and reported success is worse than one that stops and says where.

**Run it once, from a checkout, after this ships.** It is an operator step
because this repo has no deployment step to hang it on: `Dockerfile.web`'s
runtime stage is `node:20-alpine` carrying only the Next standalone output (no
bun, no `scripts/`, no `drizzle-kit`), and `docker-build-push.yml` builds and
pushes an image without ever reaching a database. Every schema change this
project has shipped, including the one that created this column, was applied by
an operator running `bun run db:push` from a checkout. Automating it means
either putting bun and the source into the runtime image or handing the build
workflow a production `DATABASE_URL` — release-engineering decisions that do not
belong in the change that introduced the writer. **ADR 0005** records all of
this.

Deletion is deliberately not a trigger. Removing a review or an imported
course can only make a *lower* tier true, and the column does not go down.
Removing an imported course can also complete a transcript and make tier 3
true; that raise waits for the next contribution rather than putting a
tier write on a delete path.

### Data access

`graph/repository.ts` gains `findReviewedCourses` and
`findTranscriptImportedCourses` under the cross-domain read exception that
`findLastReviewAt` already documents there — read-only projections feeding
one derived number, both indexed (`reviews_user_id_idx`; the
`(user_id, course_code)` primary key). The comment that said "nothing else
here may reach into `server/reviews/`" is updated to name the exact set
rather than being quietly contradicted. Routing these through the other
domains' services would have made `reviews/service` and `graph/service` a
cycle, and `taken` has no business knowing about tiers.

`findReviewedCourses` returns `userId` on every row even though the
`WHERE` already filtered on it, so the tier rule runs the same author
comparison the browser runs, through the same function, instead of
trusting the query to have meant the same thing.

**No migration.** The column, its default and its
`between 0 and 3` check constraint already exist; this only writes it.

## Validation

All three gates, from the repo root:

| gate | result |
| --- | --- |
| `bun run lint` | clean (8 pre-existing warnings, all unused imports in `server/db/schema.ts`) |
| `bun run typecheck` | clean |
| `bun run test:web` | **875 passed / 72 files** (baseline 843 / 70) |

Greptile: **5/5, zero unresolved threads**, over three rounds. Round 1 raised
that existing contributors were never seeded — valid, and fixed with the
backfill above. Round 2 asked for it as a deployment step — answered in ADR 0005
rather than in the Dockerfile, for the reasons above.

New coverage: the ladder rung by rung including the empty-import,
other-students' reviews, empty-viewer and non-monotonic-fall cases; the
writer raising, skipping tier 0, asking for a lower number and swallowing
its own failure; both trigger points firing and the duplicate-review path
not firing; the one-definition identity check; and the profile-picture
route's non-buffering, 401-before-body, in-limit, over-limit and
wrong-type paths; and the backfill paging across pages, visiting each
contributor once, the empty case, the zero-raise second run and the propagated
failure.

## Things I did not touch, and one follow-up

Files outside my scope that are now **stale**, all describing a writer
that no longer fails to exist. Someone owning `features/` should sweep
them:

- `apps/web/features/my-page/components/node-profile.tsx:33-47`
- `apps/web/features/my-page/lib/personalization-tiers.ts:7,25,38`
- `apps/web/features/landing/lib/neighbourhood-view.ts:43`

They say "nothing in `server/` writes `personalization_tier_earned`, so
every account is at tier 0". That was honest and is now wrong.

**Follow-up worth its own issue:** #161's other half — which axis each
tier unlocks — is still undecided. The My Page artboard's rendered list
and `cc-store.js`'s `TIER_AXES` disagree for tiers 2 and 3, and the code
follows the rendered list provisionally. That contradiction was harmless
while every account sat at tier 0. It is not harmless now: members can
reach tiers 2 and 3, so changing the pairing later would take back a
feature somebody had already unlocked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017EAUKDDo2BkQTFELyvV3v8
