### PR TITLE
fix(saved): every saved course listed, confirmation before destroying, one card ramp

### DIFF
--- a/apps/web/features/collections/components/collection-chip.tsx
+++ b/apps/web/features/collections/components/collection-chip.tsx
@@ -16,7 +16,7 @@ type Props = {
  * One collection as a 40px chip — the `compact` variant's answer to
  * {@link CollectionTile}.
  *
- * `Course Community - Collections.dc.html` line 174 draws this row when the
+ * `Course Community - Collections.dc.html` line 112 draws this row when the
  * artboard is embedded rather than shown as a page, which is how
  * `Course Community - Saved.dc.html` reaches collections at all. A chip is the
  * tile with everything but the name, the count and the menu taken out: the

--- a/apps/web/features/collections/components/collection-detail.tsx
+++ b/apps/web/features/collections/components/collection-detail.tsx
@@ -11,9 +11,8 @@ import {
   type CourseCardCourse,
   CourseCardItem,
   CourseItemSkeleton,
-  EXPANDED_CARD_GEOMETRY,
 } from "@/features/courses";
-import type { CourseStats } from "@/types";
+import type { CardGeometry, CourseStats } from "@/types";
 import { EmptyPanel } from "./empty-panel";
 
 /** A course the viewer has saved, with everything a card needs to draw it. */
@@ -24,6 +23,25 @@ export type SavedCourse = {
 
 type Props = {
   collection: Collection;
+  /**
+   * The card's collapse ramp, measured by whoever owns the column these rows
+   * are laid out in.
+   *
+   * This used to be `EXPANDED_CARD_GEOMETRY`, pinned here on the grounds that
+   * the page column had nothing competing for its width. That was true of
+   * `/collections` and false of `/saved`, which embeds this component inside the
+   * very column the workspace pane narrows — so one card collapsed or did not
+   * depending only on which of the page's two lists it was in, and the surplus
+   * was clipped rather than scrolled because that column is `overflow-x-hidden`
+   * (#159). The decision belongs to the host, and both hosts now measure.
+   *
+   * It is the *column's* width, not the card's: each row spends 36px on the
+   * reorder buttons before the card starts, so the ramp here runs about 36px
+   * ahead of the card's true width. That shifts where the collapse begins by a
+   * fifth of the ramp; it never leaves the ramp, and closing it would mean a
+   * second measurement per row for a card that is already interpolating.
+   */
+  geo: CardGeometry;
   /** `undefined` while the course's summary is still in flight. */
   courseFor: (courseCode: string) => SavedCourse | undefined;
   /** Saved courses this collection does not already hold. Saved-only, always. */
@@ -58,8 +76,8 @@ const MOVE_BUTTON =
  * schema has, and the card renders the same course from data that does exist —
  * so the codebase wins, as #68 has it, and the design's remove affordance
  * survives as the card's own `removeLabel` button, which #86 built for this page.
- * The geometry is pinned to the expanded end: the page column has nothing
- * competing for its width, so there is no ramp to interpolate along.
+ * The geometry arrives as a prop; see {@link Props.geo} for why this component
+ * is the wrong place to decide it.
  *
  * Reordering is a pair of move buttons per course. The artboard designs no
  * reorder control at all, and `collections.reorder` is the only ordering the
@@ -68,6 +86,7 @@ const MOVE_BUTTON =
  */
 export function CollectionDetail({
   collection,
+  geo,
   courseFor,
   addableCourseCodes,
   hasSavedCourses,
@@ -232,7 +251,7 @@ export function CollectionDetail({
                     <CourseCardItem
                       course={saved.course}
                       stats={saved.stats}
-                      geo={EXPANDED_CARD_GEOMETRY}
+                      geo={geo}
                       action="add"
                       removeLabel={`Remove ${courseCode} from ${collection.name}`}
                       onRemove={() => onRemoveCourse(courseCode)}

--- a/apps/web/features/collections/components/collections.spec.tsx
+++ b/apps/web/features/collections/components/collections.spec.tsx
@@ -1,6 +1,10 @@
 import { render, screen, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  COLLAPSED_CARD_GEOMETRY,
+  EXPANDED_CARD_GEOMETRY,
+} from "@/features/courses/lib/card-geometry";
 import { Collections } from "./collections";
 
 /**
@@ -55,6 +59,17 @@ vi.mock("@/features/courses/api/mutations", () => ({
   useMarkCourseTaken: () => ({ mutateAsync: vi.fn() }),
 }));
 vi.mock("sonner", () => ({ toast: { error: vi.fn(), success: vi.fn() } }));
+
+/*
+ * This page measures its own column through `useResultsWidth`, which lives in
+ * the workspace barrel — and the barrel also carries the pane, which carries the
+ * review editor and its stylesheet. Stubbing the pane is what keeps that CSS out
+ * of a suite that never renders one, exactly as Saved's and Explore's suites do
+ * for the pane they *do* mount.
+ */
+vi.mock("@/features/workspace/components/workspace-pane", () => ({
+  WorkspacePane: () => null,
+}));
 
 const TITLES: Record<string, string> = {
   AA1000: "Alpha",
@@ -418,7 +433,7 @@ describe("the grid", () => {
     });
   });
 
-  it("deletes a collection from its menu", async () => {
+  it("deletes a collection from its menu, once the reader confirms", async () => {
     setup({
       collections: [{ id: "c1", name: "Spring", courseCodes: [] }],
     });
@@ -429,7 +444,117 @@ describe("the grid", () => {
     );
     await userEvent.click(screen.getByRole("menuitem", { name: "Delete" }));
 
+    expect(deleteCollection).not.toHaveBeenCalled();
+
+    await userEvent.click(
+      screen.getByRole("button", { name: "Delete collection" }),
+    );
     expect(deleteCollection).toHaveBeenCalledWith({ collectionId: "c1" });
+  });
+});
+
+/**
+ * #155. Deletion was immediate and irreversible from all three entry points,
+ * and the artboards confirm *after* — a note, with no undo on it. The product
+ * decision overrides them, because the deletion genuinely cannot be undone:
+ * restoring a collection means `create` plus one `addCourse` per course, since
+ * `reorderCollectionCourses` throws `NotFoundError` for a code that is not
+ * already a member, and `addCourseToCollection` throws `ForbiddenError` for a
+ * course unsaved in between. A restore that can come back partial is not an
+ * undo, so the question is asked while the answer still costs nothing.
+ */
+describe("deleting a collection", () => {
+  const SPRING = { id: "c1", name: "Spring", courseCodes: ["AA1000"] };
+
+  async function askFromTileMenu() {
+    await userEvent.click(
+      screen.getByRole("button", { name: "More actions for Spring" }),
+    );
+    await userEvent.click(screen.getByRole("menuitem", { name: "Delete" }));
+  }
+
+  it("names the collection, and what survives it", async () => {
+    setup({ savedCourseCodes: ["AA1000"], collections: [SPRING] });
+    render(<Collections />);
+
+    await askFromTileMenu();
+
+    expect(screen.getByText("Delete “Spring”?")).toBeVisible();
+    expect(screen.getByText(/The courses themselves stay saved/)).toBeVisible();
+    expect(screen.getByText(/cannot be restored/)).toBeVisible();
+  });
+
+  it("writes nothing when the reader keeps the collection", async () => {
+    setup({ savedCourseCodes: ["AA1000"], collections: [SPRING] });
+    render(<Collections />);
+
+    await askFromTileMenu();
+    await userEvent.click(
+      screen.getByRole("button", { name: "Keep collection" }),
+    );
+
+    expect(deleteCollection).not.toHaveBeenCalled();
+    expect(screen.queryByText("Delete “Spring”?")).toBeNull();
+    expect(
+      screen.getByRole("button", { name: "Open collection Spring" }),
+    ).toBeVisible();
+  });
+
+  // Dismissing is answering "keep it".
+  it("writes nothing when the question is dismissed", async () => {
+    setup({ savedCourseCodes: ["AA1000"], collections: [SPRING] });
+    render(<Collections />);
+
+    await askFromTileMenu();
+    await userEvent.keyboard("{Escape}");
+
+    expect(deleteCollection).not.toHaveBeenCalled();
+  });
+
+  it("asks from the open collection's own Delete button", async () => {
+    setup({ savedCourseCodes: ["AA1000"], collections: [SPRING] });
+    render(<Collections openCollectionId="c1" />);
+
+    await userEvent.click(screen.getByRole("button", { name: "Delete" }));
+    expect(deleteCollection).not.toHaveBeenCalled();
+
+    await userEvent.click(
+      screen.getByRole("button", { name: "Delete collection" }),
+    );
+    expect(deleteCollection).toHaveBeenCalledWith({ collectionId: "c1" });
+  });
+
+  it("asks from the compact chip's menu", async () => {
+    setup({ savedCourseCodes: ["AA1000"], collections: [SPRING] });
+    render(<Collections compact />);
+
+    await askFromTileMenu();
+    expect(deleteCollection).not.toHaveBeenCalled();
+
+    await userEvent.click(
+      screen.getByRole("button", { name: "Delete collection" }),
+    );
+    expect(deleteCollection).toHaveBeenCalledWith({ collectionId: "c1" });
+  });
+
+  /**
+   * The note after the fact stays — it is what says the deletion happened — but
+   * it must never grow an Undo, because the procedures cannot deliver one.
+   */
+  it("says it happened, and offers no undo", async () => {
+    setup({ savedCourseCodes: ["AA1000"], collections: [SPRING] });
+    render(<Collections />);
+
+    await askFromTileMenu();
+    await userEvent.click(
+      screen.getByRole("button", { name: "Delete collection" }),
+    );
+
+    // Twice, deliberately: the live region announces it and the strip draws it.
+    expect(
+      await screen.findAllByText('Collection "Spring" deleted'),
+    ).toHaveLength(2);
+    expect(screen.queryByRole("button", { name: /undo/i })).toBeNull();
   });
 });
 
@@ -461,5 +586,58 @@ describe("what the page promises", () => {
 
     const section = render(<Collections compact />);
     expect(section.container.textContent).not.toMatch(/compar/i);
+  });
+});
+
+/**
+ * #159. The detail pinned every card to `EXPANDED_CARD_GEOMETRY`, which was
+ * right on `/collections` and wrong inside `/saved` — the same component sits in
+ * the column the workspace pane narrows there, and the surplus was clipped
+ * rather than scrolled. The ramp is now the host's to decide.
+ */
+describe("the geometry an open collection's cards get", () => {
+  /** The element `geometryVars` writes the ramp onto: the card's own wrapper. */
+  function cardShellFor(courseCode: string): HTMLElement {
+    const card = screen
+      .getAllByRole("article")
+      .find((article) => within(article).queryByText(new RegExp(courseCode)));
+    const shell = card?.parentElement;
+    if (!shell) throw new Error(`No card rendered for ${courseCode}`);
+    return shell;
+  }
+
+  it("is the one the host measured, when a host supplies it", () => {
+    setup({
+      savedCourseCodes: ["AA1000"],
+      collections: [{ id: "c1", name: "Spring", courseCodes: ["AA1000"] }],
+    });
+    render(
+      <Collections
+        compact
+        openCollectionId="c1"
+        geo={COLLAPSED_CARD_GEOMETRY}
+      />,
+    );
+
+    expect(cardShellFor("AA1000").style.getPropertyValue("--card-h")).toBe(
+      COLLAPSED_CARD_GEOMETRY.cardHeight,
+    );
+  });
+
+  /**
+   * As a page this measures its own column. jsdom lays nothing out, so
+   * `useResultsWidth` keeps its honest `Infinity` — the top of the ramp, which
+   * is what a wide column resolves to and what this page used to pin.
+   */
+  it("is the top of the ramp on an unmeasured column", () => {
+    setup({
+      savedCourseCodes: ["AA1000"],
+      collections: [{ id: "c1", name: "Spring", courseCodes: ["AA1000"] }],
+    });
+    render(<Collections openCollectionId="c1" />);
+
+    expect(cardShellFor("AA1000").style.getPropertyValue("--card-h")).toBe(
+      EXPANDED_CARD_GEOMETRY.cardHeight,
+    );
   });
 });

--- a/apps/web/features/collections/components/collections.tsx
+++ b/apps/web/features/collections/components/collections.tsx
@@ -12,15 +12,18 @@ import {
 import {
   type Collection,
   CourseItemSkeleton,
+  courseCardGeometry,
   useCollectionMutations,
   useCollections,
   useCourseSummaries,
 } from "@/features/courses";
 import { PageColumn, PageHeader } from "@/features/shell";
-import type { OpenCourseKind } from "@/features/workspace";
+import { type OpenCourseKind, useResultsWidth } from "@/features/workspace";
+import type { CardGeometry } from "@/types";
 import { CollectionChip } from "./collection-chip";
 import { CollectionDetail, type SavedCourse } from "./collection-detail";
 import { CollectionTile } from "./collection-tile";
+import { ConfirmDialog } from "./confirm-dialog";
 import { EmptyPanel } from "./empty-panel";
 import { NewCollectionDialog } from "./new-collection-dialog";
 
@@ -99,6 +102,18 @@ type Props = {
    * page renders its own when this is absent.
    */
   onRequestAuth?: (reason: AuthReason) => void;
+  /**
+   * The card collapse ramp for an open collection's courses, when the host has
+   * already measured the column they land in.
+   *
+   * `/saved` embeds this inside the very column `WorkspacePaneHost` narrows, so
+   * the geometry it computes for its own list is the geometry these cards need
+   * too — one card behaving two ways in one page is what #159 reports. Left
+   * out, this component measures the column it is standing in itself, which is
+   * what the `/collections` route does; see {@link Collections} for why that is
+   * a measurement there rather than the pinned expanded end.
+   */
+  geo?: CardGeometry;
 };
 
 /**
@@ -124,9 +139,9 @@ type Props = {
  * `Course Community - Saved.dc.html` imports the Collections artboard as a
  * section of the Saved page, in its `compact` variant. That embedding is Saved's
  * to build (#90); this is the same component as a page of its own, so the
- * feature is reachable and usable before Saved exists. The `compact` chip
- * variant is deliberately not built — it has no caller yet, and building an
- * untested second layout for one is worse than leaving it to whoever embeds it.
+ * feature is reachable and usable before Saved exists. The `compact` chip row
+ * is built and Saved is its caller — the sentence that used to stand here said
+ * it had none, which stopped being true when #90 landed.
  *
  * ## What the writes do about failure
  *
@@ -137,12 +152,37 @@ type Props = {
  * create" after a failed *add* would send the reader back to the name field,
  * and `collections.create` has no uniqueness on name, so typing it again makes a
  * second empty collection.
+ *
+ * ## Deleting asks first
+ *
+ * All three ways to delete a collection — the detail's button, the tile's menu
+ * and the chip's menu — hand the collection to one confirmation rather than to
+ * the mutation. The artboards confirm *after*, with a note; #155 settled that
+ * they lose here, because what is destroyed cannot be put back. Restoring a
+ * deleted collection means `create` and then one `addCourse` per course in
+ * order — `reorderCollectionCourses` throws `NotFoundError` for a code that is
+ * not already a member, so it can never add one — and `addCourseToCollection`
+ * throws `ForbiddenError` for a course unsaved in the meantime. An undo that
+ * comes back partial is not an undo, so the question is asked while the answer
+ * is still free. The note stays: it is what says the deletion happened.
+ *
+ * ## Where the cards' geometry comes from
+ *
+ * An open collection's courses are `CourseCardItem`s, and the card never
+ * measures anything — its host hands it a `geo`. Embedded in `/saved` that host
+ * is Saved, which already measures the column the workspace pane narrows. As a
+ * page there is no pane, but a browser window is narrowed the same way a pane
+ * narrows a column, and the ramp's input is the width itself rather than the
+ * reason for it. So this measures too rather than pinning the expanded end:
+ * measuring *is* pinning whenever the column is wide, and unlike pinning it is
+ * also right when the column is not (#159).
  */
 export function Collections({
   openCollectionId = null,
   compact = false,
   onDetailChange,
   onRequestAuth,
+  geo,
 }: Props) {
   const router = useRouter();
   // The route this is rendered on owns `?collection=`, so an embedded detail
@@ -162,6 +202,16 @@ export function Collections({
   const { create, rename, deleteCollection, reorder, addCourse, removeCourse } =
     useCollectionMutations();
 
+  /**
+   * The column an open collection's cards land in, when nobody has measured it
+   * for us. `useResultsWidth` starts at `Infinity`, which is the top of the ramp
+   * — so the first paint, the server's render and jsdom (which lays nothing out)
+   * all draw the fully expanded card this page used to pin, and the ramp only
+   * moves once something has actually measured a narrower column.
+   */
+  const [columnRef, columnWidth] = useResultsWidth();
+  const cardGeo = geo ?? courseCardGeometry(columnWidth);
+
   const [openId, setOpenId] = useState<string | null>(openCollectionId);
   const [dialogOpen, setDialogOpen] = useState(false);
   /**
@@ -170,6 +220,15 @@ export function Collections({
    * restarts rather than expiring on the first message's clock.
    */
   const [note, setNote] = useState<{ text: string } | null>(null);
+  /**
+   * The collection a delete has been asked about and not yet answered.
+   *
+   * The collection itself rather than its id: the dialog names it, and the
+   * record can leave `collections.list` between the question and the answer —
+   * another tab deleting it, or the refetch after this one lands. Holding the
+   * record means the words on screen never blank out mid-question.
+   */
+  const [pendingDelete, setPendingDelete] = useState<Collection | null>(null);
   const [ownAuthReason, setOwnAuthReason] = useState<AuthReason | null>(null);
   const setAuthReason = onRequestAuth ?? setOwnAuthReason;
 
@@ -278,7 +337,12 @@ export function Collections({
       );
   }
 
-  function onDelete(collection: Collection) {
+  /** Confirms the deletion; nothing is written until the reader answers. */
+  function onConfirmDelete() {
+    const collection = pendingDelete;
+    setPendingDelete(null);
+    if (!collection) return;
+
     deleteCollection
       .mutateAsync({ collectionId: collection.id })
       .then(() => {
@@ -327,6 +391,12 @@ export function Collections({
   const body = (
     <>
       <div
+        // The measured box is the one the cards are laid out in, so its content
+        // width is exactly what they have to share. Embedded, `geo` is already
+        // supplied and this measurement goes unread rather than unmade — one
+        // `ResizeObserver` on a box that exists either way is cheaper than a
+        // conditional hook could ever be.
+        ref={columnRef}
         className={
           compact
             ? "mt-3.5 flex flex-col gap-3.5"
@@ -404,6 +474,7 @@ export function Collections({
         {!isLoading && signedIn && openCollectionRecord ? (
           <CollectionDetail
             collection={openCollectionRecord}
+            geo={cardGeo}
             courseFor={(courseCode) => savedByCode.get(courseCode)}
             addableCourseCodes={addableCourseCodes(
               savedCourseCodes,
@@ -412,7 +483,7 @@ export function Collections({
             hasSavedCourses={savedCourseCodes.length > 0}
             onBack={() => openCollection(null)}
             onRename={(name) => onRename(openCollectionRecord, name)}
-            onDelete={() => onDelete(openCollectionRecord)}
+            onDelete={() => setPendingDelete(openCollectionRecord)}
             onAddCourse={(courseCode) =>
               onAddCourse(openCollectionRecord, courseCode)
             }
@@ -461,7 +532,7 @@ export function Collections({
                   collection={collection}
                   onOpen={() => openCollection(collection.id)}
                   onRename={(name) => onRename(collection, name)}
-                  onDelete={() => onDelete(collection)}
+                  onDelete={() => setPendingDelete(collection)}
                 />
               ))}
             </div>
@@ -499,7 +570,7 @@ export function Collections({
                   }
                   onOpen={() => openCollection(collection.id)}
                   onRename={(name) => onRename(collection, name)}
-                  onDelete={() => onDelete(collection)}
+                  onDelete={() => setPendingDelete(collection)}
                 />
               ))}
             </div>
@@ -512,6 +583,32 @@ export function Collections({
         savedCourses={savedCourses}
         onClose={() => setDialogOpen(false)}
         onCreate={onCreate}
+      />
+
+      {/*
+        One dialog for all three entry points, rendered by the component that
+        owns the mutation rather than by each menu — a tile and a chip both
+        unmount the moment the collection goes, and a dialog inside one of them
+        would be asking the question from inside the thing being deleted.
+
+        The body names what is lost and what is not: the collection and the
+        order its courses were put in, never the courses, which stay saved and
+        stay in whatever other collections hold them.
+      */}
+      <ConfirmDialog
+        request={
+          pendingDelete
+            ? {
+                eyebrow: "Collections",
+                title: `Delete “${pendingDelete.name}”?`,
+                body: "This deletes the collection and the order you put its courses in. The courses themselves stay saved, and stay in any other collection that holds them. A deleted collection cannot be restored.",
+                cancelLabel: "Keep collection",
+                actionLabel: "Delete collection",
+              }
+            : null
+        }
+        onCancel={() => setPendingDelete(null)}
+        onConfirm={onConfirmDelete}
       />
 
       {/* Only when nobody else is showing one. An embedded copy would put two

--- a/apps/web/features/collections/components/confirm-dialog.tsx
+++ b/apps/web/features/collections/components/confirm-dialog.tsx
@@ -1,0 +1,123 @@
+"use client";
+
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogTitle,
+} from "@/components/ui/dialog";
+
+/**
+ * What one confirmation asks. Held as a single object so the caller's pending
+ * state is one value rather than a flag plus the subject it is about — the
+ * dialog is open exactly when there is something to ask about.
+ */
+export type ConfirmRequest = {
+  /** The section this belongs to, in the artboard's small uppercase brand line. */
+  eyebrow: string;
+  /** The question, asked as a question. */
+  title: string;
+  /** What confirming actually does, and what it does not touch. */
+  body: string;
+  /** Names the thing being kept, never the word "Cancel" alone. */
+  cancelLabel: string;
+  /** Names the destruction, so the button and the title agree. */
+  actionLabel: string;
+};
+
+type Props = {
+  /** `null` closes it. See {@link ConfirmRequest} for why that is the whole state. */
+  request: ConfirmRequest | null;
+  onCancel: () => void;
+  onConfirm: () => void;
+};
+
+/**
+ * The confirmation that stands in front of something that cannot be taken back.
+ *
+ * ## Why this exists rather than `components/ui/alert-dialog`
+ *
+ * `Course Community - My Page.dc.html` lines 426-436 draw this dialog properly —
+ * 440px, a 14px radius, 22px of padding, a brand eyebrow over a 19px/600 title,
+ * an `rgba(20,30,45,.34)` scrim and 38px buttons. The stock shadcn
+ * `AlertDialogContent` renders its own overlay with no way to restyle it and
+ * hands its buttons to `Button`'s variants, so reaching the artboard through it
+ * would mean editing the shared primitive for one screen's sake. #134's design
+ * review recorded that the app's existing delete dialogs are the stock component
+ * and that the artboard is not; this is the artboard, built on the same
+ * `Dialog` primitive its sibling `NewCollectionDialog` already uses, so the two
+ * modals in this feature are one object drawn twice rather than two.
+ *
+ * Everything the primitive gives is what a confirmation needs and markup alone
+ * cannot: the focus trap, Escape, and focus returning to the control that
+ * opened it. Cancel is first in the DOM, so it is what opens focused — the safe
+ * half of a destructive question should be the one a stray Enter hits.
+ *
+ * ## Why confirming, rather than undoing afterwards
+ *
+ * This is a deliberate, authorised deviation from the artboards that ask *after*
+ * — see #155. Deleting a collection cannot be undone by replaying the public
+ * procedures: `reorderCollectionCourses` throws on a code that is not already a
+ * member, so `create` + `reorder` restores nothing, and `addCourseToCollection`
+ * throws `ForbiddenError` for a course that has since been unsaved. A restore
+ * that can come back partial is not an undo, so the question is asked while the
+ * answer still costs nothing.
+ */
+export function ConfirmDialog({ request, onCancel, onConfirm }: Props) {
+  return (
+    <Dialog
+      open={request !== null}
+      onOpenChange={(next) => {
+        if (!next) onCancel();
+      }}
+    >
+      {request ? (
+        <DialogContent
+          showCloseButton={false}
+          /*
+            The artboard's own scrim, and no blur under it: what is behind a
+            confirmation is the thing being confirmed about, and it has to stay
+            readable while the reader decides.
+          */
+          overlayClassName="bg-[rgba(20,30,45,0.34)] supports-backdrop-filter:backdrop-blur-none"
+          /*
+            `cc-theme` because the dialog is portalled to the body and would
+            otherwise leave the subtree that defines the `--cc-*` tokens. The
+            `sm:max-w-[440px]` is not redundant with `w-[440px]`: the primitive
+            carries an `sm:max-w-sm`, and a plain `max-w-*` sits in a different
+            tailwind-merge group, so without the responsive override the card
+            would be clamped to 384px on any screen wide enough to have room.
+          */
+          className="cc-theme w-[440px] max-w-[calc(100vw-2rem)] gap-0 rounded-[14px] bg-cc-surface p-[22px] text-cc-ink shadow-[0_18px_48px_rgba(20,30,45,0.24)] ring-0 sm:max-w-[440px]"
+        >
+          <div className="font-semibold text-[11px] text-cc-brand uppercase tracking-[0.06em]">
+            {request.eyebrow}
+          </div>
+          <DialogTitle className="mt-2 font-semibold text-[19px] leading-[1.3]">
+            {request.title}
+          </DialogTitle>
+          <DialogDescription className="mt-[9px] text-[13.5px] text-cc-muted leading-[1.55]">
+            {request.body}
+          </DialogDescription>
+
+          <div className="mt-[18px] flex justify-end gap-[9px]">
+            <button
+              type="button"
+              onClick={onCancel}
+              className="flex h-[38px] cursor-pointer items-center rounded-[9px] border border-cc-rule3 bg-cc-surface px-3.5 font-medium text-[13px] text-cc-chip-ink hover:border-cc-hov"
+            >
+              {request.cancelLabel}
+            </button>
+            <button
+              type="button"
+              onClick={onConfirm}
+              className="flex h-[38px] cursor-pointer items-center rounded-[9px] bg-cc-danger px-4 font-semibold text-[13px] text-cc-danger-fg hover:opacity-[0.88]"
+            >
+              {request.actionLabel}
+            </button>
+          </div>
+        </DialogContent>
+      ) : null}
+    </Dialog>
+  );
+}

--- a/apps/web/features/collections/index.ts
+++ b/apps/web/features/collections/index.ts
@@ -12,3 +12,19 @@
  */
 
 export { Collections } from "./components/collections";
+/**
+ * The artboard's confirmation, exported because Saved asks the same question
+ * about the same object.
+ *
+ * Unsaving a course is destructive in exactly the way deleting a collection is:
+ * `user_saved_courses` is the composite foreign key every `collection_courses`
+ * row hangs off, so an unsave cascades the course out of every collection it
+ * was in and takes its place in each of their orders with it. One dialog asks
+ * both questions (#155). It lives here because collections is where the first
+ * of them is asked; when a third screen needs it, it belongs in
+ * `components/ui/` instead.
+ */
+export {
+  ConfirmDialog,
+  type ConfirmRequest,
+} from "./components/confirm-dialog";

--- a/apps/web/features/saved/components/saved.spec.tsx
+++ b/apps/web/features/saved/components/saved.spec.tsx
@@ -180,6 +180,83 @@ describe("Saved", { timeout: 20_000 }, () => {
       expect(container.textContent).not.toMatch(/compar/i);
     });
 
+    /**
+     * #156, and `CONTEXT.md`'s **Collection**: a collection is a view over saved
+     * courses, never a place they move to. The 2026-09-05 artboard says the same
+     * — `savedCards` over every saved code, and no "Every saved course is in a
+     * collection" panel, because there is no state where this list can be empty
+     * while saves exist.
+     */
+    it("lists a course that is already in a collection", () => {
+      saved("DD2380", "DD2421");
+      collections.mockReturnValue([collection("Spring picks", "DD2380")]);
+      render(<Saved />);
+
+      expect(screen.getAllByRole("article")).toHaveLength(2);
+      expect(
+        screen.getByRole("heading", { name: "DD2380 Artificial Intelligence" }),
+      ).toBeInTheDocument();
+    });
+
+    it("lists every saved course even when all of them are filed", () => {
+      saved("DD2380", "DD2421");
+      collections.mockReturnValue([
+        collection("Spring picks", "DD2380"),
+        collection("Maybe", "DD2421", "DD2380"),
+      ]);
+      render(<Saved />);
+
+      expect(screen.getAllByRole("article")).toHaveLength(2);
+      expect(
+        screen.queryByText("Every saved course is in a collection"),
+      ).toBeNull();
+    });
+
+    // The artboard's own heading and line (lines 129-131). The line is what
+    // distinguishes this section from the `h1` of the same words above it.
+    it("heads the list the way the artboard heads it", () => {
+      saved("DD2380");
+      render(<Saved />);
+
+      const heading = screen.getByRole("heading", {
+        level: 2,
+        name: "Saved courses",
+      });
+      expect(heading).toBeVisible();
+      expect(
+        screen.getByText(
+          /All the courses you have saved, including any already grouped into a collection\./,
+        ),
+      ).toBeVisible();
+      // The superseded copy promised the opposite.
+      expect(
+        screen.queryByText(/but not yet added to a collection/),
+      ).toBeNull();
+    });
+
+    /**
+     * The 2026-09-05 artboard added `if (this.savedState.pickerFor) this.sv({
+     * pickerFor: null })` to its document handler: a pointer down outside the
+     * picker closes it, where before only the taken and overflow menus were
+     * dismissed that way. The app already behaves this way — the picker's state
+     * is per card, so `useDismissOnOutside` in `CourseCard` defines "elsewhere"
+     * from the card's own DOM — and this holds it, because the artboard now
+     * names it as a requirement rather than leaving it to the implementation.
+     */
+    it("closes an open collection picker when the reader points elsewhere", async () => {
+      saved("DD2380");
+      render(<Saved />);
+
+      const trigger = screen.getByRole("button", { name: "Add to collection" });
+      await userEvent.click(trigger);
+      expect(trigger).toHaveAttribute("aria-expanded", "true");
+
+      await userEvent.click(
+        screen.getByRole("heading", { level: 2, name: "Saved courses" }),
+      );
+      expect(trigger).toHaveAttribute("aria-expanded", "false");
+    });
+
     it("shows placeholders rather than an empty list while loading", () => {
       saved("DD2380");
       summariesPending.mockReturnValue(true);
@@ -388,6 +465,13 @@ describe("Saved", { timeout: 20_000 }, () => {
     });
   });
 
+  /**
+   * #155: deleting is confirmed *before* the write, not announced after it.
+   * The artboards ask afterwards; the product decision overrides them, because
+   * an unsave cascades the course out of every collection it was in and their
+   * stored orders cannot be replayed back (`reorderCollectionCourses` refuses a
+   * code that is not already a member).
+   */
   describe("unsaving", () => {
     function removeButtonFor(courseCode: string) {
       return within(cardFor(courseCode)).getByRole("button", {
@@ -395,13 +479,74 @@ describe("Saved", { timeout: 20_000 }, () => {
       });
     }
 
-    it("removes the save", async () => {
+    it("asks before it writes anything", async () => {
       saved("DD2380", "DD2421");
       render(<Saved />);
 
       await userEvent.click(removeButtonFor("DD2380"));
 
+      expect(
+        screen.getByText("Remove DD2380 from your saved courses?"),
+      ).toBeVisible();
+      expect(setSaved).not.toHaveBeenCalled();
+    });
+
+    it("removes the save once the reader confirms", async () => {
+      saved("DD2380", "DD2421");
+      render(<Saved />);
+
+      await userEvent.click(removeButtonFor("DD2380"));
+      await userEvent.click(
+        screen.getByRole("button", { name: "Remove course" }),
+      );
+
       expect(setSaved).toHaveBeenCalledExactlyOnceWith("DD2380", false);
+    });
+
+    it("writes nothing when the reader keeps the course", async () => {
+      saved("DD2380", "DD2421");
+      render(<Saved />);
+
+      await userEvent.click(removeButtonFor("DD2380"));
+      await userEvent.click(
+        screen.getByRole("button", { name: "Keep it saved" }),
+      );
+
+      expect(setSaved).not.toHaveBeenCalled();
+      expect(
+        screen.queryByText("Remove DD2380 from your saved courses?"),
+      ).toBeNull();
+      expect(cardFor("DD2380")).toBeInTheDocument();
+    });
+
+    // Dismissing is answering "keep it": the destructive half of the question
+    // is never the one a stray Escape reaches.
+    it("writes nothing when the question is dismissed", async () => {
+      saved("DD2380");
+      render(<Saved />);
+
+      await userEvent.click(removeButtonFor("DD2380"));
+      await userEvent.keyboard("{Escape}");
+
+      expect(setSaved).not.toHaveBeenCalled();
+    });
+
+    /**
+     * The confirmation names the one thing that really does go with the save —
+     * the course's place in the collections holding it, cascaded off
+     * `user_saved_courses` — and promises the two relationships that do not.
+     */
+    it("names the collections it cascades, and clears reviews and taken", async () => {
+      saved("DD2380");
+      render(<Saved />);
+
+      await userEvent.click(removeButtonFor("DD2380"));
+
+      const question = screen.getByText(/leaves this list and any collection/);
+      expect(question).toBeVisible();
+      expect(question.textContent).toMatch(
+        /reviews and the courses you have marked as taken are untouched/i,
+      );
     });
 
     /**
@@ -421,6 +566,9 @@ describe("Saved", { timeout: 20_000 }, () => {
       expect(takenPill).toBeInTheDocument();
 
       await userEvent.click(removeButtonFor("DD2380"));
+      await userEvent.click(
+        screen.getByRole("button", { name: "Remove course" }),
+      );
 
       // The only write is the unsave; nothing reaches taken or the collections
       // the course may have been in.
@@ -433,12 +581,18 @@ describe("Saved", { timeout: 20_000 }, () => {
       ).toBeInTheDocument();
     });
 
-    it("never warns that unsaving takes anything else with it", () => {
+    it("never warns that unsaving takes anything else with it", async () => {
       saved("DD2380");
       takenCourses.mockReturnValue([{ courseCode: "DD2380" }]);
       const { container } = render(<Saved />);
 
       expect(container.textContent).not.toMatch(/will also|also remove/i);
+
+      // Including inside the confirmation, which is the one place on this page
+      // that could plausibly overclaim what an unsave reaches.
+      await userEvent.click(removeButtonFor("DD2380"));
+      expect(document.body.textContent).not.toMatch(/will also|also remove/i);
+      expect(document.body.textContent).not.toMatch(/delete your review/i);
     });
   });
 });

--- a/apps/web/features/saved/components/saved.tsx
+++ b/apps/web/features/saved/components/saved.tsx
@@ -9,7 +9,7 @@ import {
   useMe,
   useRequireSession,
 } from "@/features/auth";
-import { Collections } from "@/features/collections";
+import { Collections, ConfirmDialog } from "@/features/collections";
 import {
   CourseCardItem,
   courseCardGeometry,
@@ -35,6 +35,9 @@ import { useSetCourseSaved } from "../api/mutations";
  */
 const SKELETON_KEYS = ["s0", "s1", "s2"] as const;
 
+/** Names the saved list's own section, under the page's `h1` of the same words. */
+const SAVED_HEADING_ID = "saved-courses-heading";
+
 /**
  * The viewer's saved courses.
  *
@@ -42,8 +45,8 @@ const SKELETON_KEYS = ["s0", "s1", "s2"] as const;
  * about it are worth knowing before changing anything here.
  *
  * **It hosts the workspace pane, so its cards ramp.** The artboard imports the
- * pane at line 166 with the same contract Explore uses, and computes the card's
- * `geo` from what the pane leaves of the row (line 844) exactly as Explore
+ * pane at line 161 with the same contract Explore uses, and computes the card's
+ * `geo` from what the pane leaves of the row (line 836) exactly as Explore
  * does. So the geometry is measured here rather than pinned: with no tab open
  * the column is wide and the ramp lands on its expanded end, which is the fixed
  * object this page used to hand out, and with a tab open the cards collapse
@@ -51,11 +54,17 @@ const SKELETON_KEYS = ["s0", "s1", "s2"] as const;
  * card's `geo` to the fully collapsed end" was decided when this page had no
  * pane to yield to; it has one now, and the artboard interpolates.
  *
- * **Unsaving removes the save and nothing else.** The trash control calls
- * `saved.unsave`, whose repository deletes one row; taken history and reviews
- * have no foreign key to it. Nothing on this screen may imply otherwise — no
- * "this will also remove…" confirmation, and no optimistic write that reaches
- * into `taken.list` or the review cache. `saved.spec.tsx` holds that.
+ * **Unsaving removes the save and its collection memberships, and nothing
+ * else.** The trash control calls `saved.unsave`, whose repository deletes one
+ * `user_saved_courses` row; taken history and reviews have no foreign key to
+ * it, so nothing on this screen may imply they go with it — no optimistic write
+ * that reaches into `taken.list` or the review cache, and no copy that says so.
+ * `saved.spec.tsx` holds that. `collection_courses` *does* hang off that row,
+ * with `on delete cascade`, so an unsave does take the course out of every
+ * collection it was in and out of each of their orders. That is what the
+ * confirmation below names, and now that this list shows organized courses too
+ * it is a thing a reader can do without ever opening the collection they are
+ * emptying (#155).
  *
  * **Collections is a section of this page, not a link away from it.** The
  * artboard imports the Collections artboard at line 82 with `compact`, which is
@@ -66,29 +75,30 @@ const SKELETON_KEYS = ["s0", "s1", "s2"] as const;
  * why a course opened from inside a collection comes back to this route as
  * `?open=`: the pane it opens into is this page's.
  *
- * **The list is flat, and the artboard's is not.** Below the chips the artboard
- * still shows only the saved courses *not* in a collection (line 128), under an
- * `h2` reading "Saved courses" and the line "Courses you have saved but not yet
- * added to a collection", with an "Every saved course is in a collection" panel
- * when none are left. That split is not built: a course would leave this list
- * the moment it joined a collection, and the only place it would then be
- * visible is behind a chip — so a reader who filed everything would find the
- * page empty under a heading promising their saved courses. The `h2` is dropped
- * with it, because "Saved courses" under an `h1` reading "Saved courses" says
- * nothing once the subtitle that distinguished them is gone. Both are a
- * deferral, not a design change: they belong with whoever makes an organized
- * course reachable from this page without opening the collection it is in
- * (#127 §4).
+ * **The list is every saved course, organized or not.** A collection is a view
+ * over saved courses, never a place they move to (`CONTEXT.md`): joining one
+ * takes nothing out of this list, and a course may be in several at once. The
+ * chips above **narrow** the list — opening one swaps this list for that
+ * collection's — rather than relocating anything out of it. The artboard says
+ * the same thing at lines 129-135: `savedCards` over every saved code and
+ * `hasSaved` where the previous export had `unorganized` and `hasUnorganized`,
+ * and no "Every saved course is in a collection" panel, because there is no
+ * state in which this list can be empty while saves exist. #156 settled it;
+ * #90's deferral and the split it deferred are both gone.
+ *
+ * The `h2` comes back with the subtitle that earns it. It repeats the `h1`, and
+ * that is the artboard's own doing — but the section under it is now one of two
+ * on the page, and the line beneath is what tells them apart.
  *
  * ## Where else it departs from the artboard
  *
  * The artboard keeps the collections strip *above* the row the pane sits in,
  * and shortens it by a flat 236px while tabs are open (`savedTopMargin`, line
- * 969). Here the strip is inside the column the pane already narrows, which
+ * 961). Here the strip is inside the column the pane already narrows, which
  * does the same job exactly rather than approximately — and, decisively, keeps
  * an open collection's detail scrollable. A fixed-height block above a row that
  * owns the page's only scroll would clip a long collection instead.
- * `resultsMax` (line 970) is computed by the artboard and never read by its
+ * `resultsMax` (line 962) is computed by the artboard and never read by its
  * markup, so there is nothing to follow.
  */
 type Props = {
@@ -115,6 +125,15 @@ export function Saved({ openCollectionId = null, openCourse = null }: Props) {
   const { user, isLoading: isSessionLoading } = useMe();
   const { setSaved } = useSetCourseSaved();
   const [authReason, setAuthReason] = useState<AuthReason | null>(null);
+  /**
+   * The course an unsave has been asked about and not yet answered.
+   *
+   * The code alone is enough — the card is what names the course on screen, and
+   * the dialog says the code back. It is cleared by answering either way, so a
+   * card that leaves the list while the question is up cannot leave a write
+   * armed behind it.
+   */
+  const [pendingUnsave, setPendingUnsave] = useState<string | null>(null);
   // Which collection's detail is open, as `Collections` reports it. The route
   // is the authority on the first paint; after that the chips are.
   const [openDetail, setOpenDetail] = useState<string | null>(openCollectionId);
@@ -200,7 +219,12 @@ export function Saved({ openCollectionId = null, openCourse = null }: Props) {
    */
   const unreadable = savedCourseCodes.length - courses.length;
 
-  function unsave(courseCode: string) {
+  /** Unsaves the course the reader confirmed, and closes the question. */
+  function onConfirmUnsave() {
+    const courseCode = pendingUnsave;
+    setPendingUnsave(null);
+    if (!courseCode) return;
+
     setSaved(courseCode, false).catch(() =>
       toast.error(`Could not remove ${courseCode} from your saved courses.`),
     );
@@ -241,6 +265,13 @@ export function Saved({ openCollectionId = null, openCourse = null }: Props) {
               openCollectionId={openCollectionId}
               onDetailChange={setOpenDetail}
               onRequestAuth={setAuthReason}
+              /*
+                An open collection's cards sit in this very column, so they get
+                the ramp this page already measured for its own list. Without it
+                they pinned the expanded end and were clipped by the column the
+                pane had just narrowed (#159).
+              */
+              geo={geo}
             />
           </div>
 
@@ -257,7 +288,28 @@ export function Saved({ openCollectionId = null, openCourse = null }: Props) {
             showing the same course twice.
           */}
           {openDetail !== null ? null : (
-            <div className="flex flex-col gap-3.5 pt-[18px] pb-5 @max-[440px]:gap-3 @max-[440px]:pt-3">
+            <section
+              aria-labelledby={SAVED_HEADING_ID}
+              className="flex flex-col gap-3.5 pt-[18px] pb-5 @max-[440px]:gap-3 @max-[440px]:pt-3"
+            >
+              {/*
+                The artboard's own heading and line, at lines 129-131. The line is
+                the whole of what #156 settled, said to the reader: a collection
+                groups saved courses, it does not take them out of this list.
+              */}
+              <div>
+                <h2
+                  id={SAVED_HEADING_ID}
+                  className="m-0 font-semibold text-[16px] leading-[1.3]"
+                >
+                  Saved courses
+                </h2>
+                <div className="mt-1 text-[12.5px] text-cc-muted">
+                  All the courses you have saved, including any already grouped
+                  into a collection.
+                </div>
+              </div>
+
               {isLoading ? (
                 SKELETON_KEYS.map((key) => <CardSkeleton key={key} />)
               ) : savedCourseCodes.length === 0 ? (
@@ -302,16 +354,24 @@ export function Saved({ openCollectionId = null, openCourse = null }: Props) {
                           // so the split Save button has nothing left to offer and
                           // the picker stands alone; removal is the trash control.
                           removeLabel={`Remove ${course.courseCode} from saved courses`}
-                          onRemove={() => unsave(course.courseCode)}
+                          onRemove={() => setPendingUnsave(course.courseCode)}
                           onOpen={() =>
                             workspace.open(course.courseCode, "details")
                           }
                           onReview={() =>
                             workspace.open(course.courseCode, "review")
                           }
-                          // The artboard opens every picker upwards on this page: a
-                          // saved list is a single column, so a panel dropping from
-                          // the last card would fall off it.
+                          /*
+                            Every picker on this page opens upwards. The
+                            2026-09-05 artboard dropped its `picker-above` from
+                            this import, but the reason it was passed is a
+                            property of the page rather than of the drawing: the
+                            saved list is a single scrolling column, and a panel
+                            dropping out of the last card falls out of a box that
+                            is `overflow-x-hidden`. Following the removal would
+                            reintroduce that; it is recorded here rather than
+                            silently kept.
+                          */
                           pickerAbove
                           onRequestAuth={setAuthReason}
                         />
@@ -320,7 +380,7 @@ export function Saved({ openCollectionId = null, openCourse = null }: Props) {
                   </ul>
                 </>
               )}
-            </div>
+            </section>
           )}
         </div>
 
@@ -348,6 +408,29 @@ export function Saved({ openCollectionId = null, openCourse = null }: Props) {
           onOpen={workspace.open}
         />
       ) : null}
+
+      {/*
+        Asked before the write, not confirmed after it (#155). The body names
+        the one thing an unsave really does take with it — the course's place in
+        every collection holding it, cascaded off `user_saved_courses` — and
+        says nothing about reviews or taken history, which have no foreign key
+        to that row and are not touched.
+      */}
+      <ConfirmDialog
+        request={
+          pendingUnsave
+            ? {
+                eyebrow: "Saved courses",
+                title: `Remove ${pendingUnsave} from your saved courses?`,
+                body: `${pendingUnsave} leaves this list and any collection it is in, together with its place in their order. Your reviews and the courses you have marked as taken are untouched. You can save it again from Explore.`,
+                cancelLabel: "Keep it saved",
+                actionLabel: "Remove course",
+              }
+            : null
+        }
+        onCancel={() => setPendingUnsave(null)}
+        onConfirm={onConfirmUnsave}
+      />
 
       {/*
         `proxy.ts` only checks that a session cookie exists, so a stale one


### PR DESCRIPTION
Closes the Saved/Collections half of the fix wave: #156, #155 and #159.

## #156 — Saved lists every saved course

A collection is a **view over** saved courses, never a place they move to.
`CONTEXT.md`'s **Collection** entry now says exactly that, and the 2026-09-05
artboard was revised to match: `unorganized` → `savedCards`, `hasUnorganized` →
`hasSaved`, the "Every saved course is in a collection" panel is gone, and the
subtitle reads *"All the courses you have saved, including any already grouped
into a collection."*

The list itself was already flat, so what changed is everything around it:

- The artboard's `h2` "Saved courses" and that subtitle come back, in a
  `<section aria-labelledby>` so the page's two lists are two landmarks. The
  `h2` repeats the `h1`; that is the artboard's own doing, and the line beneath
  is what tells them apart.
- The long deferral comment in `saved.tsx` that argued *against* the split — and
  argued the `h2` away with it — is replaced by the settled reasoning. #90's
  objection is answered rather than restated.
- Regression cover: a course in a collection still appears in the list; a
  library where *every* course is filed still shows every card and never shows
  the retired panel; the heading and the new line are asserted, and the
  superseded "…but not yet added to a collection" copy is asserted absent.

Collection chips keep **narrowing** the list: opening one swaps this list for
that collection's detail, which is the artboard's own
`showSavedSection: !collectionsOpenDetail`. Nothing is relocated out of Saved.

### The artboard's picker fix

The new export adds `if (this.savedState.pickerFor) this.sv({ pickerFor: null })`
to its document handler. What it closes is the collection picker on an outside
pointer down — previously only the taken and overflow menus were dismissed that
way, so the picker stayed open when the reader pointed elsewhere.

**The app already behaves this way.** The picker's state is per card rather than
per page, so `useDismissOnOutside` in `CourseCard` already defines "elsewhere"
from the card's own DOM and handles Escape too. No code change was needed; a
test now holds it, because the artboard has turned an implementation detail into
a stated requirement.

## #155 — confirm before, not after (deliberate, authorised deviation)

Collection deletion was immediate and irreversible from three entry points. All
three now hand the collection to a confirmation; so does the unsave control on
Saved.

**This overrides the artboards, which confirm *after* with a note.** The product
owner settled it. Recorded here as a deliberate deviation rather than a design
miss.

**Why undo is not a substitute.** The #134 audit established that a deleted
collection cannot always be restored:

- `reorderCollectionCourses` throws `NotFoundError` for a code that is not
  already a member, so a naive `create` + `reorder` restore fails outright — a
  restore is `create` plus one `addCourse` *per course*, in order.
- `addCourseToCollection` throws `ForbiddenError` if the course was unsaved in
  the meantime.

A restore that can come back partial is not an undo. The note after the fact
stays — it is what says the deletion happened — and a test asserts it never
grows an Undo button.

**Unsaving is confirmed for the same reason, and it is newly load-bearing.**
`collection_courses` hangs off `user_saved_courses` with `on delete cascade`, so
an unsave takes the course out of every collection holding it and out of each of
their stored orders. Now that Saved lists organised courses, that is something a
reader can do without ever opening the collection they are emptying. The dialog
says so — and says nothing about reviews or taken history, which have no foreign
key to that row. `saved.spec.tsx`'s independence tests are extended to check the
open dialog too.

Removing a course *from* a collection is **not** confirmed: it is one reversible
write, re-addable from the same screen, and the design does not confirm it.

### The dialog matches the artboard, not the stock component

#134's design review found the app's existing delete dialogs are stock shadcn
`AlertDialog` while `Course Community - My Page.dc.html` (lines 426-436) draws
them properly. `ConfirmDialog` is built to the artboard: **440px**, **14px**
radius, **22px** padding, a brand uppercase eyebrow, a **19px/600** title, a
13.5px/1.55 muted body, an **`rgba(20,30,45,.34)`** scrim with no blur, and
**38px** buttons with the cancel first.

It is built on the `Dialog` primitive its sibling `NewCollectionDialog` already
uses, not on `components/ui/alert-dialog.tsx`, because that wrapper renders its
own overlay with no way to restyle it and routes its buttons through `Button`'s
variants — reaching the artboard through it would mean editing a shared
primitive for one feature's sake, and `components/ui/` is not this PR's to
change. Colours are `--cc-*` tokens throughout (`--cc-danger` /
`--cc-danger-fg` for the destructive button), so both themes work.

The primitive supplies exactly what a confirmation needs and markup cannot:
focus trap, Escape, and focus returning to the control that opened it. Cancel is
first in the DOM, so the safe half is what opens focused. Dismissing — Escape or
the scrim — is answering "keep it"; tests hold that for both dialogs.

One non-obvious detail is commented in place: `sm:max-w-[440px]` is *not*
redundant with `w-[440px]`. The primitive carries `sm:max-w-sm`, and a plain
`max-w-*` lands in a different tailwind-merge group, so without the responsive
override the card is clamped to 384px on any screen wide enough to have room.

## #159 — one card, one ramp

`CollectionDetail` pinned `EXPANDED_CARD_GEOMETRY`, justified by "the page column
has nothing competing for its width". True of `/collections`; false inside
`/saved`, which embeds `Collections compact` in the very column
`WorkspacePaneHost` narrows — and that column is `overflow-x-hidden`, so the
surplus was clipped rather than scrolled.

`geo` is now a prop on `CollectionDetail`, threaded through `Collections`.

**What `/collections` gets, and why.** It **measures its own column** rather than
keeping the pin. The pin's justification was about the *pane*, but the ramp's
input is the available width itself, not the reason it is narrow — and a browser
window narrows `/collections`'s column exactly the way a pane narrows Saved's.
Between the card's 440px mobile container query and the ramp's 640px ceiling
there is a real band where pinning draws a cramped card. Measuring **is** pinning
whenever the column is wide (`useResultsWidth` starts at `Infinity`, so SSR, the
first paint and jsdom all render the fully expanded card this page used to pin),
and unlike pinning it is also right when the column is not. There is no case
where the pin wins, so keeping two behaviours for one card would have been the
only cost.

Documented in place: the measured width is the *column's*, and each row spends
36px on the reorder buttons before the card starts, so the ramp runs ~36px ahead
of the card's true width. That shifts where the collapse begins by about a fifth
of the ramp and never leaves it; closing the gap would mean a second measurement
per row.

## Files I do not own

- **`apps/web/features/courses/lib/card-geometry.ts:5-7`** still says Explore
  interpolates "while **Saved and Collections simply pin an end of the ramp**".
  After this PR neither does. #159 asks for that clause to go entirely; the file
  belongs to another agent in this wave, so it is **not** changed here and needs
  either their PR or a follow-up.
- **`components/ui/alert-dialog.tsx`** would need an `overlayClassName` escape
  hatch before an artboard-faithful confirmation could be built on it. Not
  changed; see the reasoning above.
- The Saved artboard also **dropped `picker-above`** from its card import in
  this export. It is deliberately **not** followed, and the reason is recorded in
  `saved.tsx`: the reason it was passed is a property of the page rather than of
  the drawing — the saved list is a single scrolling column and a panel dropping
  out of the last card falls out of a box that is `overflow-x-hidden`. Flagged
  here so the deviation is visible rather than silent.

## Where the shared dialog lives

`ConfirmDialog` is exported from `@/features/collections` and imported by Saved,
because both features are asking one question about one object. When a third
screen needs it — `my-page`'s delete-review and delete-account dialogs are the
obvious candidates — it belongs in `components/ui/`. Noted in the barrel.

## Validation

All three gates green from the repo root:

```
bun run lint       → 0 errors, 8 pre-existing warnings (drizzle schema imports)
bun run typecheck  → exit 0
bun run test:web   → 70 files, 859 passed  (baseline 70 / 843; +16 new)
```

New coverage:

- Saved lists a course that is in a collection; lists every course when all are
  filed; heads the section with the artboard's `h2` and new line; the retired
  copy and the retired panel are asserted absent.
- The picker closes on an outside pointer down.
- Unsave: asks before writing; writes once on confirm; writes nothing on cancel
  or Escape; names the collection cascade; still never overclaims reviews or
  taken, including with the dialog open.
- Collection delete: asks from all three entry points (tile menu, chip menu,
  detail button); writes nothing on cancel or Escape; names the collection and
  what survives it; the note appears and carries no Undo.
- Geometry: an open collection's card takes the `geo` its host supplies, and
  falls back to the top of the ramp on an unmeasured column.

One test-infrastructure note: `collections.spec.tsx` now stubs
`@/features/workspace/components/workspace-pane`, because measuring the column
pulls `useResultsWidth` in through the workspace barrel and the barrel also
carries the pane's review editor and its stylesheet. Saved's and Explore's
suites already stub it for the same reason.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017EAUKDDo2BkQTFELyvV3v8
