### PR TITLE
feat(graph): let a member choose how their node looks

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -167,6 +167,12 @@ A signal is ongoing: a node either carries one or it does not. A **one-shot
 reveal** — the ring **Find your dot** draws once on the viewer's own node — is a
 different thing, and *pulse* is its name. So `scene.pulse` is not a signal by
 another word, and the two are not interchangeable.
+_Today_: it does not move. `users_node_profiles.signal_style` stores the axis and
+`hero-network.tsx` draws each style standing still, because that canvas paints
+when an input changes rather than every frame and the pulse is the only frame
+loop it has. The ongoing/one-shot distinction still holds — a signal is painted
+whenever its node is, a pulse only while the label is up. Closed by whatever
+gives the hero a bounded loop a signal can ride on.
 _Avoid_: ping, animation, activity
 
 **Personalization tier**:

--- a/apps/web/features/landing/components/hero-network.spec.tsx
+++ b/apps/web/features/landing/components/hero-network.spec.tsx
@@ -1,5 +1,7 @@
 import { render } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { GraphWindow } from "../api/queries";
+import { NODE_RADIUS } from "../lib/neighbourhood-view";
 import { HeroNetwork } from "./hero-network";
 
 /**
@@ -16,23 +18,68 @@ import { HeroNetwork } from "./hero-network";
  * asserts that changing it repaints.
  */
 
-/** A 2d context that records what was asked of it. jsdom supplies none. */
+/**
+ * A 2d context that records what was asked of it. jsdom supplies none.
+ *
+ * `paths` keeps the traced geometry as well as the counts, because a node's
+ * *shape* is now an assertion: a diamond is four `lineTo`s and a ring is an
+ * `arc` that was stroked rather than filled, and neither is visible from a call
+ * count alone. Each entry is one `beginPath()` and everything traced onto it.
+ */
+type TracedPath = {
+  arcs: { x: number; y: number; r: number }[];
+  moves: { x: number; y: number }[];
+  lines: { x: number; y: number }[];
+  closed: boolean;
+  filled: boolean;
+  stroked: boolean;
+  dash: number[];
+};
+
 function recordingContext() {
   const calls = { arc: 0, clearRect: 0 };
+  const paths: TracedPath[] = [];
+  let dash: number[] = [];
+  const open = () => paths[paths.length - 1];
   return {
     calls,
+    paths,
     ctx: {
       setTransform: vi.fn(),
       clearRect: vi.fn(() => {
         calls.clearRect++;
       }),
-      beginPath: vi.fn(),
-      moveTo: vi.fn(),
-      lineTo: vi.fn(),
-      stroke: vi.fn(),
-      fill: vi.fn(),
-      arc: vi.fn(() => {
+      beginPath: vi.fn(() => {
+        paths.push({
+          arcs: [],
+          moves: [],
+          lines: [],
+          closed: false,
+          filled: false,
+          stroked: false,
+          dash,
+        });
+      }),
+      moveTo: vi.fn((x: number, y: number) => open()?.moves.push({ x, y })),
+      lineTo: vi.fn((x: number, y: number) => open()?.lines.push({ x, y })),
+      closePath: vi.fn(() => {
+        const path = open();
+        if (path) path.closed = true;
+      }),
+      setLineDash: vi.fn((pattern: number[]) => {
+        dash = pattern;
+      }),
+      stroke: vi.fn(() => {
+        const path = open();
+        if (path) path.stroked = true;
+      }),
+      fill: vi.fn(() => {
+        const path = open();
+        if (path) path.filled = true;
+      }),
+      arc: vi.fn((x: number, y: number, r: number) => {
         calls.arc++;
+        open()?.arcs.push({ x, y, r });
       }),
       measureText: vi.fn(() => ({ width: 20 })),
       fillText: vi.fn(),
@@ -42,18 +89,54 @@ function recordingContext() {
       fillStyle: "",
       strokeStyle: "",
       lineWidth: 1,
+      lineCap: "butt",
       font: "",
       textBaseline: "alphabetic",
     } as unknown as CanvasRenderingContext2D,
   };
 }
 
-const WINDOW = {
+/** A node as the server hands it over, unconfigured on every axis by default. */
+function node(over: Partial<GraphWindow["nodes"][number]> = {}) {
+  return {
+    id: "n",
+    x: 0,
+    y: 0,
+    color: "default",
+    style: "default",
+    signalStyle: "default",
+    isViewer: false,
+    ...over,
+  };
+}
+
+/**
+ * World coordinates that land well clear of the hero copy.
+ *
+ * A node under the copy is faded out and skipped entirely below a clearance of
+ * 0.02, so a fixture at the origin draws nothing at all: the projection puts it
+ * at the middle of the frame, which is exactly where the headline is. These are
+ * far enough out that the keep-out has no say, and the assertions below are
+ * therefore about the shape rather than about the fade.
+ */
+const CLEAR_LEFT = { x: -260, y: 0 };
+const CLEAR_RIGHT = { x: 260, y: 0 };
+
+/** A one-node window, so a shape or a signal assertion is about that node. */
+function windowOf(over: Partial<GraphWindow["nodes"][number]>): GraphWindow {
+  return {
+    centre: { x: 0, y: 0 },
+    nodes: [node({ ...CLEAR_LEFT, ...over })],
+    edges: [],
+  };
+}
+
+const WINDOW: GraphWindow = {
   centre: { x: 0, y: 0 },
   nodes: [
-    { id: "a", x: 0, y: 0, color: "default", isViewer: true },
-    { id: "b", x: 120, y: 40, color: "default", isViewer: false },
-    { id: "c", x: -90, y: 150, color: "default", isViewer: false },
+    node({ id: "a", isViewer: true }),
+    node({ id: "b", x: 120, y: 40 }),
+    node({ id: "c", x: -90, y: 150 }),
   ],
   edges: [
     { fromId: "b", toId: "a" },
@@ -314,5 +397,175 @@ describe("HeroNetwork", () => {
     await settle();
 
     expect(recorder.calls.arc).toBe(painted);
+  });
+});
+
+/**
+ * What a node's own appearance draws as.
+ *
+ * The Landing artboard has no geometry for any of this — its canvas is the older
+ * synthetic field where every node is a dot — so these assertions are the
+ * specification, not a transcription of one. They are written against the shape
+ * rather than the pixel: a diamond is a closed four-sided path, a ring is a
+ * stroked circle nothing filled, and a signal is a mark that exists at all.
+ */
+describe("HeroNetwork draws a node's appearance", () => {
+  /**
+   * The paths of exactly **one** paint.
+   *
+   * Mounting paints more than once — the empty scene, then again for the window
+   * and the label props — so counting paths across a whole render would count
+   * every shape twice and say nothing about what one frame contains. Clearing
+   * after mount and driving a single repaint is what makes "one node draws one
+   * diamond" a statement that can be false.
+   */
+  function paintOnce(graphWindow: GraphWindow, labelled = false) {
+    render(<HeroNetwork window={graphWindow} labelled={labelled} />);
+    recorder.paths.length = 0;
+    recorder.ctx.setLineDash = vi.fn(recorder.ctx.setLineDash);
+    expect(onResize).toBeTypeOf("function");
+    onResize?.();
+    return recorder.paths;
+  }
+
+  it("fills a dot for the unconfigured style, as it always has", () => {
+    const paths = paintOnce(windowOf({ style: "default" }));
+
+    expect(
+      paths.filter(
+        (path) =>
+          path.filled && path.arcs.length === 1 && path.lines.length === 0,
+      ),
+    ).toHaveLength(1);
+  });
+
+  // A ring has to be hollow or it is a dot with extra steps. Nothing may fill it.
+  it("strokes a hollow circle for the ring style", () => {
+    const circles = paintOnce(windowOf({ style: "ring" })).filter(
+      (path) => path.arcs.length === 1,
+    );
+
+    expect(circles).toHaveLength(1);
+    expect(circles[0].stroked).toBe(true);
+    expect(circles[0].filled).toBe(false);
+  });
+
+  it("traces four sides and closes them for the diamond style", () => {
+    const diamonds = paintOnce(windowOf({ style: "diamond" })).filter(
+      (path) => path.lines.length === 3,
+    );
+
+    expect(diamonds).toHaveLength(1);
+    expect(diamonds[0].moves).toHaveLength(1);
+    expect(diamonds[0].closed).toBe(true);
+    expect(diamonds[0].filled).toBe(true);
+    // No arc at all: a diamond is not a circle with corners drawn over it.
+    expect(diamonds[0].arcs).toHaveLength(0);
+  });
+
+  it("draws nothing extra when a node carries no signal", () => {
+    const paths = paintOnce(windowOf({ signalStyle: "default" }));
+
+    // One path: the node itself. A signal would add at least one more.
+    expect(paths).toHaveLength(1);
+  });
+
+  it("draws concentric rings, all wider than the node, for the fade signal", () => {
+    const rings = paintOnce(windowOf({ signalStyle: "fade" })).filter(
+      (path) => path.stroked && path.arcs.length === 1,
+    );
+
+    expect(rings.length).toBeGreaterThan(1);
+    const radii = rings.map((ring) => ring.arcs[0].r);
+    // Strictly widening, and every one of them clear of the dot's own radius.
+    expect(radii).toEqual([...radii].sort((a, b) => a - b));
+    expect(Math.min(...radii)).toBeGreaterThan(NODE_RADIUS);
+  });
+
+  it("draws a broken ring for the dashed signal, and leaves no pattern behind", () => {
+    const dashed = paintOnce(windowOf({ signalStyle: "dashed" })).filter(
+      (path) => path.dash.length > 0,
+    );
+
+    expect(dashed).toHaveLength(1);
+    expect(dashed[0].stroked).toBe(true);
+    // The pattern is cleared afterwards, or the next node's outline is dashed too.
+    expect(recorder.ctx.setLineDash).toHaveBeenLastCalledWith([]);
+  });
+
+  /**
+   * A comet needs a direction and the only stable one is geometric: away from
+   * the middle of the frame, which leans it clear of the hero copy rather than
+   * across it. A node to the right of centre must trail off to the right.
+   */
+  it("trails a comet outward, away from the centre of the frame", () => {
+    const segments = paintOnce({
+      centre: { x: 0, y: 0 },
+      nodes: [node({ id: "n", ...CLEAR_RIGHT, signalStyle: "comet" })],
+      edges: [],
+    }).filter((path) => path.moves.length === 1 && path.lines.length === 1);
+
+    expect(segments.length).toBeGreaterThan(1);
+    for (const segment of segments) {
+      // Every segment ends further out than it started.
+      expect(segment.lines[0].x).toBeGreaterThan(segment.moves[0].x);
+    }
+  });
+
+  // The reveal enlarges the node the member has; it does not swap it for a dot.
+  it("keeps the viewer's own shape when Find your dot labels it", () => {
+    const diamonds = paintOnce(
+      windowOf({ isViewer: true, style: "diamond" }),
+      true,
+    ).filter((path) => path.lines.length === 3 && path.closed);
+
+    // The node itself, and the enlarged one the reveal draws over it.
+    expect(diamonds).toHaveLength(2);
+  });
+
+  /**
+   * The whole canvas rests on painting when an input changes rather than 60
+   * times a second, and a signal is the obvious place to break that. Nothing
+   * added here animates: a scene with every signal style on it and no label
+   * must not arm a frame loop.
+   */
+  it("never starts a frame loop for a signal, however many are on screen", () => {
+    const frame = vi
+      .spyOn(window, "requestAnimationFrame")
+      .mockReturnValue(1 as unknown as number);
+    try {
+      render(
+        <HeroNetwork
+          window={{
+            centre: { x: 0, y: 0 },
+            nodes: [
+              node({ id: "f", ...CLEAR_LEFT, signalStyle: "fade" }),
+              node({ id: "c", ...CLEAR_RIGHT, signalStyle: "comet" }),
+              node({ id: "d", x: -300, y: 60, signalStyle: "dashed" }),
+            ],
+            edges: [],
+          }}
+          labelled={false}
+        />,
+      );
+
+      expect(frame).not.toHaveBeenCalled();
+    } finally {
+      frame.mockRestore();
+    }
+  });
+
+  // The column is free text and the enums may grow. A name this build has never
+  // heard of draws as an ordinary node rather than dropping somebody out of a
+  // neighbourhood or throwing on their behalf.
+  it("draws an unknown style or signal as a plain unconfigured node", () => {
+    const paths = paintOnce(
+      windowOf({ style: "hexagon", signalStyle: "fireworks" }),
+    );
+
+    expect(
+      paths.filter((path) => path.filled && path.arcs.length === 1),
+    ).toHaveLength(1);
+    expect(paths.filter((path) => path.stroked)).toHaveLength(0);
   });
 });

--- a/apps/web/features/landing/components/hero-network.tsx
+++ b/apps/web/features/landing/components/hero-network.tsx
@@ -6,9 +6,11 @@ import { fallbackRects, type Rect, SAFETY } from "../lib/hero-keepout";
 import {
   FALLBACK_NODE_COLOR_VAR,
   type GraphWindowView,
+  NO_SIGNAL,
   NODE_COLOR_VARS,
   NODE_RADIUS,
   projectGraphWindow,
+  type ScreenNode,
 } from "../lib/neighbourhood-view";
 
 /**
@@ -35,6 +37,15 @@ import {
  * this canvas is the pulse on the labelled node, so the frame loop runs only
  * while that pulse is on screen and the scene is otherwise drawn once.
  *
+ * **Node appearance is drawn, and none of it animates.** A node draws its
+ * `style` as a shape and its `signalStyle` as a mark around that shape. A signal
+ * is *ongoing* — `CONTEXT.md` — so it is painted on every frame a node is
+ * painted, unlike the **pulse**, which is a one-shot reveal on the viewer's own
+ * node and the only thing here that moves. Drawing a signal in motion would mean
+ * a frame loop that never stops, which is the one property of this canvas the
+ * whole design rests on; the trail is therefore rendered rather than played, and
+ * the geometry below says what each style looks like standing still.
+ *
  * Everything the projection derives — the scale, the centre, the screen
  * coordinates — is thrown away on the next resize. None of it is ever sent back.
  */
@@ -42,6 +53,46 @@ import {
 /** `PAL.dotA` and `PAL.lineA` from the Landing artboard's palette. */
 const NODE_ALPHA = 0.82;
 const EDGE_ALPHA = 0.26;
+
+/**
+ * A diamond's half-diagonal, as a multiple of `NODE_RADIUS`.
+ *
+ * Chosen so the square covers the same area as the circle it replaces: a square
+ * of diagonal `d` has area `d^2 / 2`, so matching `pi * r^2` gives
+ * `d = r * sqrt(2 * pi)` and a half-diagonal of `r * sqrt(pi / 2)`, about 1.25.
+ * Without it a diamond inscribed in the same radius reads as a markedly smaller
+ * node, and a member who picked a shape would appear to have shrunk.
+ */
+const DIAMOND_REACH = Math.sqrt(Math.PI / 2);
+
+/** How much fainter than its node a signal is drawn. */
+const SIGNAL_ALPHA = 0.5;
+
+/**
+ * `fade`: concentric rings, each fainter and wider than the last — a trail that
+ * has spread out and gone soft rather than one caught mid-flight.
+ *
+ * Radii are multiples of `NODE_RADIUS`, so the whole mark scales with the dot.
+ */
+const FADE_RINGS = [
+  { reach: 1.9, alpha: 0.34 },
+  { reach: 2.9, alpha: 0.19 },
+  { reach: 3.9, alpha: 0.1 },
+];
+
+/**
+ * `comet`: a tapering trail behind the node, as segments of falling width and
+ * alpha. `from`/`to` are distances from the node centre in multiples of
+ * `NODE_RADIUS`; the head is nearest the node and the tail thins away from it.
+ */
+const COMET_SEGMENTS = [
+  { from: 1.1, to: 2.5, width: 1.7, alpha: 0.62 },
+  { from: 2.5, to: 3.9, width: 1.2, alpha: 0.36 },
+  { from: 3.9, to: 5.4, width: 0.8, alpha: 0.16 },
+];
+
+/** `dashed`: one broken ring, as a radius multiple and a dash pattern in px. */
+const DASHED_RING = { reach: 2.4, dash: [2.2, 2.6], alpha: 0.55, width: 1.1 };
 
 type Scene = {
   canvas: HTMLCanvasElement;
@@ -208,13 +259,20 @@ function draw(scene: Scene) {
     ctx.stroke();
   }
 
+  // Signals go under the nodes, so a trail never sits on top of the dot it
+  // belongs to. Two passes rather than one interleaved loop, because a node
+  // drawn after its own signal would still be drawn before the *next* node's.
+  for (const node of view.nodes) {
+    if (node.clearance <= 0.02 || node.signalStyle === NO_SIGNAL) continue;
+    drawSignal(scene, palette, node, view.centre);
+  }
+
   for (const node of view.nodes) {
     if (node.clearance <= 0.02) continue;
     ctx.globalAlpha = NODE_ALPHA * node.clearance;
     ctx.fillStyle = nodeColour(palette, node.colorVar);
-    ctx.beginPath();
-    ctx.arc(node.screenX, node.screenY, NODE_RADIUS, 0, Math.PI * 2);
-    ctx.fill();
+    ctx.strokeStyle = ctx.fillStyle;
+    drawNodeShape(ctx, node.screenX, node.screenY, NODE_RADIUS, node.style);
   }
 
   if (scene.labelled) {
@@ -225,15 +283,150 @@ function draw(scene: Scene) {
 }
 
 /**
+ * One node's shape, at `radius`, in whatever style it carries.
+ *
+ * The Landing artboard has no geometry for these — its own canvas is the older
+ * synthetic field, where every node is `ctx.arc(...)` and the only shapes are
+ * dots. `cc-store.js` names the three styles and stops there. So the shapes are
+ * defined here, and they are defined by what makes them tell apart at a
+ * four-pixel radius:
+ *
+ * - `solid` is the filled dot, which is also what an unconfigured node draws.
+ * - `ring` is the same circle stroked and left hollow, so it reads as lighter
+ *   without reading as further away.
+ * - `diamond` is a square on its point, sized by `DIAMOND_REACH` to hold the
+ *   same visual weight as the circle.
+ *
+ * `ctx.fillStyle` and `ctx.strokeStyle` are the caller's: this traces and paints
+ * a shape, it does not decide a colour.
+ */
+function drawNodeShape(
+  ctx: CanvasRenderingContext2D,
+  x: number,
+  y: number,
+  radius: number,
+  style: ScreenNode["style"],
+) {
+  if (style === "ring") {
+    ctx.lineWidth = Math.max(1, radius * 0.36);
+    ctx.beginPath();
+    // Inset by half the stroke so the ring occupies the same footprint as the
+    // filled dot rather than spilling `lineWidth / 2` beyond it.
+    ctx.arc(x, y, Math.max(0.5, radius - ctx.lineWidth / 2), 0, Math.PI * 2);
+    ctx.stroke();
+    return;
+  }
+
+  if (style === "diamond") {
+    const reach = radius * DIAMOND_REACH;
+    ctx.beginPath();
+    ctx.moveTo(x, y - reach);
+    ctx.lineTo(x + reach, y);
+    ctx.lineTo(x, y + reach);
+    ctx.lineTo(x - reach, y);
+    ctx.closePath();
+    ctx.fill();
+    return;
+  }
+
+  ctx.beginPath();
+  ctx.arc(x, y, radius, 0, Math.PI * 2);
+  ctx.fill();
+}
+
+/**
+ * The signal a node carries, drawn standing still.
+ *
+ * **It does not move, and that is deliberate.** A signal is ongoing rather than
+ * one-shot, so it is painted every time its node is painted — but this canvas
+ * paints on demand, and a signal that animated would mean a frame loop running
+ * for as long as anybody has the landing page open. `hero-network.spec.tsx` is
+ * written as the checklist of what triggers a repaint precisely because there is
+ * no such loop, and the pulse on the viewer's own node remains the only motion
+ * here.
+ *
+ * `comet` needs a direction, and the only one available is geometric: the trail
+ * points away from the middle of the frame. That is stable across repaints, it
+ * costs no per-node state, and it leans every trail outward — away from the hero
+ * copy, which sits in the middle — rather than across it. A node exactly on the
+ * centre has no outward direction and falls back to a fixed diagonal.
+ */
+function drawSignal(
+  scene: Scene,
+  palette: Palette,
+  node: ScreenNode,
+  centre: { x: number; y: number },
+) {
+  const { ctx } = scene;
+  const colour = nodeColour(palette, node.colorVar);
+  const base = NODE_ALPHA * node.clearance * SIGNAL_ALPHA;
+  ctx.strokeStyle = colour;
+
+  if (node.signalStyle === "fade") {
+    for (const ring of FADE_RINGS) {
+      ctx.globalAlpha = base * ring.alpha;
+      ctx.lineWidth = 1;
+      ctx.beginPath();
+      ctx.arc(
+        node.screenX,
+        node.screenY,
+        NODE_RADIUS * ring.reach,
+        0,
+        Math.PI * 2,
+      );
+      ctx.stroke();
+    }
+    return;
+  }
+
+  if (node.signalStyle === "dashed") {
+    ctx.globalAlpha = base * DASHED_RING.alpha;
+    ctx.lineWidth = DASHED_RING.width;
+    ctx.setLineDash?.(DASHED_RING.dash);
+    ctx.beginPath();
+    ctx.arc(
+      node.screenX,
+      node.screenY,
+      NODE_RADIUS * DASHED_RING.reach,
+      0,
+      Math.PI * 2,
+    );
+    ctx.stroke();
+    // Every later stroke on this frame — the next node's, the pulse ring — is
+    // solid, so the pattern is cleared here rather than trusted to be reset.
+    ctx.setLineDash?.([]);
+    return;
+  }
+
+  const dx = node.screenX - centre.x;
+  const dy = node.screenY - centre.y;
+  const length = Math.hypot(dx, dy);
+  const ux = length > 0.5 ? dx / length : Math.SQRT1_2;
+  const uy = length > 0.5 ? dy / length : -Math.SQRT1_2;
+  ctx.lineCap = "round";
+  for (const segment of COMET_SEGMENTS) {
+    ctx.globalAlpha = base * segment.alpha;
+    ctx.lineWidth = segment.width;
+    ctx.beginPath();
+    ctx.moveTo(
+      node.screenX + ux * NODE_RADIUS * segment.from,
+      node.screenY + uy * NODE_RADIUS * segment.from,
+    );
+    ctx.lineTo(
+      node.screenX + ux * NODE_RADIUS * segment.to,
+      node.screenY + uy * NODE_RADIUS * segment.to,
+    );
+    ctx.stroke();
+  }
+  ctx.lineCap = "butt";
+}
+
+/**
  * The viewer's own node, once **Find your dot** has found it: a restrained
  * pulse and a small label, no fanfare — and drawn exactly where the node
  * already was. The reveal adds a label to the graph; it does not rearrange it.
  */
-function drawYou(
-  scene: Scene,
-  palette: Palette,
-  you: { screenX: number; screenY: number; colorVar: string },
-) {
+function drawYou(scene: Scene, palette: Palette, you: ScreenNode) {
   const { ctx } = scene;
   const x = you.screenX;
   const y = you.screenY;
@@ -252,9 +445,10 @@ function drawYou(
 
   ctx.globalAlpha = 1;
   ctx.fillStyle = colour;
-  ctx.beginPath();
-  ctx.arc(x, y, 7.5, 0, Math.PI * 2);
-  ctx.fill();
+  ctx.strokeStyle = colour;
+  // The reveal enlarges the node the member already has; it does not swap it
+  // for a generic dot. Somebody who chose a diamond is looking for a diamond.
+  drawNodeShape(ctx, x, y, 7.5, you.style);
   ctx.globalAlpha = 0.5;
   ctx.strokeStyle = colour;
   ctx.lineWidth = 1;

--- a/apps/web/features/landing/components/landing.spec.tsx
+++ b/apps/web/features/landing/components/landing.spec.tsx
@@ -118,7 +118,6 @@ const NEIGHBOURHOOD = {
     },
   ],
   edges: [{ fromId: "t-1", toId: "t-2" }],
-  effectiveTier: 1,
 };
 
 /** The same graph, as a visitor gets it: centred on the origin, with no You. */

--- a/apps/web/features/landing/components/landing.spec.tsx
+++ b/apps/web/features/landing/components/landing.spec.tsx
@@ -98,8 +98,24 @@ function graphState(over: Record<string, unknown> = {}) {
 const NEIGHBOURHOOD = {
   centre: { x: 0, y: 0 },
   nodes: [
-    { id: "t-1", x: 0, y: 0, color: "default", isViewer: true },
-    { id: "t-2", x: 240, y: -120, color: "default", isViewer: false },
+    {
+      id: "t-1",
+      x: 0,
+      y: 0,
+      color: "default",
+      style: "default",
+      signalStyle: "default",
+      isViewer: true,
+    },
+    {
+      id: "t-2",
+      x: 240,
+      y: -120,
+      color: "default",
+      style: "default",
+      signalStyle: "default",
+      isViewer: false,
+    },
   ],
   edges: [{ fromId: "t-1", toId: "t-2" }],
   effectiveTier: 1,
@@ -109,8 +125,24 @@ const NEIGHBOURHOOD = {
 const PUBLIC_WINDOW = {
   centre: { x: 0, y: 0 },
   nodes: [
-    { id: "p-1", x: 0, y: 0, color: "default", isViewer: false },
-    { id: "p-2", x: 240, y: -120, color: "default", isViewer: false },
+    {
+      id: "p-1",
+      x: 0,
+      y: 0,
+      color: "default",
+      style: "default",
+      signalStyle: "default",
+      isViewer: false,
+    },
+    {
+      id: "p-2",
+      x: 240,
+      y: -120,
+      color: "default",
+      style: "default",
+      signalStyle: "default",
+      isViewer: false,
+    },
   ],
   edges: [{ fromId: "p-1", toId: "p-2" }],
 };

--- a/apps/web/features/landing/index.ts
+++ b/apps/web/features/landing/index.ts
@@ -1,17 +1,20 @@
 export { Landing } from "./components/landing";
 /**
- * The client half of the node-colour contract: the stored colour **names**, and
- * the `--cc-*` custom property each maps onto. `server/graph/placement.ts` owns
- * the list of names and the server never stores a hex.
+ * The client half of the node-appearance contract: the stored **names** on each
+ * of the three axes, and what the canvas draws for each of them.
+ * `server/graph/appearance.ts` owns the names and the server never stores a hex.
  *
- * It crosses the feature boundary because My Page's "My dot" tab names the same
- * palette the landing canvas draws, and two tables of the same colours would be
- * two things to re-skin.
+ * It crosses the feature boundary because My Page's "My dot" tab shows the same
+ * palette and the same shapes the landing canvas draws, and two tables of the
+ * same appearance would be two things to re-skin.
  */
 export {
   DEFAULT_NODE_COLOR_VAR,
   FALLBACK_NODE_COLOR_VAR,
+  NO_SIGNAL,
   NODE_COLOR_VARS,
   type NodeColorName,
   nodeColorVar,
+  nodeSignalStyleName,
+  nodeStyleName,
 } from "./lib/neighbourhood-view";

--- a/apps/web/features/landing/lib/neighbourhood-view.spec.ts
+++ b/apps/web/features/landing/lib/neighbourhood-view.spec.ts
@@ -21,6 +21,8 @@ type NodeSpec = {
   x: number;
   y: number;
   color?: string;
+  style?: string;
+  signalStyle?: string;
   isViewer?: boolean;
 };
 
@@ -36,6 +38,8 @@ function graphWindow(
       x: node.x,
       y: node.y,
       color: node.color ?? "default",
+      style: node.style ?? "default",
+      signalStyle: node.signalStyle ?? "default",
       isViewer: node.isViewer ?? false,
     })),
     edges,
@@ -280,6 +284,8 @@ describe("projectGraphWindow", () => {
         "isViewer",
         "screenX",
         "screenY",
+        "signalStyle",
+        "style",
       ]);
     }
   });

--- a/apps/web/features/landing/lib/neighbourhood-view.ts
+++ b/apps/web/features/landing/lib/neighbourhood-view.ts
@@ -31,30 +31,36 @@
  * community so that a headline reads better.
  */
 
+import {
+  NODE_SIGNAL_STYLES,
+  NODE_STYLES,
+  type NodeColor,
+  type NodeSignalStyle,
+  type NodeStyle,
+  UNCONFIGURED,
+} from "@/server/graph/appearance";
 import { clearAt, lineClearance, type Rect } from "./hero-keepout";
 
 /**
  * The node colour palette, as the server stores it: **names, never hex**.
- * `server/graph/placement.ts` owns the list; this is the client half of the
+ * `server/graph/appearance.ts` owns the list; this is the client half of the
  * contract, mapping each name onto a `--cc-*` custom property so the palette
  * can be re-skinned in CSS without a data migration.
  *
- * Nobody is assigned one of these today, and earning a tier does not change
- * that. `server/graph/tier.ts` now writes `users.personalization_tier_earned`,
- * so tier 1 genuinely unlocks the colour axis — but no procedure writes
- * `users_node_profiles.color`, so every node still renders the `"default"`
- * brand blue. These are what a member will pick from once that writer exists.
+ * Typed as a total map over the server's `NodeColor`, so adding a name there
+ * without a token here is a build error rather than a node that quietly draws
+ * in the fallback.
  */
-export const NODE_COLOR_VARS = {
+export const NODE_COLOR_VARS: Record<NodeColor, string> = {
   aurora: "--cc-node-aurora",
   ember: "--cc-node-ember",
   frost: "--cc-node-frost",
   moss: "--cc-node-moss",
   slate: "--cc-node-slate",
   violet: "--cc-node-violet",
-} as const;
+};
 
-export type NodeColorName = keyof typeof NODE_COLOR_VARS;
+export type NodeColorName = NodeColor;
 
 /**
  * What a node with no configured appearance draws as, which today is every
@@ -81,6 +87,43 @@ export function nodeColorVar(name: string): string {
 }
 
 /**
+ * What a node with no configured shape draws as: the filled dot every node in
+ * the community has always been. `"solid"` names the same geometry, which is
+ * why an unconfigured node and a node whose owner chose "solid" are
+ * indistinguishable on the canvas — that is the design, not an oversight. The
+ * distinction lives in the column, and it matters when the member changes their
+ * mind rather than when the pixels land.
+ */
+export const DEFAULT_NODE_STYLE_NAME = "solid" as const;
+
+/** What a node with no configured signal draws as: no signal at all. */
+export const NO_SIGNAL = "none" as const;
+
+/** The shape a stored style name draws with. Anything unrecognised is a dot. */
+export function nodeStyleName(name: string): NodeStyle {
+  return (NODE_STYLES as readonly string[]).includes(name)
+    ? (name as NodeStyle)
+    : DEFAULT_NODE_STYLE_NAME;
+}
+
+/**
+ * The signal a stored name draws, or `"none"`.
+ *
+ * `UNCONFIGURED` is the common case and means the node carries no signal — a
+ * **signal** is ongoing, so "not carrying one" is a real state rather than a
+ * quieter version of carrying one. An unrecognised name lands here too: a build
+ * that has never heard of a signal style draws none rather than guessing.
+ */
+export function nodeSignalStyleName(
+  name: string,
+): NodeSignalStyle | typeof NO_SIGNAL {
+  if (name === UNCONFIGURED) return NO_SIGNAL;
+  return (NODE_SIGNAL_STYLES as readonly string[]).includes(name)
+    ? (name as NodeSignalStyle)
+    : NO_SIGNAL;
+}
+
+/**
  * Exactly the shape `graph.neighbourhood` and `graph.publicWindow` return,
  * narrowed to what is drawn.
  *
@@ -94,7 +137,15 @@ export type GraphWindowInput = {
     id: string;
     x: number;
     y: number;
+    /**
+     * The three appearance names, already masked by the server: an axis whose
+     * owner's tier has decayed arrives as `"default"` while their pick stays in
+     * the column. Nothing on this side undoes that, and nothing on this side
+     * needs a tier number to draw a node.
+     */
     color: string;
+    style: string;
+    signalStyle: string;
     isViewer: boolean;
   }[];
   edges: { fromId: string; toId: string }[];
@@ -107,6 +158,10 @@ export type ScreenNode = {
   screenY: number;
   /** The custom property this node's stored colour name maps onto. */
   colorVar: string;
+  /** The shape to draw: `solid`, `ring` or `diamond`. */
+  style: NodeStyle;
+  /** The signal to draw along it, or `"none"` when it carries none. */
+  signalStyle: NodeSignalStyle | typeof NO_SIGNAL;
   isViewer: boolean;
   /** 1 well clear of the hero copy, 0 underneath it. */
   clearance: number;
@@ -179,6 +234,8 @@ export function projectGraphWindow(args: {
       screenX,
       screenY,
       colorVar: nodeColorVar(node.color),
+      style: nodeStyleName(node.style),
+      signalStyle: nodeSignalStyleName(node.signalStyle),
       isViewer: node.isViewer,
       // The viewer's own node sits on the viewport centre, which is where the
       // hero copy is; fading it would hide the one node **Find your dot**

--- a/apps/web/features/my-page/api/mutations.ts
+++ b/apps/web/features/my-page/api/mutations.ts
@@ -11,6 +11,42 @@ export function useDeleteAccount() {
 }
 
 /**
+ * Choose how the viewer's own node looks.
+ *
+ * Sends only the axis that was clicked. An axis left out of the patch is left
+ * exactly as it is in the column, which is what keeps a dormant pick on one axis
+ * intact while another is edited.
+ *
+ * `graph.setAppearance` answers with the whole personalization state — both tier
+ * numbers and every stored axis — so the cache is *replaced* with what the
+ * server has rather than patched with what the click assumed. The two differ
+ * whenever the server refuses, and the refusal is the point: the tier gate lives
+ * there, and a picker that optimistically painted the choice would be showing a
+ * member a colour their node does not have.
+ */
+export function useSetNodeAppearance() {
+  const trpc = useTRPC();
+  const queryClient = useQueryClient();
+  return useMutation(
+    trpc.graph.setAppearance.mutationOptions({
+      onSuccess: (personalization) => {
+        queryClient.setQueryData(
+          trpc.graph.personalization.queryKey(),
+          personalization,
+        );
+        // The landing hero draws this node, so its window is now stale. It is
+        // invalidated rather than written into: the window is anonymised per
+        // response and there is no way to find this member's node in a cached
+        // one — by design, and this is what that design costs.
+        void queryClient.invalidateQueries({
+          queryKey: trpc.graph.neighbourhood.queryKey(),
+        });
+      },
+    }),
+  );
+}
+
+/**
  * Turns grade storage off by actually removing the grades.
  *
  * There is no "store my grades" column on `users` — the setting is nothing but

--- a/apps/web/features/my-page/api/queries.ts
+++ b/apps/web/features/my-page/api/queries.ts
@@ -40,17 +40,25 @@ export function useAllReviews(enabled: boolean) {
   return useQuery(trpc.reviews.list.queryOptions({}, { enabled }));
 }
 
+/** Both tier numbers and the stored appearance, as `graph.personalization` returns them. */
+export type NodePersonalization = RouterOutputs["graph"]["personalization"];
+
 /**
- * The viewer's effective personalization tier.
+ * How far the viewer has unlocked their node profile, and what they picked.
  *
  * Read-only and derived: `users.personalization_tier_earned` holds the highest
  * tier ever reached and this never touches it. Retries are off because the one
- * error worth surfacing — no graph node — is not transient.
+ * error worth surfacing — no such app user — is not transient.
+ *
+ * It answers with **both** tier numbers because the tab has three states to
+ * draw, not two. The effective tier says what may be edited; the earned tier is
+ * only ever used to tell a **dormant** axis — earned, decayed, pick still in the
+ * column — from a **locked** one that was never reached.
  */
-export function useEffectiveTier(enabled: boolean) {
+export function useNodePersonalization(enabled: boolean) {
   const trpc = useTRPC();
   return useQuery({
-    ...trpc.graph.effectiveTier.queryOptions(),
+    ...trpc.graph.personalization.queryOptions(),
     enabled,
     retry: false,
   });

--- a/apps/web/features/my-page/components/my-page.spec.tsx
+++ b/apps/web/features/my-page/components/my-page.spec.tsx
@@ -11,7 +11,8 @@ const clearGrades = vi.fn();
 const me = vi.fn();
 const taken = vi.fn();
 const reviews = vi.fn();
-const tier = vi.fn();
+const personalization = vi.fn();
+const setAppearance = vi.fn();
 const unreviewed = vi.fn();
 
 vi.mock("next/navigation", () => ({
@@ -45,13 +46,18 @@ vi.mock("sonner", () => ({
 vi.mock("../api/queries", () => ({
   useTakenCourses: () => taken(),
   useAllReviews: () => reviews(),
-  useEffectiveTier: () => tier(),
+  useNodePersonalization: () => personalization(),
   isTierUnavailable: () => false,
 }));
 
 vi.mock("../api/mutations", () => ({
   useDeleteAccount: () => ({ mutateAsync: deleteAccount, isPending: false }),
   useClearStoredGrades: () => ({ clearGrades, isPending: false }),
+  useSetNodeAppearance: () => ({
+    mutate: setAppearance,
+    isPending: false,
+    isError: false,
+  }),
 }));
 
 /**
@@ -162,13 +168,41 @@ beforeEach(() => {
   });
   taken.mockReturnValue(settled([]));
   reviews.mockReturnValue(settled([]));
-  tier.mockReturnValue({ data: 0, isError: false, error: null });
+  setAppearance.mockClear();
+  personalization.mockReturnValue(
+    personalizationState({ earnedTier: 0, effectiveTier: 0 }),
+  );
   unreviewed.mockReturnValue({
     courses: [],
     isLoading: false,
     isUnavailable: false,
   });
 });
+
+/**
+ * `graph.personalization` as My Page reads it: two tier numbers and the stored
+ * appearance. Both numbers matter — the effective one says what may be edited,
+ * the earned one is what tells a dormant axis from a locked one.
+ */
+function personalizationState(over: {
+  earnedTier: number;
+  effectiveTier: number;
+  appearance?: { color: string; style: string; signalStyle: string };
+}) {
+  return {
+    data: {
+      earnedTier: over.earnedTier,
+      effectiveTier: over.effectiveTier,
+      appearance: over.appearance ?? {
+        color: "default",
+        style: "default",
+        signalStyle: "default",
+      },
+    },
+    isError: false,
+    error: null,
+  };
+}
 
 const openTab = (name: string | RegExp) =>
   userEvent.click(screen.getByRole("tab", { name }));
@@ -479,11 +513,13 @@ describe("MyPage my dot", () => {
 
     expect(screen.getAllByText("Locked")).toHaveLength(3);
     expect(screen.queryByText("Unlocked")).not.toBeInTheDocument();
-    expect(screen.queryByText(/dormant/i)).not.toBeInTheDocument();
+    expect(screen.queryByText("Dormant")).not.toBeInTheDocument();
   });
 
   it("names the six node colours once a colour tier is reached", async () => {
-    tier.mockReturnValue({ data: 1, isError: false, error: null });
+    personalization.mockReturnValue(
+      personalizationState({ earnedTier: 1, effectiveTier: 1 }),
+    );
     render(<MyPage />);
     await openTab("My dot");
 
@@ -495,7 +531,133 @@ describe("MyPage my dot", () => {
       "slate",
       "violet",
     ]) {
-      expect(screen.getByText(name)).toBeVisible();
+      expect(screen.getByRole("button", { name })).toBeVisible();
     }
+  });
+
+  /**
+   * The palette used to be shown rather than offered, because nothing wrote
+   * `users_node_profiles`. It is a write now, and the click is the whole
+   * feature: this is the test that fails if the buttons go inert again.
+   */
+  it("writes the colour a member clicks, and only that axis", async () => {
+    personalization.mockReturnValue(
+      personalizationState({ earnedTier: 1, effectiveTier: 1 }),
+    );
+    render(<MyPage />);
+    await openTab("My dot");
+
+    await userEvent.click(screen.getByRole("button", { name: "ember" }));
+
+    expect(setAppearance).toHaveBeenCalledWith({ color: "ember" });
+  });
+
+  // The highlight is what the server last confirmed, never what was clicked:
+  // nothing here paints optimistically, because the tier gate can refuse.
+  it("marks the stored pick as the pressed option", async () => {
+    personalization.mockReturnValue(
+      personalizationState({
+        earnedTier: 1,
+        effectiveTier: 1,
+        appearance: { color: "moss", style: "default", signalStyle: "default" },
+      }),
+    );
+    render(<MyPage />);
+    await openTab("My dot");
+
+    expect(screen.getByRole("button", { name: "moss" })).toHaveAttribute(
+      "aria-pressed",
+      "true",
+    );
+    expect(screen.getByRole("button", { name: "ember" })).toHaveAttribute(
+      "aria-pressed",
+      "false",
+    );
+  });
+
+  it("offers the three shapes and the three signals at the top of the ladder", async () => {
+    personalization.mockReturnValue(
+      personalizationState({ earnedTier: 3, effectiveTier: 3 }),
+    );
+    render(<MyPage />);
+    await openTab("My dot");
+
+    for (const name of [
+      "solid",
+      "ring",
+      "diamond",
+      "fade",
+      "comet",
+      "dashed",
+    ]) {
+      expect(screen.getByRole("button", { name })).toBeVisible();
+    }
+    expect(screen.getAllByText("Unlocked")).toHaveLength(3);
+  });
+
+  /**
+   * The third badge, and the reason the read returns two numbers. Somebody who
+   * reached tier 3 and went quiet has earned every axis and can edit none of
+   * them; "Locked" there would tell them they had lost something the column
+   * still holds.
+   */
+  it("calls an earned axis that has decayed dormant, not locked", async () => {
+    personalization.mockReturnValue(
+      personalizationState({
+        earnedTier: 3,
+        effectiveTier: 1,
+        appearance: {
+          color: "violet",
+          style: "diamond",
+          signalStyle: "comet",
+        },
+      }),
+    );
+    render(<MyPage />);
+    await openTab("My dot");
+
+    expect(screen.getAllByText("Dormant")).toHaveLength(2);
+    expect(screen.getAllByText("Unlocked")).toHaveLength(1);
+    expect(screen.queryByText("Locked")).not.toBeInTheDocument();
+  });
+
+  // A dormant axis names what it is holding, because "reviewing again restores
+  // them" is otherwise unverifiable from the one screen that claims it.
+  it("names the pick a dormant axis is still holding", async () => {
+    personalization.mockReturnValue(
+      personalizationState({
+        earnedTier: 3,
+        effectiveTier: 1,
+        appearance: {
+          color: "violet",
+          style: "diamond",
+          signalStyle: "comet",
+        },
+      }),
+    );
+    render(<MyPage />);
+    await openTab("My dot");
+
+    expect(screen.getByText("diamond")).toBeVisible();
+    expect(screen.getByText("comet")).toBeVisible();
+    // Named, not offered: a dormant axis cannot be clicked.
+    expect(
+      screen.queryByRole("button", { name: "diamond" }),
+    ).not.toBeInTheDocument();
+  });
+
+  it("offers nothing at all on an axis that was never earned", async () => {
+    personalization.mockReturnValue(
+      personalizationState({ earnedTier: 1, effectiveTier: 1 }),
+    );
+    render(<MyPage />);
+    await openTab("My dot");
+
+    expect(
+      screen.queryByRole("button", { name: "diamond" }),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", { name: "comet" }),
+    ).not.toBeInTheDocument();
   });
 });

--- a/apps/web/features/my-page/components/my-page.tsx
+++ b/apps/web/features/my-page/components/my-page.tsx
@@ -18,10 +18,11 @@ import { PageColumn, PageHeader } from "@/features/shell";
 // route contract is one pure function and this is the half of it that builds
 // a link — `/taken` owns the half that reads one.
 import { reviewHref } from "@/features/taken/lib/review-deep-link";
+import { useSetNodeAppearance } from "../api/mutations";
 import {
   isTierUnavailable,
   useAllReviews,
-  useEffectiveTier,
+  useNodePersonalization,
   useTakenCourses,
 } from "../api/queries";
 import { useAveragePreference } from "../hooks/use-average-preference";
@@ -70,7 +71,8 @@ type OpenEditor = { review: EditableReview; courseCode: string };
  * tabs (Overview, Reviews, My dot, Settings) and the Mobile Preview's stacked
  * version of the same. Everything it shows is the viewer's own: `user.me` for
  * who they are, `taken.list` for their courses, `reviews.list` for what they
- * wrote and upvoted, `graph.effectiveTier` for how far their node is unlocked.
+ * wrote and upvoted, `graph.personalization` for how far their node is unlocked
+ * and what they have chosen for it.
  *
  * ## Reviews here are anonymous, and votes are not local
  *
@@ -135,7 +137,8 @@ export function MyPage() {
 
   const takenQuery = useTakenCourses(isAuthenticated);
   const reviewsQuery = useAllReviews(isAuthenticated);
-  const tierQuery = useEffectiveTier(isAuthenticated);
+  const personalizationQuery = useNodePersonalization(isAuthenticated);
+  const setAppearance = useSetNodeAppearance();
   const unreviewed = useUnreviewedTakenCourses();
 
   const takenCourses = useMemo(() => takenQuery.data ?? [], [takenQuery.data]);
@@ -396,10 +399,14 @@ export function MyPage() {
 
             {view === "node" ? (
               <NodeProfile
-                effectiveTier={tierQuery.data}
+                personalization={personalizationQuery.data}
                 isUnavailable={
-                  tierQuery.isError && isTierUnavailable(tierQuery.error)
+                  personalizationQuery.isError &&
+                  isTierUnavailable(personalizationQuery.error)
                 }
+                onChoose={(choice) => setAppearance.mutate(choice)}
+                isSaving={setAppearance.isPending}
+                saveFailed={setAppearance.isError}
               />
             ) : null}
 

--- a/apps/web/features/my-page/components/node-profile.tsx
+++ b/apps/web/features/my-page/components/node-profile.tsx
@@ -4,54 +4,75 @@ import { Lock } from "lucide-react";
 import {
   DEFAULT_NODE_COLOR_VAR,
   NODE_COLOR_VARS,
-  type NodeColorName,
+  nodeColorVar,
 } from "@/features/landing";
-import { personalizationTierRows } from "../lib/personalization-tiers";
-
-/** The six stored colour names, in the order `server/graph/placement.ts` lists them. */
-const NODE_COLOR_NAMES = Object.keys(NODE_COLOR_VARS) as NodeColorName[];
+import type { NodePersonalization } from "../api/queries";
+import {
+  type NodeAppearanceChoice,
+  type PersonalizationAxisKey,
+  type PersonalizationTierRow,
+  personalizationTierRows,
+  UNCONFIGURED,
+} from "../lib/personalization-tiers";
 
 type Props = {
   /**
-   * The viewer's **effective** tier, from `graph.effectiveTier`. Never the
-   * earned one: the earned value is the highest ever reached and is never
-   * lowered, so nothing here may be phrased as having lost a tier.
+   * Both tier numbers and the stored appearance, from `graph.personalization`.
+   * `undefined` while the read is in flight.
+   *
+   * Both numbers are needed and neither substitutes for the other. The
+   * **effective** tier decides what may be edited; the **earned** tier is used
+   * for one thing only — telling a dormant axis from a locked one — and is never
+   * phrased as something lost, because the column never lowers.
    */
-  effectiveTier: number | undefined;
+  personalization: NodePersonalization | undefined;
   /** The tier could not be read at all — distinct from an effective tier of 0. */
   isUnavailable: boolean;
+  /** Write one or more axes. The parent owns the mutation. */
+  onChoose: (choice: NodeAppearanceChoice) => void;
+  /** A write is in flight; every option is disabled until it answers. */
+  isSaving: boolean;
+  /** The last write failed. The server is the authority, so nothing was painted. */
+  saveFailed: boolean;
 };
 
 /**
  * How far the viewer has unlocked their **node profile** — a node's appearance,
- * stored separately from graph topology. This is the tab the artboard labels
- * "My dot" (`docs/design_ref/2026-09-05/Course Community - My Page.dc.html`, its
- * `isDot` branch); `CONTEXT.md` licenses "dot" for the **Find your dot** flow's
- * copy alone, so the label stays and the identifiers say what the glossary says.
+ * stored separately from graph topology — and the surface where they choose it.
+ * This is the tab the artboard labels "My dot" (`docs/design_ref/2026-09-05/
+ * Course Community - My Page.dc.html`, its `isDot` branch); `CONTEXT.md`
+ * licenses "dot" for the **Find your dot** flow's copy alone, so the label stays
+ * and the identifiers say what the glossary says.
  *
- * **Tiers are earned now, but nothing here is choosable yet.** The artboard
- * renders each unlocked tier as a row of pickable options and writes the choice
- * back. Half of that exists: `server/graph/tier.ts` raises
- * `users.personalization_tier_earned` from ADR 0005's ladder, so a row can
- * genuinely read as unlocked. The other half does not — there is still no
- * procedure that writes `users_node_profiles`, since `graph` exposes only
- * `join`, `neighbourhood`, `publicWindow` and `effectiveTier`, and placement
- * stores the column default. The palette is therefore shown as what the colours
- * *are*, not as buttons that would silently do nothing. Two of the three axes
- * could not offer a choice regardless — `node_style` and `node_signal_style`
- * are Postgres enums with exactly one value each, so unlocking them today
- * unlocks a set of one.
+ * **The palette used to be shown rather than offered, and that is closed.** It
+ * was inert for two honest reasons: no procedure wrote `users_node_profiles`,
+ * and `node_style` and `node_signal_style` were Postgres enums with one value
+ * each, so unlocking tier 2 or 3 unlocked a set of one. Both are fixed —
+ * `graph.setAppearance` is the writer and migration 0015 adds the values — so
+ * these are buttons now, and clicking one changes what the landing hero draws.
+ *
+ * **The gate is not here.** Locking an option in this component is presentation:
+ * `setNodeAppearance` re-derives the effective tier and refuses an axis it does
+ * not reach, because a signed-in caller can post whatever they like to a tRPC
+ * procedure. The two run the same `PERSONALIZATION_AXES` table, which is why
+ * what is offered and what is accepted cannot drift apart.
  *
  * The colours are drawn from `--cc-node-*`, mapped from the stored **names**
  * through the same table the landing page's canvas uses. The server stores a
  * name and never a hex; `cc-store.js` inverts that — its `NODE_COLORS` is five
- * hex strings — and is wrong about the shape. Its remark that "Tier 0 accounts keep the default
- * look; only personalized nodes carry a row" was true of every account until
- * the tier writer shipped, and is now true only of accounts that have not
- * contributed.
+ * hex strings — and is wrong about the shape.
  */
-export function NodeProfile({ effectiveTier, isUnavailable }: Props) {
-  const rows = personalizationTierRows(effectiveTier ?? 0);
+export function NodeProfile({
+  personalization,
+  isUnavailable,
+  onChoose,
+  isSaving,
+  saveFailed,
+}: Props) {
+  const rows = personalizationTierRows(
+    personalization?.earnedTier ?? 0,
+    personalization?.effectiveTier ?? 0,
+  );
 
   return (
     <div className="flex flex-col gap-3.5 px-7 pt-[22px] @max-[440px]:px-[14px] @max-[440px]:pt-3">
@@ -64,6 +85,13 @@ export function NodeProfile({ effectiveTier, isUnavailable }: Props) {
           for a while and it settles back to default.
         </p>
       </section>
+
+      {saveFailed ? (
+        <output className="block rounded-xl border border-cc-rule bg-cc-surface px-[17px] py-4 text-[12.5px] text-cc-dim">
+          That choice could not be saved. Your node still looks the way it did —
+          nothing was changed.
+        </output>
+      ) : null}
 
       {isUnavailable ? (
         <output className="block rounded-xl border border-cc-rule bg-cc-surface px-[17px] py-4 text-[12.5px] text-cc-dim">
@@ -110,11 +138,25 @@ export function NodeProfile({ effectiveTier, isUnavailable }: Props) {
                       : "bg-cc-pg text-cc-dim"
                   }`}
                 >
-                  {row.unlocked ? "Unlocked" : "Locked"}
+                  {BADGE_LABELS[row.state]}
                 </span>
               </div>
 
-              {row.unlocked && row.key === "color" ? <NodePalette /> : null}
+              {row.unlocked ? (
+                <AxisOptions
+                  row={row}
+                  chosen={personalization?.appearance[row.key] ?? UNCONFIGURED}
+                  isSaving={isSaving}
+                  onChoose={onChoose}
+                />
+              ) : null}
+
+              {row.state === "dormant" ? (
+                <DormantNote
+                  axis={row.key}
+                  stored={personalization?.appearance[row.key] ?? UNCONFIGURED}
+                />
+              ) : null}
             </li>
           ))}
         </ul>
@@ -124,54 +166,123 @@ export function NodeProfile({ effectiveTier, isUnavailable }: Props) {
 }
 
 /**
- * The node colours, named and swatched. Shown, not offered.
- *
- * The default leads the row because it is the colour of every node in the
- * community: `users_node_profiles.color` defaults to `"default"`, placement
- * stores exactly that, and the landing canvas draws it in `--cc-brand`. The
- * artboard's own list opens on the same brand blue.
- *
- * This used to say a colour was assigned on joining, which was true of the code
- * and wrong of the product — placement hashed each app user onto one of the six
- * and gave everybody a colour nobody chose. It no longer does, so the row below
- * says what is actually the case.
+ * The artboard's three badges. **Dormant is a third state, not a softer
+ * "Locked".** It means the axis was earned, the pick is still in the column, and
+ * a qualifying review brings it back; saying "Locked" there would tell a member
+ * they had lost something the database still holds.
  */
-function NodePalette() {
-  const swatches = [
-    { name: "default", variable: DEFAULT_NODE_COLOR_VAR, isDefault: true },
-    ...NODE_COLOR_NAMES.map((name) => ({
-      name,
-      variable: NODE_COLOR_VARS[name],
-      isDefault: false,
-    })),
-  ];
+const BADGE_LABELS = {
+  unlocked: "Unlocked",
+  dormant: "Dormant",
+  locked: "Locked",
+} as const;
+
+/**
+ * One axis's options, as buttons.
+ *
+ * `UNCONFIGURED` leads the row because it is what every node in the community
+ * starts as, and because a member who picked something needs a way back to it —
+ * un-picking is a choice like any other and goes through the same write.
+ *
+ * `aria-pressed` rather than a radio group: these are buttons that each perform
+ * a write, and the pressed one is the state the server last confirmed. Nothing
+ * is painted optimistically, so the highlight always says what is stored rather
+ * than what was clicked.
+ */
+function AxisOptions({
+  row,
+  chosen,
+  isSaving,
+  onChoose,
+}: {
+  row: PersonalizationTierRow;
+  chosen: string;
+  isSaving: boolean;
+  onChoose: (choice: NodeAppearanceChoice) => void;
+}) {
+  return (
+    <ul
+      aria-label={row.title}
+      className="m-0 mt-3 ml-[25px] flex list-none flex-wrap gap-2 p-0"
+    >
+      {row.options.map((option) => {
+        const selected = option === chosen;
+        return (
+          <li key={option}>
+            <button
+              type="button"
+              aria-pressed={selected}
+              disabled={isSaving}
+              onClick={() => onChoose({ [row.key]: option })}
+              className={`flex h-9 items-center gap-2 rounded-[9px] border bg-cc-surface px-[13px] text-[13px] capitalize transition-colors hover:border-cc-brand disabled:cursor-not-allowed disabled:opacity-60 ${
+                selected
+                  ? "border-cc-brand font-semibold text-cc-brand"
+                  : "border-cc-rule3 text-cc-ink"
+              }`}
+            >
+              {row.key === "color" ? <ColorSwatch name={option} /> : null}
+              {option}
+            </button>
+          </li>
+        );
+      })}
+    </ul>
+  );
+}
+
+/**
+ * The colour a name draws as, through the same table the landing canvas uses,
+ * so the swatch here and the dot there cannot disagree. `"default"` resolves to
+ * `--cc-brand`, which is the single dot colour the Landing artboard's own
+ * palette has and what every unconfigured node renders in.
+ *
+ * Only the colour axis gets a swatch, which is what the artboard does
+ * (`swatch: n === 1 ? … : null`). A shape or a signal is a mark on a canvas at a
+ * four-pixel radius, and a legible glyph of one would be a second drawing of it
+ * to keep in step with `hero-network.tsx`.
+ */
+function ColorSwatch({ name }: { name: string }) {
+  const variable =
+    name === UNCONFIGURED ? DEFAULT_NODE_COLOR_VAR : nodeColorVar(name);
+  return (
+    <span
+      aria-hidden
+      className="size-[13px] flex-none rounded-full"
+      style={{ background: `var(${variable})` }}
+    />
+  );
+}
+
+/**
+ * What a dormant axis says.
+ *
+ * It names the stored pick, because "reviewing again restores them" is otherwise
+ * unverifiable from the one screen that claims it — a member who cannot see what
+ * is waiting has only our word that anything is. Nothing here writes, and
+ * nothing anywhere clears a column because a tier decayed: the value is masked
+ * on the canvas and kept in the database.
+ */
+function DormantNote({
+  axis,
+  stored,
+}: {
+  axis: PersonalizationAxisKey;
+  stored: string;
+}) {
+  const isColor = axis === "color";
+  const known = isColor ? stored in NODE_COLOR_VARS : stored !== UNCONFIGURED;
 
   return (
-    <div className="mt-3 ml-[25px]">
-      <ul className="m-0 flex list-none flex-wrap gap-2 p-0">
-        {swatches.map((swatch) => (
-          <li
-            key={swatch.name}
-            className={`flex h-9 items-center gap-2 rounded-[9px] border bg-cc-surface px-[13px] text-[13px] capitalize ${
-              swatch.isDefault
-                ? "border-cc-brand font-semibold text-cc-brand"
-                : "border-cc-rule3 text-cc-ink"
-            }`}
-          >
-            <span
-              aria-hidden
-              className="size-[13px] flex-none rounded-full"
-              style={{ background: `var(${swatch.variable})` }}
-            />
-            {swatch.name}
-          </li>
-        ))}
-      </ul>
-      <p className="m-0 mt-2 text-[12px] text-cc-dim2">
-        Every node is the default colour. The other six are the palette
-        personalisation will use — nobody is assigned one, and choosing one is
-        not available yet.
-      </p>
-    </div>
+    <p className="m-0 mt-1.5 ml-[25px] text-[12.5px] text-cc-dim">
+      {known ? (
+        <>
+          Your node is drawn in the default while this is dormant.{" "}
+          <span className="capitalize">{stored}</span> is still saved and comes
+          back with your next review.
+        </>
+      ) : (
+        "You earned this one. It comes back with your next review."
+      )}
+    </p>
   );
 }

--- a/apps/web/features/my-page/lib/personalization-tiers.spec.ts
+++ b/apps/web/features/my-page/lib/personalization-tiers.spec.ts
@@ -1,21 +1,26 @@
 import { describe, expect, it } from "vitest";
-import { personalizationTierRows } from "./personalization-tiers";
+import { PERSONALIZATION_AXES } from "@/server/graph/appearance";
+import { personalizationTierRows, UNCONFIGURED } from "./personalization-tiers";
 
+/** An account that has never gone quiet: earned and effective are the same. */
 const unlockedKeys = (tier: number) =>
-  personalizationTierRows(tier)
+  personalizationTierRows(tier, tier)
     .filter((row) => row.unlocked)
     .map((row) => row.key);
 
+const statesAt = (earned: number, effective: number) =>
+  personalizationTierRows(earned, effective).map((row) => row.state);
+
 describe("personalizationTierRows", () => {
   it("always lists the three axes, in artboard order", () => {
-    expect(personalizationTierRows(0).map((row) => row.key)).toEqual([
+    expect(personalizationTierRows(0, 0).map((row) => row.key)).toEqual([
       "color",
       "style",
       "signalStyle",
     ]);
   });
 
-  it("locks everything at tier 0, which is where every account is today", () => {
+  it("locks everything at tier 0", () => {
     expect(unlockedKeys(0)).toEqual([]);
   });
 
@@ -26,12 +31,57 @@ describe("personalizationTierRows", () => {
   });
 
   it("clamps a tier past the top rather than dropping rows", () => {
-    expect(personalizationTierRows(9)).toHaveLength(3);
+    expect(personalizationTierRows(9, 9)).toHaveLength(3);
     expect(unlockedKeys(9)).toEqual(["color", "style", "signalStyle"]);
   });
 
   it("treats a negative or unusable tier as nothing unlocked", () => {
     expect(unlockedKeys(-2)).toEqual([]);
     expect(unlockedKeys(Number.NaN)).toEqual([]);
+  });
+
+  /**
+   * The reason this function takes two numbers. Somebody who reached tier 3 and
+   * then went quiet has earned all three axes and can edit none of them; the row
+   * that says "Locked" there is claiming they never had it, which the column
+   * contradicts.
+   */
+  it("calls an earned-but-decayed axis dormant, not locked", () => {
+    expect(statesAt(3, 1)).toEqual(["unlocked", "dormant", "dormant"]);
+    expect(statesAt(3, 0)).toEqual(["dormant", "dormant", "dormant"]);
+  });
+
+  it("still calls an axis that was never earned locked", () => {
+    expect(statesAt(1, 1)).toEqual(["unlocked", "locked", "locked"]);
+    expect(statesAt(0, 0)).toEqual(["locked", "locked", "locked"]);
+  });
+
+  // An effective tier above the earned one is not a state the server produces —
+  // `deriveEffectiveTier` clamps to `[0, earned]` — but the rows are rendered on
+  // somebody's own page and must not depend on that holding.
+  it("never lets an effective tier above the earned one read as dormant", () => {
+    expect(statesAt(0, 3)).toEqual(["unlocked", "unlocked", "unlocked"]);
+  });
+
+  it("offers the unconfigured state first on every axis", () => {
+    for (const row of personalizationTierRows(3, 3)) {
+      expect(row.options[0]).toBe(UNCONFIGURED);
+    }
+  });
+
+  /**
+   * The rows are the server's table, not a copy of it. A second list would let
+   * the picker offer something `setNodeAppearance` refuses, which is the exact
+   * failure the shared module exists to make impossible.
+   */
+  it("renders the same axes the server gates on, option for option", () => {
+    const rows = personalizationTierRows(3, 3);
+    expect(rows.map((row) => row.tier)).toEqual(
+      PERSONALIZATION_AXES.map((axis) => axis.tier),
+    );
+    for (const [index, axis] of PERSONALIZATION_AXES.entries()) {
+      expect(rows[index].key).toBe(axis.key);
+      expect(rows[index].options).toEqual([UNCONFIGURED, ...axis.options]);
+    }
   });
 });

--- a/apps/web/features/my-page/lib/personalization-tiers.ts
+++ b/apps/web/features/my-page/lib/personalization-tiers.ts
@@ -1,67 +1,52 @@
 /**
- * The personalization tiers My Page's "My dot" tab lists, and which of them the
- * viewer has reached.
+ * The personalization tiers My Page's "My dot" tab lists, and where the viewer
+ * stands on each of them.
  *
- * Two rules govern everything here, both from `CONTEXT.md` and #93.
+ * **There is one definition of the ladder and it is not here.**
+ * `@/server/graph/appearance` owns which tier unlocks which axis, what each axis
+ * offers, and the unlocked/dormant/locked rule; it lives in `server/` because
+ * Biome forbids server code importing from `features/`, so the side both halves
+ * can reach is that one. This module re-exports it and adds nothing but the row
+ * shape the tab renders. The tier gate in `server/graph/service.ts` runs the
+ * *same* `PERSONALIZATION_AXES` — offering an option the server would refuse is
+ * exactly what a second copy would produce.
  *
- * **The tier shown is the effective one.** `users.personalization_tier_earned`
- * holds the highest tier ever reached and is never lowered;
- * `graph.effectiveTier` derives what inactivity has left of it. This file takes
- * the effective number and says nothing at all about the earned one — a row
- * that read "you lost this" would assert something the database never records.
+ * Two rules govern the numbers, both from `CONTEXT.md` and #93.
  *
- * **A locked row says only that it is locked.** The artboard has a third
- * "Dormant" badge for a tier that was earned and has since decayed. Telling
- * dormant from locked needs the earned tier beside the effective one, and
- * `graph.effectiveTier` returns a single number, so the two collapse into
- * "Locked" here rather than one of them being guessed.
+ * **What may be edited is the effective tier.** `users.personalization_tier_
+ * earned` holds the highest tier ever reached and is never lowered;
+ * `graph.personalization` derives what inactivity has left of it. A row is
+ * editable only when the effective tier reaches it.
+ *
+ * **The earned tier is only ever used to say "dormant".** It never unlocks
+ * anything and it is never phrased as a loss. It exists here so that an axis
+ * somebody earned and has gone quiet on reads as **Dormant** — its pick still
+ * stored, waiting — rather than as **Locked**, which would tell them they had
+ * lost something the database still holds. This tab used to collapse the two
+ * because `graph.effectiveTier` returned a single number; it returns both now,
+ * and the limitation is gone rather than documented.
  */
 
-/**
- * The three appearance axes, in the order the artboard lists them. The index in
- * this array plus one is the tier that unlocks the axis.
- *
- * **The design disagreed with itself about tiers 2 and 3, and the product owner
- * settled it on 2026-09-05: the rendered list wins.** The My Page artboard
- * draws `mk(2, "Dot style", …, "style")` and `mk(3, "Signal on click", …,
- * "signalStyle")`, while `cc-store.js`'s `TIER_AXES` constant says
- * `{ 1: "color", 2: "signalStyle", 3: "style" }` — the opposite pairing. Both
- * halves survived the 2026-09-05 export unchanged, so the revision did not
- * settle it and a reader could not tell which half to believe.
- *
- * The rendered list is what a reader of the artboard actually sees, and it puts
- * the most visible reward behind the hardest contribution: tier 3 is reviewing
- * an entire imported transcript, and a moving signal reads louder than a static
- * shape. `cc-store.js` is the erroneous half and wants correcting at source.
- *
- * `unlockHint` is the rule from ADR 0005, which is what `server/graph/tier.ts`
- * now actually enforces. It used to carry the artboard's own copy, which named
- * a different ladder entirely — five reviews, then a fully reviewed transcript,
- * then *referring friends*, a feature that does not exist. That was harmless
- * while nothing wrote the column and every account sat at tier 0. It stopped
- * being harmless the moment the writer shipped, because a hint that names an
- * unearnable act is a promise the app cannot keep.
- */
-export const PERSONALIZATION_AXES = [
-  {
-    key: "color",
-    title: "Dot color",
-    unlockHint: "Unlocks when you publish your first review.",
-  },
-  {
-    key: "style",
-    title: "Dot style",
-    unlockHint: "Unlocks when you import a transcript.",
-  },
-  {
-    key: "signalStyle",
-    title: "Signal on click",
-    unlockHint: "Unlocks when every course in your transcript has your review.",
-  },
-] as const;
+import {
+  type AxisState,
+  axisState,
+  PERSONALIZATION_AXES,
+  type PersonalizationAxisKey,
+  UNCONFIGURED,
+} from "@/server/graph/appearance";
 
-export type PersonalizationAxisKey =
-  (typeof PERSONALIZATION_AXES)[number]["key"];
+export {
+  type AxisState,
+  axisState,
+  NODE_COLORS,
+  NODE_SIGNAL_STYLES,
+  NODE_STYLES,
+  type NodeAppearance,
+  type NodeAppearanceChoice,
+  PERSONALIZATION_AXES,
+  type PersonalizationAxisKey,
+  UNCONFIGURED,
+} from "@/server/graph/appearance";
 
 export type PersonalizationTierRow = {
   key: PersonalizationAxisKey;
@@ -69,31 +54,40 @@ export type PersonalizationTierRow = {
   tier: number;
   title: string;
   unlockHint: string;
+  state: AxisState;
+  /** Editable right now. The one thing the picker may act on. */
   unlocked: boolean;
+  /**
+   * Every value this axis may hold, unconfigured first.
+   *
+   * `UNCONFIGURED` leads because it is what every node in the community starts
+   * as and what a dormant axis renders as — and because a member who has picked
+   * something needs a way back to it.
+   */
+  options: readonly string[];
 };
 
 /**
- * The three rows, marked against an effective tier.
+ * The three rows, marked against a viewer's two tier numbers.
  *
- * `effectiveTier` is clamped rather than trusted: the column allows 0-3 today,
- * and a build that meets a wider value should still render three sensible rows
- * instead of throwing on somebody's own page.
+ * Neither number is trusted: the column allows 0-3 today, and a build that meets
+ * a wider or absent value should still render three sensible rows instead of
+ * throwing on somebody's own page. `axisState` does the clamping, once.
  */
 export function personalizationTierRows(
+  earnedTier: number,
   effectiveTier: number,
 ): PersonalizationTierRow[] {
-  const reached = Number.isFinite(effectiveTier)
-    ? Math.max(0, Math.floor(effectiveTier))
-    : 0;
-
-  return PERSONALIZATION_AXES.map((axis, index) => {
-    const tier = index + 1;
+  return PERSONALIZATION_AXES.map((axis) => {
+    const state = axisState(axis, earnedTier, effectiveTier);
     return {
       key: axis.key,
-      tier,
+      tier: axis.tier,
       title: axis.title,
       unlockHint: axis.unlockHint,
-      unlocked: reached >= tier,
+      state,
+      unlocked: state === "unlocked",
+      options: [UNCONFIGURED, ...axis.options],
     };
   });
 }

--- a/apps/web/server/db/drizzle/0015_node_appearance_axes.sql
+++ b/apps/web/server/db/drizzle/0015_node_appearance_axes.sql
@@ -1,0 +1,32 @@
+-- The style and signal axes get the values a member can actually choose (#68).
+--
+-- `node_style` and `node_signal_style` each declared exactly one value,
+-- 'default', so unlocking tier 2 or 3 unlocked a set of one and nothing could
+-- be picked. The names come from `server/graph/appearance.ts`, which is the one
+-- definition of the vocabulary; these are what the database will now accept.
+--
+-- 'default' stays first and stays the column default. It is the unconfigured
+-- state on every axis, and it is what a node renders as while a tier is
+-- dormant — the stored pick is masked at read time, never deleted, so it comes
+-- back when a qualifying review restores the tier.
+--
+-- **How this must be applied.** `bun run db:migrate` runs every pending
+-- migration inside a single transaction (drizzle-orm's `PgDialect.migrate`
+-- wraps the whole batch in `session.transaction`). PostgreSQL permits
+-- `ALTER TYPE ... ADD VALUE` in a transaction block from **12** onwards,
+-- provided the new value is not used in the same transaction — before 12 it
+-- fails outright with "cannot run inside a transaction block". Neon is well
+-- past 12, and this file only adds values: nothing here inserts, updates or
+-- casts to one, so there is no same-transaction use to trip over. Do not add a
+-- data statement using these values to this file; that is the one edit that
+-- would break it. It belongs in a later migration.
+--
+-- `IF NOT EXISTS` makes a re-run a no-op rather than a duplicate_object error,
+-- which matters because this migration may reach an environment where somebody
+-- has already run `drizzle-kit push`.
+ALTER TYPE "public"."node_signal_style" ADD VALUE IF NOT EXISTS 'fade';--> statement-breakpoint
+ALTER TYPE "public"."node_signal_style" ADD VALUE IF NOT EXISTS 'comet';--> statement-breakpoint
+ALTER TYPE "public"."node_signal_style" ADD VALUE IF NOT EXISTS 'dashed';--> statement-breakpoint
+ALTER TYPE "public"."node_style" ADD VALUE IF NOT EXISTS 'solid';--> statement-breakpoint
+ALTER TYPE "public"."node_style" ADD VALUE IF NOT EXISTS 'ring';--> statement-breakpoint
+ALTER TYPE "public"."node_style" ADD VALUE IF NOT EXISTS 'diamond';

--- a/apps/web/server/db/drizzle/meta/0015_snapshot.json
+++ b/apps/web/server/db/drizzle/meta/0015_snapshot.json
@@ -1,0 +1,1729 @@
+{
+  "id": "1fb47c03-4467-4c7f-ac67-551680dea2cb",
+  "prevId": "ca346a56-f369-4af2-8b54-74e115670f93",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.collection_courses": {
+      "name": "collection_courses",
+      "schema": "",
+      "columns": {
+        "collection_id": {
+          "name": "collection_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "collection_user_id": {
+          "name": "collection_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "course_code": {
+          "name": "course_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "collection_courses_collection_owner_idx": {
+          "name": "collection_courses_collection_owner_idx",
+          "columns": [
+            {
+              "expression": "collection_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "collection_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "collection_courses_saved_course_idx": {
+          "name": "collection_courses_saved_course_idx",
+          "columns": [
+            {
+              "expression": "collection_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "course_code",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "collection_courses_collection_owner_fk": {
+          "name": "collection_courses_collection_owner_fk",
+          "tableFrom": "collection_courses",
+          "tableTo": "collections",
+          "columnsFrom": ["collection_id", "collection_user_id"],
+          "columnsTo": ["id", "user_id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "collection_courses_saved_course_fk": {
+          "name": "collection_courses_saved_course_fk",
+          "tableFrom": "collection_courses",
+          "tableTo": "user_saved_courses",
+          "columnsFrom": ["collection_user_id", "course_code"],
+          "columnsTo": ["user_id", "course_code"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "collection_courses_collection_id_course_code_pk": {
+          "name": "collection_courses_collection_id_course_code_pk",
+          "columns": ["collection_id", "course_code"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "position_nonnegative": {
+          "name": "position_nonnegative",
+          "value": "\"collection_courses\".\"position\" >= 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.collections": {
+      "name": "collections",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "collections_user_id_idx": {
+          "name": "collections_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "collections_user_id_users_id_fk": {
+          "name": "collections_user_id_users_id_fk",
+          "tableFrom": "collections",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "collections_id_user_id_unique": {
+          "name": "collections_id_user_id_unique",
+          "nullsNotDistinct": false,
+          "columns": ["id", "user_id"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.course_examinations": {
+      "name": "course_examinations",
+      "schema": "",
+      "columns": {
+        "course_code": {
+          "name": "course_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "exam_code": {
+          "name": "exam_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "credits": {
+          "name": "credits",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "grade_scale_code": {
+          "name": "grade_scale_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "course_examinations_course_code_courses_code_fk": {
+          "name": "course_examinations_course_code_courses_code_fk",
+          "tableFrom": "course_examinations",
+          "tableTo": "courses",
+          "columnsFrom": ["course_code"],
+          "columnsTo": ["code"],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "course_examinations_course_code_exam_code_pk": {
+          "name": "course_examinations_course_code_exam_code_pk",
+          "columns": ["course_code", "exam_code"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.course_explore": {
+      "name": "course_explore",
+      "schema": "",
+      "columns": {
+        "course_code": {
+          "name": "course_code",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "embedding": {
+          "name": "embedding",
+          "type": "vector(1536)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_hash": {
+          "name": "source_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "search_vector": {
+          "name": "search_vector",
+          "type": "tsvector",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "embedding_model": {
+          "name": "embedding_model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "embedded_at": {
+          "name": "embedded_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "course_explore_search_vector_idx": {
+          "name": "course_explore_search_vector_idx",
+          "columns": [
+            {
+              "expression": "search_vector",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        },
+        "course_explore_embedding_idx": {
+          "name": "course_explore_embedding_idx",
+          "columns": [
+            {
+              "expression": "embedding",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "vector_cosine_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "hnsw",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "course_explore_course_code_courses_code_fk": {
+          "name": "course_explore_course_code_courses_code_fk",
+          "tableFrom": "course_explore",
+          "tableTo": "courses",
+          "columnsFrom": ["course_code"],
+          "columnsTo": ["code"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.course_prerequisites": {
+      "name": "course_prerequisites",
+      "schema": "",
+      "columns": {
+        "course_code": {
+          "name": "course_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "prerequisite_course_code": {
+          "name": "prerequisite_course_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "course_prerequisites_prerequisite_course_code_idx": {
+          "name": "course_prerequisites_prerequisite_course_code_idx",
+          "columns": [
+            {
+              "expression": "prerequisite_course_code",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "course_prerequisites_course_code_courses_code_fk": {
+          "name": "course_prerequisites_course_code_courses_code_fk",
+          "tableFrom": "course_prerequisites",
+          "tableTo": "courses",
+          "columnsFrom": ["course_code"],
+          "columnsTo": ["code"],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "course_prerequisites_prerequisite_course_code_courses_code_fk": {
+          "name": "course_prerequisites_prerequisite_course_code_courses_code_fk",
+          "tableFrom": "course_prerequisites",
+          "tableTo": "courses",
+          "columnsFrom": ["prerequisite_course_code"],
+          "columnsTo": ["code"],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "course_prerequisites_course_code_prerequisite_course_code_pk": {
+          "name": "course_prerequisites_course_code_prerequisite_course_code_pk",
+          "columns": ["course_code", "prerequisite_course_code"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.course_rounds": {
+      "name": "course_rounds",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "course_code": {
+          "name": "course_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "start_term": {
+          "name": "start_term",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "study_pace": {
+          "name": "study_pace",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "schema_url": {
+          "name": "schema_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "language": {
+          "name": "language",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tutoring_form": {
+          "name": "tutoring_form",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tutoring_time_of_day": {
+          "name": "tutoring_time_of_day",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "formatted_periods_and_credits": {
+          "name": "formatted_periods_and_credits",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_pu": {
+          "name": "is_pu",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_vu": {
+          "name": "is_vu",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "course_rounds_course_code_idx": {
+          "name": "course_rounds_course_code_idx",
+          "columns": [
+            {
+              "expression": "course_code",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "course_rounds_course_code_courses_code_fk": {
+          "name": "course_rounds_course_code_courses_code_fk",
+          "tableFrom": "course_rounds",
+          "tableTo": "courses",
+          "columnsFrom": ["course_code"],
+          "columnsTo": ["code"],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "study_pace_range": {
+          "name": "study_pace_range",
+          "value": "\"course_rounds\".\"study_pace\" between 1 and 100"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.courses": {
+      "name": "courses",
+      "schema": "",
+      "columns": {
+        "code": {
+          "name": "code",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name_swedish": {
+          "name": "name_swedish",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name_english": {
+          "name": "name_english",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "state": {
+          "name": "state",
+          "type": "course_state",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "credits": {
+          "name": "credits",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "credit_unit": {
+          "name": "credit_unit",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "department_code": {
+          "name": "department_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "department": {
+          "name": "department",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "educational_level_code": {
+          "name": "educational_level_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "grade_scale_code": {
+          "name": "grade_scale_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "goals": {
+          "name": "goals",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "eligibility": {
+          "name": "eligibility",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "courses_code_trgm_idx": {
+          "name": "courses_code_trgm_idx",
+          "columns": [
+            {
+              "expression": "code",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "gin_trgm_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.feedback_form": {
+      "name": "feedback_form",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "message": {
+          "name": "message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.review_votes": {
+      "name": "review_votes",
+      "schema": "",
+      "columns": {
+        "voter_user_id": {
+          "name": "voter_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "review_id": {
+          "name": "review_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "vote_type": {
+          "name": "vote_type",
+          "type": "review_vote_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "review_votes_review_id_idx": {
+          "name": "review_votes_review_id_idx",
+          "columns": [
+            {
+              "expression": "review_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "review_votes_voter_user_id_users_id_fk": {
+          "name": "review_votes_voter_user_id_users_id_fk",
+          "tableFrom": "review_votes",
+          "tableTo": "users",
+          "columnsFrom": ["voter_user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "review_votes_review_id_reviews_id_fk": {
+          "name": "review_votes_review_id_reviews_id_fk",
+          "tableFrom": "review_votes",
+          "tableTo": "reviews",
+          "columnsFrom": ["review_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "review_votes_voter_user_id_review_id_pk": {
+          "name": "review_votes_voter_user_id_review_id_pk",
+          "columns": ["voter_user_id", "review_id"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.reviews": {
+      "name": "reviews",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "course_code": {
+          "name": "course_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "examination_distribution": {
+          "name": "examination_distribution",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "approach_theory_percent": {
+          "name": "approach_theory_percent",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "workload_score": {
+          "name": "workload_score",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "learning_score": {
+          "name": "learning_score",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "happy_took": {
+          "name": "happy_took",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "message": {
+          "name": "message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "reviews_user_id_idx": {
+          "name": "reviews_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "reviews_course_code_idx": {
+          "name": "reviews_course_code_idx",
+          "columns": [
+            {
+              "expression": "course_code",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "reviews_user_id_users_id_fk": {
+          "name": "reviews_user_id_users_id_fk",
+          "tableFrom": "reviews",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "reviews_course_code_courses_code_fk": {
+          "name": "reviews_course_code_courses_code_fk",
+          "tableFrom": "reviews",
+          "tableTo": "courses",
+          "columnsFrom": ["course_code"],
+          "columnsTo": ["code"],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "approach_theory_percent_range": {
+          "name": "approach_theory_percent_range",
+          "value": "\"reviews\".\"approach_theory_percent\" between 0 and 100"
+        },
+        "workload_score_range": {
+          "name": "workload_score_range",
+          "value": "\"reviews\".\"workload_score\" between 1 and 10"
+        },
+        "learning_score_range": {
+          "name": "learning_score_range",
+          "value": "\"reviews\".\"learning_score\" between 1 and 10"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.user_saved_courses": {
+      "name": "user_saved_courses",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "course_code": {
+          "name": "course_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "user_saved_courses_course_code_idx": {
+          "name": "user_saved_courses_course_code_idx",
+          "columns": [
+            {
+              "expression": "course_code",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_saved_courses_user_id_users_id_fk": {
+          "name": "user_saved_courses_user_id_users_id_fk",
+          "tableFrom": "user_saved_courses",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "user_saved_courses_course_code_courses_code_fk": {
+          "name": "user_saved_courses_course_code_courses_code_fk",
+          "tableFrom": "user_saved_courses",
+          "tableTo": "courses",
+          "columnsFrom": ["course_code"],
+          "columnsTo": ["code"],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "user_saved_courses_user_id_course_code_pk": {
+          "name": "user_saved_courses_user_id_course_code_pk",
+          "columns": ["user_id", "course_code"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_taken_courses": {
+      "name": "user_taken_courses",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "course_code": {
+          "name": "course_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "attendance_periods": {
+          "name": "attendance_periods",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "attendance_year": {
+          "name": "attendance_year",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "grade": {
+          "name": "grade",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "earned_credits": {
+          "name": "earned_credits",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "transcript_imported_at": {
+          "name": "transcript_imported_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "user_taken_courses_course_code_idx": {
+          "name": "user_taken_courses_course_code_idx",
+          "columns": [
+            {
+              "expression": "course_code",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_taken_courses_user_id_users_id_fk": {
+          "name": "user_taken_courses_user_id_users_id_fk",
+          "tableFrom": "user_taken_courses",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "user_taken_courses_course_code_courses_code_fk": {
+          "name": "user_taken_courses_course_code_courses_code_fk",
+          "tableFrom": "user_taken_courses",
+          "tableTo": "courses",
+          "columnsFrom": ["course_code"],
+          "columnsTo": ["code"],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "user_taken_courses_user_id_course_code_pk": {
+          "name": "user_taken_courses_user_id_course_code_pk",
+          "columns": ["user_id", "course_code"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users_graph_backbone_edges": {
+      "name": "users_graph_backbone_edges",
+      "schema": "",
+      "columns": {
+        "node_user_id": {
+          "name": "node_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "anchor_user_id": {
+          "name": "anchor_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "users_graph_backbone_edges_anchor_user_id_idx": {
+          "name": "users_graph_backbone_edges_anchor_user_id_idx",
+          "columns": [
+            {
+              "expression": "anchor_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "users_graph_backbone_edges_node_user_id_users_graph_nodes_user_id_fk": {
+          "name": "users_graph_backbone_edges_node_user_id_users_graph_nodes_user_id_fk",
+          "tableFrom": "users_graph_backbone_edges",
+          "tableTo": "users_graph_nodes",
+          "columnsFrom": ["node_user_id"],
+          "columnsTo": ["user_id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "users_graph_backbone_edges_anchor_user_id_users_graph_nodes_user_id_fk": {
+          "name": "users_graph_backbone_edges_anchor_user_id_users_graph_nodes_user_id_fk",
+          "tableFrom": "users_graph_backbone_edges",
+          "tableTo": "users_graph_nodes",
+          "columnsFrom": ["anchor_user_id"],
+          "columnsTo": ["user_id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "users_graph_backbone_edges_node_user_id_anchor_user_id_pk": {
+          "name": "users_graph_backbone_edges_node_user_id_anchor_user_id_pk",
+          "columns": ["node_user_id", "anchor_user_id"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "no_self_backbone_edge": {
+          "name": "no_self_backbone_edge",
+          "value": "\"users_graph_backbone_edges\".\"node_user_id\" <> \"users_graph_backbone_edges\".\"anchor_user_id\""
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.users_graph_nodes": {
+      "name": "users_graph_nodes",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "x": {
+          "name": "x",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "y": {
+          "name": "y",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "users_graph_nodes_user_id_users_id_fk": {
+          "name": "users_graph_nodes_user_id_users_id_fk",
+          "tableFrom": "users_graph_nodes",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users_node_profiles": {
+      "name": "users_node_profiles",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "color": {
+          "name": "color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'default'"
+        },
+        "style": {
+          "name": "style",
+          "type": "node_style",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'default'"
+        },
+        "signal_style": {
+          "name": "signal_style",
+          "type": "node_signal_style",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'default'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "users_node_profiles_user_id_users_id_fk": {
+          "name": "users_node_profiles_user_id_users_id_fk",
+          "tableFrom": "users_node_profiles",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.accounts": {
+      "name": "accounts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "issuer": {
+          "name": "issuer",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "accounts_issuer_accountId_uidx": {
+          "name": "accounts_issuer_accountId_uidx",
+          "columns": [
+            {
+              "expression": "issuer",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "accounts_userId_idx": {
+          "name": "accounts_userId_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "accounts_user_id_users_id_fk": {
+          "name": "accounts_user_id_users_id_fk",
+          "tableFrom": "accounts",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sessions": {
+      "name": "sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "sessions_userId_idx": {
+          "name": "sessions_userId_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "sessions_user_id_users_id_fk": {
+          "name": "sessions_user_id_users_id_fk",
+          "tableFrom": "sessions",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "sessions_token_unique": {
+          "name": "sessions_token_unique",
+          "nullsNotDistinct": false,
+          "columns": ["token"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "personalization_tier_earned": {
+          "name": "personalization_tier_earned",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "nullsNotDistinct": false,
+          "columns": ["email"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "personalization_tier_earned_range": {
+          "name": "personalization_tier_earned_range",
+          "value": "\"users\".\"personalization_tier_earned\" between 0 and 3"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.verifications": {
+      "name": "verifications",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "verifications_identifier_idx": {
+          "name": "verifications_identifier_idx",
+          "columns": [
+            {
+              "expression": "identifier",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.course_state": {
+      "name": "course_state",
+      "schema": "public",
+      "values": ["CANCELLED", "ESTABLISHED", "DEACTIVATED"]
+    },
+    "public.node_signal_style": {
+      "name": "node_signal_style",
+      "schema": "public",
+      "values": ["default", "fade", "comet", "dashed"]
+    },
+    "public.node_style": {
+      "name": "node_style",
+      "schema": "public",
+      "values": ["default", "solid", "ring", "diamond"]
+    },
+    "public.review_vote_type": {
+      "name": "review_vote_type",
+      "schema": "public",
+      "values": ["up", "down"]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/apps/web/server/db/drizzle/meta/_journal.json
+++ b/apps/web/server/db/drizzle/meta/_journal.json
@@ -78,6 +78,13 @@
       "when": 1788595554355,
       "tag": "0014_unconfigured_node_colour",
       "breakpoints": true
+    },
+    {
+      "idx": 15,
+      "version": "7",
+      "when": 1788644467098,
+      "tag": "0015_node_appearance_axes",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/web/server/db/schema.ts
+++ b/apps/web/server/db/schema.ts
@@ -36,9 +36,31 @@ export const courseState = pgEnum("course_state", [
 
 export const reviewVoteType = pgEnum("review_vote_type", ["up", "down"]);
 
-export const nodeStyle = pgEnum("node_style", ["default"]);
+/**
+ * The two shape axes of a node profile, as Postgres enums.
+ *
+ * `"default"` leads each list and is the column default: it is what an
+ * unconfigured node stores, and what a node whose tier has decayed renders as
+ * while its stored pick is left untouched. The chosen values come from
+ * `server/graph/appearance.ts`, which is the one definition of the vocabulary —
+ * these declarations exist so the database refuses anything outside it.
+ *
+ * A value added here needs an `ALTER TYPE ... ADD VALUE` migration; see
+ * `drizzle/0015_node_appearance_axes.sql` for the constraints on writing one.
+ */
+export const nodeStyle = pgEnum("node_style", [
+  "default",
+  "solid",
+  "ring",
+  "diamond",
+]);
 
-export const nodeSignalStyle = pgEnum("node_signal_style", ["default"]);
+export const nodeSignalStyle = pgEnum("node_signal_style", [
+  "default",
+  "fade",
+  "comet",
+  "dashed",
+]);
 
 // used for pgvector full-text search
 const tsvector = customType<{ data: string }>({

--- a/apps/web/server/graph/appearance.ts
+++ b/apps/web/server/graph/appearance.ts
@@ -1,0 +1,207 @@
+/**
+ * Node appearance: the three axes a member may personalise, what each axis
+ * offers, and which personalization tier unlocks it.
+ *
+ * This is the **one definition** of that vocabulary, and it sits in `server/`
+ * for the same reason `server/reviews/unreviewed.ts` does: Biome forbids server
+ * code importing from `features/`, so anything both halves must agree on has to
+ * live on the side the other can reach. `features/my-page/lib/
+ * personalization-tiers.ts` re-exports it. Do not write a second copy of the
+ * ladder — the tier gate in `graph/service.ts` and the picker on My Page have to
+ * be the *same* rule, or a member is offered an option the server will refuse.
+ *
+ * **Names, never hex.** The server stores a name on every axis and the client
+ * maps it onto a `--cc-*` custom property, so the palette can be re-skinned in
+ * CSS without a data migration. `docs/design_ref/2026-09-05/cc-store.js` inverts
+ * that — its `NODE_COLORS` is five raw hex strings — and is wrong about the
+ * shape rather than about the colours.
+ *
+ * **Which tier unlocks which axis was settled by the product owner on
+ * 2026-09-05: the rendered My Page artboard wins.** That artboard draws
+ * `mk(1, "Dot color", …)`, `mk(2, "Dot style", …)`, `mk(3, "Signal on click",
+ * …)`, while `cc-store.js`'s `TIER_AXES` constant says
+ * `{ 1: "color", 2: "signalStyle", 3: "style" }` — the opposite pairing for 2
+ * and 3. `cc-store.js` is the erroneous half and wants correcting at source.
+ */
+
+/**
+ * What an unconfigured axis stores, and what a dormant one renders as. It is
+ * the column default on all three columns of `users_node_profiles`, and it is
+ * a legal *choice* as well as a default — un-picking is picking `"default"`.
+ */
+export const UNCONFIGURED = "default" as const;
+
+/**
+ * The node colour palette. Six names, mapped to `--cc-node-*` tokens by
+ * `features/landing/lib/neighbourhood-view.ts`.
+ */
+export const NODE_COLORS = [
+  "aurora",
+  "ember",
+  "frost",
+  "moss",
+  "slate",
+  "violet",
+] as const;
+
+/**
+ * The node shapes, from `cc-store.js`'s `NODE_STYLES`. These are geometry the
+ * hero canvas draws, not tokens: `solid` is the filled dot every node has always
+ * been, `ring` is the same dot stroked and hollow, `diamond` is it turned on its
+ * point.
+ */
+export const NODE_STYLES = ["solid", "ring", "diamond"] as const;
+
+/**
+ * The signal styles, from `cc-store.js`'s `NODE_SIGNAL_STYLES`.
+ *
+ * A **signal** is ongoing — `CONTEXT.md` — so it is drawn on every paint of a
+ * node that carries one, unlike the **pulse** that **Find your dot** shows once
+ * on the viewer's own node. The two are different things and this file names
+ * neither of them `pulse`; `cc-store.js`'s *other* signal list, `DOT_SIGNALS =
+ * ["ripple", "pulse", "spark"]`, does, and would collide with the glossary. It
+ * is a third naming of this axis in one export and the settled set is this one.
+ */
+export const NODE_SIGNAL_STYLES = ["fade", "comet", "dashed"] as const;
+
+export type NodeColor = (typeof NODE_COLORS)[number];
+export type NodeStyle = (typeof NODE_STYLES)[number];
+export type NodeSignalStyle = (typeof NODE_SIGNAL_STYLES)[number];
+
+/** Every value each column may hold: the unconfigured state, or a chosen name. */
+export type StoredNodeColor = NodeColor | typeof UNCONFIGURED;
+export type StoredNodeStyle = NodeStyle | typeof UNCONFIGURED;
+export type StoredNodeSignalStyle = NodeSignalStyle | typeof UNCONFIGURED;
+
+/** What placement writes, matching the column defaults on `users_node_profiles`. */
+export const DEFAULT_NODE_COLOR = UNCONFIGURED;
+export const DEFAULT_NODE_STYLE = UNCONFIGURED;
+export const DEFAULT_NODE_SIGNAL_STYLE = UNCONFIGURED;
+
+/**
+ * A name on each axis, without promising it is one this build knows.
+ *
+ * The window read gets its three names out of a `coalesce` over a left join and
+ * `color` is a free-text column besides, so an unrecognised name is possible and
+ * this is the honest type for it. The client draws one as unconfigured rather
+ * than dropping somebody out of a neighbourhood.
+ */
+export type AppearanceNames = {
+  color: string;
+  style: string;
+  signalStyle: string;
+};
+
+/** One node's stored appearance, all three axes together. */
+export type NodeAppearance = {
+  color: StoredNodeColor;
+  style: StoredNodeStyle;
+  signalStyle: StoredNodeSignalStyle;
+};
+
+/** What a node with no profile row, or with every axis dormant, looks like. */
+export const UNCONFIGURED_APPEARANCE: NodeAppearance = {
+  color: DEFAULT_NODE_COLOR,
+  style: DEFAULT_NODE_STYLE,
+  signalStyle: DEFAULT_NODE_SIGNAL_STYLE,
+};
+
+/**
+ * The three axes, in the order My Page lists them, each with the tier that
+ * unlocks it and the options it offers.
+ *
+ * `unlockHint` states ADR 0005's ladder, which is what `graph/tier.ts` actually
+ * enforces. The artboard's own copy named a different ladder entirely — five
+ * reviews, then a fully reviewed transcript, then *referring friends*, a feature
+ * that does not exist — and a hint naming an unearnable act is a promise the app
+ * cannot keep, so the rule the code enforces is the one shown.
+ *
+ * `UNCONFIGURED` is not listed in `options`: it is on every axis by definition
+ * and the picker adds it at the head of each row, because it is what a node
+ * looks like before anybody chooses and what it settles back to when a tier
+ * decays.
+ */
+export const PERSONALIZATION_AXES = [
+  {
+    key: "color",
+    tier: 1,
+    title: "Dot color",
+    unlockHint: "Unlocks when you publish your first review.",
+    options: NODE_COLORS,
+  },
+  {
+    key: "style",
+    tier: 2,
+    title: "Dot style",
+    unlockHint: "Unlocks when you import a transcript.",
+    options: NODE_STYLES,
+  },
+  {
+    key: "signalStyle",
+    tier: 3,
+    title: "Signal on click",
+    unlockHint: "Unlocks when every course in your transcript has your review.",
+    options: NODE_SIGNAL_STYLES,
+  },
+] as const;
+
+export type PersonalizationAxis = (typeof PERSONALIZATION_AXES)[number];
+export type PersonalizationAxisKey = PersonalizationAxis["key"];
+
+/** A choice on some of the axes. An absent key is left exactly as it is. */
+export type NodeAppearanceChoice = Partial<NodeAppearance>;
+
+/**
+ * Where one axis stands for a member, given both of their tier numbers.
+ *
+ * The third state is the whole reason `graph.personalization` returns two
+ * numbers rather than one. **Dormant is not locked**: the axis was earned, the
+ * pick is still stored, and reviewing again brings it back — `cc-store.js`,
+ * "Values stay stored while an axis is dormant; reviewing again restores them."
+ * Telling a member they had lost something the database still holds would be a
+ * lie about their own history.
+ */
+export type AxisState = "unlocked" | "dormant" | "locked";
+
+/**
+ * `effectiveTier` decides what may be edited; `earnedTier` only separates
+ * dormant from locked. Both are floored and clamped rather than trusted: the
+ * column allows 0-3 today and a build meeting a wider value should still render
+ * three sensible rows instead of throwing on somebody's own page.
+ */
+export function axisState(
+  axis: { tier: number },
+  earnedTier: number,
+  effectiveTier: number,
+): AxisState {
+  const effective = wholeTier(effectiveTier);
+  if (effective >= axis.tier) return "unlocked";
+  return wholeTier(earnedTier) >= axis.tier ? "dormant" : "locked";
+}
+
+function wholeTier(value: number): number {
+  return Number.isFinite(value) ? Math.max(0, Math.floor(value)) : 0;
+}
+
+/**
+ * The appearance a node actually renders as, once decay is applied.
+ *
+ * A dormant axis draws as unconfigured while its stored value is left alone —
+ * this masks, it never deletes, and there is deliberately no write anywhere in
+ * this file. My Page's own copy promises exactly this: "Go quiet for a while and
+ * it settles back to default." Restoring is nothing more than the effective tier
+ * rising again, which a single qualifying review does.
+ */
+export function renderedAppearance(
+  stored: AppearanceNames,
+  earnedTier: number,
+  effectiveTier: number,
+): AppearanceNames {
+  const rendered = { ...stored };
+  for (const axis of PERSONALIZATION_AXES) {
+    if (axisState(axis, earnedTier, effectiveTier) !== "unlocked") {
+      rendered[axis.key] = UNCONFIGURED;
+    }
+  }
+  return rendered;
+}

--- a/apps/web/server/graph/placement.ts
+++ b/apps/web/server/graph/placement.ts
@@ -8,50 +8,26 @@
  */
 
 /**
- * The node colour palette. The server stores a **name**; the client maps names
- * onto its `--cc-*` tokens, so the palette can be re-skinned without a data
- * migration. This is the one place the list lives.
+ * The appearance vocabulary lives in `./appearance.ts` — the palette, the two
+ * shape axes, the unconfigured state, and which tier unlocks each of them. It
+ * is re-exported here because placement writes the unconfigured state on join
+ * and every existing importer of these names came through this module.
  *
- * **Nobody is assigned one of these today.** Placement used to hash every app
- * user onto a name here, which gave everyone a colour nobody chose, and a node
- * profile is personalisation: a colour is chosen, never dealt out.
- *
- * `users.personalization_tier_earned` does have a writer now —
- * `recordEarnedPersonalizationTier` raises it from #161's ladder — so accounts
- * are no longer all at tier 0 and the axis a tier unlocks can genuinely open.
- * What is still missing is the other half: nothing writes
- * `users_node_profiles.color`, because no surface yet lets a member pick one.
- * The palette stays for the moment that surface exists.
+ * **Nobody is assigned a colour.** Placement used to hash every app user onto a
+ * palette name, which gave everyone a colour nobody chose, and a node profile is
+ * personalisation: a colour is chosen, never dealt out. `graph.setAppearance` is
+ * the only writer of a chosen value, and it is driven by a member clicking one.
  */
-export const NODE_COLORS = [
-  "aurora",
-  "ember",
-  "frost",
-  "moss",
-  "slate",
-  "violet",
-] as const;
-
-export type NodeColor = (typeof NODE_COLORS)[number];
-
-/**
- * What an unconfigured node stores, matching the column default on
- * `users_node_profiles.color`. The client draws it in `--cc-brand`, which is
- * the single dot colour the Landing artboard's own palette uses.
- */
-export const DEFAULT_NODE_COLOR = "default" as const;
-
-/** Every value the colour column may hold: the default, or a chosen palette name. */
-export type StoredNodeColor = NodeColor | typeof DEFAULT_NODE_COLOR;
-
-/**
- * `node_style` and `node_signal_style` are Postgres enums that today declare
- * exactly one value. Adding values needs an `ALTER TYPE` migration, and node
- * appearance is being redesigned wholesale, so placement writes the only value
- * there is.
- */
-export const DEFAULT_NODE_STYLE = "default" as const;
-export const DEFAULT_NODE_SIGNAL_STYLE = "default" as const;
+export {
+  DEFAULT_NODE_COLOR,
+  DEFAULT_NODE_SIGNAL_STYLE,
+  DEFAULT_NODE_STYLE,
+  NODE_COLORS,
+  type NodeColor,
+  type StoredNodeColor,
+  type StoredNodeSignalStyle,
+  type StoredNodeStyle,
+} from "./appearance";
 
 /** A joining node takes roughly three to five anchors. */
 export const MIN_ANCHORS = 3;

--- a/apps/web/server/graph/repository.ts
+++ b/apps/web/server/graph/repository.ts
@@ -381,17 +381,23 @@ export async function findNodeTierBases(
   userIds: string[],
 ): Promise<NodeTierBasis[]> {
   if (userIds.length === 0) return [];
-  return db
-    .select({
-      userId: schema.users.id,
-      earnedTier: schema.users.personalizationTierEarned,
-      accountCreatedAt: schema.users.createdAt,
-      lastReviewAt: max(schema.reviews.createdAt),
-    })
-    .from(schema.users)
-    .leftJoin(schema.reviews, eq(schema.reviews.userId, schema.users.id))
-    .where(inArray(schema.users.id, userIds))
-    .groupBy(schema.users.id);
+  return (
+    db
+      .select({
+        userId: schema.users.id,
+        earnedTier: schema.users.personalizationTierEarned,
+        accountCreatedAt: schema.users.createdAt,
+        lastReviewAt: max(schema.reviews.createdAt),
+      })
+      .from(schema.users)
+      .leftJoin(schema.reviews, eq(schema.reviews.userId, schema.users.id))
+      .where(inArray(schema.users.id, userIds))
+      // Grouping on the primary key alone is legal here and deliberate: Postgres
+      // treats every other `users` column as functionally dependent on it, so
+      // `personalization_tier_earned` and `created_at` need not be repeated in
+      // the clause and the aggregate stays over `reviews` only.
+      .groupBy(schema.users.id)
+  );
 }
 
 /**

--- a/apps/web/server/graph/repository.ts
+++ b/apps/web/server/graph/repository.ts
@@ -12,11 +12,13 @@ import {
 import { db } from "../db";
 import * as schema from "../db/schema";
 import type {
-  DEFAULT_NODE_SIGNAL_STYLE,
-  DEFAULT_NODE_STYLE,
+  NodeAppearance,
+  NodeAppearanceChoice,
   StoredNodeColor,
-  WorldPosition,
-} from "./placement";
+  StoredNodeSignalStyle,
+  StoredNodeStyle,
+} from "./appearance";
+import type { WorldPosition } from "./placement";
 
 /** A node's identity and its persistent world position. */
 export type GraphNode = {
@@ -25,11 +27,34 @@ export type GraphNode = {
   y: number;
 };
 
-/** A node plus the appearance the client needs to draw it. */
+/**
+ * A node plus the appearance **as stored**, which is not always the appearance
+ * it draws with: a member whose tier has decayed keeps their pick in the column
+ * and renders unconfigured until it comes back. Masking that is the service's
+ * job — see `renderedAppearance` — because it needs the tier basis this row does
+ * not carry.
+ *
+ * The three fields are plain `string` rather than the stored unions because they
+ * come back from a `coalesce` over a left join: a node with no profile row at
+ * all is legal and reads as `"default"` on every axis.
+ */
 export type NeighbourNode = GraphNode & {
   color: string;
   style: string;
   signalStyle: string;
+};
+
+/**
+ * What deciding one app user's *effective* tier needs, for a whole window of
+ * them at once.
+ *
+ * `lastReviewAt` is null for somebody who has never reviewed; the service falls
+ * back to `accountCreatedAt` there, exactly as the single-user read does, so a
+ * brand-new account is not instantly decayed.
+ */
+export type NodeTierBasis = TierBasis & {
+  userId: string;
+  lastReviewAt: Date | null;
 };
 
 /**
@@ -48,8 +73,8 @@ export type PlacementWrite = {
   profile: {
     userId: string;
     color: StoredNodeColor;
-    style: typeof DEFAULT_NODE_STYLE;
-    signalStyle: typeof DEFAULT_NODE_SIGNAL_STYLE;
+    style: StoredNodeStyle;
+    signalStyle: StoredNodeSignalStyle;
   };
   edges: BackboneEdge[];
 };
@@ -207,9 +232,9 @@ export async function findTierBasis(
  * it, and routing it through `server/reviews/service.ts` would couple the graph
  * domain to a review domain that is being rewritten in parallel.
  *
- * `findReviewedCourses` below is the same exception for the same reason. Those
- * two are the whole of it: nothing else here may reach into `server/reviews/`,
- * and neither of them may grow a write.
+ * `findReviewedCourses` and `findNodeTierBases` below are the same exception
+ * for the same reason. Those three are the whole of it: nothing else here may
+ * reach into `server/reviews/`, and none of them may grow a write.
  */
 export async function findLastReviewAt(userId: string): Promise<Date | null> {
   const [row] = await db
@@ -333,4 +358,106 @@ export async function raiseEarnedTier(
     )
     .returning({ userId: schema.users.id });
   return raised.length > 0;
+}
+
+/**
+ * The tier basis for a whole window of app users, in one read.
+ *
+ * The landing hero masks a dormant axis back to unconfigured, which needs an
+ * effective tier per node rather than only for the viewer — so this is
+ * `findTierBasis` and `findLastReviewAt` for up to `MAX_PUBLIC_WINDOW_NODES`
+ * people at once. One grouped join rather than a query per node: a 150-node
+ * window would otherwise be 300 round trips on every load of `/`.
+ *
+ * The left join is what makes an app user who has never reviewed come back at
+ * all, with a null `lastReviewAt` for the service to fall back from. Both sides
+ * are indexed — `users` by primary key, `reviews` by `reviews_user_id_idx`.
+ *
+ * It returns **no appearance and no name**: this answers "how far has each of
+ * these people decayed", nothing else, and the public window must never learn a
+ * user id it did not already have.
+ */
+export async function findNodeTierBases(
+  userIds: string[],
+): Promise<NodeTierBasis[]> {
+  if (userIds.length === 0) return [];
+  return db
+    .select({
+      userId: schema.users.id,
+      earnedTier: schema.users.personalizationTierEarned,
+      accountCreatedAt: schema.users.createdAt,
+      lastReviewAt: max(schema.reviews.createdAt),
+    })
+    .from(schema.users)
+    .leftJoin(schema.reviews, eq(schema.reviews.userId, schema.users.id))
+    .where(inArray(schema.users.id, userIds))
+    .groupBy(schema.users.id);
+}
+
+/**
+ * One app user's stored node profile, or `undefined` if they have no row.
+ *
+ * No row is a normal state, not an error: `users_node_profiles` is written on
+ * placement, and accounts that predate the community graph never saw it. The
+ * service reads the absence as `UNCONFIGURED_APPEARANCE`, which is exactly what
+ * the column defaults would have stored.
+ *
+ * This returns what is **stored**, never what renders. Decay is applied above.
+ */
+export async function findNodeProfile(
+  userId: string,
+): Promise<NodeAppearance | undefined> {
+  const [row] = await db
+    .select({
+      color: schema.usersNodeProfiles.color,
+      style: schema.usersNodeProfiles.style,
+      signalStyle: schema.usersNodeProfiles.signalStyle,
+    })
+    .from(schema.usersNodeProfiles)
+    .where(eq(schema.usersNodeProfiles.userId, userId))
+    .limit(1);
+  // `color` is a free-text column, so a name this build has never heard of is
+  // possible and the cast is the honest place to admit it. The client draws an
+  // unrecognised name as unconfigured rather than dropping the node.
+  return row as NodeAppearance | undefined;
+}
+
+/**
+ * Write one app user's chosen appearance, creating their profile row if they
+ * have none.
+ *
+ * **A patch, not a row.** Only the axes named in `choice` are written; an axis
+ * left out keeps whatever it held, which is what makes a dormant pick survive a
+ * write to a different axis. There is no path here that clears a column because
+ * a tier decayed — decay is masked at read time and this repository has no
+ * opinion about tiers at all. Un-picking is a member choosing `"default"`, and
+ * arrives as an ordinary value.
+ *
+ * `on conflict do update` rather than a read-then-write, so two clicks landing
+ * together cannot lose one another's axis: each statement touches only the
+ * columns it names.
+ *
+ * The whole stored appearance comes back, so the caller never has to guess what
+ * the untouched axes were or issue a second read to find out.
+ */
+export async function upsertNodeProfile(
+  userId: string,
+  choice: NodeAppearanceChoice,
+): Promise<NodeAppearance> {
+  const [row] = await db
+    .insert(schema.usersNodeProfiles)
+    .values({ userId, ...choice })
+    .onConflictDoUpdate({
+      target: schema.usersNodeProfiles.userId,
+      set: { ...choice, updatedAt: new Date() },
+    })
+    .returning({
+      color: schema.usersNodeProfiles.color,
+      style: schema.usersNodeProfiles.style,
+      signalStyle: schema.usersNodeProfiles.signalStyle,
+    });
+  if (!row) {
+    throw new Error(`Could not write the node profile for app user ${userId}`);
+  }
+  return row as NodeAppearance;
 }

--- a/apps/web/server/graph/router.spec.ts
+++ b/apps/web/server/graph/router.spec.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import { createCallerFactory } from "../api/trpc";
 import { graphRouter } from "./router";
 import * as graphService from "./service";
@@ -12,6 +12,13 @@ function caller(session: { user: { id: string } } | null) {
   });
 }
 
+// The service is auto-mocked once for the file, so call history has to be
+// cleared between tests or an assertion that a procedure wrote *nothing* sees
+// the previous test's write. Implementations are kept.
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
 describe("graph router", () => {
   it("rejects visitors on everything that is about a person", async () => {
     const visitor = caller(null);
@@ -22,9 +29,12 @@ describe("graph router", () => {
     await expect(visitor.neighbourhood()).rejects.toMatchObject({
       code: "UNAUTHORIZED",
     });
-    await expect(visitor.effectiveTier()).rejects.toMatchObject({
+    await expect(visitor.personalization()).rejects.toMatchObject({
       code: "UNAUTHORIZED",
     });
+    await expect(
+      visitor.setAppearance({ color: "ember" }),
+    ).rejects.toMatchObject({ code: "UNAUTHORIZED" });
   });
 
   // The landing hero draws the real community to anybody who loads `/`, so this
@@ -55,5 +65,95 @@ describe("graph router", () => {
     await caller({ user: { id: "user-1" } }).neighbourhood();
 
     expect(graphService.getNeighbourhood).toHaveBeenCalledWith("user-1");
+  });
+});
+
+describe("graph router: choosing a node's appearance", () => {
+  const STATE = {
+    earnedTier: 3,
+    effectiveTier: 3,
+    appearance: {
+      color: "ember" as const,
+      style: "default" as const,
+      signalStyle: "default" as const,
+    },
+  };
+
+  it("writes for the signed-in app user, never an id from the input", async () => {
+    vi.mocked(graphService.setNodeAppearance).mockResolvedValue(STATE);
+
+    await caller({ user: { id: "user-1" } }).setAppearance({ color: "ember" });
+
+    expect(graphService.setNodeAppearance).toHaveBeenCalledWith("user-1", {
+      color: "ember",
+    });
+  });
+
+  it("passes only the axes the caller named", async () => {
+    vi.mocked(graphService.setNodeAppearance).mockResolvedValue(STATE);
+
+    await caller({ user: { id: "user-1" } }).setAppearance({ style: "ring" });
+
+    expect(graphService.setNodeAppearance).toHaveBeenCalledWith("user-1", {
+      style: "ring",
+    });
+  });
+
+  /**
+   * The schema bounds the vocabulary and nothing else. It is not the gate —
+   * whether this caller may set this axis is a question about their effective
+   * tier and is answered in the service — but a name outside the enum should
+   * never reach it, because the database would refuse it as a type error rather
+   * than as a rule.
+   */
+  it("refuses a name that is not on the axis", async () => {
+    const member = caller({ user: { id: "user-1" } });
+
+    await expect(
+      member.setAppearance({ color: "chartreuse" } as never),
+    ).rejects.toMatchObject({ code: "BAD_REQUEST" });
+    await expect(
+      member.setAppearance({ style: "hexagon" } as never),
+    ).rejects.toMatchObject({ code: "BAD_REQUEST" });
+    await expect(
+      member.setAppearance({ signalStyle: "ripple" } as never),
+    ).rejects.toMatchObject({ code: "BAD_REQUEST" });
+    expect(graphService.setNodeAppearance).not.toHaveBeenCalled();
+  });
+
+  // A field nobody declared is a caller trying something. It is refused rather
+  // than dropped, so the attempt is visible instead of silently ignored.
+  it("refuses a field the axes do not have", async () => {
+    await expect(
+      caller({ user: { id: "user-1" } }).setAppearance({
+        userId: "somebody-else",
+      } as never),
+    ).rejects.toMatchObject({ code: "BAD_REQUEST" });
+  });
+
+  // Un-picking is a real choice and has to be spellable.
+  it("accepts a return to the unconfigured default on every axis", async () => {
+    vi.mocked(graphService.setNodeAppearance).mockResolvedValue(STATE);
+
+    await caller({ user: { id: "user-1" } }).setAppearance({
+      color: "default",
+      style: "default",
+      signalStyle: "default",
+    });
+
+    expect(graphService.setNodeAppearance).toHaveBeenCalledWith("user-1", {
+      color: "default",
+      style: "default",
+      signalStyle: "default",
+    });
+  });
+
+  it("reads the caller's own personalization and nobody else's", async () => {
+    vi.mocked(graphService.getNodePersonalization).mockResolvedValue(STATE);
+
+    await expect(
+      caller({ user: { id: "user-1" } }).personalization(),
+    ).resolves.toEqual(STATE);
+    expect(graphService.getNodePersonalization).toHaveBeenCalledWith("user-1");
   });
 });

--- a/apps/web/server/graph/router.ts
+++ b/apps/web/server/graph/router.ts
@@ -1,17 +1,25 @@
+import { z } from "zod";
 import {
   baseProcedure,
   createTRPCRouter,
   protectedProcedure,
 } from "../api/trpc";
 import {
-  getEffectiveTier,
+  NODE_COLORS,
+  NODE_SIGNAL_STYLES,
+  NODE_STYLES,
+  UNCONFIGURED,
+} from "./appearance";
+import {
   getNeighbourhood,
+  getNodePersonalization,
   getPublicWindow,
   joinCommunityGraph,
+  setNodeAppearance,
 } from "./service";
 
 /**
- * Reading the community graph.
+ * Reading the community graph, and choosing how your own node looks.
  *
  * Everything about a *person* is protected: a neighbourhood is centred on the
  * caller's own node, and a tier belongs to the caller. `publicWindow` is the
@@ -20,6 +28,30 @@ import {
  * it. It is centred on the community origin, it names nobody, and the service
  * strips every user id out of what it returns.
  */
+
+/**
+ * A choice on some of the three axes, each drawn from the one definition in
+ * `./appearance.ts`.
+ *
+ * `UNCONFIGURED` is accepted on every axis because un-picking is a real choice:
+ * a member who has earned a colour may go back to the community default, and
+ * they would otherwise have no way to say so. Every axis is optional so the
+ * picker can send exactly the one that was clicked, which is what lets a write
+ * to one axis leave a dormant pick on another untouched.
+ *
+ * **This schema is not the gate.** It bounds the vocabulary; whether *this*
+ * caller may set *this* axis is a question about their effective tier, and it
+ * is answered in `setNodeAppearance`. A schema that a signed-in stranger can
+ * satisfy is not an authorisation check.
+ */
+const appearanceChoice = z
+  .object({
+    color: z.enum([UNCONFIGURED, ...NODE_COLORS]).optional(),
+    style: z.enum([UNCONFIGURED, ...NODE_STYLES]).optional(),
+    signalStyle: z.enum([UNCONFIGURED, ...NODE_SIGNAL_STYLES]).optional(),
+  })
+  .strict();
+
 export const graphRouter = createTRPCRouter({
   join: protectedProcedure.mutation(({ ctx }) =>
     joinCommunityGraph(ctx.session.user.id),
@@ -28,7 +60,28 @@ export const graphRouter = createTRPCRouter({
     getNeighbourhood(ctx.session.user.id),
   ),
   publicWindow: baseProcedure.query(() => getPublicWindow()),
-  effectiveTier: protectedProcedure.query(({ ctx }) =>
-    getEffectiveTier(ctx.session.user.id),
+  /**
+   * How far the caller has unlocked their node profile, and what they picked.
+   *
+   * It answers with **both** tier numbers. One was not enough: the earned tier
+   * is what separates a dormant axis from a locked one, and without it My Page
+   * could only tell a member their axis was locked — which, for somebody who
+   * earned it and went quiet, is a claim about their own history that the
+   * database contradicts.
+   */
+  personalization: protectedProcedure.query(({ ctx }) =>
+    getNodePersonalization(ctx.session.user.id),
   ),
+  /**
+   * Set one or more axes of the caller's own node.
+   *
+   * The app user is always `ctx.session.user.id` and never an id from the
+   * input — there is no way to spell "somebody else's node" in this procedure.
+   * The tier gate is the service's, deliberately: see `setNodeAppearance`.
+   */
+  setAppearance: protectedProcedure
+    .input(appearanceChoice)
+    .mutation(({ ctx, input }) =>
+      setNodeAppearance(ctx.session.user.id, input),
+    ),
 });

--- a/apps/web/server/graph/service.spec.ts
+++ b/apps/web/server/graph/service.spec.ts
@@ -1,5 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import { NotFoundError } from "../errors";
+import { ForbiddenError, NotFoundError } from "../errors";
+import { UNCONFIGURED_APPEARANCE } from "./appearance";
 import {
   DEFAULT_NODE_COLOR,
   MAX_ANCHORS,
@@ -11,8 +12,9 @@ import * as graphRepo from "./repository";
 import {
   backfillEarnedPersonalizationTiers,
   COMMUNITY_ORIGIN,
-  getEffectiveTier,
   getNeighbourhood,
+  getNodePersonalization,
+  getPersonalizationTiers,
   getPublicWindow,
   joinCommunityGraph,
   joinCommunityGraphOnSignUp,
@@ -20,13 +22,21 @@ import {
   MAX_PUBLIC_WINDOW_NODES,
   recordEarnedPersonalizationTier,
   recordEarnedPersonalizationTierOnContribution,
+  setNodeAppearance,
 } from "./service";
 
 vi.mock("./repository");
 
 const JOINED = new Date("2024-01-15T12:00:00.000Z");
 
-function neighbour(userId: string, x: number, y: number): NeighbourNode {
+function neighbour(
+  userId: string,
+  x: number,
+  y: number,
+  appearance: Partial<
+    Pick<NeighbourNode, "color" | "style" | "signalStyle">
+  > = {},
+): NeighbourNode {
   return {
     userId,
     x,
@@ -34,7 +44,28 @@ function neighbour(userId: string, x: number, y: number): NeighbourNode {
     color: DEFAULT_NODE_COLOR,
     style: "default",
     signalStyle: "default",
+    ...appearance,
   };
+}
+
+/**
+ * A tier basis for every node in a window, all at the same pair of numbers.
+ *
+ * `lastReviewAt` defaults to the moment the window is read, so nothing has
+ * decayed unless a test says so. That keeps "what does this node draw with" a
+ * question about the numbers rather than about the clock.
+ */
+function tierBases(
+  nodes: NeighbourNode[],
+  earnedTier: number,
+  lastReviewAt: Date | null = new Date(),
+) {
+  return nodes.map((node) => ({
+    userId: node.userId,
+    earnedTier,
+    accountCreatedAt: JOINED,
+    lastReviewAt,
+  }));
 }
 
 /** An established community of `size` nodes on a coarse grid. */
@@ -100,6 +131,11 @@ beforeEach(() => {
     accountCreatedAt: JOINED,
   });
   vi.mocked(graphRepo.findLastReviewAt).mockResolvedValue(null);
+  vi.mocked(graphRepo.findNodeTierBases).mockResolvedValue([]);
+  vi.mocked(graphRepo.findNodeProfile).mockResolvedValue(undefined);
+  vi.mocked(graphRepo.upsertNodeProfile).mockImplementation(
+    async (_userId, choice) => ({ ...UNCONFIGURED_APPEARANCE, ...choice }),
+  );
 });
 
 describe("joinCommunityGraph", () => {
@@ -345,11 +381,19 @@ describe("getNeighbourhood", () => {
     expect(byId.get(edges[0].toId)).toMatchObject({ x: 2, y: 2 });
   });
 
-  // The landing reads this on every visit now, so it must not carry work the
-  // page does not need. The tier lives on `graph.effectiveTier`, which is what
-  // My Page asks, and reading it here cost two queries for a number nothing on
-  // the landing looks at.
-  it("returns a window and nothing else, reading no tier", async () => {
+  /**
+   * The landing reads this on every visit, so it must not carry work the page
+   * does not need. It answers with a window and nothing else: the viewer's own
+   * tier numbers live on `graph.personalization`, which is what My Page asks,
+   * and returning them here cost two queries for numbers nothing on the landing
+   * looks at.
+   *
+   * The per-node tier bases are a different thing and are read. They are what
+   * masks a dormant axis back to unconfigured, they are one query for the whole
+   * window rather than two per node, and no number out of them reaches the
+   * response.
+   */
+  it("returns a window and nothing else, and never reads the viewer's own tier", async () => {
     placedViewer();
     vi.mocked(graphRepo.findNearestNodes).mockResolvedValue([viewer]);
 
@@ -362,6 +406,7 @@ describe("getNeighbourhood", () => {
     ]);
     expect(graphRepo.findTierBasis).not.toHaveBeenCalled();
     expect(graphRepo.findLastReviewAt).not.toHaveBeenCalled();
+    expect(graphRepo.findNodeTierBases).toHaveBeenCalledTimes(1);
   });
 
   it("places an app user who has no node yet, rather than turning them away", async () => {
@@ -449,6 +494,8 @@ describe("getPublicWindow", () => {
         "color",
         "id",
         "isViewer",
+        "signalStyle",
+        "style",
         "x",
         "y",
       ]);
@@ -507,7 +554,7 @@ describe("getPublicWindow", () => {
   });
 });
 
-describe("getEffectiveTier", () => {
+describe("getPersonalizationTiers", () => {
   it("decays from the app user's most recent review", async () => {
     vi.mocked(graphRepo.findTierBasis).mockResolvedValue({
       earnedTier: 3,
@@ -515,12 +562,32 @@ describe("getEffectiveTier", () => {
     });
     vi.mocked(graphRepo.findLastReviewAt).mockResolvedValue(JOINED);
 
-    const tier = await getEffectiveTier(
+    const tiers = await getPersonalizationTiers(
       "reviewer",
       new Date("2025-01-15T12:00:00.000Z"),
     );
 
-    expect(tier).toBe(1);
+    expect(tiers.effectiveTier).toBe(1);
+  });
+
+  /**
+   * The earned number is what tells a dormant axis from a locked one, so it has
+   * to come back undecayed beside the other. This is the whole reason the read
+   * answers with two numbers rather than one.
+   */
+  it("reports the earned tier untouched beside the decayed one", async () => {
+    vi.mocked(graphRepo.findTierBasis).mockResolvedValue({
+      earnedTier: 3,
+      accountCreatedAt: new Date("2020-01-01T00:00:00.000Z"),
+    });
+    vi.mocked(graphRepo.findLastReviewAt).mockResolvedValue(JOINED);
+
+    expect(
+      await getPersonalizationTiers(
+        "reviewer",
+        new Date("2044-01-15T12:00:00.000Z"),
+      ),
+    ).toEqual({ earnedTier: 3, effectiveTier: 0 });
   });
 
   it("decays from the account creation date when the app user has never reviewed", async () => {
@@ -530,24 +597,26 @@ describe("getEffectiveTier", () => {
     });
     vi.mocked(graphRepo.findLastReviewAt).mockResolvedValue(null);
 
-    expect(
-      await getEffectiveTier("quiet", new Date("2024-07-14T12:00:00.000Z")),
-    ).toBe(2);
-    expect(
-      await getEffectiveTier("quiet", new Date("2024-07-15T12:00:00.000Z")),
-    ).toBe(1);
+    const at = async (iso: string) =>
+      (await getPersonalizationTiers("quiet", new Date(iso))).effectiveTier;
+
+    expect(await at("2024-07-14T12:00:00.000Z")).toBe(2);
+    expect(await at("2024-07-15T12:00:00.000Z")).toBe(1);
   });
 
   it("rejects an unknown app user", async () => {
     vi.mocked(graphRepo.findTierBasis).mockResolvedValue(undefined);
 
-    await expect(getEffectiveTier("ghost")).rejects.toBeInstanceOf(
+    await expect(getPersonalizationTiers("ghost")).rejects.toBeInstanceOf(
       NotFoundError,
     );
   });
 
   it("never writes the earned tier back", async () => {
-    await getEffectiveTier("reader", new Date("2044-01-01T00:00:00.000Z"));
+    await getPersonalizationTiers(
+      "reader",
+      new Date("2044-01-01T00:00:00.000Z"),
+    );
 
     // Decay is derived and thrown away. The graph domain owns exactly two
     // writes — placement, and the monotonic tier raise — and reading a decayed
@@ -559,7 +628,8 @@ describe("getEffectiveTier", () => {
       Object.keys(graphRepo).filter((name) =>
         /^(insert|update|upsert|delete|save|persist|set|raise)/.test(name),
       ),
-    ).toEqual(["persistPlacement", "raiseEarnedTier"]);
+    ).toEqual(["persistPlacement", "raiseEarnedTier", "upsertNodeProfile"]);
+    expect(graphRepo.upsertNodeProfile).not.toHaveBeenCalled();
   });
 });
 
@@ -722,5 +792,328 @@ describe("backfillEarnedPersonalizationTiers", () => {
     await expect(backfillEarnedPersonalizationTiers()).rejects.toThrow(
       "neon is having a day",
     );
+  });
+});
+
+describe("a window's node appearance", () => {
+  const PICKED = { color: "ember", style: "diamond", signalStyle: "comet" };
+  const nodes = [neighbour("them", 10, 10, PICKED)];
+
+  beforeEach(() => {
+    vi.mocked(graphRepo.findNearestNodes).mockResolvedValue(nodes);
+  });
+
+  it("draws what a member with the tier for it has chosen", async () => {
+    vi.mocked(graphRepo.findNodeTierBases).mockResolvedValue(
+      tierBases(nodes, 3),
+    );
+
+    const [node] = (await getPublicWindow()).nodes;
+
+    expect(node).toMatchObject(PICKED);
+  });
+
+  /**
+   * "Go quiet for a while and it settles back to default" — My Page's own copy
+   * about the network, so decay has to reach the canvas and not only the tab.
+   * A member at earned 3 who has not reviewed for eighteen months is at
+   * effective 0, and every axis renders unconfigured.
+   */
+  it("settles a decayed member's node back to the default it started as", async () => {
+    vi.mocked(graphRepo.findNodeTierBases).mockResolvedValue(
+      tierBases(nodes, 3, new Date("2020-01-01T00:00:00.000Z")),
+    );
+
+    const [node] = (await getPublicWindow()).nodes;
+
+    expect(node).toMatchObject(UNCONFIGURED_APPEARANCE);
+  });
+
+  // Decay costs one tier per six months, so it uncovers the axes one at a time,
+  // from the top. The colour a member earned first is the last thing to go.
+  it("masks only the axes the effective tier no longer reaches", async () => {
+    vi.mocked(graphRepo.findNodeTierBases).mockResolvedValue([
+      {
+        userId: "them",
+        earnedTier: 3,
+        accountCreatedAt: JOINED,
+        // Seven months without a review: one decay step, so tier 3 is dormant.
+        lastReviewAt: new Date("2024-01-15T12:00:00.000Z"),
+      },
+    ]);
+    vi.mocked(graphRepo.findNearestNodes).mockResolvedValue(nodes);
+
+    vi.setSystemTime(new Date("2024-08-16T12:00:00.000Z"));
+    try {
+      const [node] = (await getPublicWindow()).nodes;
+
+      expect(node).toMatchObject({
+        color: "ember",
+        style: "diamond",
+        signalStyle: "default",
+      });
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  /**
+   * Masking is a read-time derivation and this is the assertion that keeps it
+   * one. Nothing about drawing a decayed node may reach a column: the pick has
+   * to be there, intact, when the member reviews again.
+   */
+  it("writes nothing at all while masking", async () => {
+    vi.mocked(graphRepo.findNodeTierBases).mockResolvedValue(
+      tierBases(nodes, 3, new Date("2020-01-01T00:00:00.000Z")),
+    );
+
+    await getPublicWindow();
+
+    expect(graphRepo.upsertNodeProfile).not.toHaveBeenCalled();
+    expect(graphRepo.persistPlacement).not.toHaveBeenCalled();
+    expect(graphRepo.raiseEarnedTier).not.toHaveBeenCalled();
+  });
+
+  // An account removed between the two reads. Unconfigured is the conservative
+  // answer and the same one the column defaults give, so it is not a special
+  // case; drawing the stored pick on no evidence would be.
+  it("draws a node whose tier basis did not come back as unconfigured", async () => {
+    vi.mocked(graphRepo.findNodeTierBases).mockResolvedValue([]);
+
+    const [node] = (await getPublicWindow()).nodes;
+
+    expect(node).toMatchObject(UNCONFIGURED_APPEARANCE);
+  });
+
+  // The public window is unauthenticated. Appearance is drawn on the landing by
+  // design; a tier number is not, and neither is anybody's id.
+  it("still carries no user id and no tier number", async () => {
+    vi.mocked(graphRepo.findNodeTierBases).mockResolvedValue(
+      tierBases(nodes, 3),
+    );
+
+    const payload = JSON.stringify(await getPublicWindow());
+
+    expect(payload).not.toContain("them");
+    expect(payload).not.toContain("Tier");
+    expect(payload).not.toContain("tier");
+  });
+});
+
+describe("getNodePersonalization", () => {
+  it("reports both tier numbers and the stored appearance", async () => {
+    vi.mocked(graphRepo.findTierBasis).mockResolvedValue({
+      earnedTier: 2,
+      accountCreatedAt: JOINED,
+    });
+    vi.mocked(graphRepo.findLastReviewAt).mockResolvedValue(JOINED);
+    vi.mocked(graphRepo.findNodeProfile).mockResolvedValue({
+      color: "moss",
+      style: "ring",
+      signalStyle: "default",
+    });
+
+    expect(await getNodePersonalization("u1", JOINED)).toEqual({
+      earnedTier: 2,
+      effectiveTier: 2,
+      appearance: { color: "moss", style: "ring", signalStyle: "default" },
+    });
+  });
+
+  /**
+   * The tab shows the pick a dormant axis is holding, unmasked. Hiding it would
+   * make "reviewing again restores them" unverifiable from the one screen that
+   * says so — the member would have only our word that anything is waiting.
+   */
+  it("shows a dormant axis's pick rather than the default the canvas draws", async () => {
+    vi.mocked(graphRepo.findTierBasis).mockResolvedValue({
+      earnedTier: 3,
+      accountCreatedAt: JOINED,
+    });
+    vi.mocked(graphRepo.findLastReviewAt).mockResolvedValue(JOINED);
+    vi.mocked(graphRepo.findNodeProfile).mockResolvedValue({
+      color: "violet",
+      style: "diamond",
+      signalStyle: "comet",
+    });
+
+    const state = await getNodePersonalization(
+      "quiet",
+      new Date("2044-01-01T00:00:00.000Z"),
+    );
+
+    expect(state.effectiveTier).toBe(0);
+    expect(state.earnedTier).toBe(3);
+    expect(state.appearance).toEqual({
+      color: "violet",
+      style: "diamond",
+      signalStyle: "comet",
+    });
+  });
+
+  // Placement writes a profile row, but accounts predating the community graph
+  // never saw it. No row is unconfigured, which is what the defaults would say.
+  it("reads a missing profile row as unconfigured", async () => {
+    vi.mocked(graphRepo.findNodeProfile).mockResolvedValue(undefined);
+
+    expect((await getNodePersonalization("u1")).appearance).toEqual(
+      UNCONFIGURED_APPEARANCE,
+    );
+  });
+
+  it("rejects an unknown app user", async () => {
+    vi.mocked(graphRepo.findTierBasis).mockResolvedValue(undefined);
+
+    await expect(getNodePersonalization("ghost")).rejects.toBeInstanceOf(
+      NotFoundError,
+    );
+  });
+});
+
+describe("setNodeAppearance", () => {
+  /** An app user whose effective tier is exactly `tier`, with no decay. */
+  function at(tier: number) {
+    vi.mocked(graphRepo.findTierBasis).mockResolvedValue({
+      earnedTier: tier,
+      accountCreatedAt: JOINED,
+    });
+    vi.mocked(graphRepo.findLastReviewAt).mockResolvedValue(new Date());
+  }
+
+  it("writes an axis the app user's effective tier unlocks", async () => {
+    at(1);
+
+    const state = await setNodeAppearance("u1", { color: "frost" });
+
+    expect(graphRepo.upsertNodeProfile).toHaveBeenCalledWith("u1", {
+      color: "frost",
+    });
+    expect(state.appearance.color).toBe("frost");
+  });
+
+  /**
+   * The gate, one rung at a time. A member at tier 1 may choose a colour and
+   * nothing else; the picker disables the rest, but the picker is presentation
+   * and this is the check that actually decides.
+   */
+  it("refuses every axis above the effective tier", async () => {
+    at(1);
+
+    await expect(
+      setNodeAppearance("u1", { style: "ring" }),
+    ).rejects.toBeInstanceOf(ForbiddenError);
+    await expect(
+      setNodeAppearance("u1", { signalStyle: "comet" }),
+    ).rejects.toBeInstanceOf(ForbiddenError);
+    expect(graphRepo.upsertNodeProfile).not.toHaveBeenCalled();
+  });
+
+  it("refuses the whole write when one axis of several is out of reach", async () => {
+    at(2);
+
+    await expect(
+      setNodeAppearance("u1", { color: "ember", signalStyle: "dashed" }),
+    ).rejects.toBeInstanceOf(ForbiddenError);
+    // Not a partial write: the colour it *could* have taken is not stored either.
+    expect(graphRepo.upsertNodeProfile).not.toHaveBeenCalled();
+  });
+
+  it("accepts every axis at the top of the ladder", async () => {
+    at(3);
+
+    await setNodeAppearance("u1", {
+      color: "aurora",
+      style: "diamond",
+      signalStyle: "fade",
+    });
+
+    expect(graphRepo.upsertNodeProfile).toHaveBeenCalledWith("u1", {
+      color: "aurora",
+      style: "diamond",
+      signalStyle: "fade",
+    });
+  });
+
+  /**
+   * **The gate is the effective tier, not the earned one.** A member who
+   * reached tier 3 and went quiet cannot set a tier-3 axis today — and their
+   * stored pick is untouched by the refusal, which is the difference between
+   * dormant and lost.
+   */
+  it("refuses a dormant axis, and does not disturb what it holds", async () => {
+    vi.mocked(graphRepo.findTierBasis).mockResolvedValue({
+      earnedTier: 3,
+      accountCreatedAt: JOINED,
+    });
+    vi.mocked(graphRepo.findLastReviewAt).mockResolvedValue(JOINED);
+
+    await expect(
+      setNodeAppearance(
+        "quiet",
+        { signalStyle: "comet" },
+        new Date("2044-01-01T00:00:00.000Z"),
+      ),
+    ).rejects.toBeInstanceOf(ForbiddenError);
+    expect(graphRepo.upsertNodeProfile).not.toHaveBeenCalled();
+  });
+
+  // Un-picking is a choice like any other and goes through the same gate: a
+  // member at tier 0 may not clear a colour any more than they may set one.
+  it("treats a return to the default as a write on that axis", async () => {
+    at(1);
+    await setNodeAppearance("u1", { color: "default" });
+    expect(graphRepo.upsertNodeProfile).toHaveBeenCalledWith("u1", {
+      color: "default",
+    });
+
+    at(0);
+    await expect(
+      setNodeAppearance("u1", { color: "default" }),
+    ).rejects.toBeInstanceOf(ForbiddenError);
+  });
+
+  // Only the axis that was named. An axis left out keeps whatever it held,
+  // which is what lets a dormant pick survive an edit to a different one.
+  it("sends the repository only the axes it was asked for", async () => {
+    at(3);
+
+    await setNodeAppearance("u1", { style: "ring" });
+
+    expect(graphRepo.upsertNodeProfile).toHaveBeenCalledWith("u1", {
+      style: "ring",
+    });
+  });
+
+  it("answers with the current state for a choice that names nothing", async () => {
+    at(3);
+    vi.mocked(graphRepo.findNodeProfile).mockResolvedValue({
+      color: "slate",
+      style: "default",
+      signalStyle: "default",
+    });
+
+    const state = await setNodeAppearance("u1", {});
+
+    expect(graphRepo.upsertNodeProfile).not.toHaveBeenCalled();
+    expect(state.appearance.color).toBe("slate");
+  });
+
+  it("rejects an unknown app user before it writes anything", async () => {
+    vi.mocked(graphRepo.findTierBasis).mockResolvedValue(undefined);
+
+    await expect(
+      setNodeAppearance("ghost", { color: "ember" }),
+    ).rejects.toBeInstanceOf(NotFoundError);
+    expect(graphRepo.upsertNodeProfile).not.toHaveBeenCalled();
+  });
+
+  // Choosing a colour must not touch the tier. The earned column has exactly one
+  // writer and personalisation is not it.
+  it("never raises the earned tier as a side effect of a choice", async () => {
+    at(3);
+
+    await setNodeAppearance("u1", { color: "ember" });
+
+    expect(graphRepo.raiseEarnedTier).not.toHaveBeenCalled();
   });
 });

--- a/apps/web/server/graph/service.ts
+++ b/apps/web/server/graph/service.ts
@@ -1,13 +1,26 @@
-import { NotFoundError } from "../errors";
+import { ForbiddenError, NotFoundError } from "../errors";
 import {
-  chooseAnchorCount,
-  computeWorldPosition,
+  type AppearanceNames,
   DEFAULT_NODE_COLOR,
   DEFAULT_NODE_SIGNAL_STYLE,
   DEFAULT_NODE_STYLE,
+  type NodeAppearance,
+  type NodeAppearanceChoice,
+  PERSONALIZATION_AXES,
+  renderedAppearance,
+  UNCONFIGURED_APPEARANCE,
+} from "./appearance";
+import {
+  chooseAnchorCount,
+  computeWorldPosition,
   type WorldPosition,
 } from "./placement";
-import type { BackboneEdge, GraphNode, NeighbourNode } from "./repository";
+import type {
+  BackboneEdge,
+  GraphNode,
+  NeighbourNode,
+  NodeTierBasis,
+} from "./repository";
 import * as graphRepo from "./repository";
 import { deriveEarnedTier, deriveEffectiveTier } from "./tier";
 
@@ -54,12 +67,20 @@ export type WindowNode = {
   x: number;
   y: number;
   /**
-   * The stored appearance name. Node appearance is drawn on a public landing
-   * page by design, so it is not a disclosure; it is also `"default"` for
-   * everybody until a member has some way to choose a colour. The earned tier
-   * has a writer now, but nothing writes `users_node_profiles.color`.
+   * The appearance names this node **renders** with, which is its stored
+   * profile with every dormant axis masked back to `"default"`. Node appearance
+   * is drawn on a public landing page by design, so it is not a disclosure, and
+   * these three names are the whole of what leaves: no tier number, no user id,
+   * nothing about who decayed.
+   *
+   * Masking rather than reading the column straight is what My Page's own copy
+   * promises — "Go quiet for a while and it settles back to default" — and it
+   * is a read-time derivation only. The stored pick is untouched and returns
+   * the moment a qualifying review restores the tier.
    */
   color: string;
+  style: string;
+  signalStyle: string;
   /** The one node belonging to the caller. Never true in a public window. */
   isViewer: boolean;
 };
@@ -201,27 +222,118 @@ export async function getPublicWindow(): Promise<GraphWindow> {
   return readWindow(COMMUNITY_ORIGIN, MAX_PUBLIC_WINDOW_NODES);
 }
 
+/** Both tier numbers for one app user, and the appearance they have stored. */
+export type NodePersonalization = {
+  /** The highest tier ever reached. Never lowered, by anything. */
+  earnedTier: number;
+  /** What inactivity has left of it. Derived here and stored nowhere. */
+  effectiveTier: number;
+  /** The stored pick on each axis, unmasked — a dormant axis still shows it. */
+  appearance: NodeAppearance;
+};
+
 /**
- * The personalization tier an app user effectively has right now.
+ * Both personalization tier numbers for an app user.
+ *
+ * **Two numbers, not one, and that is the point.** This read used to answer with
+ * the effective tier alone, which left My Page unable to tell a *dormant* axis —
+ * earned, decayed, pick still stored — from a *locked* one that was never
+ * earned. The artboard has three badges and the UI could only draw two, so it
+ * collapsed dormant into "Locked" and told members they had lost something the
+ * database still holds. The earned number closes that and does nothing else.
  *
  * Read-only by construction: the earned tier is the highest ever reached and
  * decay is derived from it, never written back.
  */
-export async function getEffectiveTier(
+export async function getPersonalizationTiers(
   userId: string,
   now: Date = new Date(),
-): Promise<number> {
+): Promise<{ earnedTier: number; effectiveTier: number }> {
   const basis = await graphRepo.findTierBasis(userId);
   if (!basis) throw new NotFoundError(`No such app user: ${userId}`);
 
   const lastReviewAt = await graphRepo.findLastReviewAt(userId);
   // An app user who has never reviewed decays from when they joined, so a
   // brand-new account is not instantly decayed.
-  return deriveEffectiveTier(
-    basis.earnedTier,
-    lastReviewAt ?? basis.accountCreatedAt,
-    now,
+  return {
+    earnedTier: basis.earnedTier,
+    effectiveTier: deriveEffectiveTier(
+      basis.earnedTier,
+      lastReviewAt ?? basis.accountCreatedAt,
+      now,
+    ),
+  };
+}
+
+/**
+ * Everything My Page's "My dot" tab needs: how far this app user has unlocked
+ * their node profile, and what they have picked.
+ *
+ * The appearance comes back **as stored**, deliberately. A dormant axis renders
+ * as unconfigured on the landing canvas, but the tab has to show the member the
+ * pick that is waiting for them — hiding it would make "reviewing again restores
+ * them" unverifiable from the one screen that says it.
+ *
+ * An app user with no profile row reads as unconfigured on all three axes, which
+ * is exactly what the column defaults would have stored for them.
+ */
+export async function getNodePersonalization(
+  userId: string,
+  now: Date = new Date(),
+): Promise<NodePersonalization> {
+  const [tiers, stored] = await Promise.all([
+    getPersonalizationTiers(userId, now),
+    graphRepo.findNodeProfile(userId),
+  ]);
+  return { ...tiers, appearance: stored ?? UNCONFIGURED_APPEARANCE };
+}
+
+/**
+ * Set one or more appearance axes for an app user.
+ *
+ * **The gate is here, and it is the effective tier.** A caller may only write an
+ * axis their *current* tier unlocks: colour needs 1, style 2, signal style 3 —
+ * `PERSONALIZATION_AXES`, the same table the picker renders from, so the two
+ * cannot drift apart. A dormant axis is refused like a locked one, because the
+ * member cannot edit it right now; what separates the two is that the dormant
+ * one still holds its value, and nothing in this function goes near a column it
+ * was not asked to write.
+ *
+ * This has to be server-side. The picker knows the tier and disables what is
+ * not unlocked, but that is presentation: the mutation is a public tRPC
+ * procedure and any signed-in caller can post to it with whatever body they
+ * like. A client-side-only gate is not a gate — it is a suggestion, and the
+ * database would happily store a tier-3 signal for an account at tier 0.
+ *
+ * Reports the whole personalization state afterwards, so the caller replaces its
+ * cache with a fact rather than patching it with an assumption.
+ */
+export async function setNodeAppearance(
+  userId: string,
+  choice: NodeAppearanceChoice,
+  now: Date = new Date(),
+): Promise<NodePersonalization> {
+  const tiers = await getPersonalizationTiers(userId, now);
+
+  for (const axis of PERSONALIZATION_AXES) {
+    if (choice[axis.key] === undefined) continue;
+    if (tiers.effectiveTier >= axis.tier) continue;
+    throw new ForbiddenError(
+      `Personalization tier ${axis.tier} is needed to set ${axis.key}`,
+    );
+  }
+
+  // Nothing to write is not an error — it is a caller that asked for no change.
+  // Answering with the current state costs one read and keeps the procedure
+  // total, rather than making "did you name an axis" a second failure mode.
+  const named = PERSONALIZATION_AXES.some(
+    (axis) => choice[axis.key] !== undefined,
   );
+  const appearance = named
+    ? await graphRepo.upsertNodeProfile(userId, choice)
+    : ((await graphRepo.findNodeProfile(userId)) ?? UNCONFIGURED_APPEARANCE);
+
+  return { ...tiers, appearance };
 }
 
 /**
@@ -371,12 +483,18 @@ async function readWindow(
   centre: WorldPosition,
   limit: number,
   viewerUserId?: string,
+  now: Date = new Date(),
 ): Promise<GraphWindow> {
   const nodes = await graphRepo.findNearestNodes(centre, limit);
-  const edges = await graphRepo.findBackboneEdgesWithin(
-    nodes.map((node) => node.userId),
-  );
-  return anonymise({ centre, nodes, edges, viewerUserId });
+  const userIds = nodes.map((node) => node.userId);
+  // Two independent reads over the same bounded set. The tier bases are what
+  // masks a dormant axis back to unconfigured, and they are fetched for the
+  // whole window in one query rather than per node — see `findNodeTierBases`.
+  const [edges, tierBases] = await Promise.all([
+    graphRepo.findBackboneEdgesWithin(userIds),
+    graphRepo.findNodeTierBases(userIds),
+  ]);
+  return anonymise({ centre, nodes, edges, viewerUserId, tierBases, now });
 }
 
 /**
@@ -394,16 +512,32 @@ function anonymise(args: {
   nodes: NeighbourNode[];
   edges: BackboneEdge[];
   viewerUserId?: string;
+  tierBases: NodeTierBasis[];
+  now: Date;
 }): GraphWindow {
+  const basisByUserId = new Map(
+    args.tierBases.map((basis) => [basis.userId, basis]),
+  );
   const tokens = new Map<string, string>();
   const nodes = args.nodes.map((node) => {
     const id = crypto.randomUUID();
     tokens.set(node.userId, id);
+    // A node whose basis did not come back — an account removed between the two
+    // reads — renders unconfigured rather than being dropped or drawn with a
+    // pick nothing vouches for. Tier 0 is the same answer the column default
+    // gives, so this is the conservative branch and not a special case.
+    const appearance = appearanceFor(
+      basisByUserId.get(node.userId),
+      node,
+      args.now,
+    );
     return {
       id,
       x: node.x,
       y: node.y,
-      color: node.color,
+      color: appearance.color,
+      style: appearance.style,
+      signalStyle: appearance.signalStyle,
       isViewer: node.userId === args.viewerUserId,
     };
   });
@@ -438,4 +572,26 @@ async function findAnchors(
   return candidates
     .filter((candidate) => candidate.userId !== userId)
     .slice(0, anchorCount);
+}
+
+/**
+ * What one node in a window draws with: its stored appearance, with every axis
+ * its owner's effective tier no longer reaches masked back to unconfigured.
+ *
+ * This is the read-time half of "dormant reverts, it does not lose". Nothing is
+ * written, nothing is cleared, and the same stored row produces the full
+ * appearance again the moment a qualifying review lifts the effective tier.
+ */
+function appearanceFor(
+  basis: NodeTierBasis | undefined,
+  stored: NeighbourNode,
+  now: Date,
+): AppearanceNames {
+  if (!basis) return UNCONFIGURED_APPEARANCE;
+  const effectiveTier = deriveEffectiveTier(
+    basis.earnedTier,
+    basis.lastReviewAt ?? basis.accountCreatedAt,
+    now,
+  );
+  return renderedAppearance(stored, basis.earnedTier, effectiveTier);
 }


### PR DESCRIPTION
Node personalization had an earning half and no choosing half. `deriveEarnedTier` wrote `users.personalization_tier_earned`, but nothing wrote `users_node_profiles`, `graph` exposed only `join`/`neighbourhood`/`publicWindow`/`effectiveTier`, every node rendered the `"default"` brand blue, and `node_style` and `node_signal_style` were Postgres enums with exactly one value each — so tiers 2 and 3 unlocked a set of one. This is the choosing half: schema, write path, tier gate, picker and canvas.

## The migration, and how it must be applied

`apps/web/server/db/drizzle/0015_node_appearance_axes.sql` adds `solid`/`ring`/`diamond` to `node_style` and `fade`/`comet`/`dashed` to `node_signal_style`. Generated with `drizzle-kit generate` (snapshot and journal entry included), renamed to match `0011_saved_contract` / `0014_unconfigured_node_colour`, and given a header.

**It has not been run against any database.** It needs applying with `bun run db:migrate`.

On the transaction question, from this repo's own dependencies rather than from assumption: `db:migrate` is `drizzle-kit migrate`, which for the Neon driver delegates to drizzle-orm's `migrate` (`node_modules/drizzle-kit/bin.cjs`, the `@neondatabase/serverless` branch), and `PgDialect.migrate` wraps every pending migration's every statement in one `session.transaction` (`node_modules/drizzle-orm/pg-core/dialect.cjs:62`). So the whole batch runs inside a transaction block. PostgreSQL permits `ALTER TYPE ... ADD VALUE` there **from 12 onwards**, provided the new value is not used in the same transaction; before 12 it fails outright. Neon is well past 12, and this migration adds values and nothing else — no insert, update or cast uses one — so there is no same-transaction use to trip over. The file says this, and says that adding a data statement to it is the one edit that would break it. `IF NOT EXISTS` makes a re-run a no-op rather than a `duplicate_object` error, which matters where somebody has already run `drizzle-kit push`.

## The gate, and why it is server-side

`graph.setAppearance` is a `protectedProcedure` taking a patch of axes. The router's zod schema bounds the *vocabulary* — the names on each axis, plus `"default"` on every one of them, `.strict()` — and that is all it does.

The gate itself is `setNodeAppearance` in `server/graph/service.ts`. It re-derives the effective tier through `getPersonalizationTiers` (which reuses `deriveEffectiveTier` unchanged) and refuses any axis that tier does not reach: colour needs 1, style 2, signal style 3. A partial refusal is a whole refusal — a choice naming one reachable and one unreachable axis writes neither.

It has to be here. The picker disables what is locked, but that is presentation: the mutation is a public tRPC procedure and any signed-in caller can post whatever body they like to it. A client-side-only gate would let the database store a tier-3 signal for an account at tier 0. The two halves run the *same* `PERSONALIZATION_AXES` table out of `server/graph/appearance.ts` — re-exported to the client by `features/my-page/lib/personalization-tiers.ts`, the way `selectUnreviewedCourses` is shared — so what the picker offers and what the service accepts cannot drift apart.

Router → service → repository is kept: the router imports only `./service`, and the new `upsertNodeProfile` / `findNodeProfile` / `findNodeTierBases` are Drizzle-only.

## Earned *and* effective

`graph.effectiveTier` returned one number, which is why `personalization-tiers.ts` collapsed **dormant** into **locked** and said so in its docstring. It is now `graph.personalization`, returning `{ earnedTier, effectiveTier, appearance }`. The effective number decides what may be edited; the earned number is used for exactly one thing — telling a dormant axis from a locked one — and is never phrased as a loss. The docstring's limitation is gone rather than documented.

`deriveEffectiveTier` is untouched.

## Dormant preserves the pick

Nothing anywhere deletes a stored value because a tier decayed. There is no such code path, and `setNodeAppearance` only ever writes the axes it was handed.

Dormancy is applied at **read time**, in two places, each drawing a different conclusion from the same stored row:

- **The canvas.** `readWindow` reads a tier basis for the whole window in one query (`findNodeTierBases`) and `renderedAppearance` masks every axis its owner's effective tier no longer reaches back to `"default"`. This is My Page's own copy taken literally — "Go quiet for a while and it settles back to default" is a claim about the network, not only about the tab. The window carries no tier number and no user id out.
- **My Page.** `getNodePersonalization` returns the appearance **unmasked**, and a dormant row names the pick it is holding. Hiding it would make "reviewing again restores them" unverifiable from the one screen that claims it.

## What the canvas draws

`hero-network.tsx` drew every node as a dot. It now draws:

- `solid` — the filled dot, which is also what an unconfigured node draws.
- `ring` — the same circle stroked and hollow, inset by half its stroke so it keeps the dot's footprint.
- `diamond` — a square on its point, half-diagonal `r * sqrt(pi / 2)`, so it covers the same area as the circle it replaces rather than reading as a shrunken node.
- `fade` — three concentric rings, each fainter and wider.
- `comet` — a tapering trail of three segments, pointing away from the middle of the frame. That direction is the only stable one available, costs no per-node state, and leans every trail outward, away from the hero copy rather than across it.
- `dashed` — one broken ring; the dash pattern is cleared afterwards so no later stroke inherits it.

An unrecognised name on either axis draws as unconfigured rather than dropping somebody out of a neighbourhood. **Find your dot** now enlarges the shape the member has instead of swapping it for a generic dot.

**No frame loop was added, and nothing here animates.** The pulse on a labelled node is still the only `requestAnimationFrame` on this canvas. A signal is *ongoing* — `CONTEXT.md` — so it is painted every time its node is painted; that is a different thing from moving, and the distinction is what keeps `hero-network.spec.tsx`'s repaint checklist meaningful. A test asserts it directly: a scene carrying all three signal styles and no label starts no loop.

## Design and schema contradictions hit

1. **The Landing artboard has no geometry for any of this.** The brief said its `<script type="text/x-dc">` block was the authority for how to draw the styles and signals. It is not, in the 2026-09-05 export: a case-insensitive count for `diamond`, `comet`, `dashed`, `setLineDash`, `signalStyle` and `profile` over `Course Community - Landing.dc.html` returns 0 for every one. Its canvas is the older synthetic drifting field where every node is `ctx.arc(...)`, and its signals travel *along edges* as recommendations — which this repo's canvas rejects outright, because a backbone edge records placement history and is not a friendship. **Minimal change:** the geometry is defined in `hero-network.tsx`, in named constants, with the reasoning written down and asserted by tests, and the comment says the artboard has none rather than citing it as if it had.
2. **`cc-store.js` names the signal axis twice, differently.** `NODE_SIGNAL_STYLES = ["fade","comet","dashed"]` is what the settled decision uses; the My Page artboard actually renders from `DOT_SIGNALS = ["ripple","pulse","spark"]`. The second collides with `CONTEXT.md`, where *pulse* is the one-shot Find-your-dot reveal and explicitly not a signal. **Minimal change:** the settled set stands; `appearance.ts` records that there was a third naming and why it was not taken.
3. **`cc-store.js`'s `NODE_COLORS` is five hexes and `DOT_COLORS` is five more.** The server stores six names. **Minimal change:** none — names are kept, and the note that `cc-store.js` is wrong about the shape is carried forward.
4. **`CONTEXT.md` says a signal is "the moving trail".** It does not move, for the frame-loop reason above. **Minimal change:** a `_Today_` line on the **Signal** entry recording what the code actually does and what would close it. The ongoing/one-shot distinction it exists to protect is unaffected.
5. **A third `server/reviews/` read from `server/graph/repository.ts`.** `findLastReviewAt`'s comment named itself and `findReviewedCourses` as "the whole of it". `findNodeTierBases` is a third; it is the same kind — one read-only aggregate feeding one derived number, covered by `reviews_user_id_idx`. **Minimal change:** the comment now names three and still forbids a write on any of them.

## Deliberately not done

- **No new `--cc-*` tokens.** Styles and signals are geometry, not colour; they draw in the node's own colour token.
- **No shape or signal glyph on the picker's buttons.** Only the colour axis is swatched, which is what the artboard does. A legible glyph of a four-pixel mark would be a second drawing of it to keep in step with the canvas.
- **The artboard's `title: unlocked ? title : "Unknown"`.** The rows keep their real titles, as they did before this PR; "Unknown" beside a hint that says how to unlock it is incoherent.
- **No optimistic painting.** The highlighted option is what the server last confirmed, because the gate can refuse.
- **No backfill and no data migration.** Nothing needs one: every existing row is already `"default"` on all three axes.

## Validation

All three gates from the repo root, on the pushed head:

- `bun run lint` — clean (8 warnings, all pre-existing, all in `.agents/skills/neon-drizzle/`, none touched here).
- `bun run typecheck` — exit 0.
- `bun run test:web` — **972 passed / 74 files**, up from the 924/74 baseline, in 35s. No change in run time or memory profile.

New coverage sits at the layer that owns each rule: the tier gate per axis and the dormant refusal (`server/graph/service.spec.ts`), dormant masking on the window including "writes nothing at all while masking" and the still-no-user-id/no-tier assertion, the router's vocabulary and its `ctx.session.user.id`-only writes (`server/graph/router.spec.ts`), the three badge states and the shared-axes identity (`features/my-page/lib/personalization-tiers.spec.ts`), the click that writes and the pressed option (`features/my-page/components/my-page.spec.tsx`), and each shape and signal plus the no-frame-loop guarantee (`features/landing/components/hero-network.spec.tsx`). Every repository is mocked; no test touches a database.

One existing test earned its keep: `service.spec.ts` enumerates the graph repository's write-shaped function names, so adding `upsertNodeProfile` failed it until the list was updated deliberately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017EAUKDDo2BkQTFELyvV3v8
