### PR TITLE
fix(workspace): stop the pane deleting the review draft it just restored

### DIFF
--- a/apps/web/features/auth/components/auth-providers.tsx
+++ b/apps/web/features/auth/components/auth-providers.tsx
@@ -7,6 +7,7 @@ import { Button } from "@/components/ui/button";
 import { Spinner } from "@/components/ui/spinner";
 import { authClient } from "@/lib/auth-client";
 import type { OauthProvider } from "@/types";
+import { requestedReturnTo } from "../lib/return-to";
 
 export function AuthProviders() {
   const [isLoading, setIsLoading] = useState(false);
@@ -20,7 +21,10 @@ export function AuthProviders() {
     try {
       const { error } = await authClient.signIn.social({
         provider,
-        callbackURL: "/search",
+        // `?next=` if `AuthReasonDialog` sent them here, `/search` otherwise —
+        // the same promise the dialog's own buttons make, kept by the page it
+        // hands off to.
+        callbackURL: requestedReturnTo(),
       });
       if (error) {
         toast.error("Failed to sign in");

--- a/apps/web/features/auth/components/auth-reason-dialog.spec.tsx
+++ b/apps/web/features/auth/components/auth-reason-dialog.spec.tsx
@@ -122,14 +122,64 @@ describe("AuthReasonDialog", () => {
     );
   });
 
-  it("routes to the full auth page for email", async () => {
+  // The email path leaves this tab for `/auth`, and the link `/auth` mails is
+  // opened in a *new* one — so the destination has to travel in the URL or it
+  // does not travel at all.
+  it("routes to the full auth page for email, carrying where to come back to", async () => {
     const user = userEvent.setup();
     open("log-in");
     await user.click(
       screen.getByRole("button", { name: /continue with email/i }),
     );
-    expect(push).toHaveBeenCalledWith("/auth");
+    expect(push).toHaveBeenCalledWith(
+      "/auth?next=%2Fcourse%2FDD2380%3Fq%3Dagents",
+    );
     expect(signInSocial).not.toHaveBeenCalled();
+  });
+
+  // `?next=` is read straight back out and handed to Better Auth, so a
+  // destination that is not this site is an open redirect with a real sign-in
+  // in front of it. Rejected here, before it can be offered to anyone.
+  it.each([
+    "https://evil.example/steal",
+    "//evil.example/steal",
+    String.raw`/\evil.example/steal`,
+  ])("refuses to come back to %s", async (destination) => {
+    window.history.replaceState({}, "", "/search");
+    const user = userEvent.setup();
+    render(
+      <AuthReasonDialog
+        reason="log-in"
+        onReasonChange={vi.fn()}
+        onClose={vi.fn()}
+        returnTo={() => destination}
+      />,
+    );
+    await user.click(screen.getByRole("button", { name: /google/i }));
+
+    await waitFor(() => expect(signInSocial).toHaveBeenCalled());
+    expect(signInSocial.mock.calls[0][0].callbackURL).toBe("/search");
+  });
+
+  // A caller may know something the URL has stopped saying — the review draft
+  // panel puts back the `?open=` a host has already spent — so the destination
+  // is a mapper over where the visitor is, not a fixed string.
+  it("lets the caller adjust where the sign-in comes back to", async () => {
+    const user = userEvent.setup();
+    render(
+      <AuthReasonDialog
+        reason="post-review"
+        onReasonChange={vi.fn()}
+        onClose={vi.fn()}
+        returnTo={(here) => `${here}&open=DD2380&kind=review`}
+      />,
+    );
+    await user.click(screen.getByRole("button", { name: /google/i }));
+
+    await waitFor(() => expect(signInSocial).toHaveBeenCalled());
+    expect(signInSocial.mock.calls[0][0].callbackURL).toBe(
+      "/course/DD2380?q=agents&open=DD2380&kind=review",
+    );
   });
 
   it("reports a failed sign-in instead of failing silently", async () => {

--- a/apps/web/features/auth/components/auth-reason-dialog.tsx
+++ b/apps/web/features/auth/components/auth-reason-dialog.tsx
@@ -13,6 +13,7 @@ import {
 import { Spinner } from "@/components/ui/spinner";
 import { authClient } from "@/lib/auth-client";
 import type { OauthProvider } from "@/types";
+import { authHref, currentReturnTo, safeReturnTo } from "../lib/return-to";
 
 /**
  * Why the visitor is being asked to sign in. Browsing never needs an account, so
@@ -55,20 +56,46 @@ type Props = {
   reason: AuthReason | null;
   onReasonChange: (reason: AuthReason) => void;
   onClose: () => void;
+  /**
+   * Adjust where the sign-in comes back to.
+   *
+   * Given the page the visitor is on — path and query, which is the default —
+   * return where they should land instead. It exists for the review draft,
+   * whose caller knows something the URL has stopped saying: `?open=` is spent
+   * on arrival and taken back out, so by the time a guest presses "Post
+   * review" the URL no longer names the tab they are writing in. Putting it
+   * back is what lets the *email* path work at all, since the link in that mail
+   * opens a new tab where the URL is the only thing that arrived.
+   *
+   * A mapper rather than a string, because the page it maps from is read off
+   * `window.location` at the moment of leaving, and this component renders on
+   * the server too.
+   */
+  returnTo?: (here: string) => string;
 };
 
-export function AuthReasonDialog({ reason, onReasonChange, onClose }: Props) {
+export function AuthReasonDialog({
+  reason,
+  onReasonChange,
+  onClose,
+  returnTo,
+}: Props) {
   const router = useRouter();
   const [pending, setPending] = useState<OauthProvider | null>(null);
   const copy = REASONS[reason ?? "log-in"];
 
+  /** Come back to exactly where they were — nothing they were reading is lost. */
+  function destination(): string {
+    const here = currentReturnTo();
+    return safeReturnTo(returnTo ? returnTo(here) : here);
+  }
+
   async function signInWith(provider: OauthProvider) {
     setPending(provider);
     try {
-      // Come back to exactly where they were — nothing they were reading is lost.
       const { error } = await authClient.signIn.social({
         provider,
-        callbackURL: window.location.pathname + window.location.search,
+        callbackURL: destination(),
       });
       if (error) toast.error("Could not sign in. Try again.");
     } catch (error) {
@@ -130,7 +157,7 @@ export function AuthReasonDialog({ reason, onReasonChange, onClose }: Props) {
           <button
             type="button"
             disabled={pending !== null}
-            onClick={() => router.push("/auth")}
+            onClick={() => router.push(authHref(destination()))}
             className="flex h-[42px] items-center justify-center rounded-[9px] border border-cc-rule3 bg-cc-surface font-medium text-[13.5px] text-cc-ink hover:border-cc-hov disabled:opacity-60"
           >
             Continue with email

--- a/apps/web/features/auth/components/magic-link-form.tsx
+++ b/apps/web/features/auth/components/magic-link-form.tsx
@@ -22,6 +22,7 @@ import {
 import { Input } from "@/components/ui/input";
 import { Spinner } from "@/components/ui/spinner";
 import { authClient } from "@/lib/auth-client";
+import { requestedReturnTo } from "../lib/return-to";
 
 const formSchema = z.object({
   email: z.string().email("Enter a valid email address."),
@@ -35,7 +36,11 @@ export function MagicLinkForm() {
     onSubmit: async ({ value }) => {
       const { error } = await authClient.signIn.magicLink({
         email: value.email,
-        callbackURL: "/search",
+        // Where the visitor was when they asked for the link, not the front
+        // door. This is the path that cannot recover a destination any other
+        // way: the link is opened in a new tab, so nothing but the URL the
+        // mail carries survives to say where they were going.
+        callbackURL: requestedReturnTo(),
         errorCallbackURL: "/auth",
       });
       if (error) {

--- a/apps/web/features/auth/lib/return-to.spec.ts
+++ b/apps/web/features/auth/lib/return-to.spec.ts
@@ -1,0 +1,71 @@
+import { describe, expect, it } from "vitest";
+import { authHref, DEFAULT_RETURN_TO, safeReturnTo } from "./return-to";
+
+describe("safeReturnTo", () => {
+  it("keeps a same-site path with its query", () => {
+    expect(safeReturnTo("/search?q=graphs&open=DD2380&kind=review")).toBe(
+      "/search?q=graphs&open=DD2380&kind=review",
+    );
+  });
+
+  it("falls back when nothing was asked for", () => {
+    expect(safeReturnTo(null)).toBe(DEFAULT_RETURN_TO);
+    expect(safeReturnTo(undefined)).toBe(DEFAULT_RETURN_TO);
+    expect(safeReturnTo("")).toBe(DEFAULT_RETURN_TO);
+  });
+
+  /*
+   * The open redirect, in every spelling that has ever been used for one.
+   *
+   * `?next=` is as easy to write as it is to read, so a sign-in that will
+   * forward anywhere is a link on the real site that really signs the victim in
+   * and then hands them to somebody else. A scheme-relative `//host` and a
+   * `/\host` — which browsers normalise to the same thing — are the two that
+   * look local enough to slip a "starts with a slash" check.
+   */
+  it.each([
+    "https://evil.example/steal",
+    "http://evil.example",
+    "//evil.example/steal",
+    String.raw`/\evil.example/steal`,
+    "javascript:alert(1)",
+    "search?q=graphs",
+    "../search",
+  ])("refuses %s", (candidate) => {
+    expect(safeReturnTo(candidate)).toBe(DEFAULT_RETURN_TO);
+  });
+
+  it("refuses a path carrying a control character", () => {
+    const newline = String.fromCharCode(10);
+    const nul = String.fromCharCode(0);
+    expect(safeReturnTo(`/search${newline}Set-Cookie: x`)).toBe(
+      DEFAULT_RETURN_TO,
+    );
+    expect(safeReturnTo(`/search${nul}`)).toBe(DEFAULT_RETURN_TO);
+  });
+
+  // Signing in and landing back on the sign-in page, signed in.
+  it("refuses to come back to the sign-in page", () => {
+    expect(safeReturnTo("/auth")).toBe(DEFAULT_RETURN_TO);
+    expect(safeReturnTo("/auth?next=%2Fsearch")).toBe(DEFAULT_RETURN_TO);
+    expect(safeReturnTo("/auth/callback")).toBe(DEFAULT_RETURN_TO);
+  });
+
+  // `/authors` is not `/auth`, and prefix matching alone would say it is.
+  it("does not mistake another route for the sign-in page", () => {
+    expect(safeReturnTo("/authors")).toBe("/authors");
+  });
+});
+
+describe("authHref", () => {
+  it("carries the destination the email path cannot carry any other way", () => {
+    expect(authHref("/search?q=graphs&open=DD2380&kind=review")).toBe(
+      "/auth?next=%2Fsearch%3Fq%3Dgraphs%26open%3DDD2380%26kind%3Dreview",
+    );
+  });
+
+  it("says nothing when there is nothing to say", () => {
+    expect(authHref(DEFAULT_RETURN_TO)).toBe("/auth");
+    expect(authHref("https://evil.example")).toBe("/auth");
+  });
+});

--- a/apps/web/features/auth/lib/return-to.ts
+++ b/apps/web/features/auth/lib/return-to.ts
@@ -1,0 +1,99 @@
+/**
+ * Where a sign-in comes back to.
+ *
+ * Signing in is a round trip through somebody else's site, and Better Auth
+ * needs to be told where to land afterwards. `AuthReasonDialog` has always told
+ * it the truth — "You keep everything you were looking at" is a promise its
+ * `callbackURL` keeps — while the two controls on `/auth` sent everyone to
+ * `/search` regardless of where they came from. That is the difference between
+ * a student returning to the draft they were writing and a student returning to
+ * an empty search box, and it is the whole of what this file is for.
+ *
+ * The route carries the destination in `?next=`, because the email path has no
+ * other way to carry anything: the dialog navigates to `/auth`, `/auth` sends
+ * mail, and the link in that mail is opened in a new tab whose React state,
+ * history and per-tab storage are all empty. The URL is the only thing that
+ * survives that.
+ *
+ * ## Only a path, ever
+ *
+ * A destination taken off the URL is attacker-controlled — `?next=` is exactly
+ * as easy to write as it is to read, and a sign-in flow that will forward to
+ * anything is the standard shape of an open redirect: the victim clicks a link
+ * on the real site, really signs in, and lands somewhere else entirely with
+ * their guard down. So `safeReturnTo` takes a same-site *path* or nothing, and
+ * every way of spelling "somewhere else" is nothing: an absolute URL, a
+ * scheme-relative `//evil.example`, a backslash the browser normalises into
+ * one, or anything that does not begin at the site root.
+ *
+ * Better Auth checks `callbackURL` against its trusted origins too. This is the
+ * near side of that, and it is the side that decides whether the fallback is
+ * used at all.
+ */
+
+/** Where sign-in lands when the URL does not say, and the app's front door. */
+export const DEFAULT_RETURN_TO = "/search";
+
+/** The parameter `/auth` reads its destination from. */
+export const RETURN_TO_PARAM = "next";
+
+/**
+ * A same-site path to return to, or `DEFAULT_RETURN_TO`.
+ *
+ * Pure, and takes the candidate rather than reading the URL, so the rules above
+ * are testable without a browser.
+ */
+export function safeReturnTo(candidate: string | null | undefined): string {
+  if (typeof candidate !== "string") return DEFAULT_RETURN_TO;
+  const path = candidate.trim();
+
+  // A path, from the root. Not `//host`, not `/\host` — browsers read the
+  // backslash as a slash and both are "leave this site" written to look local.
+  if (!path.startsWith("/")) return DEFAULT_RETURN_TO;
+  if (path.startsWith("//") || path.startsWith("/\\")) return DEFAULT_RETURN_TO;
+
+  // A control character inside a URL is either an encoding accident or a header
+  // trick; neither is a page. Checked by code point rather than by regex, so
+  // what is being rejected is named rather than typed.
+  for (const character of path) {
+    const code = character.codePointAt(0) ?? 0;
+    if (code < 0x20 || code === 0x7f) return DEFAULT_RETURN_TO;
+  }
+
+  // Coming back to the sign-in page from the sign-in page is a loop with a
+  // signed-in user standing in it.
+  const route = path.split(/[?#]/, 1)[0];
+  if (route === "/auth" || route.startsWith("/auth/")) return DEFAULT_RETURN_TO;
+
+  return path;
+}
+
+/** The page the visitor is on, query intact, as a return destination. */
+export function currentReturnTo(): string {
+  return safeReturnTo(window.location.pathname + window.location.search);
+}
+
+/** `/auth`, told where to send the visitor once they are in. */
+export function authHref(returnTo: string): string {
+  const path = safeReturnTo(returnTo);
+  if (path === DEFAULT_RETURN_TO) return "/auth";
+  return `/auth?${RETURN_TO_PARAM}=${encodeURIComponent(path)}`;
+}
+
+/**
+ * What `/auth` was asked to return to, read off its own URL.
+ *
+ * Read from `window.location` rather than through `useSearchParams`, because
+ * both callers need it inside a submit handler and neither needs it during a
+ * render — so there is nothing here for a Suspense boundary to wait on, and
+ * `/auth` stays as statically renderable as it was.
+ */
+export function requestedReturnTo(): string {
+  try {
+    return safeReturnTo(
+      new URLSearchParams(window.location.search).get(RETURN_TO_PARAM),
+    );
+  } catch {
+    return DEFAULT_RETURN_TO;
+  }
+}

--- a/apps/web/features/reviews/lib/reviewer-session.ts
+++ b/apps/web/features/reviews/lib/reviewer-session.ts
@@ -14,11 +14,18 @@ import {
  * is not re-derivable from the server: which courses were skipped, and which
  * were already answered this round, exist nowhere else.
  *
- * `sessionStorage`, not `localStorage`, for the same reason the workspace pane
- * chose it (`features/workspace/lib/workspace-storage.ts`): a half-finished
- * queue belongs to the tab it was started in and has no business still being
- * there next week. Nothing kept here is data — an unsaved card has no row —
- * which is exactly why the browser is the right place for it.
+ * `sessionStorage`, not `localStorage`, for the reason the workspace pane
+ * still keeps its *open list* there (`features/workspace/lib/workspace-storage.ts`):
+ * a half-finished queue belongs to the tab it was started in and has no business
+ * still being there next week. Nothing kept here is data — an unsaved card has no
+ * row — which is exactly why the browser is the right place for it.
+ *
+ * That file's *draft* has since moved to `localStorage`, and the difference is
+ * worth naming rather than copying by habit: the workspace throws a guest out of
+ * the tab to sign in, and the magic-link path lands them in a new one. Nothing
+ * here does that. `/taken` is behind `proxy.ts`, so a reviewer working through
+ * this queue is already signed in and the tab they started in is the tab they
+ * finish in.
  *
  * Every read is defensive. What comes back is whatever was in the tab's
  * storage, possibly written by an older build, so anything that does not match

--- a/apps/web/features/workspace/components/review-draft-panel.tsx
+++ b/apps/web/features/workspace/components/review-draft-panel.tsx
@@ -27,6 +27,7 @@ import {
   MAX_REVIEW_SCORE,
   MIN_REVIEW_SCORE,
 } from "@/types";
+import { withOpenCourse } from "../lib/open-courses";
 import {
   EMPTY_REVIEW_DRAFT,
   isUntouched,
@@ -219,7 +220,7 @@ export function ReviewDraftPanel({
    * What was published, once something was.
    *
    * A published draft is no longer a draft — it is a Review, with a row — so
-   * the workspace forgets it and stops keeping it in the tab's storage.
+   * the workspace forgets it and stops keeping it in the browser's storage.
    * Reopening the tab a week later must not offer a second copy of a review
    * that is already live. The panel keeps its own snapshot so the writer can
    * still see what they sent, and stops taking edits to it.
@@ -237,8 +238,10 @@ export function ReviewDraftPanel({
   }
 
   // Signing in navigated the page away and back. The draft came with it
-  // through `sessionStorage`; this is the note that says so, and only the
-  // course that asked for the sign-in may claim it.
+  // through `localStorage`; this is the note that says so, and only the course
+  // that asked for the sign-in may claim it. The note itself is per-tab, so it
+  // greets the tab that was thrown out — the magic link opens a new one, which
+  // gets its draft back without being told it was ever at risk.
   useEffect(() => {
     if (sessionLoading || !isAuthenticated) return;
     if (claimAwaitingSignIn(courseCode)) setJustSignedIn(true);
@@ -725,10 +728,36 @@ export function ReviewDraftPanel({
           Recorded because a deviation nobody wrote down is a deviation the next
           pass "restores". Do not add the button. */}
       <div className="sticky bottom-0 mt-auto border-cc-rule border-t bg-cc-surface">
-        {justSignedIn && !justPublished && (
+        {/* Two greetings, because there are two things that can have happened
+            and the banner used to claim the good one either way.
+
+            "Your draft came back untouched" was rendered on `justSignedIn`
+            alone, with nothing in the condition that had so much as looked at
+            the draft — so the guest whose draft had just been overwritten with
+            `{}` was told, on the empty form, that it had come back untouched.
+            The overwrite is fixed in `workspace-pane.tsx`, and this is fixed
+            separately, because a banner that asserts something it never checked
+            is wrong even on the day nothing else is.
+
+            The empty case is a sentence rather than silence. `publish()` only
+            reaches the sign-in prompt with an answered draft (`:353`), so a
+            draft that is untouched on the way back is not a writer who typed
+            nothing — it is work that existed and is gone, and the only useful
+            thing to say is which. Silence would leave them staring at a blank
+            form deciding whether they had imagined filling it in; the tint is
+            the danger family, because this is the one banner here that reports
+            a loss. */}
+        {justSignedIn && !justPublished && !isUntouched(draft) && (
           <p className="flex items-center gap-2.5 border-cc-rule border-b bg-cc-pill px-5 py-2.5 text-[12.5px] text-cc-brand leading-[1.45]">
             Signed in{user?.name ? ` as ${user.name}` : ""}. Your draft came
             back untouched — check it and publish when you are ready.
+          </p>
+        )}
+        {justSignedIn && !justPublished && isUntouched(draft) && (
+          <p className="flex items-center gap-2.5 border-cc-rule border-b bg-cc-danger-tint px-5 py-2.5 text-[12.5px] text-cc-danger-ink leading-[1.45]">
+            Signed in{user?.name ? ` as ${user.name}` : ""}, but your draft did
+            not come back — this browser did not keep it. Sorry; you will have
+            to write it again.
           </p>
         )}
         {/* The success tint family, which is what the artboard draws:
@@ -786,6 +815,12 @@ export function ReviewDraftPanel({
       <AuthReasonDialog
         reason={authReason}
         onReasonChange={setAuthReason}
+        // Sign in and come back to *this tab*, not just to this page. `?open=`
+        // has been spent and removed by now, so the URL alone would bring them
+        // back to the search behind the pane with the draft nowhere on screen.
+        // It matters most on the email path, which opens a new tab where the
+        // URL is the only thing that arrives.
+        returnTo={(here) => withOpenCourse(here, courseCode, "review")}
         onClose={() => {
           setAuthReason(null);
           // Backing out of the dialog is not signing in, so the note that

--- a/apps/web/features/workspace/components/review-draft-panel.tsx
+++ b/apps/web/features/workspace/components/review-draft-panel.tsx
@@ -740,8 +740,9 @@ export function ReviewDraftPanel({
             is wrong even on the day nothing else is.
 
             The empty case is a sentence rather than silence. `publish()` only
-            reaches the sign-in prompt with an answered draft (`:353`), so a
-            draft that is untouched on the way back is not a writer who typed
+            reaches the sign-in prompt with an answered draft — it returns before
+            it unless `toReviewFormData` gave it a form — so a draft that is
+            untouched on the way back is not a writer who typed
             nothing — it is work that existed and is gone, and the only useful
             thing to say is which. Silence would leave them staring at a blank
             form deciding whether they had imagined filling it in; the tint is

--- a/apps/web/features/workspace/components/workspace-pane.spec.tsx
+++ b/apps/web/features/workspace/components/workspace-pane.spec.tsx
@@ -10,7 +10,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import { sanitizeHtml } from "@/lib/sanitize-html";
 import type { CourseDetails, CourseStats } from "@/types";
 import type { OpenCourse } from "../lib/open-courses";
-import { EMPTY_REVIEW_DRAFT } from "../lib/review-draft";
+import { EMPTY_REVIEW_DRAFT, type ReviewDraft } from "../lib/review-draft";
 import {
   markAwaitingSignIn,
   readDrafts,
@@ -818,7 +818,7 @@ describe("what survives a page load", () => {
  */
 describe("a stored draft, and what mounting does to it", () => {
   it("does not blank a draft belonging to a course the pane never shows", () => {
-    writeDrafts({
+    storeDraft({
       SF1626: { ...EMPTY_REVIEW_DRAFT, message: "Half a thought" },
     });
 
@@ -828,7 +828,7 @@ describe("a stored draft, and what mounting does to it", () => {
   });
 
   it("hands a stored draft back to its tab, and leaves it in storage", async () => {
-    writeDrafts({
+    storeDraft({
       DD2380: { ...EMPTY_REVIEW_DRAFT, message: "Half a thought" },
     });
 
@@ -850,7 +850,7 @@ describe("a stored draft, and what mounting does to it", () => {
    * exclusive ternary — so this test is the conditional, not the screens.
    */
   it("does not blank a draft when two panes mount in the same commit", async () => {
-    writeDrafts({
+    storeDraft({
       DD2380: { ...EMPTY_REVIEW_DRAFT, message: "Half a thought" },
     });
     const props = {
@@ -885,7 +885,7 @@ describe("a stored draft, and what mounting does to it", () => {
 describe("what the writer is told on the way back", () => {
   function comeBackSignedIn(stored?: string) {
     if (stored !== undefined) {
-      writeDrafts({ DD2380: { ...EMPTY_REVIEW_DRAFT, message: stored } });
+      storeDraft({ DD2380: { ...EMPTY_REVIEW_DRAFT, message: stored } });
     }
     markAwaitingSignIn("DD2380");
     useMe.mockReturnValue({
@@ -915,6 +915,15 @@ describe("what the writer is told on the way back", () => {
     expect(screen.queryByText(/came back untouched/)).not.toBeInTheDocument();
   });
 });
+
+/**
+ * A draft already in the browser when the pane mounts — another tab's, or this
+ * one's from before the sign-in. The empty baseline says "nothing synchronised
+ * yet", which is what a first write is.
+ */
+function storeDraft(drafts: Record<string, ReviewDraft>) {
+  writeDrafts(drafts, {});
+}
 
 /** The score tracks are range inputs behind the design's own bar. */
 function setScore(label: string, value: number) {

--- a/apps/web/features/workspace/components/workspace-pane.spec.tsx
+++ b/apps/web/features/workspace/components/workspace-pane.spec.tsx
@@ -10,6 +10,12 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import { sanitizeHtml } from "@/lib/sanitize-html";
 import type { CourseDetails, CourseStats } from "@/types";
 import type { OpenCourse } from "../lib/open-courses";
+import { EMPTY_REVIEW_DRAFT } from "../lib/review-draft";
+import {
+  markAwaitingSignIn,
+  readDrafts,
+  writeDrafts,
+} from "../lib/workspace-storage";
 import { WorkspacePane } from "./workspace-pane";
 
 const useCourseDetails = vi.fn();
@@ -785,6 +791,128 @@ describe("what survives a page load", () => {
     renderPane([openCourse("review", "SF1626")]);
 
     expect(screen.queryByText(/Signed in as/)).not.toBeInTheDocument();
+  });
+});
+
+/*
+ * The bug this block exists for, and why the round trip above never caught it.
+ *
+ * The pane mirrors its drafts into storage in an effect, gated on having
+ * restored them first. That gate used to be a ref, set synchronously inside the
+ * restore effect while the state it described was still `{}` — so for one
+ * render the mirror was armed over nothing and wrote `{}` over every stored
+ * draft. It healed on the next commit, and anything reading storage in between
+ * adopted the blank. Strict Mode's replayed mount reads exactly there:
+ *
+ *     GET drafts -> {"DD2380":{... "message":"Half a thought"}}
+ *     SET drafts = {}
+ *     GET drafts -> {}
+ *     SET drafts = {}
+ *
+ * "keeps a draft across a remount" never caught it because it unmounts and
+ * mounts again — one mount each, and this needs two in a row. Every test in
+ * this file now runs in Strict Mode (`vitest.setup.ts`), so a mount here is the
+ * mount a developer gets. These assert on what is left in storage rather than
+ * on what is on screen, because the screen recovers a render later and storage
+ * does not.
+ */
+describe("a stored draft, and what mounting does to it", () => {
+  it("does not blank a draft belonging to a course the pane never shows", () => {
+    writeDrafts({
+      SF1626: { ...EMPTY_REVIEW_DRAFT, message: "Half a thought" },
+    });
+
+    renderPane([openCourse("details")]);
+
+    expect(readDrafts().SF1626?.message).toBe("Half a thought");
+  });
+
+  it("hands a stored draft back to its tab, and leaves it in storage", async () => {
+    writeDrafts({
+      DD2380: { ...EMPTY_REVIEW_DRAFT, message: "Half a thought" },
+    });
+
+    renderPane([openCourse("review")]);
+
+    expect(
+      await screen.findByRole("textbox", { name: "Write your review" }),
+    ).toHaveValue("Half a thought");
+    await waitFor(() =>
+      expect(readDrafts().DD2380?.message).toBe("Half a thought"),
+    );
+  });
+
+  /*
+   * The same failure with no Strict Mode in it. Two panes mounting in one
+   * commit is the second pane restoring from storage that the first pane's
+   * premature mirror has already emptied. It is unreachable through Explore and
+   * Saved today, which gate their column and their mobile sheet on one mutually
+   * exclusive ternary — so this test is the conditional, not the screens.
+   */
+  it("does not blank a draft when two panes mount in the same commit", async () => {
+    writeDrafts({
+      DD2380: { ...EMPTY_REVIEW_DRAFT, message: "Half a thought" },
+    });
+    const props = {
+      openCourses: [openCourse("review")],
+      activeId: "review:DD2380",
+      onActivate: vi.fn(),
+      onClose: vi.fn(),
+      onOpen: vi.fn(),
+    };
+
+    render(
+      <>
+        <WorkspacePane {...props} />
+        <WorkspacePane {...props} hideTabs />
+      </>,
+    );
+
+    await waitFor(() =>
+      expect(readDrafts().DD2380?.message).toBe("Half a thought"),
+    );
+  });
+});
+
+/*
+ * "Your draft came back untouched" used to render on `justSignedIn` alone, with
+ * nothing in the condition that had looked at the draft — so the writer whose
+ * draft had just been destroyed was told, on the empty form, that it had come
+ * back untouched. Publishing only ever reaches the sign-in prompt with an
+ * answered draft, so an empty one on the way back is not somebody who typed
+ * nothing.
+ */
+describe("what the writer is told on the way back", () => {
+  function comeBackSignedIn(stored?: string) {
+    if (stored !== undefined) {
+      writeDrafts({ DD2380: { ...EMPTY_REVIEW_DRAFT, message: stored } });
+    }
+    markAwaitingSignIn("DD2380");
+    useMe.mockReturnValue({
+      isAuthenticated: true,
+      isLoading: false,
+      userId: "u1",
+      user: { name: "Elsa Lindqvist" },
+    });
+    renderPane([openCourse("review")]);
+  }
+
+  it("says the draft came back when it did", async () => {
+    comeBackSignedIn("Half a thought");
+
+    expect(
+      await screen.findByText(/Your draft came back untouched/),
+    ).toBeInTheDocument();
+    expect(screen.queryByText(/did not come back/)).not.toBeInTheDocument();
+  });
+
+  it("says the draft did not come back rather than claiming it did", async () => {
+    comeBackSignedIn();
+
+    expect(
+      await screen.findByText(/your draft did not come back/),
+    ).toBeInTheDocument();
+    expect(screen.queryByText(/came back untouched/)).not.toBeInTheDocument();
   });
 });
 

--- a/apps/web/features/workspace/components/workspace-pane.tsx
+++ b/apps/web/features/workspace/components/workspace-pane.tsx
@@ -64,12 +64,15 @@ export interface WorkspacePaneProps {
  *
  * Each open course is a tab, and a tab is either the course's **details** or a
  * **review draft** for it — so a student can read three courses and write a
- * review without losing the search behind them. Nothing here is persisted;
- * closing the last tab is the whole of "closing the pane".
+ * review without losing the search behind them. Closing the last tab is the
+ * whole of "closing the pane".
  *
  * The open list belongs to the host screen (`useWorkspacePane`), which needs
  * it to size its results column. Drafts belong here, keyed by course, so
- * switching tabs never loses half-written text.
+ * switching tabs never loses half-written text — and outlive the page, in
+ * `localStorage`, because signing in navigates away and back and sometimes
+ * lands in a different tab entirely. `workspace-storage.ts` is where that split
+ * is argued.
  */
 export function WorkspacePane({
   openCourses,
@@ -82,25 +85,85 @@ export function WorkspacePane({
 }: Readonly<WorkspacePaneProps>) {
   const [drafts, setDrafts] = useState<Record<string, ReviewDraft>>({});
   const [published, setPublished] = useState<Record<string, number>>({});
-  const restored = useRef(false);
+  /**
+   * Whether the two states above hold what storage held, and why this is state
+   * and not a `useRef`.
+   *
+   * Drafts, and what has already been published, outlive the tab they were
+   * written in: signing in navigates the page away and back, and a review tab
+   * is a thing you come back to. Both are restored in an effect rather than in
+   * the initial state, so the first client render matches the server's, and
+   * mirrored back in an effect on every change.
+   *
+   * That pairing needs a gate — the mirror must not run before the restore —
+   * and the gate has to *move with the value it guards*. A ref does not. A ref
+   * set inside the restore effect flips synchronously while `drafts` is still
+   * `{}`, so for one render the mirror is armed over pre-restore state and
+   * writes `{}` over everything stored. It self-heals on the next commit, which
+   * is why this survived review, and it self-heals too late for anything that
+   * reads storage inside that window:
+   *
+   *     GET drafts -> {"DD2380":{…,"message":"Half a thought"}}   restore
+   *     SET drafts = {}                                           mirror, too early
+   *     GET drafts -> {}                                          restore, replayed
+   *     SET drafts = {}
+   *
+   * That third line is React Strict Mode replaying the mount effects, which it
+   * does in development on every App Router page — and it lands exactly in the
+   * window, adopts the blank it just caused, and makes the loss permanent. The
+   * guest who filled in a draft, signed in and came back to an empty form was
+   * reading their own draft being overwritten with nothing.
+   *
+   * As state, `hydrated` is committed in the same batch as the value it
+   * describes: no render exists in which it is `true` and the state is still
+   * empty, so no mirror can carry an empty value. That holds for a replayed
+   * mount, and it holds for the case with no Strict Mode in it at all — two
+   * panes mounting in one commit, where the second pane's restore reads what
+   * the first pane's premature mirror wrote. `explore.tsx` and `saved.tsx`
+   * happen to gate their two hosts on the same ternary today, so that one is
+   * latent rather than live; it is closed here either way, because "latent"
+   * means "one conditional away".
+   *
+   * The alternative is to drop the mirror and write through from `patchDraft` /
+   * `markPublished` instead, which cannot regress this way because there is no
+   * effect to arm early. It was rejected for two reasons. It spreads the
+   * obligation to persist across every mutator that exists — including
+   * `forgetPublished`, and including the next one somebody adds, which fails
+   * silently by simply not writing — where one effect covers all of them by
+   * construction. And computing the value to write means either doing it inside
+   * the state updater, which Strict Mode double-invokes, or reading `drafts`
+   * from the render closure, which gives up the functional updater that keeps
+   * two courses' edits in one batch from overwriting each other. The gate below
+   * is a total invariant over one write path; write-through is a promise every
+   * future call site has to keep.
+   *
+   * The *read* below is guarded the other way round, by a ref, and the
+   * asymmetry is the point. Restoring has to happen once per mount and not once
+   * per effect run: a replayed restore reads storage that whatever has happened
+   * since has not been mirrored into yet, and puts the older value back over the
+   * newer one. A ref is what survives the replay to say "already done"; state
+   * would be `false` in both passes, because neither has re-rendered. So the
+   * read is gated on a ref and the write on state, each on the only thing that
+   * can do its job.
+   */
+  const [hydrated, setHydrated] = useState(false);
+  const read = useRef(false);
 
-  // Drafts, and what has already been published, outlive the tab they were
-  // written in: signing in navigates the page away and back, and a review tab
-  // is a thing you come back to. Restored in an effect so the first client
-  // render matches the server's.
   useEffect(() => {
+    if (read.current) return;
+    read.current = true;
     setDrafts(readDrafts());
     setPublished(readPublished());
-    restored.current = true;
+    setHydrated(true);
   }, []);
 
   useEffect(() => {
-    if (restored.current) writeDrafts(drafts);
-  }, [drafts]);
+    if (hydrated) writeDrafts(drafts);
+  }, [hydrated, drafts]);
 
   useEffect(() => {
-    if (restored.current) writePublished(published);
-  }, [published]);
+    if (hydrated) writePublished(published);
+  }, [hydrated, published]);
 
   const active =
     openCourses.find((entry) => entry.id === activeId) ?? openCourses[0];

--- a/apps/web/features/workspace/components/workspace-pane.tsx
+++ b/apps/web/features/workspace/components/workspace-pane.tsx
@@ -148,17 +148,33 @@ export function WorkspacePane({
    */
   const [hydrated, setHydrated] = useState(false);
   const read = useRef(false);
+  /**
+   * What this pane and storage last agreed on, per course.
+   *
+   * `localStorage` is shared between tabs, so "what the pane holds" is no
+   * longer the same statement as "what should be stored": a pane carries every
+   * draft it hydrated, including ones it has not touched since, and another tab
+   * may have moved them on. Handing `writeDrafts` this baseline is what lets it
+   * tell "I changed this" from "I am simply still holding it", and write only
+   * the first. Set at the restore and after every write, which are exactly the
+   * moments the two are known to agree.
+   */
+  const synced = useRef<Record<string, ReviewDraft>>({});
 
   useEffect(() => {
     if (read.current) return;
     read.current = true;
-    setDrafts(readDrafts());
+    const restored = readDrafts();
+    synced.current = restored;
+    setDrafts(restored);
     setPublished(readPublished());
     setHydrated(true);
   }, []);
 
   useEffect(() => {
-    if (hydrated) writeDrafts(drafts);
+    if (!hydrated) return;
+    writeDrafts(drafts, synced.current);
+    synced.current = drafts;
   }, [hydrated, drafts]);
 
   useEffect(() => {

--- a/apps/web/features/workspace/hooks/use-workspace-pane.spec.tsx
+++ b/apps/web/features/workspace/hooks/use-workspace-pane.spec.tsx
@@ -64,12 +64,17 @@ describe("useWorkspacePane", () => {
    * allocate a workspace per turn, and the value every host reads keeps its
    * identity, so no dependency downstream is rebuilt and nothing calls back in.
    *
-   * The count is asserted with a ceiling rather than an equality because React
-   * may still render the owner of the state once before it bails out of the
-   * tree — that is documented and bounded. What the loop needed was a count
-   * that climbed with every turn, and that is what stops here. Every other
-   * assertion is an identity one: a structural comparison would pass on exactly
-   * the value that used to loop.
+   * The count is asserted as *not growing with the turns* rather than against a
+   * number, because there is no honest number to assert. React may render the
+   * owner of the state once before it bails out of the tree — documented and
+   * bounded — and Strict Mode renders everything twice on top of that, so any
+   * literal here would be a transcription of today's React rather than a
+   * statement about this hook. What the loop needed was a count that climbed
+   * with every turn; five more turns adding nothing is exactly the absence of
+   * that, and it stays true whatever the multiplier is.
+   *
+   * Every other assertion is an identity one: a structural comparison would
+   * pass on exactly the value that used to loop.
    */
   it("settles when the course already in front is opened again", () => {
     let renders = 0;
@@ -80,16 +85,50 @@ describe("useWorkspacePane", () => {
 
     act(() => result.current.open("DD2380", "details"));
     const workspace = result.current;
-    const settled = renders;
 
-    for (let turn = 0; turn < 5; turn += 1) {
-      act(() => result.current.open("DD2380", "details"));
-      act(() => result.current.activate("details:DD2380"));
+    function reopenFiveTimes() {
+      for (let turn = 0; turn < 5; turn += 1) {
+        act(() => result.current.open("DD2380", "details"));
+        act(() => result.current.activate("details:DD2380"));
+      }
     }
 
-    expect(renders).toBeLessThanOrEqual(settled + 1);
+    reopenFiveTimes();
+    const settled = renders;
+    reopenFiveTimes();
+
+    expect(renders).toBe(settled);
     expect(result.current).toBe(workspace);
     expect(result.current.openCourses).toBe(workspace.openCourses);
+  });
+
+  /*
+   * The bug, at the hook. The mirror effect used to be gated on a ref set
+   * inside the restore effect, which flips while `workspace` is still empty —
+   * so one render's mirror wrote an empty workspace over the stored one, and
+   * Strict Mode's replayed restore read exactly there and adopted it. A stored
+   * workspace with one open tab came back as zero tabs.
+   *
+   * Asserted on what is left in storage as well as on what the hook returns,
+   * because the return value recovers a render later and the storage does not.
+   */
+  it("does not blank the stored open list on the way to restoring it", () => {
+    sessionStorage.setItem(
+      "cc.workspace.open",
+      JSON.stringify({
+        open: [{ id: "review:DD2380", courseCode: "DD2380", kind: "review" }],
+        activeId: "review:DD2380",
+      }),
+    );
+
+    const { result } = renderHook(() => useWorkspacePane());
+
+    expect(result.current.openCourses.map((entry) => entry.id)).toEqual([
+      "review:DD2380",
+    ]);
+    expect(
+      JSON.parse(sessionStorage.getItem("cc.workspace.open") ?? "{}").open,
+    ).toHaveLength(1);
   });
 
   it("ignores whatever else is in the tab's storage", () => {

--- a/apps/web/features/workspace/hooks/use-workspace-pane.ts
+++ b/apps/web/features/workspace/hooks/use-workspace-pane.ts
@@ -24,19 +24,57 @@ import { readWorkspace, writeWorkspace } from "../lib/workspace-storage";
  * OAuth redirect away and back — returns the student to the courses they had
  * open rather than to an empty pane. Restoring happens in an effect rather
  * than in the initial state so the server and the first client render agree.
+ *
+ * ## Why `hydrated` is state and not a ref
+ *
+ * The mirror effect below must not run before the restore effect above, and
+ * the gate that says so has to be committed *with* the value it guards. A ref
+ * is not: `restored.current = true` inside the restore effect flips
+ * synchronously while `workspace` is still `EMPTY_WORKSPACE`, so for exactly
+ * one render the mirror is armed over pre-restore state and writes an empty
+ * workspace over the stored one. It self-heals on the next commit — and too
+ * late for anything that reads storage inside that window. React Strict Mode
+ * replaying the mount effects reads precisely there, which is why a stored
+ * workspace with one open tab came back as zero tabs in development.
+ *
+ * As state, `hydrated` cannot be `true` in a render where `workspace` is still
+ * the placeholder, so there is no write path that can carry one. Same bug, same
+ * shape and same fix as the drafts and published maps in `workspace-pane.tsx`;
+ * the long version of the reasoning, including why write-through was not the
+ * answer, is written out there.
+ *
+ * ## And why the *read* is guarded by a ref, which is not the same thing
+ *
+ * Restoring must happen once per mount, ever — not once per effect run. Strict
+ * Mode runs the mount effects, tears them down and runs them again, and by the
+ * second pass the workspace may already have moved: `use-explore.ts` spends a
+ * `?open=` in its own mount effect, so a reader arriving on
+ * `/course/DD2380` has a tab open before the replay, and a replayed restore
+ * reads storage that has not caught up yet and puts the empty workspace back.
+ * The tab opens and vanishes in the same commit, and `use-explore` will not
+ * reopen it because it has already spent the instruction.
+ *
+ * So the two guards guard different things and are deliberately different
+ * kinds. `read.current` is a ref because it has to survive the replay — that is
+ * exactly what makes it able to say "already done". `hydrated` is state because
+ * it has to arrive *with* the value it describes. Swapping them is the bug at
+ * both ends.
  */
 export function useWorkspacePane() {
   const [workspace, setWorkspace] = useState<Workspace>(EMPTY_WORKSPACE);
-  const restored = useRef(false);
+  const [hydrated, setHydrated] = useState(false);
+  const read = useRef(false);
 
   useEffect(() => {
+    if (read.current) return;
+    read.current = true;
     setWorkspace(readWorkspace());
-    restored.current = true;
+    setHydrated(true);
   }, []);
 
   useEffect(() => {
-    if (restored.current) writeWorkspace(workspace);
-  }, [workspace]);
+    if (hydrated) writeWorkspace(workspace);
+  }, [hydrated, workspace]);
 
   const open = useCallback((courseCode: string, kind: OpenCourseKind) => {
     setWorkspace((current) => openCourse(current, courseCode, kind));

--- a/apps/web/features/workspace/lib/open-courses.spec.ts
+++ b/apps/web/features/workspace/lib/open-courses.spec.ts
@@ -9,6 +9,7 @@ import {
   tabLabel,
   tabLayout,
   type Workspace,
+  withOpenCourse,
 } from "./open-courses";
 
 function withOpen(...codes: string[]): Workspace {
@@ -206,5 +207,26 @@ describe("openCourseRequest", () => {
     expect(openCourseRequest(null, "review")).toBeNull();
     expect(openCourseRequest(undefined, undefined)).toBeNull();
     expect(openCourseRequest("   ", "details")).toBeNull();
+  });
+});
+
+describe("withOpenCourse", () => {
+  it("puts the instruction back into a location that has spent it", () => {
+    expect(withOpenCourse("/search?q=graphs", "DD2380", "review")).toBe(
+      "/search?q=graphs&open=DD2380&kind=review",
+    );
+  });
+
+  it("works on a location with no query at all", () => {
+    expect(withOpenCourse("/saved", "SF1626", "details")).toBe(
+      "/saved?open=SF1626&kind=details",
+    );
+  });
+
+  // Two instructions in one URL is one host obeying whichever it reads first.
+  it("replaces an instruction already there rather than adding a second", () => {
+    expect(
+      withOpenCourse("/search?open=SF1626&kind=details", "DD2380", "review"),
+    ).toBe("/search?open=DD2380&kind=review");
   });
 });

--- a/apps/web/features/workspace/lib/open-courses.ts
+++ b/apps/web/features/workspace/lib/open-courses.ts
@@ -67,6 +67,37 @@ export function openCourseRequest(
   return { courseCode, kind: kind === "review" ? "review" : "details" };
 }
 
+/**
+ * A location with `?open=` set to this course, so arriving there opens the tab.
+ *
+ * The inverse of `openCourseRequest`, and it exists for one caller: the sign-in
+ * a guest is sent through from a half-written review. `?open=` is an
+ * instruction, spent and removed the moment a host obeys it, so the URL a
+ * reviewer is looking at while they write has stopped naming the tab they are
+ * writing in. A sign-in that returns to that URL returns to the page without
+ * the tab.
+ *
+ * That is survivable when the sign-in comes back to the same tab, where the
+ * open list is still in `sessionStorage`. It is the whole game when it does
+ * not: the magic link opens a **new** tab, and the URL the mail carries is the
+ * only thing that reaches it. Putting the instruction back is what makes the
+ * draft — which now waits in `localStorage` — have a tab to appear in.
+ *
+ * Takes and returns a path with its query, never an absolute URL, because that
+ * is what a `callbackURL` is allowed to be. See `features/auth/lib/return-to`.
+ */
+export function withOpenCourse(
+  location: string,
+  courseCode: string,
+  kind: OpenCourseKind,
+): string {
+  const [path, query = ""] = location.split("?");
+  const params = new URLSearchParams(query);
+  params.set("open", courseCode);
+  params.set("kind", kind);
+  return `${path}?${params.toString()}`;
+}
+
 /** The id a `(courseCode, kind)` pair always gets, so opening twice is idempotent. */
 function openCourseId(courseCode: string, kind: OpenCourseKind): string {
   return `${kind}:${courseCode}`;

--- a/apps/web/features/workspace/lib/review-draft.ts
+++ b/apps/web/features/workspace/lib/review-draft.ts
@@ -101,7 +101,7 @@ export function isUntouched(draft: ReviewDraft): boolean {
  *
  * The flags are folded away first, and explicitly rather than by relying on the
  * checkboxes having cleared the answers they cover. A draft comes back out of
- * `sessionStorage`, where it may have been written by an older build or by a
+ * `localStorage`, where it may have been written by an older build or by a
  * tab that never finished a keystroke, and `toDraft` reads each field on its
  * own — so a stored draft carrying both a ticked box and the methods it was
  * meant to clear is a shape this has to survive. "I don't remember" wins,

--- a/apps/web/features/workspace/lib/workspace-storage.spec.tsx
+++ b/apps/web/features/workspace/lib/workspace-storage.spec.tsx
@@ -1,0 +1,242 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { EMPTY_REVIEW_DRAFT, type ReviewDraft } from "./review-draft";
+import {
+  claimAwaitingSignIn,
+  markAwaitingSignIn,
+  readDrafts,
+  readPublished,
+  readWorkspace,
+  writeDrafts,
+  writePublished,
+  writeWorkspace,
+} from "./workspace-storage";
+
+/*
+ * A `.spec.tsx` for a module with no JSX in it, on purpose.
+ *
+ * The `logic` vitest project runs `features/**` + `/lib/**` + `.spec.ts` in a node
+ * environment with no DOM, which is right for the arithmetic next door in
+ * `open-courses.ts` and useless here — this module is about `localStorage` and
+ * `sessionStorage`, and there is nothing to assert without them. The `ui`
+ * project is the one with jsdom, and it takes `.spec.tsx`. The extension is the
+ * only thing choosing between them.
+ */
+
+const DRAFTS_KEY = "cc.workspace.drafts";
+const WEEK_MS = 7 * 24 * 60 * 60 * 1000;
+
+function draftWith(over: Partial<ReviewDraft> = {}): ReviewDraft {
+  return { ...EMPTY_REVIEW_DRAFT, message: "Half a thought", ...over };
+}
+
+/** What is actually sitting in the browser, decoder and all bypassed. */
+function storedDrafts(): Record<string, { savedAt: number; draft: unknown }> {
+  return JSON.parse(localStorage.getItem(DRAFTS_KEY) ?? "{}");
+}
+
+function storeRawDraft(
+  courseCode: string,
+  draft: unknown,
+  savedAt = Date.now(),
+) {
+  localStorage.setItem(
+    DRAFTS_KEY,
+    JSON.stringify({ [courseCode]: { savedAt, draft } }),
+  );
+}
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe("drafts", () => {
+  /*
+   * The storage a draft is in is not a detail — it is the whole of whether the
+   * magic-link path works. That link is opened in a new tab, where per-tab
+   * storage is empty by construction, so a draft in `sessionStorage` is a draft
+   * that cannot be there. This asserts the *location*, because a round trip
+   * would pass either way.
+   */
+  it("keeps a draft in localStorage, where a new tab can still find it", () => {
+    writeDrafts({ DD2380: draftWith() });
+
+    expect(localStorage.getItem(DRAFTS_KEY)).not.toBeNull();
+    expect(sessionStorage.getItem(DRAFTS_KEY)).toBeNull();
+    expect(readDrafts().DD2380?.message).toBe("Half a thought");
+  });
+
+  it("forgets a draft nobody came back to for a week", () => {
+    storeRawDraft("DD2380", draftWith(), Date.now() - WEEK_MS - 1000);
+
+    expect(readDrafts()).toEqual({});
+  });
+
+  it("keeps one that is only a day old", () => {
+    storeRawDraft("DD2380", draftWith(), Date.now() - 24 * 60 * 60 * 1000);
+
+    expect(readDrafts().DD2380?.message).toBe("Half a thought");
+  });
+
+  /*
+   * The stamp measures the draft, not the workspace. Every keystroke rewrites
+   * the whole record — the pane mirrors its state — so a stamp that moved on
+   * every write would keep an abandoned draft alive for as long as the student
+   * kept working on the tab beside it, and the week would never elapse.
+   */
+  it("leaves the stamp alone while the draft says the same thing", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-01-01T00:00:00Z"));
+    writeDrafts({ DD2380: draftWith() });
+    const first = storedDrafts().DD2380.savedAt;
+
+    vi.setSystemTime(new Date("2026-01-03T00:00:00Z"));
+    writeDrafts({ DD2380: draftWith() });
+
+    expect(storedDrafts().DD2380.savedAt).toBe(first);
+  });
+
+  it("moves the stamp when the draft changes", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-01-01T00:00:00Z"));
+    writeDrafts({ DD2380: draftWith() });
+    const first = storedDrafts().DD2380.savedAt;
+
+    vi.setSystemTime(new Date("2026-01-03T00:00:00Z"));
+    writeDrafts({ DD2380: draftWith({ message: "A whole thought" }) });
+
+    expect(storedDrafts().DD2380.savedAt).toBeGreaterThan(first);
+  });
+
+  // What `publish()` does: it hands the pane an empty draft for the course it
+  // just sent. That has to be a delete, not a stored blank.
+  it("drops a draft that has been emptied, which is how publishing clears up", () => {
+    writeDrafts({ DD2380: draftWith(), SF1626: draftWith() });
+
+    writeDrafts({ DD2380: EMPTY_REVIEW_DRAFT, SF1626: draftWith() });
+
+    expect(storedDrafts().DD2380).toBeUndefined();
+    expect(readDrafts().SF1626).toBeDefined();
+  });
+
+  it("survives a browser that refuses storage entirely", () => {
+    const getItem = vi
+      .spyOn(Storage.prototype, "getItem")
+      .mockImplementation(() => {
+        throw new Error("storage disabled");
+      });
+    const setItem = vi
+      .spyOn(Storage.prototype, "setItem")
+      .mockImplementation(() => {
+        throw new Error("storage disabled");
+      });
+
+    expect(readDrafts()).toEqual({});
+    expect(() => writeDrafts({ DD2380: draftWith() })).not.toThrow();
+
+    getItem.mockRestore();
+    setItem.mockRestore();
+  });
+});
+
+/*
+ * A decoder that rejects is a decoder that deletes, because the pane writes its
+ * state straight back over storage. So a stored draft that is wrong in one
+ * field has to come back missing that field and nothing else.
+ */
+describe("a stored draft that does not quite fit", () => {
+  it("keeps the write-up and the scores when the examination split is broken", () => {
+    storeRawDraft("DD2380", {
+      ...draftWith({ workloadScore: 8, happyTook: true }),
+      methods: ["exam", "labs"],
+      shares: [60],
+    });
+
+    const draft = readDrafts().DD2380;
+    expect(draft?.message).toBe("Half a thought");
+    expect(draft?.workloadScore).toBe(8);
+    expect(draft?.happyTook).toBe(true);
+    expect(draft?.methods).toEqual([]);
+    expect(draft?.shares).toEqual([]);
+  });
+
+  // A method this build has never heard of used to be cast into
+  // `ExaminationKey[]` unchecked and drawn as a segment with no colour.
+  it("drops a split naming a method this build does not have", () => {
+    storeRawDraft("DD2380", {
+      ...draftWith(),
+      methods: ["exam", "quiz"],
+      shares: [60, 40],
+    });
+
+    expect(readDrafts().DD2380?.methods).toEqual([]);
+    expect(readDrafts().DD2380?.message).toBe("Half a thought");
+  });
+
+  it("drops a split that does not add up to 100", () => {
+    storeRawDraft("DD2380", {
+      ...draftWith(),
+      methods: ["exam", "labs"],
+      shares: [60, 30],
+    });
+
+    expect(readDrafts().DD2380?.methods).toEqual([]);
+  });
+
+  it("keeps a split that is entirely fine", () => {
+    storeRawDraft("DD2380", {
+      ...draftWith(),
+      methods: ["exam", "labs"],
+      shares: [60, 40],
+    });
+
+    expect(readDrafts().DD2380?.methods).toEqual(["exam", "labs"]);
+    expect(readDrafts().DD2380?.shares).toEqual([60, 40]);
+  });
+
+  it("ignores an entry that is not a draft at all", () => {
+    localStorage.setItem(DRAFTS_KEY, JSON.stringify({ DD2380: "nope" }));
+
+    expect(readDrafts()).toEqual({});
+  });
+
+  it("ignores an entry with no stamp, which no build of this ever wrote", () => {
+    localStorage.setItem(DRAFTS_KEY, JSON.stringify({ DD2380: draftWith() }));
+
+    expect(readDrafts()).toEqual({});
+  });
+});
+
+/*
+ * Everything else stayed in the tab, and the split is the point of the change:
+ * an open workspace belongs to the tab it was opened in, a half-written review
+ * belongs to the person who wrote it.
+ */
+describe("what stayed in the tab", () => {
+  it("keeps the open list in sessionStorage", () => {
+    writeWorkspace({
+      open: [{ id: "review:DD2380", courseCode: "DD2380", kind: "review" }],
+      activeId: "review:DD2380",
+    });
+
+    expect(sessionStorage.getItem("cc.workspace.open")).not.toBeNull();
+    expect(localStorage.getItem("cc.workspace.open")).toBeNull();
+    expect(readWorkspace().open).toHaveLength(1);
+  });
+
+  it("keeps the published note in sessionStorage", () => {
+    writePublished({ DD2380: 1700000000000 });
+
+    expect(sessionStorage.getItem("cc.workspace.published")).not.toBeNull();
+    expect(localStorage.getItem("cc.workspace.published")).toBeNull();
+    expect(readPublished().DD2380).toBe(1700000000000);
+  });
+
+  it("keeps the awaiting-sign-in note in sessionStorage, and spends it once", () => {
+    markAwaitingSignIn("DD2380");
+
+    expect(localStorage.getItem("cc.workspace.awaiting-sign-in")).toBeNull();
+    expect(claimAwaitingSignIn("SF1626")).toBe(false);
+    expect(claimAwaitingSignIn("DD2380")).toBe(true);
+    expect(claimAwaitingSignIn("DD2380")).toBe(false);
+  });
+});

--- a/apps/web/features/workspace/lib/workspace-storage.spec.tsx
+++ b/apps/web/features/workspace/lib/workspace-storage.spec.tsx
@@ -29,6 +29,15 @@ function draftWith(over: Partial<ReviewDraft> = {}): ReviewDraft {
   return { ...EMPTY_REVIEW_DRAFT, message: "Half a thought", ...over };
 }
 
+/**
+ * A pane writing drafts it has just typed — nothing synchronised yet, so every
+ * course named is one this tab changed. The baseline is the whole point of the
+ * second argument, so the tests that care about it pass their own.
+ */
+function writeFresh(drafts: Record<string, ReviewDraft>) {
+  writeDrafts(drafts, {});
+}
+
 /** What is actually sitting in the browser, decoder and all bypassed. */
 function storedDrafts(): Record<string, { savedAt: number; draft: unknown }> {
   return JSON.parse(localStorage.getItem(DRAFTS_KEY) ?? "{}");
@@ -58,7 +67,7 @@ describe("drafts", () => {
    * would pass either way.
    */
   it("keeps a draft in localStorage, where a new tab can still find it", () => {
-    writeDrafts({ DD2380: draftWith() });
+    writeFresh({ DD2380: draftWith() });
 
     expect(localStorage.getItem(DRAFTS_KEY)).not.toBeNull();
     expect(sessionStorage.getItem(DRAFTS_KEY)).toBeNull();
@@ -86,11 +95,11 @@ describe("drafts", () => {
   it("leaves the stamp alone while the draft says the same thing", () => {
     vi.useFakeTimers();
     vi.setSystemTime(new Date("2026-01-01T00:00:00Z"));
-    writeDrafts({ DD2380: draftWith() });
+    writeFresh({ DD2380: draftWith() });
     const first = storedDrafts().DD2380.savedAt;
 
     vi.setSystemTime(new Date("2026-01-03T00:00:00Z"));
-    writeDrafts({ DD2380: draftWith() });
+    writeFresh({ DD2380: draftWith() });
 
     expect(storedDrafts().DD2380.savedAt).toBe(first);
   });
@@ -98,24 +107,60 @@ describe("drafts", () => {
   it("moves the stamp when the draft changes", () => {
     vi.useFakeTimers();
     vi.setSystemTime(new Date("2026-01-01T00:00:00Z"));
-    writeDrafts({ DD2380: draftWith() });
+    writeFresh({ DD2380: draftWith() });
     const first = storedDrafts().DD2380.savedAt;
 
     vi.setSystemTime(new Date("2026-01-03T00:00:00Z"));
-    writeDrafts({ DD2380: draftWith({ message: "A whole thought" }) });
+    writeFresh({ DD2380: draftWith({ message: "A whole thought" }) });
 
     expect(storedDrafts().DD2380.savedAt).toBeGreaterThan(first);
   });
 
   // What `publish()` does: it hands the pane an empty draft for the course it
-  // just sent. That has to be a delete, not a stored blank.
+  // just sent. That has to be a delete, not a stored blank — and the baseline
+  // is what says so, since an empty draft a tab never had is not a deletion.
   it("drops a draft that has been emptied, which is how publishing clears up", () => {
-    writeDrafts({ DD2380: draftWith(), SF1626: draftWith() });
+    const held = { DD2380: draftWith(), SF1626: draftWith() };
+    writeFresh(held);
 
-    writeDrafts({ DD2380: EMPTY_REVIEW_DRAFT, SF1626: draftWith() });
+    writeDrafts({ ...held, DD2380: EMPTY_REVIEW_DRAFT }, held);
 
     expect(storedDrafts().DD2380).toBeUndefined();
     expect(readDrafts().SF1626).toBeDefined();
+  });
+
+  /*
+   * A tab carries every draft it hydrated, including ones it has not touched
+   * since. Writing that whole record back would replace a course another tab
+   * has moved on with the copy this tab happens to still be holding — losing
+   * newer work on the way to saving an unrelated draft. The baseline is what
+   * tells "I changed this" apart from "I am still holding it".
+   */
+  it("does not write back a course it is only still holding", () => {
+    // Tab 2 hydrates DD2380 as it stands.
+    writeFresh({ DD2380: draftWith({ message: "First pass" }) });
+    const hydrated = readDrafts();
+
+    // Tab 1 gets further with the same course.
+    writeDrafts(
+      { ...hydrated, DD2380: draftWith({ message: "Second pass" }) },
+      hydrated,
+    );
+
+    // Tab 2, which never touched DD2380 again, saves a different course.
+    writeDrafts({ ...hydrated, SF1626: draftWith() }, hydrated);
+
+    expect(readDrafts().DD2380?.message).toBe("Second pass");
+    expect(readDrafts().SF1626?.message).toBe("Half a thought");
+  });
+
+  it("still writes a course it did change since it synchronised", () => {
+    writeFresh({ DD2380: draftWith({ message: "First pass" }) });
+    const hydrated = readDrafts();
+
+    writeDrafts({ DD2380: draftWith({ message: "Mine now" }) }, hydrated);
+
+    expect(readDrafts().DD2380?.message).toBe("Mine now");
   });
 
   /*
@@ -125,9 +170,9 @@ describe("drafts", () => {
    * must not take the first tab's work with it.
    */
   it("leaves a draft it has never heard of where another tab put it", () => {
-    writeDrafts({ SF1626: draftWith({ message: "Written next door" }) });
+    writeFresh({ SF1626: draftWith({ message: "Written next door" }) });
 
-    writeDrafts({ DD2380: draftWith() });
+    writeFresh({ DD2380: draftWith() });
 
     expect(readDrafts().SF1626?.message).toBe("Written next door");
     expect(readDrafts().DD2380?.message).toBe("Half a thought");
@@ -146,10 +191,66 @@ describe("drafts", () => {
       });
 
     expect(readDrafts()).toEqual({});
-    expect(() => writeDrafts({ DD2380: draftWith() })).not.toThrow();
+    expect(() => writeFresh({ DD2380: draftWith() })).not.toThrow();
 
     getItem.mockRestore();
     setItem.mockRestore();
+  });
+});
+
+/*
+ * Shipping this change must not be the data loss it fixes. The release it
+ * replaces wrote `{ [courseCode]: ReviewDraft }` under the same key in the
+ * tab's `sessionStorage`; a student with a half-written review open at deploy
+ * time still has it, in the place the new code no longer looks.
+ */
+describe("drafts the previous release left behind", () => {
+  const LEGACY = { DD2380: { ...EMPTY_REVIEW_DRAFT, message: "From before" } };
+
+  it("brings a legacy draft across, once, and drops the old key", () => {
+    sessionStorage.setItem(DRAFTS_KEY, JSON.stringify(LEGACY));
+
+    expect(readDrafts().DD2380?.message).toBe("From before");
+    expect(sessionStorage.getItem(DRAFTS_KEY)).toBeNull();
+    expect(storedDrafts().DD2380.savedAt).toBeTypeOf("number");
+    // And it is genuinely in the new home now, not read from the old one again.
+    expect(readDrafts().DD2380?.message).toBe("From before");
+  });
+
+  // A draft written since the deploy is the current one; the copy an old tab
+  // left behind must not replace it.
+  it("lets a draft written since the deploy win", () => {
+    writeFresh({ DD2380: draftWith({ message: "Written since" }) });
+    sessionStorage.setItem(DRAFTS_KEY, JSON.stringify(LEGACY));
+
+    expect(readDrafts().DD2380?.message).toBe("Written since");
+  });
+
+  // The old build stored cleared drafts; this one does not. Carrying one across
+  // would put back an entry the student had emptied.
+  it("does not resurrect a legacy draft that was already empty", () => {
+    sessionStorage.setItem(
+      DRAFTS_KEY,
+      JSON.stringify({ DD2380: EMPTY_REVIEW_DRAFT }),
+    );
+
+    expect(readDrafts()).toEqual({});
+  });
+
+  // Losing the legacy key before the new one is safely written would be the
+  // migration losing the draft it exists to save.
+  it("keeps the old key when the new one cannot be written", () => {
+    sessionStorage.setItem(DRAFTS_KEY, JSON.stringify(LEGACY));
+    const setItem = vi
+      .spyOn(Storage.prototype, "setItem")
+      .mockImplementation(() => {
+        throw new Error("quota exceeded");
+      });
+
+    expect(readDrafts().DD2380?.message).toBe("From before");
+
+    setItem.mockRestore();
+    expect(sessionStorage.getItem(DRAFTS_KEY)).not.toBeNull();
   });
 });
 

--- a/apps/web/features/workspace/lib/workspace-storage.spec.tsx
+++ b/apps/web/features/workspace/lib/workspace-storage.spec.tsx
@@ -118,6 +118,21 @@ describe("drafts", () => {
     expect(readDrafts().SF1626).toBeDefined();
   });
 
+  /*
+   * `localStorage` is shared between tabs, which is the point — and the hazard.
+   * A pane rewriting its whole record used to be exactly right, because the
+   * record *was* the tab's storage. Now a second tab writing its own record
+   * must not take the first tab's work with it.
+   */
+  it("leaves a draft it has never heard of where another tab put it", () => {
+    writeDrafts({ SF1626: draftWith({ message: "Written next door" }) });
+
+    writeDrafts({ DD2380: draftWith() });
+
+    expect(readDrafts().SF1626?.message).toBe("Written next door");
+    expect(readDrafts().DD2380?.message).toBe("Half a thought");
+  });
+
   it("survives a browser that refuses storage entirely", () => {
     const getItem = vi
       .spyOn(Storage.prototype, "getItem")

--- a/apps/web/features/workspace/lib/workspace-storage.ts
+++ b/apps/web/features/workspace/lib/workspace-storage.ts
@@ -96,11 +96,16 @@ function read(which: Area, key: string): unknown {
   }
 }
 
-function write(which: Area, key: string, value: unknown): void {
+/** Reports whether the value landed. The migration below has to know. */
+function write(which: Area, key: string, value: unknown): boolean {
   try {
-    area(which)?.setItem(key, JSON.stringify(value));
+    const store = area(which);
+    if (!store) return false;
+    store.setItem(key, JSON.stringify(value));
+    return true;
   } catch {
     // A browser with storage disabled or full still works; it just forgets.
+    return false;
   }
 }
 
@@ -217,7 +222,7 @@ interface StoredDraft {
  * Every stored draft that is still readable and still young enough, with its
  * stamp — the shape `readDrafts` presents and `writeDrafts` re-stamps against.
  */
-function readStoredDrafts(): Record<string, StoredDraft> {
+function decodeStoredDrafts(): Record<string, StoredDraft> {
   const value = read("local", DRAFTS_KEY);
   if (!isRecord(value)) return {};
 
@@ -232,6 +237,51 @@ function readStoredDrafts(): Record<string, StoredDraft> {
     if (draft) stored[courseCode] = { savedAt, draft };
   }
   return stored;
+}
+
+/**
+ * Drafts the previous release left in `sessionStorage`, brought across once.
+ *
+ * The release this replaces wrote `{ [courseCode]: ReviewDraft }` under the
+ * same key in the tab's storage. Without this, shipping the fix is itself the
+ * data loss it fixes: every student with a half-written review open at deploy
+ * time reloads into a blank form, and their tab still had the draft — it was
+ * simply being looked for in the wrong place. A migration is cheap and the
+ * alternative is a one-off outage of exactly the thing this PR is about.
+ *
+ * Deliberately conservative. The new format wins for any course present in
+ * both, so a draft written since the deploy is never overwritten by the stale
+ * copy the old tab left behind. An untouched legacy draft is not carried at
+ * all — the old build stored those, the new one does not, and resurrecting one
+ * would put an entry back that the student had cleared. The legacy key is
+ * removed only once the new one has actually been written, so a browser that
+ * refuses the write keeps the old value and can try again on the next read.
+ *
+ * It runs at most once per browser: the first read moves everything and drops
+ * the key, and thereafter there is nothing to find.
+ */
+function adoptLegacyDrafts(
+  stored: Record<string, StoredDraft>,
+): Record<string, StoredDraft> | null {
+  const legacy = read("session", DRAFTS_KEY);
+  if (!isRecord(legacy)) return null;
+
+  const now = Date.now();
+  const merged: Record<string, StoredDraft> = { ...stored };
+  for (const [courseCode, candidate] of Object.entries(legacy)) {
+    if (courseCode in merged) continue;
+    const draft = toDraft(candidate);
+    if (!draft || isUntouched(draft)) continue;
+    merged[courseCode] = { savedAt: now, draft };
+  }
+
+  if (write("local", DRAFTS_KEY, merged)) remove("session", DRAFTS_KEY);
+  return merged;
+}
+
+function readStoredDrafts(): Record<string, StoredDraft> {
+  const stored = decodeStoredDrafts();
+  return adoptLegacyDrafts(stored) ?? stored;
 }
 
 export function readDrafts(): Record<string, ReviewDraft> {
@@ -273,47 +323,63 @@ function sameDraft(a: ReviewDraft, b: ReviewDraft): boolean {
 }
 
 /**
- * Store what the pane holds, without trampling what it does not.
+ * Store what this pane has *changed*, and leave everything else alone.
  *
- * A pane says two different things by not naming a course, and the whole of
- * this function is telling them apart.
+ * The second argument is what the pane's state held the last time it and
+ * storage agreed — at hydration, and after each write. Without it this function
+ * cannot tell the two meanings of "the pane is holding an old value" apart, and
+ * both of them matter:
  *
- * A course the pane holds **as an untouched draft** has been cleared, and the
- * entry goes. That is how publishing tidies up after itself — `publish()` hands
- * the pane an empty draft for the course it just sent — and equally how a
- * writer who selects all and deletes gets what they asked for rather than their
- * old text back on the next page load. An untouched draft is not a smaller
- * draft; it is the absence of one.
+ * - The pane has the same text it hydrated, and storage has since moved on.
+ *   Another tab wrote it. This tab has nothing to say and must say nothing.
+ * - The pane's text differs from what it last synchronised. This tab edited it,
+ *   and its version is the one the student is looking at.
  *
- * A course the pane **has never heard of** is somebody else's, and is carried
- * through untouched. This did not arise while drafts were per-tab: a pane's
- * record was the whole of its tab's storage, so rewriting it wholesale was
- * exactly right. `localStorage` is shared, so it no longer is — a second tab
- * writing its own record would silently delete the first tab's draft for
- * another course. The pane hydrates every stored draft into its state, so
- * anything genuinely its own is named here either way; anything unnamed
- * appeared after it hydrated and belongs to whoever wrote it.
+ * Comparing against storage alone cannot separate those — a difference between
+ * memory and storage is equally consistent with either — so `synced` is passed
+ * in rather than guessed at. That is what stops a tab from carrying its whole
+ * hydrated record forward and writing a stale copy of course A back over a
+ * newer one, on its way to saving an unrelated draft for course B.
  *
- * Two tabs editing the *same* course still race, and last write wins. That is
- * the same race two tabs have always had over one draft, and the same one the
- * open list has; nothing here can arbitrate it, and nothing needs to — the
- * losing tab still has its own copy on screen.
+ * The two other rules fall out of the same idea. A course the pane has never
+ * heard of is somebody else's and is carried through untouched. A course the
+ * pane holds as an untouched draft *and has changed since syncing* has been
+ * cleared, and the entry goes — that is how publishing tidies up after itself,
+ * and how a writer who selects all and deletes gets what they asked for rather
+ * than their old text back on the next page load.
+ *
+ * Two tabs editing the *same* course still race, and the last write wins. That
+ * is the race two tabs have always had over one draft, and the losing tab still
+ * has its own copy on screen; what is fixed here is the tab that was not
+ * editing that course at all.
  */
-export function writeDrafts(drafts: Record<string, ReviewDraft>): void {
+export function writeDrafts(
+  drafts: Record<string, ReviewDraft>,
+  synced: Record<string, ReviewDraft>,
+): void {
   const stored = readStoredDrafts();
   const now = Date.now();
+  const changed = (courseCode: string, draft: ReviewDraft) =>
+    !sameDraft(synced[courseCode] ?? EMPTY_REVIEW_DRAFT, draft);
 
   const next: Record<string, StoredDraft> = {};
   for (const [courseCode, entry] of Object.entries(stored)) {
-    if (!(courseCode in drafts)) next[courseCode] = entry;
-  }
-  for (const [courseCode, draft] of Object.entries(drafts)) {
+    const draft = drafts[courseCode];
+    if (draft === undefined || !changed(courseCode, draft)) {
+      next[courseCode] = entry;
+      continue;
+    }
     if (isUntouched(draft)) continue;
-    const previous = stored[courseCode];
-    const unchanged =
-      previous !== undefined && sameDraft(previous.draft, draft);
-    next[courseCode] = { savedAt: unchanged ? previous.savedAt : now, draft };
+    const unchanged = sameDraft(entry.draft, draft);
+    next[courseCode] = { savedAt: unchanged ? entry.savedAt : now, draft };
   }
+
+  for (const [courseCode, draft] of Object.entries(drafts)) {
+    if (courseCode in stored) continue;
+    if (isUntouched(draft) || !changed(courseCode, draft)) continue;
+    next[courseCode] = { savedAt: now, draft };
+  }
+
   write("local", DRAFTS_KEY, next);
 }
 

--- a/apps/web/features/workspace/lib/workspace-storage.ts
+++ b/apps/web/features/workspace/lib/workspace-storage.ts
@@ -273,20 +273,40 @@ function sameDraft(a: ReviewDraft, b: ReviewDraft): boolean {
 }
 
 /**
- * Replace what is stored with what the pane holds.
+ * Store what the pane holds, without trampling what it does not.
  *
- * The whole record is rewritten rather than merged, which is what makes
- * publishing clear up after itself: `publish()` hands the pane an empty draft
- * for the course it just sent, that draft is not written, and the entry is
- * gone. It is also what stops a draft the writer emptied on purpose coming back
- * on the next page load — an untouched draft is not a smaller draft, it is the
- * absence of one, and storage says so.
+ * A pane says two different things by not naming a course, and the whole of
+ * this function is telling them apart.
+ *
+ * A course the pane holds **as an untouched draft** has been cleared, and the
+ * entry goes. That is how publishing tidies up after itself — `publish()` hands
+ * the pane an empty draft for the course it just sent — and equally how a
+ * writer who selects all and deletes gets what they asked for rather than their
+ * old text back on the next page load. An untouched draft is not a smaller
+ * draft; it is the absence of one.
+ *
+ * A course the pane **has never heard of** is somebody else's, and is carried
+ * through untouched. This did not arise while drafts were per-tab: a pane's
+ * record was the whole of its tab's storage, so rewriting it wholesale was
+ * exactly right. `localStorage` is shared, so it no longer is — a second tab
+ * writing its own record would silently delete the first tab's draft for
+ * another course. The pane hydrates every stored draft into its state, so
+ * anything genuinely its own is named here either way; anything unnamed
+ * appeared after it hydrated and belongs to whoever wrote it.
+ *
+ * Two tabs editing the *same* course still race, and last write wins. That is
+ * the same race two tabs have always had over one draft, and the same one the
+ * open list has; nothing here can arbitrate it, and nothing needs to — the
+ * losing tab still has its own copy on screen.
  */
 export function writeDrafts(drafts: Record<string, ReviewDraft>): void {
   const stored = readStoredDrafts();
   const now = Date.now();
 
   const next: Record<string, StoredDraft> = {};
+  for (const [courseCode, entry] of Object.entries(stored)) {
+    if (!(courseCode in drafts)) next[courseCode] = entry;
+  }
   for (const [courseCode, draft] of Object.entries(drafts)) {
     if (isUntouched(draft)) continue;
     const previous = stored[courseCode];

--- a/apps/web/features/workspace/lib/workspace-storage.ts
+++ b/apps/web/features/workspace/lib/workspace-storage.ts
@@ -1,29 +1,57 @@
+import type { ExaminationKey } from "@/features/reviews/lib/review-draft";
+import { EXAMINATION_DISTRIBUTION_KEYS } from "@/types";
 import {
   EMPTY_WORKSPACE,
   type OpenCourse,
   type OpenCourseKind,
   type Workspace,
 } from "./open-courses";
-import { EMPTY_REVIEW_DRAFT, type ReviewDraft } from "./review-draft";
+import {
+  EMPTY_REVIEW_DRAFT,
+  isUntouched,
+  type ReviewDraft,
+} from "./review-draft";
 
 /**
  * What the workspace keeps across a page load, and why it has to.
  *
- * Signing in is an OAuth redirect: the page navigates away and comes back, and
+ * Signing in is a redirect: the page navigates away and comes back, and
  * everything in React state goes with it. `AuthReasonDialog` promises the
  * opposite — "Your draft is held as it is — text, ratings and the course all
  * stay put" — and the artboard says the same in its own words. Keeping that
  * promise is the whole reason this file exists.
  *
- * `sessionStorage`, not `localStorage`: an open workspace belongs to the tab
- * the student is working in, and it should not still be there next week. And
- * nothing here is data — an open course and an unpublished draft have no row
- * anywhere, which is exactly why the browser is the right place for them. A
- * vote or a saved course would not belong here; those have tables.
+ * ## Two storages, because the two things have different lifetimes
  *
- * Every read is defensive. What comes back is whatever was in the tab's
- * storage, which may be from an older build, so anything that does not match
- * the shape is dropped rather than trusted.
+ * The open list, what this workspace published, and the note that it is waiting
+ * on a sign-in are all in `sessionStorage`: an open workspace belongs to the tab
+ * the student is working in, and it should not still be there next week. That
+ * argument is right about tabs and this file still makes it.
+ *
+ * It is not right about the **draft**. A draft's lifetime is "until published or
+ * abandoned", not "until this tab closes", and the one moment we lean hardest on
+ * that promise is the moment we throw the user out of the tab entirely. Google
+ * and GitHub redirect in place, so `sessionStorage` survives them; the magic
+ * link does not. It leaves for `/auth`, sends mail, and the link in that mail is
+ * a plain `href` — the student opens it in a **new tab**, where per-tab storage
+ * is empty by construction and no amount of care on this side can make it not
+ * be. So the draft lives in `localStorage`, keyed by course, and carries a
+ * `savedAt` so a week-old abandoned draft is dropped rather than kept forever —
+ * which is the part of the `sessionStorage` argument worth keeping, expressed as
+ * an explicit expiry instead of as a side effect of closing a tab.
+ *
+ * Nothing here is data either way. An open course and an unpublished draft have
+ * no row anywhere, which is exactly why the browser is the right place for them.
+ * A vote or a saved course would not belong here; those have tables.
+ *
+ * ## Every read is defensive, and a failed read is not a delete
+ *
+ * What comes back is whatever was in storage, which may be from an older build,
+ * so anything that does not match the shape is dropped rather than trusted. But
+ * "dropped" is narrower than it looks: the pane writes its state back over
+ * storage, so anything this file refuses to decode is deleted a keystroke later.
+ * A draft therefore salvages what it can — see `toDraft` — instead of failing
+ * whole.
  */
 
 const WORKSPACE_KEY = "cc.workspace.open";
@@ -31,22 +59,56 @@ const DRAFTS_KEY = "cc.workspace.drafts";
 const PUBLISHED_KEY = "cc.workspace.published";
 const AWAITING_SIGN_IN_KEY = "cc.workspace.awaiting-sign-in";
 
+/**
+ * How long an unpublished draft is kept.
+ *
+ * Long enough that "I will finish this after the exam" works, short enough that
+ * a browser is not still holding half a review from last term. It is checked on
+ * read; the pane writes its hydrated state straight back, so an expired entry is
+ * gone from storage within a commit of being ignored.
+ */
+const DRAFT_TTL_MS = 7 * 24 * 60 * 60 * 1000;
+
 const KINDS: OpenCourseKind[] = ["details", "review"];
 
-function read(key: string): unknown {
+/** The tab's storage, and the browser's. */
+type Area = "session" | "local";
+
+/**
+ * Reading `window.localStorage` at all throws in a few real configurations —
+ * a blocked third-party frame, Firefox with cookies disabled — so even getting
+ * hold of the object is inside the guard, not just using it.
+ */
+function area(which: Area): Storage | null {
   try {
-    const raw = sessionStorage.getItem(key);
+    return which === "local" ? window.localStorage : window.sessionStorage;
+  } catch {
+    return null;
+  }
+}
+
+function read(which: Area, key: string): unknown {
+  try {
+    const raw = area(which)?.getItem(key) ?? null;
     return raw === null ? null : JSON.parse(raw);
   } catch {
     return null;
   }
 }
 
-function write(key: string, value: unknown): void {
+function write(which: Area, key: string, value: unknown): void {
   try {
-    sessionStorage.setItem(key, JSON.stringify(value));
+    area(which)?.setItem(key, JSON.stringify(value));
   } catch {
-    // A tab with storage disabled or full still works; it just forgets.
+    // A browser with storage disabled or full still works; it just forgets.
+  }
+}
+
+function remove(which: Area, key: string): void {
+  try {
+    area(which)?.removeItem(key);
+  } catch {
+    // Nothing to clear if storage is unavailable.
   }
 }
 
@@ -63,7 +125,7 @@ function toOpenCourse(value: unknown): OpenCourse | null {
 }
 
 export function readWorkspace(): Workspace {
-  const value = read(WORKSPACE_KEY);
+  const value = read("session", WORKSPACE_KEY);
   if (!isRecord(value) || !Array.isArray(value.open)) return EMPTY_WORKSPACE;
 
   const open = value.open
@@ -80,29 +142,61 @@ export function readWorkspace(): Workspace {
 }
 
 export function writeWorkspace(workspace: Workspace): void {
-  write(WORKSPACE_KEY, workspace);
+  write("session", WORKSPACE_KEY, workspace);
+}
+
+function isExaminationKey(value: unknown): value is ExaminationKey {
+  return (EXAMINATION_DISTRIBUTION_KEYS as readonly unknown[]).includes(value);
+}
+
+/** The examination split as `ReviewDraft` holds it: two parallel arrays. */
+type ExaminationSplit = Pick<ReviewDraft, "methods" | "shares">;
+
+/**
+ * The stored examination split, or no split at all.
+ *
+ * `methods` and `shares` are parallel, always add up to 100, and name methods
+ * *this* build knows about. A stored `"quiz"` from a build that offered one used
+ * to be cast straight into `ExaminationKey[]` and reach the bar as a segment
+ * with no colour and no label; a length mismatch used to reach `moveDivider` as
+ * arithmetic over `undefined`.
+ *
+ * Anything that fails drops the split and **nothing else**. This check used to
+ * reject the whole draft, and since the pane writes its state back over storage
+ * on the next keystroke, a draft rejected here was a draft permanently deleted —
+ * the write-up and the scores went with the one bad field. A split we cannot
+ * read is a question left unanswered; the rest of the review is still the
+ * writer's work and there is no reason to burn it.
+ */
+function toExaminationSplit(value: Record<string, unknown>): ExaminationSplit {
+  const none: ExaminationSplit = { methods: [], shares: [] };
+
+  const { methods, shares } = value;
+  if (!Array.isArray(methods) || !Array.isArray(shares)) return none;
+  if (methods.length !== shares.length || methods.length === 0) return none;
+
+  const named = methods.filter(isExaminationKey);
+  if (named.length !== methods.length) return none;
+  if (new Set(named).size !== named.length) return none;
+
+  const sizes = shares.filter(
+    (share): share is number => typeof share === "number" && share > 0,
+  );
+  if (sizes.length !== shares.length) return none;
+  if (sizes.reduce((total, share) => total + share, 0) !== 100) return none;
+
+  return { methods: named, shares: sizes };
 }
 
 function toDraft(value: unknown): ReviewDraft | null {
   if (!isRecord(value)) return null;
-
-  const methods = Array.isArray(value.methods) ? value.methods : [];
-  const shares = Array.isArray(value.shares) ? value.shares : [];
-  if (
-    !methods.every((method) => typeof method === "string") ||
-    !shares.every((share) => typeof share === "number") ||
-    methods.length !== shares.length
-  ) {
-    return null;
-  }
 
   const score = (candidate: unknown) =>
     typeof candidate === "number" ? candidate : null;
 
   return {
     ...EMPTY_REVIEW_DRAFT,
-    methods: methods as ReviewDraft["methods"],
-    shares,
+    ...toExaminationSplit(value),
     examinationForgotten: value.examinationForgotten === true,
     approachTheoryPercent: score(value.approachTheoryPercent),
     approachForgotten: value.approachForgotten === true,
@@ -113,20 +207,94 @@ function toDraft(value: unknown): ReviewDraft | null {
   };
 }
 
-export function readDrafts(): Record<string, ReviewDraft> {
-  const value = read(DRAFTS_KEY);
+/** One course's draft with the clock reading that decides when to forget it. */
+interface StoredDraft {
+  savedAt: number;
+  draft: ReviewDraft;
+}
+
+/**
+ * Every stored draft that is still readable and still young enough, with its
+ * stamp — the shape `readDrafts` presents and `writeDrafts` re-stamps against.
+ */
+function readStoredDrafts(): Record<string, StoredDraft> {
+  const value = read("local", DRAFTS_KEY);
   if (!isRecord(value)) return {};
 
+  const oldest = Date.now() - DRAFT_TTL_MS;
+  const stored: Record<string, StoredDraft> = {};
+  for (const [courseCode, entry] of Object.entries(value)) {
+    if (!isRecord(entry)) continue;
+    const { savedAt } = entry;
+    if (typeof savedAt !== "number" || !Number.isFinite(savedAt)) continue;
+    if (savedAt < oldest) continue;
+    const draft = toDraft(entry.draft);
+    if (draft) stored[courseCode] = { savedAt, draft };
+  }
+  return stored;
+}
+
+export function readDrafts(): Record<string, ReviewDraft> {
   const drafts: Record<string, ReviewDraft> = {};
-  for (const [courseCode, candidate] of Object.entries(value)) {
-    const draft = toDraft(candidate);
-    if (draft) drafts[courseCode] = draft;
+  for (const [courseCode, entry] of Object.entries(readStoredDrafts())) {
+    drafts[courseCode] = entry.draft;
   }
   return drafts;
 }
 
+/**
+ * Whether two drafts say the same thing.
+ *
+ * Only used to decide whether a stamp moves. Writing happens on every
+ * keystroke — the pane mirrors its state to storage — and stamping every entry
+ * on every write would mean the TTL measured "when this workspace was last
+ * used" rather than "when this draft was last touched", so a draft abandoned in
+ * one tab would be kept alive by work done in another course's tab beside it.
+ * Never stamping would be worse: a draft edited daily would expire mid-edit.
+ *
+ * Field by field rather than by serialising: both sides are small, and the two
+ * come from different places — one from `toDraft`, one from the panel's
+ * spreads — so their key order is not something to bet a comparison on.
+ */
+function sameDraft(a: ReviewDraft, b: ReviewDraft): boolean {
+  return (
+    a.message === b.message &&
+    a.happyTook === b.happyTook &&
+    a.workloadScore === b.workloadScore &&
+    a.learningScore === b.learningScore &&
+    a.approachTheoryPercent === b.approachTheoryPercent &&
+    a.approachForgotten === b.approachForgotten &&
+    a.examinationForgotten === b.examinationForgotten &&
+    a.methods.length === b.methods.length &&
+    a.shares.length === b.shares.length &&
+    a.methods.every((method, index) => method === b.methods[index]) &&
+    a.shares.every((share, index) => share === b.shares[index])
+  );
+}
+
+/**
+ * Replace what is stored with what the pane holds.
+ *
+ * The whole record is rewritten rather than merged, which is what makes
+ * publishing clear up after itself: `publish()` hands the pane an empty draft
+ * for the course it just sent, that draft is not written, and the entry is
+ * gone. It is also what stops a draft the writer emptied on purpose coming back
+ * on the next page load — an untouched draft is not a smaller draft, it is the
+ * absence of one, and storage says so.
+ */
 export function writeDrafts(drafts: Record<string, ReviewDraft>): void {
-  write(DRAFTS_KEY, drafts);
+  const stored = readStoredDrafts();
+  const now = Date.now();
+
+  const next: Record<string, StoredDraft> = {};
+  for (const [courseCode, draft] of Object.entries(drafts)) {
+    if (isUntouched(draft)) continue;
+    const previous = stored[courseCode];
+    const unchanged =
+      previous !== undefined && sameDraft(previous.draft, draft);
+    next[courseCode] = { savedAt: unchanged ? previous.savedAt : now, draft };
+  }
+  write("local", DRAFTS_KEY, next);
 }
 
 /**
@@ -135,8 +303,14 @@ export function writeDrafts(drafts: Record<string, ReviewDraft>): void {
  * The review itself is the durable record and `reviews.list` is where the pane
  * reads it from — but that is a refetch away, and a review tab reopened before
  * it lands would offer a second draft for a review that already exists. This
- * is the workspace's own memory of what it sent, which needs no round trip and
- * survives the tab being closed and reopened.
+ * is the workspace's own memory of what it sent, which needs no round trip.
+ *
+ * It stays in `sessionStorage` while the draft moves out, and the difference is
+ * what each one is for. The draft is the student's unfinished work and has to
+ * follow them into whatever tab the sign-in link opens. This is a stopgap for
+ * one request in flight, and `reviews.list` — the real record — answers within
+ * seconds of the tab that published. A tab that never asked has nothing to be
+ * stopped from doing.
  *
  * It carries *when*, not just *that*, because it has to know which list
  * responses came after it: a response fetched before the write says nothing
@@ -144,7 +318,7 @@ export function writeDrafts(drafts: Record<string, ReviewDraft>): void {
  * review is there, or somebody deleted it and its author may write another.
  */
 export function readPublished(): Record<string, number> {
-  const value = read(PUBLISHED_KEY);
+  const value = read("session", PUBLISHED_KEY);
   if (!isRecord(value)) return {};
 
   const published: Record<string, number> = {};
@@ -156,7 +330,7 @@ export function readPublished(): Record<string, number> {
 }
 
 export function writePublished(published: Record<string, number>): void {
-  write(PUBLISHED_KEY, published);
+  write("session", PUBLISHED_KEY, published);
 }
 
 /**
@@ -166,23 +340,26 @@ export function writePublished(published: Record<string, number>): void {
  * draft when the pane comes back. It is a one-shot note to the next page load,
  * so claiming it clears it — and only the course it names may claim it, or a
  * different tab coming forward first would swallow the note.
+ *
+ * `sessionStorage`, deliberately, even though the draft it accompanies is not.
+ * The note only drives a greeting — "Signed in. Your draft came back untouched"
+ * — and that sentence is only true of the tab that was thrown out and came
+ * back. The magic link opens a *new* tab, which was never thrown out of
+ * anything and has nothing to reassure anyone about; the draft still arrives
+ * there, from `localStorage`, without a note about it.
  */
 export function markAwaitingSignIn(courseCode: string): void {
-  write(AWAITING_SIGN_IN_KEY, courseCode);
+  write("session", AWAITING_SIGN_IN_KEY, courseCode);
 }
 
 export function claimAwaitingSignIn(courseCode: string): boolean {
-  if (read(AWAITING_SIGN_IN_KEY) !== courseCode) return false;
+  if (read("session", AWAITING_SIGN_IN_KEY) !== courseCode) return false;
   clearAwaitingSignIn(courseCode);
   return true;
 }
 
 /** Drop the note unclaimed — the visitor backed out of the dialog. */
 export function clearAwaitingSignIn(courseCode: string): void {
-  if (read(AWAITING_SIGN_IN_KEY) !== courseCode) return;
-  try {
-    sessionStorage.removeItem(AWAITING_SIGN_IN_KEY);
-  } catch {
-    // Nothing to clear if storage is unavailable.
-  }
+  if (read("session", AWAITING_SIGN_IN_KEY) !== courseCode) return;
+  remove("session", AWAITING_SIGN_IN_KEY);
 }

--- a/apps/web/features/workspace/lib/workspace-storage.ts
+++ b/apps/web/features/workspace/lib/workspace-storage.ts
@@ -257,8 +257,11 @@ function decodeStoredDrafts(): Record<string, StoredDraft> {
  * removed only once the new one has actually been written, so a browser that
  * refuses the write keeps the old value and can try again on the next read.
  *
- * It runs at most once per browser: the first read moves everything and drops
- * the key, and thereafter there is nothing to find.
+ * It runs at most once per tab, which is where the old key lives: the first
+ * read moves that tab's drafts across and drops its key, and thereafter there
+ * is nothing to find. A second tab still carrying its own legacy value gets the
+ * same treatment when it reloads into this build, and the rule above is what
+ * keeps its staler copy from displacing what the first tab already moved.
  */
 function adoptLegacyDrafts(
   stored: Record<string, StoredDraft>,

--- a/apps/web/vitest.setup.ts
+++ b/apps/web/vitest.setup.ts
@@ -1,10 +1,33 @@
 import "@testing-library/jest-dom/vitest";
-import { cleanup } from "@testing-library/react";
+import { cleanup, configure } from "@testing-library/react";
 import { afterEach, vi } from "vitest";
+
+/**
+ * Render every component test the way the app actually runs.
+ *
+ * Next enables Strict Mode for the App Router by default and `next.config.ts`
+ * does not turn it off, so every mount in development runs its effects twice —
+ * mount, clean up, mount again. Tests rendered without it, which is how a pane
+ * that destroyed a stored review draft on its second mount shipped green: the
+ * round-trip test in `workspace-pane.spec.tsx` unmounted and remounted, which
+ * is one mount each, and the bug needed two in a row.
+ *
+ * Turning it on globally is deliberate. Anything that breaks under it is
+ * something the development build is already doing to a real user, so the fix
+ * belongs in the component and not in an exemption here.
+ */
+configure({ reactStrictMode: true });
 
 afterEach(() => {
   cleanup();
   vi.clearAllMocks();
+  // Both, and here rather than in each suite's own `beforeEach`. The workspace
+  // keeps its open list in `sessionStorage` and its review drafts in
+  // `localStorage`, so a suite that clears only the one it remembers about
+  // leaks the other into the next test — which is a failure in whichever test
+  // runs second, about state it never set.
+  sessionStorage.clear();
+  localStorage.clear();
 });
 
 // jsdom ships neither of these, and Radix's dialog needs both to open.


### PR DESCRIPTION
## The bug

A guest fills in a review draft in the workspace pane, is asked to sign in, comes back — and the form is blank while a banner tells them *"Your draft came back untouched."*

The product owner reproduced it on `bun run dev`. Their open tabs survived, which initially looked like a contradiction and is in fact the corroboration: tabs are restored from `?open=` in the URL (`auth-reason-dialog.tsx` sends `callbackURL: pathname + search`, `use-explore.ts` reads it back), while the draft lived only in storage. The one thing depending solely on storage is the one thing that died.

## Root cause

`workspace-pane.tsx` restores drafts from storage in one effect and mirrors them back in another, gated on having restored first. That gate was a **ref**, set synchronously inside the restore effect while `drafts` was still `{}` — so for exactly one render the mirror was armed over pre-restore state and wrote `{}` over every stored draft. It self-heals on the next commit, which is why it survived review, and it self-heals too late for anything that reads storage inside that window.

React Strict Mode is on by default for the App Router (`next.config.ts` sets no `reactStrictMode`) and its replayed mount reads exactly there. Instrumented trace of one Strict Mode render with a stored draft:

```
GET drafts -> {"DD2380":{… "message":"Half a thought"}}   restore #1
SET drafts = {}                                            mirror, pre-restore state
GET drafts -> {}                                           restore #2 (Strict replay)
SET drafts = {}
```

The replay adopts the blank the premature mirror just wrote, and the loss becomes permanent.

`use-workspace-pane.ts` carried the identical bug — verified: a stored workspace with one open tab came back as zero tabs.

## The fix

### The gate is state, not a ref

```ts
const [hydrated, setHydrated] = useState(false);
useEffect(() => { setDrafts(readDrafts()); setHydrated(true); }, []);
useEffect(() => { if (hydrated) writeDrafts(drafts); }, [hydrated, drafts]);
```

`hydrated` is committed in the same batch as the value it describes, so no render exists in which it is `true` and the state is still empty. No write path can carry an empty value.

**The stronger form — write-through from `patchDraft` / `markPublished`, no mirror effect at all — was considered and rejected**, and the reasoning is written into the file. It cannot regress this way, but it spreads the obligation to persist across every mutator that exists (`forgetPublished` included) and every one somebody adds later, which fails silently by simply not writing; the mirror covers all of them by construction. And computing the value to write means either doing it inside the state updater — which Strict Mode double-invokes, reintroducing exactly the order-sensitivity being removed — or reading `drafts` from the render closure, which gives up the functional updater. The gate is a total invariant over one write path; write-through is a promise every future call site has to keep.

### The *read* is guarded by a ref, and the asymmetry is deliberate

Turning Strict Mode on in tests surfaced a second, pre-existing failure of the same family in the other direction: a **replayed restore** puts stale storage back over state that has since moved. `use-explore.ts` spends a `?open=` in its own mount effect, so `/course/DD2380` opened a tab in pass 1 and the replayed restore in pass 2 wiped it — and `use-explore` would not reopen it, having already spent the instruction. Two `explore.spec.tsx` tests caught this the moment Strict Mode went on.

So the restore is now `if (read.current) return; read.current = true; …`. A ref is what survives the replay to say "already done"; state would be `false` in both passes because neither has re-rendered. The read is gated on a ref and the write on state, each on the only thing that can do its job.

### The latent no-Strict-Mode variant is closed too

Two panes mounting in one commit destroys the draft: the second pane's restore reads what the first pane's premature mirror emptied. It is unreachable today only because `explore.tsx` and `saved.tsx` gate their column and their mobile sheet on one mutually exclusive ternary. `does not blank a draft when two panes mount in the same commit` renders both panes in one tree and asserts storage survives — it fails on the old code and passes on the new.

## Which storage each thing uses now, and why

| | Storage | Lifetime it models |
|---|---|---|
| Review draft | **`localStorage`**, keyed by course, with `savedAt` + 1 week | until published or abandoned |
| Open list | `sessionStorage` | this tab |
| Published note | `sessionStorage` | one request in flight |
| Awaiting-sign-in note | `sessionStorage` | the tab that was thrown out |

The existing comment in `workspace-storage.ts` argued for `sessionStorage` on the grounds that *"an open workspace belongs to the tab the student is working in, and it should not still be there next week."* That argument is correct **about tabs**, and the file still makes it — it is engaged with rather than deleted, and now explains the split.

It is not correct about a draft. A draft's lifetime is "until published or abandoned", not "until this tab closes", and the one moment we lean hardest on that promise is the moment we throw the user out of the tab. Google and GitHub redirect in place, so `sessionStorage` survives them. The magic link does not: it leaves for `/auth`, sends mail, and the link in that mail is a plain `href` opened in a **new tab**, where per-tab storage is empty by construction. That path lost the draft 100% of the time, in production, with no Strict Mode involved.

The "should not still be there next week" half of the argument is kept, as an explicit `savedAt` and a one-week expiry dropped on read, rather than as a side effect of closing a tab. The stamp measures the *draft*, not the workspace: it moves only when the draft's content changes, so a draft abandoned in one tab is not kept alive by work done on the tab beside it. Publishing already hands the pane an empty draft, and an untouched draft is now not written at all — so publishing deletes the entry, and so does a writer who empties their draft on purpose.

The awaiting-sign-in note stays per-tab deliberately: it only drives the greeting, and "your draft came back untouched" is only true of the tab that was thrown out and came back. A new tab gets its draft without being told it was ever at risk.

## The banner stops lying

`justSignedIn && !justPublished` had nothing in it that had looked at the draft, so the writer whose draft had just been destroyed was told, on the empty form, that it had come back untouched. It now also requires `!isUntouched(draft)`.

**On an unrestorable draft it says so, rather than rendering nothing.** `publish()` only reaches the sign-in prompt with an answered draft, so an untouched draft on the way back is never someone who typed nothing — it is work that existed and is gone. Silence would leave them staring at a blank form deciding whether they had imagined filling it in. It renders in the danger tint (`--cc-danger-tint` / `--cc-danger-ink`), the only banner here that reports a loss:

> Signed in as Elsa Lindqvist, but your draft did not come back — this browser did not keep it. Sorry; you will have to write it again.

## The return location

`magic-link-form.tsx` and `auth-providers.tsx` hardcoded `callbackURL: "/search"`, discarding where the visitor was. `AuthReasonDialog` now sends them to `/auth?next=<path>` and both controls read it back.

New `features/auth/lib/return-to.ts` validates every destination down to a same-site path: `?next=` is as easy to write as it is to read, and a sign-in that will forward anywhere is an open redirect with a real sign-in in front of it. Absolute URLs, `//host`, `/\host`, control characters and `/auth` itself (a loop) all fall back to `/search`. Covered by a table test.

`AuthReasonDialog` also takes an optional `returnTo` mapper. The review panel uses it to put back the `?open=` a host has already spent — without it the email path lands the student on `/search` with their draft in storage and no tab to show it in.

## Strict Mode: what broke and how it was fixed

`configure({ reactStrictMode: true })` in `apps/web/vitest.setup.ts`. Six tests broke; none was exempted.

| Test | Cause | Fix |
|---|---|---|
| `workspace-pane.spec` — "says nothing is saved until there is something to save" | drafts now in `localStorage`, which no suite cleared, so a draft leaked between tests | both storages cleared in the setup's `afterEach` |
| `workspace-pane.spec` — "splits the examination bar evenly" | same leak | same |
| `explore.spec` ×2 — course named by the route | **real dev-mode bug**: replayed restore wiped the `?open=` tab | one-shot ref guard on the read |
| `use-workspace-pane.spec` — "settles when the course already in front is opened again" | asserted `renders <= settled + 1`; Strict Mode doubles renders | reworked to assert the count does not *grow with the turns* — five more turns add nothing — which is the property the OOM loop actually violated and is independent of any render multiplier |
| `auth-reason-dialog.spec` — "routes to the full auth page for email" | `push("/auth")` now carries `?next=` | assertion updated, plus new cases |

## Validation

- Baseline on `origin/feat/frontend`: **972 tests / 74 files**, green, no Strict Mode.
- This branch: **1015 tests / 76 files**, green, **all UI tests in Strict Mode**.
- `bun run lint` clean (the 8 warnings are pre-existing, all in `.agents/skills/neon-drizzle` templates), `bun run typecheck` clean.
- **The regression tests were verified against the bug**: reverting `workspace-pane.tsx` to the ref gate fails 8 tests in that file — including the pre-existing round-trip test, which only ever passed because it rendered without Strict Mode. Reverting `use-workspace-pane.ts` fails 2.

## Adjacent, in files I own

`readDrafts` used to reject a whole draft over one bad field, and the mirror then permanently deleted it — the write-up and the scores went with the one broken examination split. It now drops **only the split**. It also validates `methods` against `EXAMINATION_DISTRIBUTION_KEYS` instead of casting to `ExaminationKey[]` unchecked, rejects duplicate methods, and rejects shares that do not add up to 100.

## Not fixed here

- **Issue #166** — the same decoder is duplicated in `features/reviews/lib/reviewer-session.ts:52-84`, differing by four lines, and now differs by rather more: this copy salvages where that one rejects. That file is outside this change's scope; the duplication is real and the two have now diverged in behaviour, which is worth taking seriously.
- `reviewer-session.ts` is otherwise **not** at risk from this mechanism — ref-guarded one-shot read, state seeded from a prop in a lazy `useState`, writes that always carry real data. It is the counter-example worth copying. Its header comment cited the workspace pane's `sessionStorage` reasoning as shared, which is no longer true of the draft; the comment is updated to say which half still holds and why `/taken` does not have the problem (it is behind `proxy.ts`, so its reviewer is already signed in and never leaves the tab). That is the only edit outside `features/workspace/**` and `features/auth/**`, and it is comment-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017EAUKDDo2BkQTFELyvV3v8
