### PR TITLE
fix(dialog): stop DialogContent clamping every wider dialog to 384px

### DIFF
--- a/apps/web/components/editor/editor-hooks/use-modal.tsx
+++ b/apps/web/components/editor/editor-hooks/use-modal.tsx
@@ -28,7 +28,12 @@ export function useEditorModal(): [
     const { title, content } = modalContent;
     return (
       <Dialog open={true} onOpenChange={onClose}>
-        <DialogContent>
+        {/*
+          384px, stated rather than inherited: `DialogContent` used to clamp
+          every dialog to it and no longer does (#178). This modal is one of the
+          two that were happy with the clamp, so it keeps it explicitly.
+        */}
+        <DialogContent className="sm:max-w-sm">
           <DialogHeader>
             <DialogTitle>{title}</DialogTitle>
           </DialogHeader>

--- a/apps/web/components/ui/alert-dialog.tsx
+++ b/apps/web/components/ui/alert-dialog.tsx
@@ -45,14 +45,28 @@ function AlertDialogOverlay({
 
 function AlertDialogContent({
   className,
+  overlayClassName,
   size = "default",
   ...props
 }: React.ComponentProps<typeof AlertDialogPrimitive.Content> & {
   size?: "default" | "sm";
+  /**
+   * Restyle the scrim — e.g. to drop the blur when what is behind must stay
+   * legible, which is the usual reason to reach for it.
+   *
+   * Parity with {@link DialogContent}, which has had this prop all along.
+   * Without it this primitive rendered an overlay no caller could reach, and
+   * #178 records what that cost: the two confirmations that needed the
+   * artboard's own scrim were built on `Dialog` instead, purely because only
+   * `Dialog` let them at it. Which primitive a confirmation uses should follow
+   * from whether the question is destructive enough to want `alertdialog`
+   * semantics, not from which one happens to expose a prop.
+   */
+  overlayClassName?: string;
 }) {
   return (
     <AlertDialogPortal>
-      <AlertDialogOverlay />
+      <AlertDialogOverlay className={overlayClassName} />
       <AlertDialogPrimitive.Content
         data-slot="alert-dialog-content"
         data-size={size}

--- a/apps/web/components/ui/command.tsx
+++ b/apps/web/components/ui/command.tsx
@@ -50,7 +50,13 @@ function CommandDialog({
       </DialogHeader>
       <DialogContent
         className={cn(
-          "top-1/3 translate-y-0 overflow-hidden rounded-xl! p-0",
+          /*
+            384px, stated rather than inherited. `DialogContent` used to carry an
+            `sm:max-w-sm` in its base classes, where it silently clamped every
+            caller that asked for something wider (#178). It is gone from there,
+            so the palette — which does want 384px — says so itself.
+          */
+          "top-1/3 translate-y-0 overflow-hidden rounded-xl! p-0 sm:max-w-sm",
           className,
         )}
         showCloseButton={showCloseButton}

--- a/apps/web/components/ui/dialog.tsx
+++ b/apps/web/components/ui/dialog.tsx
@@ -63,7 +63,27 @@ function DialogContent({
       <DialogPrimitive.Content
         data-slot="dialog-content"
         className={cn(
-          "fixed top-1/2 left-1/2 z-50 grid w-full max-w-[calc(100%-2rem)] -translate-x-1/2 -translate-y-1/2 gap-4 rounded-xl bg-popover p-4 text-sm text-popover-foreground ring-1 ring-foreground/10 duration-100 outline-none sm:max-w-sm data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95 data-closed:animate-out data-closed:fade-out-0 data-closed:zoom-out-95",
+          /*
+            `max-w-[calc(100%-2rem)]` is the phone guard, and it is the only
+            opinion this primitive has about width. There used to be an
+            `sm:max-w-sm` beside it, and it was a trap (#178).
+
+            tailwind-merge keeps `sm:max-w-*` and plain `max-w-*` in different
+            groups, so neither a caller's `w-[440px]` nor its `max-w-4xl`
+            replaced it: from the `sm` breakpoint up the dialog rendered at
+            384px, whatever it had asked for. Nothing errored and no test failed,
+            so it only showed up if someone measured — and two dialogs were wrong
+            on screen for it while two more carried an `sm:max-w-[440px]` to work
+            around a clamp that is invisible from the call site.
+
+            So a caller now states its own width and gets it. A caller that wants
+            a *cap* rather than a width overrides this class and takes the phone
+            guard with it, so it should state both at once —
+            `max-w-[min(56rem,calc(100vw-2rem))]`, the way `Review` does. The two
+            callers that were happy at 384px, `CommandDialog` and the editor's
+            `useEditorModal`, now say `sm:max-w-sm` for themselves.
+          */
+          "fixed top-1/2 left-1/2 z-50 grid w-full max-w-[calc(100%-2rem)] -translate-x-1/2 -translate-y-1/2 gap-4 rounded-xl bg-popover p-4 text-sm text-popover-foreground ring-1 ring-foreground/10 duration-100 outline-none data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95 data-closed:animate-out data-closed:fade-out-0 data-closed:zoom-out-95",
           className,
         )}
         {...props}

--- a/apps/web/features/collections/components/confirm-dialog.spec.tsx
+++ b/apps/web/features/collections/components/confirm-dialog.spec.tsx
@@ -1,0 +1,49 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { ConfirmDialog, type ConfirmRequest } from "./confirm-dialog";
+
+const REQUEST: ConfirmRequest = {
+  eyebrow: "Collections",
+  title: "Delete this collection?",
+  body: "The courses stay saved. The collection and its order do not.",
+  cancelLabel: "Keep collection",
+  actionLabel: "Delete collection",
+};
+
+function open(request: ConfirmRequest | null = REQUEST) {
+  render(
+    <ConfirmDialog request={request} onCancel={vi.fn()} onConfirm={vi.fn()} />,
+  );
+}
+
+/** See `new-collection-dialog.spec.tsx` for why the class list is the surface. */
+function widthClasses() {
+  const content = document.querySelector('[data-slot="dialog-content"]');
+  expect(content).not.toBeNull();
+  return (content as HTMLElement).className
+    .split(/\s+/)
+    .filter((name) => /(^|:)(min-w|max-w|w)-/.test(name));
+}
+
+describe("ConfirmDialog", () => {
+  it("is shut when there is nothing to confirm", () => {
+    open(null);
+    expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+  });
+
+  it("keeps its 440px without the workaround it used to need", () => {
+    open();
+    const classes = widthClasses();
+
+    // `My Page.dc.html:428` draws the confirmation at `width:440px`. This
+    // component used to state that twice — `w-[440px]` plus an
+    // `sm:max-w-[440px]` — because `DialogContent` carried an `sm:max-w-sm` that
+    // a plain width could not merge away. #178 removed the clamp, so the second
+    // statement went with it; this asserts the first one is now enough.
+    expect(classes).toContain("w-[440px]");
+    expect(classes.filter((name) => name.startsWith("sm:max-w-"))).toEqual([]);
+    expect(classes.filter((name) => name.startsWith("max-w-"))).toEqual([
+      "max-w-[calc(100vw-2rem)]",
+    ]);
+  });
+});

--- a/apps/web/features/collections/components/confirm-dialog.tsx
+++ b/apps/web/features/collections/components/confirm-dialog.tsx
@@ -82,13 +82,16 @@ export function ConfirmDialog({ request, onCancel, onConfirm }: Props) {
           overlayClassName="bg-[rgba(20,30,45,0.34)] supports-backdrop-filter:backdrop-blur-none"
           /*
             `cc-theme` because the dialog is portalled to the body and would
-            otherwise leave the subtree that defines the `--cc-*` tokens. The
-            `sm:max-w-[440px]` is not redundant with `w-[440px]`: the primitive
-            carries an `sm:max-w-sm`, and a plain `max-w-*` sits in a different
-            tailwind-merge group, so without the responsive override the card
-            would be clamped to 384px on any screen wide enough to have room.
+            otherwise leave the subtree that defines the `--cc-*` tokens.
+
+            There used to be an `sm:max-w-[440px]` here too, to defeat an
+            `sm:max-w-sm` the primitive carried in its own base classes — a plain
+            `max-w-*` sits in a different tailwind-merge group and so did not
+            replace it. #178 took that clamp out of the primitive, which is where
+            the problem was, so the override is gone: `w-[440px]` now means
+            440px, and `max-w-[calc(100vw-2rem)]` is the only thing narrowing it.
           */
-          className="cc-theme w-[440px] max-w-[calc(100vw-2rem)] gap-0 rounded-[14px] bg-cc-surface p-[22px] text-cc-ink shadow-[0_18px_48px_rgba(20,30,45,0.24)] ring-0 sm:max-w-[440px]"
+          className="cc-theme w-[440px] max-w-[calc(100vw-2rem)] gap-0 rounded-[14px] bg-cc-surface p-[22px] text-cc-ink shadow-[0_18px_48px_rgba(20,30,45,0.24)] ring-0"
         >
           <div className="font-semibold text-[11px] text-cc-brand uppercase tracking-[0.06em]">
             {request.eyebrow}

--- a/apps/web/features/collections/components/new-collection-dialog.spec.tsx
+++ b/apps/web/features/collections/components/new-collection-dialog.spec.tsx
@@ -1,0 +1,57 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { NewCollectionDialog } from "./new-collection-dialog";
+
+/**
+ * The width-related utilities the dialog actually renders with.
+ *
+ * jsdom computes no layout and there is no Tailwind stylesheet at test time, so
+ * the class list is what a test can hold. It is the right surface anyway: the
+ * string is `cn`'s output, and #178 was a `cn` bug — `DialogContent` carried an
+ * `sm:max-w-sm`, tailwind-merge keeps that in a different group from a plain
+ * `max-w-*` or a `w-*`, and so the caller's width did not replace it.
+ */
+function widthClasses() {
+  const content = document.querySelector('[data-slot="dialog-content"]');
+  expect(content).not.toBeNull();
+  return (content as HTMLElement).className
+    .split(/\s+/)
+    .filter((name) => /(^|:)(min-w|max-w|w)-/.test(name));
+}
+
+function open() {
+  render(
+    <NewCollectionDialog
+      open
+      savedCourses={[]}
+      onClose={vi.fn()}
+      onCreate={vi.fn()}
+    />,
+  );
+}
+
+describe("NewCollectionDialog", () => {
+  it("opens on the artboard's title", () => {
+    open();
+    expect(
+      screen.getByRole("heading", { name: "New collection" }),
+    ).toBeInTheDocument();
+  });
+
+  it("renders at the 440px the artboard draws, not the primitive's 384px", () => {
+    open();
+    const classes = widthClasses();
+
+    // `Collections.dc.html:183` draws this dialog at `width:440px`. It rendered
+    // at 384px until #178, because the primitive's `sm:max-w-sm` outlived this
+    // `w-[440px]` from the `sm` breakpoint up.
+    expect(classes).toContain("w-[440px]");
+
+    // Nothing narrows it above `sm` any more. The one cap left is the artboard's
+    // own gutter, which only bites below 472px.
+    expect(classes.filter((name) => name.startsWith("sm:max-w-"))).toEqual([]);
+    expect(classes.filter((name) => name.startsWith("max-w-"))).toEqual([
+      "max-w-[calc(100vw-2rem)]",
+    ]);
+  });
+});

--- a/apps/web/features/reviews/components/review.spec.tsx
+++ b/apps/web/features/reviews/components/review.spec.tsx
@@ -1,0 +1,91 @@
+import { render, screen } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { Review } from "./review";
+
+vi.mock("@/features/auth", () => ({
+  useMe: () => ({ userId: "u1", isLoading: false }),
+}));
+vi.mock("../hooks/use-add-review", () => ({ useAddReview: () => vi.fn() }));
+vi.mock("../hooks/use-edit-review", () => ({ useEditReview: () => vi.fn() }));
+
+// Lexical boots a whole editor and this suite is about the dialog's box, not
+// about what is typed into it.
+vi.mock("@/components/RichEditor", () => ({
+  RichTextEditor: () => <div data-testid="rich-text-editor" />,
+}));
+
+/** A published review, as the dialog takes it when My Page opens it to edit. */
+const EDITING = {
+  id: "r1",
+  happyTook: true,
+  message: "<p>Worth it.</p>",
+  examinationDistribution: null,
+  approachTheoryPercent: null,
+  workloadScore: 6,
+  learningScore: 8,
+};
+
+/**
+ * The width-related utilities the dialog actually renders with.
+ *
+ * jsdom computes no layout — `getBoundingClientRect` is zeros and no Tailwind
+ * stylesheet exists at test time — so the class list is the surface a test can
+ * hold. It is not a proxy for the real thing either: this string is the output
+ * of `cn`, which is where #178's bug lived, so a `sm:max-w-*` creeping back into
+ * `DialogContent`'s base classes shows up here exactly as it would on screen.
+ */
+function widthClasses() {
+  const content = document.querySelector('[data-slot="dialog-content"]');
+  expect(content).not.toBeNull();
+  return (content as HTMLElement).className
+    .split(/\s+/)
+    .filter((name) => /(^|:)(min-w|max-w|w)-/.test(name));
+}
+
+beforeEach(() => {
+  // A phone. `Review` reads nothing off it, but the assertions below are about
+  // what happens at this width, so the test states it rather than implying it.
+  Object.defineProperty(window, "innerWidth", {
+    configurable: true,
+    value: 390,
+  });
+});
+
+describe("Review, as the edit-review dialog", () => {
+  it("opens straight into editing when handed a review", () => {
+    render(<Review courseCode="DD2380" editing={EDITING} onClose={vi.fn()} />);
+    expect(
+      screen.getByRole("heading", { name: /edit your review/i }),
+    ).toBeInTheDocument();
+  });
+
+  it("never sets a min-width that could outgrow a phone", () => {
+    render(<Review courseCode="DD2380" editing={EDITING} onClose={vi.fn()} />);
+
+    // #165: this dialog carried `min-w-3xl`, 768px. Min-width beats max-width in
+    // CSS, so it beat `DialogContent`'s own `max-w-[calc(100%-2rem)]` too and the
+    // page scrolled sideways on every handset. Any `min-w-*` in a fixed unit is
+    // the same bug wearing a different number, so none is allowed at all.
+    expect(widthClasses().filter((name) => name.includes("min-w-"))).toEqual(
+      [],
+    );
+  });
+
+  it("caps its width against the viewport rather than a breakpoint", () => {
+    render(<Review courseCode="DD2380" editing={EDITING} onClose={vi.fn()} />);
+    const classes = widthClasses();
+
+    // The cap has to name the viewport, or a phone gets 896px of dialog.
+    expect(
+      classes.some(
+        (name) => name.startsWith("max-w-") && name.includes("100vw"),
+      ),
+    ).toBe(true);
+
+    // #178: `DialogContent` must contribute no width of its own. If it does, it
+    // arrives as an `sm:max-w-*` — a different tailwind-merge group from the
+    // `max-w-*` above, so it would not replace it and would silently win from
+    // 640px up.
+    expect(classes.filter((name) => name.startsWith("sm:max-w-"))).toEqual([]);
+  });
+});

--- a/apps/web/features/reviews/components/review.tsx
+++ b/apps/web/features/reviews/components/review.tsx
@@ -205,7 +205,23 @@ export function Review({
             </Button>
           </DialogTrigger>
         )}
-        <DialogContent className="scrollbar-subtle max-h-[100vh] max-w-4xl min-w-3xl overflow-y-auto">
+        {/*
+          The width is one `max-w-*` that already carries its own viewport
+          guard. It used to be `max-w-4xl min-w-3xl`, and the floor was the bug
+          (#165): `min-w-3xl` is 768px, min-width beats max-width in CSS, and it
+          therefore beat `DialogContent`'s own `max-w-[calc(100%-2rem)]` too — so
+          on any phone the dialog was wider than the screen and the page scrolled
+          sideways. This is reachable: it is the edit-review dialog, opened from
+          My Page.
+
+          `w-full` is what supplies the floor now, and it cannot fight the
+          viewport the way a fixed `min-w-*` could: the element is `fixed`, so it
+          takes the whole viewport and the `min()` caps it — 896px wherever there
+          is room for 896px, and the viewport less a 1rem gutter wherever there
+          is not. Both halves of the cap are stated here because a plain
+          `max-w-*` replaces the primitive's guard rather than joining it.
+        */}
+        <DialogContent className="scrollbar-subtle max-h-[100vh] w-full max-w-[min(56rem,calc(100vw-2rem))] overflow-y-auto">
           <DialogHeader>
             <DialogTitle>
               {editing ? "Edit your review" : "Share Your Experience"}

--- a/apps/web/features/saved/components/saved.tsx
+++ b/apps/web/features/saved/components/saved.tsx
@@ -153,15 +153,22 @@ export function Saved({ openCollectionId = null, openCourse = null }: Props) {
   /**
    * The request this page has already acted on, so it acts on it exactly once.
    *
-   * The guard is not belt-and-braces. `openCourse` is not idempotent at the
-   * state level — re-opening an open tab still returns a *new* workspace — so
-   * every run of the effect below re-renders this component, and any dependency
-   * whose identity is not stable across that render sends the effect round
-   * again immediately. `router` is exactly such a dependency: Next's own object
-   * happens to be stable, nothing promises it, and a test double that returns
-   * `{ push, replace }` per call is not. That is an unbounded loop that
-   * allocates a workspace per turn, and it shows up as an out-of-memory crash
-   * rather than as a failing assertion.
+   * This used to be load-bearing, and said so. `openCourse` was not idempotent
+   * at the state level — re-opening a tab that was already open and already in
+   * front still returned a *new* workspace — so every run of the effect below
+   * re-rendered this component, and any dependency whose identity is not stable
+   * across that render sent the effect round again immediately. `router` is
+   * exactly such a dependency. That was an unbounded loop allocating a workspace
+   * per turn, and it surfaced as an out-of-memory crash rather than as a failed
+   * assertion. #154 fixed it at the value: a no-op open now returns the very
+   * same `Workspace`, `useState` bails out, and the loop has no fuel.
+   *
+   * The guard stays, demoted to belt-and-braces. What it still defends against
+   * is a *second* instruction rather than the loop — the same `?open=` surviving
+   * one more render before `router.replace` has taken it back out of the URL
+   * would reopen a tab the reader may already have closed. Next's `router` is
+   * stable in practice; nothing promises it, and a test double that returns
+   * `{ push, replace }` per call is not.
    *
    * Clearing it when the request goes away is what keeps it a one-shot rather
    * than a once-ever: the same course opened from a collection a second time is


### PR DESCRIPTION
Fixes #178, #165 and #172.

## #178 — `DialogContent` silently clamped every wider dialog to 384px

`DialogContent` carried `sm:max-w-sm` in its base classes. tailwind-merge keeps
`sm:max-w-*` and plain `max-w-*` in different groups, so a caller's `w-[440px]`
or `max-w-4xl` did not replace it: from 640px up the dialog rendered at 384px,
whatever it had asked for. Nothing errored, no test failed, and it only showed
up if someone measured.

The clamp is gone from the primitive. Below is the audit that came first.

### Every `DialogContent` consumer, and what changed

Eleven call sites. Six render wider than they used to; five are unchanged.

| Call site | Asked for | Rendered before | Renders now |
|---|---|---|---|
| `components/editor/editor-hooks/use-modal.tsx` | nothing | 384px | **384px — now stated** |
| `components/ui/command.tsx` (`CommandDialog`) | nothing | 384px | **384px — now stated** |
| `features/auth/components/auth-reason-dialog.tsx` | `w-[400px]` | 384px | **400px** |
| `features/collections/components/new-collection-dialog.tsx` | `w-[440px]` | 384px | **440px** |
| `features/collections/components/confirm-dialog.tsx` | `w-[440px]` + workaround | 440px | 440px — **workaround removed** |
| `features/landing/components/find-your-dot.tsx` | `w-[396px]` + workaround | 396px | 396px — workaround now dead |
| `features/reviews/components/review.tsx` | `max-w-4xl min-w-3xl` | 768px+ | **viewport-bounded, see #165** |
| `features/taken/components/add-taken-course-dialog.tsx` | `w-[560px]` | 384px | **560px** |
| `features/taken/components/remove-taken-course-dialog.tsx` | `w-[440px]` + workaround | 440px | 440px — workaround now dead |
| `features/taken/components/taken-courses.tsx` (transcript) | `w-[460px]` | 384px | **460px** |
| `components/ui/dialog.tsx` | — | the primitive itself | — |

The two callers that were genuinely happy at 384px now say `sm:max-w-sm`
themselves, so removing the clamp changes nothing for them and the number lives
where someone can see it. `ConfirmDialog`'s `sm:max-w-[440px]` is removed: a
workaround left standing after the bug is fixed is the next reader's trap, and
its comment used to assert the override was *not* redundant.

Four dialogs that were wrong on screen are now the width their artboard draws:
`NewCollectionDialog` at 440px (`Collections.dc.html:183`), the "Read a newer
transcript" dialog at 460px, `AddTakenCourseDialog` at 560px, and
`AuthReasonDialog` at 400px (`Landing.dc.html:242` draws 400px).

### `AlertDialogContent` now takes an `overlayClassName`

The related half of the issue. `AlertDialogContent` rendered an overlay no
caller could reach, and that is the whole reason both artboard-faithful
confirmations in the last wave were built on `Dialog` — only `DialogContent`
exposed the prop. Which primitive a confirmation reaches for should follow from
whether the question wants `alertdialog` semantics, not from which one happens
to expose a prop, so the two now have parity. No existing caller passes it, so
nothing changes on screen.

## #165 — the edit-review dialog overflowed every phone

`review.tsx` set `min-w-3xl` (768px) alongside the primitive's
`max-w-[calc(100%-2rem)]`. Min-width beats max-width in CSS, so the dialog was
wider than the viewport on any handset and the page scrolled sideways. It is
reachable: it is the edit-review dialog, opened from My Page.

It is now `w-full max-w-[min(56rem,calc(100vw-2rem))]` — the same 896px on a
desktop, the viewport less a 1rem gutter on a phone. The floor the old
`min-w-3xl` was reaching for is supplied by `w-full` on a `fixed` element, which
cannot outgrow the viewport. Both halves of the cap are stated at the call site
because a plain `max-w-*` replaces the primitive's guard rather than joining it —
that is the same tailwind-merge fact #178 is about, and the comment says so.

**Left in the issue, deliberately.** #165 also notes that this dialog is a stock
shadcn form with no design classes, that its copy is Title Case against the app's
sentence case, and that the designed composer already exists as
`features/workspace/components/review-draft-panel.tsx`. That file is not mine to
touch, and "should this dialog exist at all" is a decision rather than a fix.
Only the overflow is fixed here.

## #172 — a comment that overclaimed

`features/saved/components/saved.tsx` still described its `spentRequest` guard as
load-bearing against a live render loop that ends in an out-of-memory crash. #154
closed that loop at the value — a no-op `openCourse` returns the very same
`Workspace`, so `useState` bails out. The guard stays; the comment now says it is
belt-and-braces and names what it still defends against, which is a second
`?open=` instruction arriving before `router.replace` has taken the first back out
of the URL. `use-explore.ts`, the model the issue points at, was already correct
after #171 and is untouched.

## Not mine — reporting rather than reaching in

- **`features/taken/components/taken-courses.tsx`** carries the third
  `spentRequest` comment (`hasReadArrival`), same shape, still wrong. #172 stays
  open for it.
- **`features/taken/components/remove-taken-course-dialog.tsx:74`** and
  **`features/landing/components/find-your-dot.tsx:147`** still carry
  `sm:max-w-[440px]` / `sm:max-w-[396px]`. Both are now dead weight against a
  clamp that no longer exists, and both should lose them the way `ConfirmDialog`
  did. Neither is wrong on screen.
- The three dialogs that **grow** with this change — `auth-reason-dialog.tsx`
  (400px), `add-taken-course-dialog.tsx` (560px) and the transcript dialog in
  `taken-courses.tsx` (460px) — are all in files I do not own. They now render
  the width they always asked for and the width their artboard draws, so this is
  the fix landing rather than a regression, but it is worth a look on screen by
  whoever owns them.

## Dropped from this branch

#169 (design fidelity) and #167 (the focus treatment) were in scope and were
pulled back out mid-flight by the product owner: both are polish or a
pre-existing accessibility gap rather than regressions, and both want their own
pass. `app/globals.css` is untouched. Both issues stay open.

## Validation

- `bun run lint` — clean (the 8 warnings are the pre-existing unused
  `drizzle-orm/pg-core` imports on `origin/feat/frontend`).
- `bun run typecheck` — clean.
- `bun run test:web` — **979 passed / 77 files**, against a baseline of 972 / 74.

Three new specs, all in the `ui` project:

- `review.spec.tsx` — at a 390px viewport, asserts the dialog carries no
  `min-w-*` at all (#165's bug wearing any number), that its cap names the
  viewport, and that the primitive contributes no `sm:max-w-*` of its own.
- `new-collection-dialog.spec.tsx` — asserts the 440px the artboard draws
  survives, and that nothing narrows it above `sm`.
- `confirm-dialog.spec.tsx` — asserts 440px still holds now that the workaround
  is gone, which is the change most able to regress silently.

jsdom computes no layout and there is no Tailwind stylesheet at test time, so
these assert the rendered class list. That is the right surface rather than a
proxy: the string is `cn`'s output, and `cn` is exactly where #178's bug lived —
an `sm:max-w-*` creeping back into the primitive fails all three.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017EAUKDDo2BkQTFELyvV3v8
