### PR TITLE
feat(search): remove the undesigned minimum-rating filter

### DIFF
--- a/apps/web/features/search/api/queries.ts
+++ b/apps/web/features/search/api/queries.ts
@@ -8,14 +8,13 @@ export type SearchCourses = RouterOutputs["search"]["courses"];
 /**
  * Explore's filter state, in the units the procedures take.
  *
- * `minRatingStars` is deliberately named for its scale. The dropdown asks for a
- * minimum in stars, 1-5, and `search/service.ts` converts that to the 1-10 scale
- * learning scores are stored on — so the browser sends stars and never a score.
- * Sending 8 here would mean eight stars, and zod would reject it.
+ * School is the only filter. A minimum-rating threshold used to live here too;
+ * it was in no artboard and has been removed — see `server/search/service.ts`
+ * for what went and why. An old `?rating=` link is simply not read any more, so
+ * it lands on unfiltered results rather than on an error.
  */
 export type ExploreFilters = {
   department?: string;
-  minRatingStars?: number;
 };
 
 /** Exactly the input `search.courses` takes, from a query and Explore's filters. */
@@ -23,15 +22,10 @@ export function toSearchCoursesInput(query: string, filters: ExploreFilters) {
   return {
     q: query,
     department: filters.department || undefined,
-    minRating: filters.minRatingStars,
   };
 }
 
-export function useSearchCourses(input: {
-  q: string;
-  department?: string;
-  minRating?: number;
-}) {
+export function useSearchCourses(input: { q: string; department?: string }) {
   const trpc = useTRPC();
   return useQuery(
     trpc.search.courses.queryOptions(input, {

--- a/apps/web/features/search/components/explore.spec.tsx
+++ b/apps/web/features/search/components/explore.spec.tsx
@@ -77,8 +77,8 @@ vi.mock("@/features/workspace/components/workspace-pane", () => ({
   WorkspacePane: () => <section aria-label="Open courses" />,
 }));
 
-// `toSearchCoursesInput` stays real: that the browser sends a star threshold and
-// never a 1-10 score is the point of it (#67).
+// `toSearchCoursesInput` stays real: exactly which filters reach `search.courses`
+// is the point of it, and a removed one must not reappear on the wire.
 vi.mock("../api/queries", async (importOriginal) => ({
   ...(await importOriginal<typeof import("../api/queries")>()),
   useSearchCourses: (input: unknown) => useSearchCourses(input),
@@ -167,8 +167,9 @@ describe("Explore", () => {
     });
 
     // The count is what came back, not what matched: `search.courses` returns one
-    // page and post-filters after fetching, so "2 courses match" would be a
-    // claim the server cannot support (#74).
+    // page of a de-duplicated union of two rankings and cannot count the rest,
+    // so "2 courses match" would be a claim the server cannot support (#74,
+    // and #148 for the pager that count would need).
     it("says how many results it is showing, not how many matched", () => {
       render(<Explore />);
       expect(screen.getByText("Showing 2 courses for “graphs”")).toBeVisible();
@@ -556,21 +557,6 @@ describe("Explore", () => {
       search = "q=graphs";
     });
 
-    // The dropdown asks for stars; `search/service.ts` converts to the stored
-    // 1-10 scale and thresholds the learning mean alone (#67).
-    it("sends the rating threshold in stars", async () => {
-      render(<Explore />);
-
-      await userEvent.selectOptions(
-        screen.getByLabelText("Minimum rating"),
-        "4",
-      );
-
-      expect(replace).toHaveBeenCalledWith("/search?q=graphs&rating=4", {
-        scroll: false,
-      });
-    });
-
     it("offers the schools the catalogue actually holds", () => {
       render(<Explore />);
       const school = screen.getByLabelText("School");
@@ -582,12 +568,11 @@ describe("Explore", () => {
       ).toBeInTheDocument();
     });
 
-    it("keeps both filters in the URL, so a filtered search is shareable", async () => {
-      search = "q=graphs&department=EECS&rating=3";
+    it("keeps the school in the URL, so a filtered search is shareable", async () => {
+      search = "q=graphs&department=EECS";
       render(<Explore />);
 
       expect(screen.getByLabelText("School")).toHaveValue("EECS");
-      expect(screen.getByLabelText("Minimum rating")).toHaveValue("3");
 
       await userEvent.click(
         screen.getByRole("button", { name: "Clear filters" }),
@@ -597,14 +582,47 @@ describe("Explore", () => {
       });
     });
 
-    // A hand-edited threshold outside 1-5 would be rejected by the procedure.
-    it("ignores a rating the procedure would reject", () => {
-      search = "q=graphs&rating=9";
-      render(<Explore />);
-      expect(screen.getByLabelText("Minimum rating")).toHaveValue("");
-      expect(useSearchCourses).toHaveBeenCalledWith(
-        expect.objectContaining({ minRating: undefined }),
+    /**
+     * The minimum-rating filter was removed — it was in no artboard, and it was
+     * applied after the query, so it could silently return short results. Links
+     * carrying `?rating=` were shareable while it existed, and they are still
+     * out there.
+     *
+     * Such a link must be *boring*: no control comes back, the parameter is not
+     * sent to `search.courses`, and the reader gets the unfiltered search the
+     * link named. Not an error, not a warning, not an empty page.
+     */
+    it("ignores a stale ?rating= from an old shared link", () => {
+      search = "q=graphs&department=EECS&rating=4";
+      useSearchCourses.mockReturnValue(
+        results(course("SF2740", "Graph Theory")),
       );
+      render(<Explore />);
+
+      expect(screen.queryByLabelText("Minimum rating")).not.toBeInTheDocument();
+      expect(useSearchCourses).toHaveBeenCalledWith({
+        q: "graphs",
+        department: "EECS",
+      });
+      expect(
+        screen.getByRole("heading", { name: "SF2740 Graph Theory" }),
+      ).toBeVisible();
+    });
+
+    // Clearing must not depend on the removed filter: school alone still turns
+    // "Clear filters" on, and clearing it turns the button back off.
+    it("offers Clear filters for the school alone", async () => {
+      search = "q=graphs";
+      render(<Explore />);
+      expect(
+        screen.queryByRole("button", { name: "Clear filters" }),
+      ).not.toBeInTheDocument();
+
+      await userEvent.selectOptions(screen.getByLabelText("School"), "EECS");
+
+      expect(replace).toHaveBeenCalledWith("/search?q=graphs&department=EECS", {
+        scroll: false,
+      });
     });
   });
 

--- a/apps/web/features/search/components/explore.tsx
+++ b/apps/web/features/search/components/explore.tsx
@@ -37,7 +37,7 @@ import { useExplore } from "../hooks/use-explore";
  *
  * ## Where it departs from the artboard, and why
  *
- * - The artboard's **pager** (lines 260-266) is not built, and stays unbuilt by
+ * - The artboard's **pager** (lines 263-265) is not built, and stays unbuilt by
  *   decision: it is **#148**. `search.courses` accepts a `page` input and
  *   ignores it, and returns `total: results.length` — the count of what it just
  *   returned. A pager over that would invent pages that do not exist, which is

--- a/apps/web/features/search/components/explore.tsx
+++ b/apps/web/features/search/components/explore.tsx
@@ -13,11 +13,7 @@ import {
   useWorkspacePresentation,
   WorkspacePaneHost,
 } from "@/features/workspace";
-import {
-  MAX_RATING_STARS,
-  RATING_STAR_OPTIONS,
-  useExplore,
-} from "../hooks/use-explore";
+import { useExplore } from "../hooks/use-explore";
 
 /**
  * Explore: the search-and-browse workspace, and the app's front door to the
@@ -41,16 +37,24 @@ import {
  *
  * ## Where it departs from the artboard, and why
  *
- * - The artboard's **pager** (lines 263-265) is not built, and stays unbuilt by
+ * - The artboard's **pager** (lines 260-266) is not built, and stays unbuilt by
  *   decision: it is **#148**. `search.courses` accepts a `page` input and
  *   ignores it, and returns `total: results.length` — the count of what it just
  *   returned. A pager over that would invent pages that do not exist, which is
  *   the same error class as scoring an unreviewed course 0%. The real fix is a
  *   `COUNT` query and an honoured offset in the search domain, which is server
  *   work; nothing here should grow a pager over the contract as it stands.
+ *   Removing the minimum-rating filter cleared one of the three reasons that
+ *   count could not be told truthfully; the other two — a union of two rankings
+ *   with no natural count, and a semantic path with no cutoff — are structural
+ *   and still there. `server/search/service.ts` carries the detail.
  * - The artboard's **filter row does not exist** at all; its search block is the
- *   field alone. #89 requires filters, so they are built here in the artboard's
- *   own control vocabulary.
+ *   field alone. One filter is built here anyway — **school** — in the
+ *   artboard's own control vocabulary. It earns the deviation by filtering in
+ *   SQL, so it is cheap, exact, and does not distort the result count. A
+ *   minimum-rating dropdown was built beside it for #89 and has since been
+ *   removed: it had no design behind it and could only be applied after the
+ *   query, which made searches silently return short.
  * - The artboard narrows its **search bar** by 236px while tabs are open
  *   (`searchBarMargin`, line 1351) so the field stays centred over the results
  *   rather than over the whole row. Not built: the bar is centred inside a
@@ -243,10 +247,15 @@ export function Explore() {
  *
  * The artboard says "12 courses match “x”", counting the whole catalogue behind
  * its own mock store. The server cannot answer that question: `search.courses`
- * returns one page and reports `total` as the length of that page, and its
- * department and rating filters run *after* the fetch, so the set it returns can
- * be shorter than the set that matches (#74). "Showing" is the smallest edit
- * that keeps the sentence true.
+ * returns one page and reports `total` as the length of that page, and that
+ * page is a de-duplicated union of a keyword ranking and a semantic one, which
+ * has no count short of running both unbounded (#74). "Showing" is the smallest
+ * edit that keeps the sentence true.
+ *
+ * The rating filter used to be a third reason — it thresholded rows *after* the
+ * fetch, so the page could come back shorter than the window it was cut from.
+ * It is gone, and the sentence is no less true for it: the school filter runs
+ * in SQL and removes nothing after the fact.
  */
 function resultsLabel(explore: ReturnType<typeof useExplore>): string {
   if (explore.isError) return "Catalogue unavailable";
@@ -402,18 +411,19 @@ const SELECT_CLASS =
   "h-[34px] cursor-pointer rounded-[8px] border border-cc-rule3 bg-cc-surface px-2.5 font-medium text-[12.5px] text-cc-chip-ink hover:border-cc-hov focus-visible:outline-cc-brand";
 
 /**
- * The department and rating filters.
+ * The school filter, and the only filter.
  *
- * The artboard draws no filter row, so these follow its own control vocabulary —
+ * The artboard draws no filter row, so this follows its own control vocabulary —
  * a 34px pill in `--cc-surface` over `--cc-rule3` — rather than inventing a
- * treatment. They are native selects: the row is two one-click choices, and a
+ * treatment. It is a native select: the row is one one-click choice, and a
  * native control is keyboard- and screen-reader-correct on every platform
  * without a portal.
  *
- * The rating threshold is sent in **stars**. `search/service.ts` converts it to
- * the 1-10 scale learning scores are stored on, and it thresholds the learning
- * mean alone — workload is not a verdict, so averaging it in would rank a
- * punishing course like a rewarding one (#67).
+ * A "Minimum rating" select stood beside it until it was removed. It was in no
+ * artboard, and unlike school it could not be pushed into SQL — the scores live
+ * in the reviews domain — so it was applied after the query over an inflated
+ * window, and a search could come back short with nothing saying so. School
+ * stays because `department ILIKE` runs in the query itself.
  */
 function Filters({ explore }: { explore: ReturnType<typeof useExplore> }) {
   return (
@@ -433,25 +443,6 @@ function Filters({ explore }: { explore: ReturnType<typeof useExplore> }) {
         {explore.departments.map((department) => (
           <option key={department} value={department}>
             {department}
-          </option>
-        ))}
-      </select>
-
-      <select
-        aria-label="Minimum rating"
-        title="How much reviewers said they learned, in stars"
-        value={explore.minRatingStars ?? ""}
-        onChange={(event) =>
-          explore.onMinRatingChange(
-            event.target.value ? Number(event.target.value) : null,
-          )
-        }
-        className={SELECT_CLASS}
-      >
-        <option value="">Any rating</option>
-        {RATING_STAR_OPTIONS.map((stars) => (
-          <option key={stars} value={stars}>
-            {stars === MAX_RATING_STARS ? `${stars} stars` : `${stars}+ stars`}
           </option>
         ))}
       </select>

--- a/apps/web/features/search/hooks/use-explore.ts
+++ b/apps/web/features/search/hooks/use-explore.ts
@@ -23,37 +23,6 @@ import {
 } from "../api/queries";
 import { useDebouncedQuery } from "./use-debounced-query";
 
-/** The lowest and highest thresholds the rating dropdown offers, in stars. */
-const MIN_RATING_STARS = 1;
-export const MAX_RATING_STARS = 5;
-
-/**
- * Every threshold the dropdown offers.
- *
- * The control renders this and `readStars` below accepts exactly it, so the two
- * cannot drift into a filter the reader can pick and the page then discards.
- */
-export const RATING_STAR_OPTIONS = Array.from(
-  { length: MAX_RATING_STARS - MIN_RATING_STARS + 1 },
-  (_, index) => MIN_RATING_STARS + index,
-);
-
-/**
- * A star threshold as the URL can carry it, or `null` for "any rating".
- *
- * The URL is typed by hand as often as it is clicked, and `search.courses`
- * rejects anything outside 1-5, so an unusable value is dropped here rather than
- * turned into a failed request the reader cannot explain.
- */
-function readStars(raw: string | null): number | null {
-  const stars = Number(raw);
-  return Number.isInteger(stars) &&
-    stars >= MIN_RATING_STARS &&
-    stars <= MAX_RATING_STARS
-    ? stars
-    : null;
-}
-
 export interface ExploreOptions {
   /**
    * Where a course named by `?open=` is sent. Explore hands it to the workspace
@@ -82,8 +51,9 @@ export interface ExploreOptions {
  * adopts it. Without that, the mirror would win every argument and quietly
  * undo a Back the moment the reader pressed it.
  *
- * The filters need none of this: each is one discrete click with nothing to keep
- * up with, so the URL simply drives them, and Back undoes a filter for free.
+ * The school filter needs none of this: it is one discrete click with nothing to
+ * keep up with, so the URL simply drives it, and Back undoes a filter for free.
+ * It is also the only filter left; `department` below says what went and why.
  *
  * What the two paths *do* share is `setParams`, and they write through it at
  * genuinely independent moments — see `issuedParams` for why a write cannot
@@ -115,8 +85,20 @@ export function useExplore({ onOpenCourse }: ExploreOptions = {}) {
   /** The last `?q=` this hook wrote. Anything else in the URL came from outside. */
   const writtenQuery = useRef(urlQuery);
 
+  /**
+   * School, the only filter.
+   *
+   * `?rating=` used to be read here too, into a minimum-star threshold. The
+   * artboard drew no filter row at all, so that control was invented; it is
+   * gone, along with the post-fetch filtering in `server/search/service.ts`
+   * that made it quietly return short pages.
+   *
+   * Nothing replaces the read, and nothing strips the parameter: an old shared
+   * `?rating=4` link is simply a parameter this page does not look at. It opens
+   * on unfiltered results, with no error and no warning — a link someone sent
+   * last month should still work, just without a filter that no longer exists.
+   */
   const department = searchParams.get("department") ?? "";
-  const minRatingStars = readStars(searchParams.get("rating"));
 
   const liveParams = searchParams.toString();
 
@@ -236,7 +218,6 @@ export function useExplore({ onOpenCourse }: ExploreOptions = {}) {
 
   const filters: ExploreFilters = {
     department: department || undefined,
-    minRatingStars: minRatingStars ?? undefined,
   };
 
   const search = useSearchCourses(toSearchCoursesInput(query, filters));
@@ -279,14 +260,8 @@ export function useExplore({ onOpenCourse }: ExploreOptions = {}) {
     [setParams],
   );
 
-  const onMinRatingChange = useCallback(
-    (stars: number | null) =>
-      setParams({ rating: stars ? String(stars) : null }),
-    [setParams],
-  );
-
   const onClearFilters = useCallback(
-    () => setParams({ department: null, rating: null }),
+    () => setParams({ department: null }),
     [setParams],
   );
 
@@ -309,12 +284,10 @@ export function useExplore({ onOpenCourse }: ExploreOptions = {}) {
     onRetry: () => void search.refetch(),
 
     department,
-    minRatingStars,
     departments: departments.data?.departments ?? [],
     onDepartmentChange,
-    onMinRatingChange,
     onClearFilters,
-    hasFilters: Boolean(department) || minRatingStars !== null,
+    hasFilters: Boolean(department),
 
     authReason,
     setAuthReason,

--- a/apps/web/server/search/repository.spec.ts
+++ b/apps/web/server/search/repository.spec.ts
@@ -17,7 +17,7 @@ describe("searchByKeyword", () => {
   });
 
   it("does not require a course_explore row for code and title matches", async () => {
-    await searchByKeyword("machine learning", 10, null, false);
+    await searchByKeyword("machine learning", 10, null);
 
     const query = vi.mocked(db.execute).mock.calls[0]?.[0] as SQL | undefined;
     expect(query).toBeDefined();
@@ -26,5 +26,23 @@ describe("searchByKeyword", () => {
       .sqlToQuery(query as SQL)
       .sql.toLowerCase();
     expect(queryText).toContain('left join "course_explore"');
+  });
+
+  /**
+   * The LIMIT is the size it was handed, full stop.
+   *
+   * It used to be `size * 5` whenever the caller flagged a minimum-rating
+   * filter, so the service had a window to throw rows out of after the fact.
+   * That filter is gone; a five-fold over-fetch left behind would cost every
+   * search and buy nothing.
+   */
+  it("limits to exactly the size it was given", async () => {
+    await searchByKeyword("machine learning", 10, null);
+
+    const query = vi.mocked(db.execute).mock.calls[0]?.[0] as SQL | undefined;
+    const { sql: text, params } = new PgDialect().sqlToQuery(query as SQL);
+    const limitIndex = Number(text.match(/limit \$(\d+)/i)?.[1]);
+    expect(limitIndex).toBeGreaterThan(0);
+    expect(params[limitIndex - 1]).toBe(10);
   });
 });

--- a/apps/web/server/search/repository.ts
+++ b/apps/web/server/search/repository.ts
@@ -7,15 +7,22 @@ export type SearchHit = {
   score: number | null;
 };
 
+/**
+ * `size` is the LIMIT, exactly. It used to be inflated to `size * 5` whenever a
+ * minimum-rating filter was set, because the service thresholded ratings in
+ * application code after the query and needed a window wide enough to survive
+ * that pass. The rating filter is gone (it was in no artboard), so the window
+ * has nothing to absorb: what is asked for is what is fetched. The department
+ * filter needs no window at all — it is a SQL predicate below, so every row the
+ * query returns already satisfies it.
+ */
 export async function searchByKeyword(
   query: string,
   size: number,
   departmentFilter: string | null,
-  hasMinRatingFilter: boolean,
 ): Promise<SearchHit[]> {
   const normalizedQuery = query.trim();
   const queryUpper = normalizedQuery.toUpperCase();
-  const fetchSize = hasMinRatingFilter ? size * 5 : size;
   const textPattern = `%${normalizedQuery}%`;
   const codePrefix = `${queryUpper}%`;
   const codeContains = `%${queryUpper}%`;
@@ -64,7 +71,7 @@ export async function searchByKeyword(
           ELSE 0
         END DESC,
         ${schema.courses.code} ASC
-      LIMIT ${fetchSize}
+      LIMIT ${size}
     `);
 
   return (result.rows as Array<{ code: string }>).map((r) => ({

--- a/apps/web/server/search/router.ts
+++ b/apps/web/server/search/router.ts
@@ -10,9 +10,6 @@ export const searchRouter = createTRPCRouter({
         page: z.number().int().positive().optional(),
         size: z.number().int().positive().optional(),
         department: z.string().optional(),
-        // Stars, as the filter dropdown renders them. The service converts
-        // this to the 1-10 scale review scores are stored on.
-        minRating: z.number().int().min(1).max(5).optional(),
       }),
     )
     .query(async ({ input }) => {
@@ -20,7 +17,6 @@ export const searchRouter = createTRPCRouter({
       const pageSize = input.size ?? 10;
       const results = await searchCourses(input.q, pageSize, {
         department: input.department,
-        minRating: input.minRating,
       });
       return {
         results,

--- a/apps/web/server/search/service.spec.ts
+++ b/apps/web/server/search/service.spec.ts
@@ -2,15 +2,15 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { CourseSummary } from "@/types";
 import { embedSingle } from "../ai";
 import { getSummariesByCodes } from "../course/service";
-import {
-  getAggregatesByCourseCodes,
-  type ReviewAggregate,
-} from "../reviews/service";
+import { getAggregatesByCourseCodes } from "../reviews/service";
 import { searchByEmbedding, searchByKeyword } from "./repository";
 import { searchCourses } from "./service";
 
 vi.mock("./repository");
 vi.mock("../course/service");
+// Search no longer imports the reviews domain at all. The mock stays so this
+// suite can assert that: if the rating filter is ever reintroduced, the call
+// comes back and the test below fails rather than silently passing.
 vi.mock("../reviews/service");
 vi.mock("../ai", () => ({
   embedSingle: vi.fn().mockRejectedValue(new Error("no embeddings in tests")),
@@ -31,108 +31,17 @@ function summary(courseCode: string): CourseSummary {
   };
 }
 
-/**
- * A reviewed course, described by the two 1-10 axes the filter can see. These
- * are raw aggregates straight from the database, deliberately unrounded.
- */
-function reviewed(
-  courseCode: string,
-  workloadMean: number,
-  learningMean: number,
-): ReviewAggregate {
-  return {
-    courseCode,
-    reviewCount: 10,
-    happyCount: 5,
-    workloadMean,
-    learningMean,
-    approachTheoryMean: null,
-    approachTheoryAnswerCount: 0,
-    examinationAnswerCount: 0,
-    examinationMeans: null,
-  };
-}
-
-describe("searchCourses minimum-rating filter", () => {
+describe("searchCourses", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     vi.mocked(searchByKeyword).mockResolvedValue([
       { courseCode: "SF1625", score: 1 },
       { courseCode: "DD2421", score: 0.9 },
     ]);
-    vi.mocked(getAggregatesByCourseCodes).mockResolvedValue([]);
+    vi.mocked(searchByEmbedding).mockResolvedValue([]);
     vi.mocked(getSummariesByCodes).mockImplementation(async (codes: string[]) =>
       codes.map(summary),
     );
-  });
-
-  it("rates a course on what reviewers learned, not on how hard they worked", async () => {
-    // SF1625 is punishing and teaches little; DD2421 is gentle and teaches a
-    // lot. Averaging workload in would rank them equally at 5.5.
-    vi.mocked(getAggregatesByCourseCodes).mockResolvedValue([
-      reviewed("SF1625", 10, 1),
-      reviewed("DD2421", 1, 10),
-    ]);
-
-    const results = await searchCourses("maths", 10, { minRating: 4 });
-
-    expect(results.map((r) => r.courseCode)).toEqual(["DD2421"]);
-  });
-
-  it("reads the star filter on its 1-5 scale, not the stored 1-10 one", async () => {
-    // 4/10 learned is a poor course; a four-star filter must not return it.
-    vi.mocked(getAggregatesByCourseCodes).mockResolvedValue([
-      reviewed("SF1625", 5, 4),
-      reviewed("DD2421", 5, 9),
-    ]);
-
-    const results = await searchCourses("maths", 10, { minRating: 4 });
-
-    expect(results.map((r) => r.courseCode)).toEqual(["DD2421"]);
-  });
-
-  it("keeps a course whose stored score clears the converted threshold", async () => {
-    vi.mocked(getAggregatesByCourseCodes).mockResolvedValue([
-      reviewed("SF1625", 5, 6),
-      reviewed("DD2421", 5, 5),
-    ]);
-
-    const results = await searchCourses("maths", 10, { minRating: 3 });
-
-    expect(results.map((r) => r.courseCode)).toEqual(["SF1625"]);
-  });
-
-  it("filters on the raw mean, so a near miss is still a miss", async () => {
-    // 5.99 is below a three-star threshold of 6. Rounded to the one decimal
-    // the card displays it becomes 6.0 and would sneak through, so the filter
-    // must read the aggregate rather than the card's numbers.
-    vi.mocked(getAggregatesByCourseCodes).mockResolvedValue([
-      reviewed("SF1625", 5, 5.99),
-      reviewed("DD2421", 5, 6),
-    ]);
-
-    const results = await searchCourses("maths", 10, { minRating: 3 });
-
-    expect(results.map((r) => r.courseCode)).toEqual(["DD2421"]);
-  });
-
-  it("drops an unreviewed course from a minimum-rating search", async () => {
-    // No reviews is absent, not zero — but a course with no rating cannot
-    // clear a minimum one either, so it is not in these results.
-    vi.mocked(getAggregatesByCourseCodes).mockResolvedValue([
-      reviewed("DD2421", 5, 8),
-    ]);
-
-    const results = await searchCourses("maths", 10, { minRating: 2 });
-
-    expect(results.map((r) => r.courseCode)).toEqual(["DD2421"]);
-  });
-
-  it("does not filter when no minimum rating is asked for", async () => {
-    const results = await searchCourses("maths", 10);
-
-    expect(results.map((r) => r.courseCode)).toEqual(["SF1625", "DD2421"]);
-    expect(getAggregatesByCourseCodes).not.toHaveBeenCalled();
   });
 
   it("keeps keyword order and appends only new semantic hits", async () => {
@@ -156,5 +65,49 @@ describe("searchCourses minimum-rating filter", () => {
       "DD2421",
       "ID2209",
     ]);
+  });
+
+  /**
+   * The minimum-rating filter is gone, and with it the `size * 5` window that
+   * existed only to leave something for a post-fetch pass to throw away.
+   *
+   * This asserts the window is not merely unused but absent: both legs are
+   * asked for exactly `size`. An inflated fetch that nothing filters is a
+   * five-fold cost on every search, and the slice would hide it from any test
+   * that only looked at the returned codes.
+   */
+  it("fetches exactly the size it was asked for, on both legs", async () => {
+    vi.mocked(embedSingle).mockResolvedValueOnce({
+      embedding: [0.25, 0.5],
+      usage: { tokens: 2 },
+    });
+
+    await searchCourses("maths", 4, { department: "EECS" });
+
+    expect(searchByKeyword).toHaveBeenCalledWith("maths", 4, "EECS");
+    expect(searchByEmbedding).toHaveBeenCalledWith([0.25, 0.5], 4, "EECS");
+  });
+
+  it("never reads review aggregates: rating is not a search filter", async () => {
+    // The removed filter thresholded a learning mean it had to fetch from the
+    // reviews domain, after the query, for every search that set it. Choosing
+    // courses is now purely the catalogue's business.
+    await searchCourses("maths", 10, { department: "EECS" });
+
+    expect(getAggregatesByCourseCodes).not.toHaveBeenCalled();
+  });
+
+  it("returns nothing for a blank query without touching the database", async () => {
+    const results = await searchCourses("   ", 10);
+
+    expect(results).toEqual([]);
+    expect(searchByKeyword).not.toHaveBeenCalled();
+    expect(searchByEmbedding).not.toHaveBeenCalled();
+  });
+
+  it("returns every hit when no filter is given", async () => {
+    const results = await searchCourses("maths", 10);
+
+    expect(results.map((r) => r.courseCode)).toEqual(["SF1625", "DD2421"]);
   });
 });

--- a/apps/web/server/search/service.ts
+++ b/apps/web/server/search/service.ts
@@ -1,7 +1,6 @@
 import type { CourseSummary } from "@/types";
 import { embedSingle } from "../ai";
 import { getSummariesByCodes } from "../course/service";
-import { getAggregatesByCourseCodes } from "../reviews/service";
 import {
   listDepartments,
   type SearchHit,
@@ -10,14 +9,6 @@ import {
 } from "./repository";
 
 export type { SearchHit };
-
-/**
- * The search filter asks for a minimum in stars, 1-5, because that is how the
- * dropdown renders. Review scores are stored 1-10. Convert the threshold up
- * rather than the averages down: the comparison then happens in the scale the
- * columns actually use, and no rounding is invented on the way.
- */
-const SCORE_POINTS_PER_STAR = 2;
 
 const embeddingCache = new Map<string, number[]>();
 const embeddingInflight = new Map<string, Promise<number[]>>();
@@ -102,68 +93,70 @@ async function searchWithEmbedding(
 }
 
 /**
- * `minRating` is the dropdown's "at least N stars", and what it measures is
- * the **learning score**: how much reviewers got out of the course.
+ * Hybrid search: keyword and embedding in parallel, keyword order kept, new
+ * semantic hits appended, sliced to `size`.
  *
- * It used to be the mean of workload and learning together, which made a
- * punishing course score like a rewarding one. `CONTEXT.md` is explicit that
- * workload is not a verdict — a heavy course is not a bad one — so averaging
- * it into a rating filter told users the opposite of what they asked. Of the
- * axes a review actually stores, learning is the only one that moves in the
- * direction a minimum-rating filter means; `happy_took` is a yes/no share on
- * a different question, not a 1-10 score to threshold. See #67.
+ * ## `department` is the only filter, and it is deliberate
  *
- * A course with no reviews has no rating, so it cannot clear a minimum and is
- * filtered out — absent, rather than a zero that would rank it last.
+ * There used to be a second one — a minimum-rating dropdown, "at least N
+ * stars", thresholding the learning mean. It has been removed. It was in no
+ * artboard: `docs/design_ref/2026-09-05/Course Community - Explore.dc.html`
+ * draws no filter row at all, and the control was invented to satisfy #89.
+ * With no design behind it there was nothing to be right about, so it went
+ * rather than staying as a permanent, undesigned deviation.
  *
- * The threshold is compared against the raw stored mean. Search is choosing
- * courses, not drawing a card, so it takes the reviews domain's aggregate
- * rather than the rounded figures `course/service.ts` assembles for display.
+ * It also took a live bug with it. It could not be expressed in SQL — the
+ * scores live in the reviews domain, so the threshold was applied here, in
+ * application code, *after* the query had come back. To leave something to
+ * filter, the query over-fetched `size * 5`. If more than four fifths of that
+ * window missed the threshold the caller silently got fewer results than it
+ * asked for, with nothing on the wire saying more existed. That failure mode
+ * left with the feature, and the over-fetch went with it: `size` is now what
+ * is fetched.
+ *
+ * `department` stays, and is still a deviation from the artboard — but a cheap
+ * and honest one. It filters in SQL (`department ILIKE`, in the repository),
+ * so the database does the narrowing, every returned row already satisfies it,
+ * and the result count is whatever the caller asked for. It needs no window,
+ * no second round trip, and no post-fetch pass.
+ *
+ * ## Why `total` is still a lie, and still #148
+ *
+ * The router returns `total: results.length` — the count of what it just
+ * returned, not of what matches. Removing the rating filter clears **one of
+ * three** reasons a truthful count could not be computed; two remain, and they
+ * are the structural ones:
+ *
+ * - the result set is the union of two independent rankings, de-duplicated,
+ *   which has no natural count short of running both queries unbounded; and
+ * - the semantic path has no cutoff — every course with an embedding is a hit
+ *   at some distance, so "how many match" is not a question it can answer.
+ *
+ * So a real pager still needs server work (a `COUNT` and an honoured offset),
+ * and #148 still owns it. One fewer obstacle, not none.
  */
 export async function searchCourses(
   query: string,
   size = 10,
-  /** `minRating` is in stars (1-5), not in stored score points (1-10). */
-  filters?: { department?: string; minRating?: number },
+  filters?: { department?: string },
 ): Promise<CourseSummary[]> {
   if (!query?.trim()) return [];
   const departmentFilter = resolveDepartmentFilter(filters?.department);
-  const hasMinRatingFilter = Boolean(filters?.minRating);
 
-  const fetchSize = hasMinRatingFilter ? size * 5 : size;
   const [keywordHits, semanticHits] = await Promise.all([
-    searchByKeyword(query, size, departmentFilter, hasMinRatingFilter),
-    searchWithEmbedding(query, fetchSize, departmentFilter),
+    searchByKeyword(query, size, departmentFilter),
+    searchWithEmbedding(query, size, departmentFilter),
   ]);
 
   const seen = new Set(keywordHits.map((h) => h.courseCode));
-  const ranked = [
+  const codes = [
     ...keywordHits,
     ...semanticHits.filter((h) => !seen.has(h.courseCode)),
-  ].slice(0, fetchSize);
+  ]
+    .slice(0, size)
+    .map((h) => h.courseCode);
 
-  if (ranked.length === 0) return [];
-
-  let codes = ranked.map((h) => h.courseCode);
-
-  const minRating = filters?.minRating;
-  if (minRating) {
-    // The reviews domain's raw aggregate, not the course card's numbers: the
-    // card rounds its means to one decimal for display, and a 5.99 rounded up
-    // to 6.0 would clear a three-star threshold it actually misses. Filtering
-    // reads the unrounded score; rounding stays at the presentation edge.
-    const aggregates = await getAggregatesByCourseCodes(codes);
-    const learningMeanByCode = new Map(
-      aggregates.map((row) => [row.courseCode, row.learningMean]),
-    );
-    const threshold = minRating * SCORE_POINTS_PER_STAR;
-    codes = codes.filter((code) => {
-      const learningMean = learningMeanByCode.get(code);
-      return learningMean !== undefined && learningMean >= threshold;
-    });
-  }
-
-  codes = codes.slice(0, size);
+  if (codes.length === 0) return [];
 
   return getSummariesByCodes(codes);
 }


### PR DESCRIPTION
Explore's minimum-rating filter is removed. The department (school) filter stays.

## The evidence the artboard never had it

`docs/design_ref/2026-09-05/Course Community - Explore.dc.html` draws **no filter row at all** — its search block is the field alone. Every `filter` string in that file is an `Array.filter()` in its store logic (lines 672, 736, 752, 998, 1049, 1097, 1642), and every "star" is `startPct`, `startX`, `startW`, `starts`, or `flex-start`. #89 recorded that the artboard's filter row "does not exist" and built one "in the artboard's own control vocabulary" — which is to say invented it. There was no design to be right about, so it goes rather than staying as a permanent undesigned deviation. The product owner has settled it.

## Why department stays

It filters in SQL — `department ILIKE`, in `server/search/repository.ts` — so the database does the narrowing, every returned row already satisfies it, and the result count is whatever the caller asked for. No window, no second round trip, no post-fetch pass. It is still a deviation from the artboard, and it is now recorded as one deliberately, in the `Filters` doc comment and in `searchCourses`.

## This deletes a live bug

The rating filter could not be expressed in SQL: the scores live in the reviews domain. So it was applied in `server/search/service.ts` in application code, **after** the query returned, reading `getAggregatesByCourseCodes`. To leave something to filter, the query over-fetched `size * 5`. If more than four fifths of that window missed the threshold, the caller silently got fewer results than it asked for, with nothing on the wire saying more existed. That failure mode leaves with the feature.

The over-fetch leaves too: `size` is now the LIMIT on the keyword leg and the `limit` on the embedding leg. Nothing else depended on the inflated window — `searchByKeyword` has exactly two callers (`service.ts` and its own spec), `searchByEmbedding` exactly two (`searchWithEmbedding` and its spec), and `searchCourses` exactly two (`router.ts` and its spec). The over-fetch was only ever consumed by the post-fetch filter and the `.slice(0, size)` that followed it.

## What happens to an old `?rating=4` link

Nothing reads the parameter any more, and nothing strips it. Such a link opens on **unfiltered results** — no error, no warning, no control reappearing. `explore.spec.tsx` covers it: `?q=graphs&department=EECS&rating=4` renders results, sends exactly `{ q, department }` to `search.courses`, and has no "Minimum rating" control. The school filter in the same URL still applies, so an old link loses only the filter that no longer exists.

## Consequence for #148

`searchCourses` is a **hybrid** search: keyword and embedding run in parallel, are de-duplicated, and sliced. The post-fetch rating filter was **one of three** reasons a truthful `total` could not be computed. Removing it clears one. The other two are structural and remain:

- the result set is the union of two independent rankings, which has no natural count short of running both unbounded; and
- the semantic path has no cutoff — every course with an embedding is a hit at some distance, so "how many match" is not a question it can answer.

So this does **not** make a pager possible on its own. #148 still owns it, and it still needs a `COUNT` query and an honoured offset in the search domain. The deferral comments in `features/search/components/explore.tsx` and the new one in `server/search/service.ts` say exactly that, still citing #148, with one fewer reason. `resultsLabel`'s comment was also corrected: it claimed the department filter runs after the fetch, which was never true.

## Everything removed

**Client**
- `features/search/components/explore.tsx` — the "Minimum rating" `<select>`, the `MAX_RATING_STARS` / `RATING_STAR_OPTIONS` imports
- `features/search/hooks/use-explore.ts` — `MIN_RATING_STARS`, `MAX_RATING_STARS`, `RATING_STAR_OPTIONS`, `readStars`, the `?rating=` read, `minRatingStars`, `onMinRatingChange`, and `rating: null` from `onClearFilters`. `hasFilters` is now `Boolean(department)`
- `features/search/api/queries.ts` — `minRatingStars` from `ExploreFilters`, its mapping to `minRating` in `toSearchCoursesInput`, and `minRating` from `useSearchCourses`'s input type

**Server**
- `server/search/router.ts` — the `minRating` Zod input and its pass-through
- `server/search/service.ts` — `SCORE_POINTS_PER_STAR`, `hasMinRatingFilter`, `fetchSize`, the whole post-fetch filter block, and the `getAggregatesByCourseCodes` import
- `server/search/repository.ts` — the `hasMinRatingFilter` parameter and `size * 5`

`getAggregatesByCourseCodes` itself **stays**: `server/course/service.ts:141` still calls it, so search dropping its import orphans nothing.

## Tests

Removed rather than neutered — a test asserting a deleted behaviour should not survive asserting nothing. Five `service.spec.ts` cases and two `explore.spec.tsx` cases went. In their place, regressions for what now holds:

- `service.spec.ts` — both legs are asked for exactly `size` (an unused five-fold over-fetch would be invisible behind the slice, so this asserts the calls, not the codes); search never reads review aggregates; a blank query touches nothing
- `repository.spec.ts` — the keyword `LIMIT` binds exactly the size it was given
- `explore.spec.tsx` — a stale `?rating=` from an old shared link is ignored; "Clear filters" works on the school alone

`bun run lint`, `bun run typecheck`, `bun run test:web` all green — 79 files, 1052 tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017EAUKDDo2BkQTFELyvV3v8
