### PR TITLE
feat(auth): bring /auth onto the design system (#164)

### DIFF
--- a/apps/web/features/auth/components/auth-providers.spec.tsx
+++ b/apps/web/features/auth/components/auth-providers.spec.tsx
@@ -1,0 +1,164 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { AuthProviders } from "./auth-providers";
+
+const signInSocial = vi.fn();
+const toastError = vi.fn();
+
+vi.mock("@/lib/auth-client", () => ({
+  authClient: {
+    signIn: {
+      get social() {
+        return signInSocial;
+      },
+    },
+  },
+}));
+vi.mock("sonner", () => ({
+  toast: {
+    get error() {
+      return toastError;
+    },
+  },
+}));
+
+beforeEach(() => {
+  signInSocial.mockReset();
+  signInSocial.mockResolvedValue({ data: null, error: null });
+  toastError.mockReset();
+  window.history.replaceState({}, "", "/auth");
+});
+
+// The provider icons carry a `<title>` of their own, so the accessible name
+// of each button is "<Provider> logo <Provider>". Matched loosely, the way
+// `auth-reason-dialog.spec.tsx` matches the same two buttons.
+function providerButton(provider: "Google" | "GitHub") {
+  return screen.getByRole("button", { name: new RegExp(provider, "i") });
+}
+
+function google() {
+  return providerButton("Google");
+}
+
+describe("AuthProviders", () => {
+  // The numbers the "Controls" row of
+  // `docs/design_ref/2026-09-05/Course Community - Design System.dc.html` gives
+  // for its Secondary button. shadcn's default is 32px at a 10px radius, which
+  // is what these were and what nothing else on any other screen looks like.
+  it("wears the design's secondary control, not shadcn's default", () => {
+    render(<AuthProviders />);
+    for (const provider of ["Google", "GitHub"] as const) {
+      expect(providerButton(provider)).toHaveClass(
+        "h-[38px]",
+        "rounded-[9px]",
+        "border-cc-rule3",
+        "bg-cc-surface",
+        "text-[13.5px]",
+        "text-cc-ink",
+      );
+    }
+  });
+
+  // Not a media query: the pair fits or does not fit the *card*, which is
+  // 400px wide on a 1440px display.
+  it("stacks the pair on the card's width rather than the window's", () => {
+    const { container } = render(<AuthProviders />);
+    expect(container.firstElementChild).toHaveClass(
+      "grid-cols-1",
+      "@xs:grid-cols-2",
+    );
+  });
+
+  // #180 fixed the two controls on `/auth` sending everyone to `/search`
+  // whatever they were doing when they left. Styling this page must not undo
+  // it, so the promise is asserted here rather than only in `return-to`'s own
+  // unit tests.
+  describe("where the sign-in comes back to", () => {
+    it("returns to the page `?next=` names", async () => {
+      window.history.replaceState(
+        {},
+        "",
+        "/auth?next=%2Fcourse%2FDD2380%3Fq%3Dagents",
+      );
+      const user = userEvent.setup();
+      render(<AuthProviders />);
+      await user.click(google());
+
+      await waitFor(() => expect(signInSocial).toHaveBeenCalledTimes(1));
+      expect(signInSocial).toHaveBeenCalledWith({
+        provider: "google",
+        callbackURL: "/course/DD2380?q=agents",
+      });
+    });
+
+    it("falls back to the front door when the URL does not say", async () => {
+      const user = userEvent.setup();
+      render(<AuthProviders />);
+      await user.click(providerButton("GitHub"));
+
+      await waitFor(() => expect(signInSocial).toHaveBeenCalledTimes(1));
+      expect(signInSocial).toHaveBeenCalledWith({
+        provider: "github",
+        callbackURL: "/search",
+      });
+    });
+
+    // `?next=` is read off the URL and handed to Better Auth, so anything that
+    // is not a same-site path is an open redirect with a real sign-in in front
+    // of it.
+    it.each([
+      "https://evil.example/steal",
+      "//evil.example/steal",
+      String.raw`/\evil.example/steal`,
+    ])("refuses to come back to %s", async (destination) => {
+      window.history.replaceState(
+        {},
+        "",
+        `/auth?next=${encodeURIComponent(destination)}`,
+      );
+      const user = userEvent.setup();
+      render(<AuthProviders />);
+      await user.click(google());
+
+      await waitFor(() => expect(signInSocial).toHaveBeenCalled());
+      expect(signInSocial.mock.calls[0][0].callbackURL).toBe("/search");
+    });
+  });
+
+  it("holds both buttons shut while one is in flight", async () => {
+    let release: (value: { data: null; error: null }) => void = () => {};
+    signInSocial.mockReturnValue(
+      new Promise<{ data: null; error: null }>((resolve) => {
+        release = resolve;
+      }),
+    );
+    const user = userEvent.setup();
+    render(<AuthProviders />);
+    await user.click(google());
+
+    await waitFor(() => expect(google()).toBeDisabled());
+    expect(providerButton("GitHub")).toBeDisabled();
+
+    release({ data: null, error: null });
+    await waitFor(() => expect(google()).toBeEnabled());
+  });
+
+  it("reports a refused sign-in instead of failing silently", async () => {
+    signInSocial.mockResolvedValue({ data: null, error: { message: "nope" } });
+    const user = userEvent.setup();
+    render(<AuthProviders />);
+    await user.click(google());
+    await waitFor(() => expect(toastError).toHaveBeenCalled());
+  });
+
+  it("survives the client throwing", async () => {
+    signInSocial.mockRejectedValue(new Error("network down"));
+    vi.spyOn(console, "error").mockImplementation(() => {});
+    const user = userEvent.setup();
+    render(<AuthProviders />);
+    await user.click(google());
+    await waitFor(() => expect(toastError).toHaveBeenCalled());
+    expect(google()).toBeEnabled();
+  });
+});

--- a/apps/web/features/auth/components/auth-providers.tsx
+++ b/apps/web/features/auth/components/auth-providers.tsx
@@ -3,11 +3,26 @@
 import { useState } from "react";
 import { toast } from "sonner";
 import { GithubIcon, GoogleIcon } from "@/components/icon";
-import { Button } from "@/components/ui/button";
 import { Spinner } from "@/components/ui/spinner";
 import { authClient } from "@/lib/auth-client";
 import type { OauthProvider } from "@/types";
 import { requestedReturnTo } from "../lib/return-to";
+
+/**
+ * The design's **Secondary** control, from the "Controls" row of
+ * `docs/design_ref/2026-09-05/Course Community - Design System.dc.html`: 38px
+ * tall, 9px radius, 15px of side padding, `--rule3` around `--surface`, 13.5px
+ * at 500 in `--ink`, and `--hov` on hover. shadcn's default button is 32px at a
+ * 10px radius, which is what stood here and what nothing else in the app looks
+ * like.
+ *
+ * The artboard sets no focus state — a mock cannot be tabbed through — so the
+ * hover border doubles as the focus border and picks up the ring
+ * `feedback-form.tsx` established, keeping a keyboard something to follow
+ * without introducing a colour the palette does not have.
+ */
+const PROVIDER_BUTTON =
+  "flex h-[38px] w-full cursor-pointer items-center justify-center gap-2 rounded-[9px] border border-cc-rule3 bg-cc-surface px-[15px] font-medium text-[13.5px] text-cc-ink outline-none hover:border-cc-hov focus-visible:border-cc-hov focus-visible:ring-2 focus-visible:ring-cc-hov/40 disabled:cursor-not-allowed disabled:opacity-60 [&>svg]:size-4 [&>svg]:shrink-0";
 
 export function AuthProviders() {
   const [isLoading, setIsLoading] = useState(false);
@@ -39,35 +54,37 @@ export function AuthProviders() {
   }
 
   return (
-    <div className="grid grid-cols-2 gap-4">
-      <Button
+    // Two words fit side by side in the card at any width worth calling a
+    // phone, so they stay a pair and stack only when the card itself drops
+    // under 20rem — a container query, because the card is what constrains
+    // them and it is 400px wide long before the viewport is.
+    <div className="grid grid-cols-1 gap-2 @xs:grid-cols-2">
+      <button
         disabled={isLoading}
-        variant="outline"
         type="button"
-        className="w-full"
+        className={PROVIDER_BUTTON}
         onClick={() => handleSubmit("google")}
       >
         {isLoading && providerClicked === "google" ? (
-          <Spinner data-icon="inline-start" />
+          <Spinner />
         ) : (
           <GoogleIcon />
         )}
         Google
-      </Button>
-      <Button
+      </button>
+      <button
         disabled={isLoading}
-        variant="outline"
         type="button"
-        className="w-full"
+        className={PROVIDER_BUTTON}
         onClick={() => handleSubmit("github")}
       >
         {isLoading && providerClicked === "github" ? (
-          <Spinner data-icon="inline-start" />
+          <Spinner />
         ) : (
           <GithubIcon />
         )}
         GitHub
-      </Button>
+      </button>
     </div>
   );
 }

--- a/apps/web/features/auth/components/auth.spec.tsx
+++ b/apps/web/features/auth/components/auth.spec.tsx
@@ -1,0 +1,133 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { Auth } from "./auth";
+
+// The page composes two client components that reach for the auth client at
+// import time. Neither is what this suite is about, so both get a client that
+// does nothing rather than a network.
+vi.mock("@/lib/auth-client", () => ({
+  authClient: {
+    signIn: { social: vi.fn(), magicLink: vi.fn() },
+  },
+}));
+
+function ground() {
+  return screen.getByRole("main");
+}
+
+function card() {
+  const surface = ground().firstElementChild;
+  if (!surface) throw new Error("the page rendered no card");
+  return surface;
+}
+
+describe("Auth", () => {
+  // The regression this route exists to hold. `/auth` was shadcn's `login-02`
+  // block and the only file under `features/` with no `--cc-*` class at all,
+  // which is how it ended up painting `bg-muted` — an alias of `--cc-pill`, and
+  // in dark theme a 16% cream over the page that composites to a `#2d3a4d`
+  // grey. The card under it is `#0b254c`. A ground lighter than the thing
+  // standing on it is the surface hierarchy upside down, and it was the first
+  // screen a signed-out visitor saw.
+  describe("surfaces", () => {
+    it("rests the card on the page ground, not the other way round", () => {
+      render(<Auth />);
+      expect(ground()).toHaveClass("bg-cc-pg");
+      expect(ground()).not.toHaveClass("bg-muted");
+      expect(card()).toHaveClass("bg-cc-surface", "border-cc-rule2");
+    });
+
+    it("opts the page into the theme cross-fade", () => {
+      render(<Auth />);
+      expect(ground()).toHaveClass("cc-theme");
+    });
+
+    // The provider pair reflows on the card's width, not the viewport's: the
+    // card is 400px wide long before the window is narrow.
+    it("makes the card the container the controls measure", () => {
+      render(<Auth />);
+      expect(card()).toHaveClass("@container", "max-w-[400px]");
+    });
+
+    // A flex item centred by justification overflows *both* ends of a container
+    // it outgrows, and the top end is the one nothing can scroll back to. This
+    // card grows: the expired-link banner adds most of a hundred pixels to it,
+    // which is enough on a landscape phone.
+    it("centres the card without putting its top out of reach", () => {
+      render(<Auth error="INVALID_TOKEN" />);
+      expect(card()).toHaveClass("m-auto");
+      expect(ground()).not.toHaveClass("justify-center");
+    });
+  });
+
+  describe("copy", () => {
+    // `REASONS["log-in"]` from `Course Community - Landing.dc.html` — the same
+    // three lines `AuthReasonDialog` renders. What was here was shadcn's
+    // "Welcome!".
+    it("greets a visitor in the design's own words", () => {
+      render(<Auth />);
+      expect(screen.getByText("Welcome back")).toBeInTheDocument();
+      expect(
+        screen.getByRole("heading", {
+          level: 1,
+          name: "Log in to Course Community",
+        }),
+      ).toBeInTheDocument();
+      expect(
+        screen.getByText(/browsing never needs an account/i),
+      ).toBeVisible();
+      expect(screen.queryByText("Welcome!")).not.toBeInTheDocument();
+    });
+
+    // `server/auth.ts` configures no KTH IdP, so the artboard's own
+    // "Continue with KTH account" must not ship however well it reads.
+    it("names only providers the server actually has", () => {
+      render(<Auth />);
+      expect(screen.getByRole("button", { name: /google/i })).toBeVisible();
+      expect(screen.getByRole("button", { name: /github/i })).toBeVisible();
+      expect(
+        screen.queryByRole("button", { name: /kth account/i }),
+      ).not.toBeInTheDocument();
+    });
+  });
+
+  describe("a link that did not work", () => {
+    it("says why and what to do, in the artboard's words", () => {
+      render(<Auth error="INVALID_TOKEN" />);
+      const banner = screen.getByRole("alert");
+      expect(banner).toHaveTextContent("This link no longer works");
+      expect(banner).toHaveTextContent(
+        /private links expire after a short while/i,
+      );
+      // The Design System's `BANNERS` pairs these three for "Error banner".
+      expect(banner).toHaveClass(
+        "bg-cc-danger-tint",
+        "border-cc-danger-tint-border",
+      );
+    });
+
+    // Better Auth sends the visitor back here rather than nowhere, and the two
+    // working ways in have to stay reachable underneath the bad news.
+    it("keeps both ways in offered underneath it", () => {
+      render(<Auth error="INVALID_TOKEN" />);
+      expect(screen.getByRole("button", { name: /google/i })).toBeVisible();
+      expect(screen.getByLabelText("Email")).toBeVisible();
+    });
+
+    it("says nothing when the visitor simply arrived", () => {
+      render(<Auth />);
+      expect(screen.queryByRole("alert")).not.toBeInTheDocument();
+    });
+  });
+
+  // The stock divider was a centred `after:border-t` with a label repainting
+  // the card's background over the middle of it, which only works while the
+  // label is one line on the exact surface it assumes.
+  it("draws the divider as two hairlines around its label", () => {
+    const { container } = render(<Auth />);
+    const label = screen.getByText("Or continue with email");
+    const rules = label.parentElement?.querySelectorAll("span.bg-cc-rule");
+    expect(rules).toHaveLength(2);
+    expect(container.querySelector("[class*='after:border-t']")).toBeNull();
+  });
+});

--- a/apps/web/features/auth/components/auth.tsx
+++ b/apps/web/features/auth/components/auth.tsx
@@ -1,47 +1,114 @@
-import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
-import {
-  Card,
-  CardContent,
-  CardDescription,
-  CardHeader,
-  CardTitle,
-} from "@/components/ui/card";
 import { AuthProviders } from "./auth-providers";
 import { MagicLinkForm } from "./magic-link-form";
 
+/**
+ * The **sign-in page**, `/auth`.
+ *
+ * No artboard draws it, and that is not an oversight: the design's sign-in
+ * surface is a panel over the page it interrupted —
+ * `docs/design_ref/2026-09-05/Course Community - Landing.dc.html` draws it as a
+ * 400px card on `--surface` at a 14px radius, which `AuthReasonDialog` renders.
+ * This route exists because one branch of that panel cannot stay a panel: the
+ * link we mail is opened in a new tab, so the email path has to survive leaving
+ * this document entirely, and a modal does not.
+ *
+ * So the page is that panel with the scrim taken away. Same width, same radius,
+ * same `--cc-surface` inside `--cc-rule2`, same kicker → title → body block; it
+ * rests on `--cc-pg` under the artboards' own resting-card shadow rather than
+ * floating over a darkened page. Control metrics come from the "Controls" row
+ * of `docs/design_ref/2026-09-05/Course Community - Design System.dc.html`,
+ * which is the authority for the numbers no other artboard states.
+ *
+ * What it deliberately does *not* copy is the artboard's labels. The Landing
+ * panel offers "Continue with KTH account", and `server/auth.ts` configures no
+ * KTH IdP — naming a provider that does not exist is the one way this page
+ * could lie to a first-time visitor, so the buttons keep the providers that do.
+ *
+ * Before this, `/auth` was shadcn's `login-02` block close to verbatim and the
+ * only file under `features/` with no `--cc-*` class at all (#164). The visible
+ * cost was not only that it looked borrowed: `bg-muted` resolves through
+ * `globals.css` to `--cc-pill`, which in dark theme is a 16% cream over
+ * `--cc-pg` — a `#2d3a4d` grey ground standing behind the `#0b254c` card. The
+ * ground was lighter than the thing on it, which is the surface hierarchy
+ * upside down, and it was the first screen a signed-out visitor saw.
+ */
 export function Auth({ error }: { error?: string }) {
   return (
-    <div className="bg-muted flex min-h-svh flex-col items-center justify-center gap-6 p-6 md:p-10">
-      <div className="flex w-full max-w-sm flex-col gap-6">
-        <Card>
-          <CardHeader className="text-center">
-            <CardTitle className="text-xl">Welcome!</CardTitle>
-            <CardDescription>
-              Sign in with Google, GitHub, or email
-            </CardDescription>
-          </CardHeader>
-          <CardContent>
-            <div className="flex flex-col gap-6">
-              {error ? (
-                <Alert variant="destructive">
-                  <AlertTitle>Sign-in failed</AlertTitle>
-                  <AlertDescription>
-                    This sign-in link is invalid or has expired. Request a new
-                    one.
-                  </AlertDescription>
-                </Alert>
-              ) : null}
-              <AuthProviders />
-              <div className="relative text-center text-sm after:absolute after:inset-x-0 after:top-1/2 after:border-t after:border-border">
-                <span className="bg-card text-muted-foreground relative z-10 px-2">
-                  Or continue with email
-                </span>
-              </div>
-              <MagicLinkForm />
-            </div>
-          </CardContent>
-        </Card>
+    <main className="cc-theme flex min-h-svh flex-col bg-cc-pg px-4 py-10 text-cc-ink">
+      {/* Centred with auto margins rather than `justify-center`, which is the
+          difference between a card that stays reachable and one whose top is
+          cut off the screen: a flex item centred by justification overflows
+          both ends of a container it outgrows, and this card grows — the
+          expired-link banner adds most of a hundred pixels to it on a landscape
+          phone. Auto margins collapse to nothing instead.
+
+          The container is the card, not the viewport, because what reflows here
+          is the pair of provider buttons inside it and the card's own width is
+          what decides whether they fit side by side. */}
+      <div className="@container m-auto w-full max-w-[400px] rounded-[14px] border border-cc-rule2 bg-cc-surface p-6 shadow-[0_4px_20px_rgba(20,30,45,0.08)]">
+        {/* `REASONS["log-in"]` from the Landing artboard — the same three lines
+            `AuthReasonDialog` renders when it asks this question. Written out
+            rather than shared with the dialog, because that map is keyed by
+            *why* a protected action interrupted somebody, and `/auth` is
+            reached with no such reason: a visitor typed the URL, or took the
+            dialog's own email hand-off. Sharing the map would make this page
+            claim a reason it has no way to know. */}
+        <p className="font-semibold text-[11px] text-cc-brand uppercase tracking-[0.06em]">
+          Welcome back
+        </p>
+        <h1 className="mt-2 font-semibold text-[19px] leading-[1.25] tracking-[-0.012em]">
+          Log in to Course Community
+        </h1>
+        <p className="mt-1.5 text-[13.5px] text-cc-muted leading-[1.5]">
+          Browsing never needs an account — logging in adds saved courses, your
+          reviews and your own sidebar.
+        </p>
+
+        {/* `?error=` on this route means one thing: Better Auth was handed a
+            magic link it would not accept. The artboard has words for exactly
+            that — its `isDotExpired` state — and they are better than the ones
+            that were here, because they say why it happened and what to do
+            rather than only that something failed.
+
+            Shaped as the Design System's "Error banner" (`BANNERS` pairs
+            `--dangerTint` with `--dangerTintBorder` and `--dangerInk`) instead
+            of the artboard's whole-panel takeover, since this page still has
+            two working ways in underneath it and should not hide them. */}
+        {error ? (
+          <div
+            role="alert"
+            className="mt-4 rounded-[11px] border border-cc-danger-tint-border bg-cc-danger-tint px-[14px] py-[13px]"
+          >
+            <p className="font-semibold text-[13.5px] text-cc-danger-ink">
+              This link no longer works
+            </p>
+            <p className="mt-1 text-[12.5px] text-cc-muted leading-[1.5]">
+              Private links expire after a short while, and each one can be used
+              once. Request a new link to try again.
+            </p>
+          </div>
+        ) : null}
+
+        <div className="mt-4">
+          <AuthProviders />
+        </div>
+
+        {/* The stock block drew this with `after:border-t` on a centred line and
+            a label that had to repaint the card's own background over it. Two
+            real hairlines and the label between them need no such trick, and
+            they survive a label that wraps. `--cc-rule` is "hairline between
+            rows"; the label is the Design System's eyebrow — 11px, 600, .09em,
+            uppercase, `--cc-dim`. */}
+        <div className="mt-[18px] flex items-center gap-3">
+          <span className="h-px flex-1 bg-cc-rule" />
+          <span className="font-semibold text-[11px] text-cc-dim uppercase tracking-[0.09em]">
+            Or continue with email
+          </span>
+          <span className="h-px flex-1 bg-cc-rule" />
+        </div>
+
+        <MagicLinkForm />
       </div>
-    </div>
+    </main>
   );
 }

--- a/apps/web/features/auth/components/magic-link-form.spec.tsx
+++ b/apps/web/features/auth/components/magic-link-form.spec.tsx
@@ -85,7 +85,10 @@ describe("MagicLinkForm", () => {
 
       const message = await screen.findByRole("alert");
       expect(message).toHaveTextContent("Enter a valid email address.");
-      expect(message).toHaveClass("text-cc-danger-ink");
+      expect(message).toHaveClass("text-cc-danger");
+      // The border says the same thing the message does, in the same colour —
+      // which is what `find-your-dot.tsx` does with the same artboard.
+      expect(field()).toHaveClass("aria-invalid:border-cc-danger");
     });
 
     it("points the field at the message so a screen reader reaches it", async () => {

--- a/apps/web/features/auth/components/magic-link-form.spec.tsx
+++ b/apps/web/features/auth/components/magic-link-form.spec.tsx
@@ -1,0 +1,201 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { MagicLinkForm } from "./magic-link-form";
+
+const signInMagicLink = vi.fn();
+const toastError = vi.fn();
+
+vi.mock("@/lib/auth-client", () => ({
+  authClient: {
+    signIn: {
+      get magicLink() {
+        return signInMagicLink;
+      },
+    },
+  },
+}));
+vi.mock("sonner", () => ({
+  toast: {
+    get error() {
+      return toastError;
+    },
+  },
+}));
+
+beforeEach(() => {
+  signInMagicLink.mockReset();
+  signInMagicLink.mockResolvedValue({ data: null, error: null });
+  toastError.mockReset();
+  window.history.replaceState({}, "", "/auth");
+});
+
+function field() {
+  return screen.getByLabelText("Email");
+}
+
+function submit() {
+  return screen.getByRole("button", { name: "Email me a sign-in link" });
+}
+
+async function send(address: string) {
+  const user = userEvent.setup();
+  if (address) await user.type(field(), address);
+  await user.click(submit());
+  return user;
+}
+
+describe("MagicLinkForm", () => {
+  // The "Controls" row of
+  // `docs/design_ref/2026-09-05/Course Community - Design System.dc.html`: a
+  // field is 40px at a 10px radius, a primary button 38px at 9px. Both were
+  // shadcn's 32px at 10px.
+  describe("control metrics", () => {
+    it("gives the address the design's field", () => {
+      render(<MagicLinkForm />);
+      expect(field()).toHaveClass(
+        "h-10",
+        "rounded-[10px]",
+        "border-cc-rule3",
+        "bg-cc-surface",
+        "text-[14px]",
+      );
+    });
+
+    it("gives the send the design's primary action", () => {
+      render(<MagicLinkForm />);
+      expect(submit()).toHaveClass(
+        "h-[38px]",
+        "rounded-[9px]",
+        "bg-cc-btn",
+        "text-cc-btn-fg",
+        "text-[13.5px]",
+      );
+    });
+  });
+
+  describe("an address that is not one", () => {
+    // `type="email"` alone hands this to the browser, which refuses the submit
+    // and raises its own bubble — native chrome the design has no say over, and
+    // which left `formSchema`'s message unreachable. The form opts out so the
+    // designed line is what a visitor actually sees.
+    it("shows the schema's own message rather than the browser's bubble", async () => {
+      render(<MagicLinkForm />);
+      await send("not-an-email");
+
+      const message = await screen.findByRole("alert");
+      expect(message).toHaveTextContent("Enter a valid email address.");
+      expect(message).toHaveClass("text-cc-danger-ink");
+    });
+
+    it("points the field at the message so a screen reader reaches it", async () => {
+      render(<MagicLinkForm />);
+      await send("not-an-email");
+
+      const message = await screen.findByRole("alert");
+      await waitFor(() =>
+        expect(field()).toHaveAttribute("aria-invalid", "true"),
+      );
+      expect(field()).toHaveAttribute("aria-describedby", message.id);
+    });
+
+    it("sends nothing", async () => {
+      render(<MagicLinkForm />);
+      await send("not-an-email");
+      await screen.findByRole("alert");
+      expect(signInMagicLink).not.toHaveBeenCalled();
+    });
+
+    it("says nothing before the visitor has tried", () => {
+      render(<MagicLinkForm />);
+      expect(screen.queryByRole("alert")).not.toBeInTheDocument();
+      expect(field()).toHaveAttribute("aria-invalid", "false");
+    });
+  });
+
+  // #180 fixed the magic link hardcoding `callbackURL: "/search"` and throwing
+  // the return location away. This is the path that cannot recover it any other
+  // way — the link is opened in a new tab, where the URL the mail carries is
+  // the only thing that survives — so the promise is asserted here rather than
+  // left to `return-to`'s unit tests alone.
+  describe("where the link comes back to", () => {
+    it("mails a link back to the page `?next=` names", async () => {
+      window.history.replaceState(
+        {},
+        "",
+        "/auth?next=%2Fcourse%2FDD2380%3Fq%3Dagents",
+      );
+      render(<MagicLinkForm />);
+      await send("elsa@kth.se");
+
+      await waitFor(() => expect(signInMagicLink).toHaveBeenCalledTimes(1));
+      expect(signInMagicLink).toHaveBeenCalledWith({
+        email: "elsa@kth.se",
+        callbackURL: "/course/DD2380?q=agents",
+        errorCallbackURL: "/auth",
+      });
+    });
+
+    it("falls back to the front door when the URL does not say", async () => {
+      render(<MagicLinkForm />);
+      await send("elsa@kth.se");
+
+      await waitFor(() => expect(signInMagicLink).toHaveBeenCalledTimes(1));
+      expect(signInMagicLink.mock.calls[0][0].callbackURL).toBe("/search");
+    });
+
+    it("refuses to come back to somewhere that is not this site", async () => {
+      window.history.replaceState(
+        {},
+        "",
+        "/auth?next=https%3A%2F%2Fevil.example%2Fsteal",
+      );
+      render(<MagicLinkForm />);
+      await send("elsa@kth.se");
+
+      await waitFor(() => expect(signInMagicLink).toHaveBeenCalled());
+      expect(signInMagicLink.mock.calls[0][0].callbackURL).toBe("/search");
+    });
+  });
+
+  describe("once the link is on its way", () => {
+    it("confirms it in the artboard's words, with the address it used", async () => {
+      render(<MagicLinkForm />);
+      await send("elsa@kth.se");
+
+      const sent = await screen.findByRole("status");
+      expect(sent).toHaveTextContent("Check your inbox");
+      expect(sent).toHaveTextContent(/sign-in link to elsa@kth\.se/);
+      // `BANNERS` in the Design System artboard pairs these for a banner that
+      // says something worked.
+      expect(sent).toHaveClass(
+        "bg-cc-success-tint",
+        "border-cc-success-tint-border",
+      );
+    });
+
+    it("takes the form away so nothing is sent twice", async () => {
+      render(<MagicLinkForm />);
+      await send("elsa@kth.se");
+
+      await screen.findByRole("status");
+      expect(screen.queryByLabelText("Email")).not.toBeInTheDocument();
+      expect(
+        screen.queryByRole("button", { name: "Email me a sign-in link" }),
+      ).not.toBeInTheDocument();
+    });
+  });
+
+  it("reports a refused send and leaves the form standing", async () => {
+    signInMagicLink.mockResolvedValue({
+      data: null,
+      error: { message: "nope" },
+    });
+    render(<MagicLinkForm />);
+    await send("elsa@kth.se");
+
+    await waitFor(() => expect(toastError).toHaveBeenCalled());
+    expect(field()).toBeInTheDocument();
+    expect(screen.queryByRole("status")).not.toBeInTheDocument();
+  });
+});

--- a/apps/web/features/auth/components/magic-link-form.tsx
+++ b/apps/web/features/auth/components/magic-link-form.tsx
@@ -22,9 +22,16 @@ const formSchema = z.object({
  * Focus follows `feedback-form.tsx` for the reason recorded there — the
  * artboards draw no focus state, and `--cc-hov` is the palette's own emphasis
  * border, so a keyboard gets something to follow without a new colour.
+ *
+ * The invalid border is `--cc-danger`, matching `find-your-dot.tsx`, which is
+ * the other place in this repo that asks for an email address and mails a link
+ * back. The Landing artboard draws that border as a saturated `#c2410c` rather
+ * than a tint, and no `--cc-*` token is that colour; `--cc-danger` is the one
+ * the sibling settled on and the one the message underneath uses, so the two
+ * halves of "this is wrong" are the same colour.
  */
 const FIELD =
-  "h-10 w-full rounded-[10px] border border-cc-rule3 bg-cc-surface px-[14px] text-[14px] text-cc-ink outline-none focus-visible:border-cc-hov focus-visible:ring-2 focus-visible:ring-cc-hov/40 aria-invalid:border-cc-danger-tint-border";
+  "h-10 w-full rounded-[10px] border border-cc-rule3 bg-cc-surface px-[14px] text-[14px] text-cc-ink outline-none focus-visible:border-cc-hov focus-visible:ring-2 focus-visible:ring-cc-hov/40 aria-invalid:border-cc-danger";
 
 /**
  * The design's **Primary action**, same row: 38px tall, 9px radius, 16px of
@@ -163,7 +170,7 @@ export function MagicLinkForm() {
                 <p
                   id={`${id}-email-error`}
                   role="alert"
-                  className="mt-2 text-[12.5px] text-cc-danger-ink"
+                  className="mt-2 text-[12.5px] text-cc-danger"
                 >
                   {message}
                 </p>

--- a/apps/web/features/auth/components/magic-link-form.tsx
+++ b/apps/web/features/auth/components/magic-link-form.tsx
@@ -2,24 +2,9 @@
 
 import { useForm } from "@tanstack/react-form";
 import { Mail } from "lucide-react";
-import { useState } from "react";
+import { useId, useState } from "react";
 import { toast } from "sonner";
 import { z } from "zod";
-import { Button } from "@/components/ui/button";
-import {
-  Empty,
-  EmptyDescription,
-  EmptyHeader,
-  EmptyMedia,
-  EmptyTitle,
-} from "@/components/ui/empty";
-import {
-  Field,
-  FieldError,
-  FieldGroup,
-  FieldLabel,
-} from "@/components/ui/field";
-import { Input } from "@/components/ui/input";
 import { Spinner } from "@/components/ui/spinner";
 import { authClient } from "@/lib/auth-client";
 import { requestedReturnTo } from "../lib/return-to";
@@ -28,8 +13,50 @@ const formSchema = z.object({
   email: z.string().email("Enter a valid email address."),
 });
 
+/**
+ * The design's **field**, from the "Controls" row of
+ * `docs/design_ref/2026-09-05/Course Community - Design System.dc.html`: 40px
+ * tall, 10px radius, 14px of side padding, `--rule3` around `--surface`, 14px
+ * text. shadcn's `Input` is 32px at a 10px radius, which is what this was.
+ *
+ * Focus follows `feedback-form.tsx` for the reason recorded there — the
+ * artboards draw no focus state, and `--cc-hov` is the palette's own emphasis
+ * border, so a keyboard gets something to follow without a new colour.
+ */
+const FIELD =
+  "h-10 w-full rounded-[10px] border border-cc-rule3 bg-cc-surface px-[14px] text-[14px] text-cc-ink outline-none focus-visible:border-cc-hov focus-visible:ring-2 focus-visible:ring-cc-hov/40 aria-invalid:border-cc-danger-tint-border";
+
+/**
+ * The design's **Primary action**, same row: 38px tall, 9px radius, 16px of
+ * side padding, `--btn` under `--btnFg` at 13.5px/600, and `.88` opacity on
+ * hover.
+ */
+const SUBMIT =
+  "flex h-[38px] w-full cursor-pointer items-center justify-center gap-2 rounded-[9px] bg-cc-btn px-4 font-semibold text-[13.5px] text-cc-btn-fg outline-none hover:opacity-[0.88] focus-visible:ring-2 focus-visible:ring-cc-hov/40 disabled:cursor-not-allowed disabled:opacity-60";
+
+/**
+ * The first thing wrong with the address, in the words `formSchema` gave it.
+ *
+ * TanStack Form hands back whatever the validator produced, which for a
+ * Standard Schema is an issue object rather than a string. Reading `message`
+ * off it — and tolerating a bare string — keeps the schema the single place the
+ * wording lives, instead of a second copy of "Enter a valid email address."
+ * sitting in the markup and drifting from it.
+ */
+function firstError(errors: readonly unknown[]): string | null {
+  for (const error of errors) {
+    if (typeof error === "string" && error) return error;
+    if (error && typeof error === "object" && "message" in error) {
+      const { message } = error as { message?: unknown };
+      if (typeof message === "string" && message) return message;
+    }
+  }
+  return null;
+}
+
 export function MagicLinkForm() {
   const [sentTo, setSentTo] = useState<string | null>(null);
+  const id = useId();
   const form = useForm({
     defaultValues: { email: "" },
     validators: { onSubmit: formSchema },
@@ -53,60 +80,111 @@ export function MagicLinkForm() {
 
   if (sentTo) {
     return (
-      <Empty>
-        <EmptyHeader>
-          <EmptyMedia variant="icon">
-            <Mail />
-          </EmptyMedia>
-          <EmptyTitle>Check your email</EmptyTitle>
-          <EmptyDescription>
+      // `output` is the element for a result the page computed; its implicit
+      // role is `status`, which is what announces this without stealing focus
+      // from a visitor who is already reaching for their inbox. Same element
+      // and same banner the contact form's "Message sent" uses, on the Design
+      // System's success family (`BANNERS`: `--successTint` on
+      // `--successTintBorder` with `--successInk`).
+      //
+      // "Check your inbox" is the artboard's own title for this state
+      // (`Course Community - Landing.dc.html`, the `isDotSent` branch). Its
+      // body is not, because the artboard's mock cannot send anything and hedges
+      // — "if an account exists for this email" — where we know perfectly well
+      // that one was just sent, to an address the visitor typed a moment ago
+      // and may want to check for a typo, and that it does not last long.
+      <output className="mt-4 flex animate-in items-start gap-[11px] rounded-[12px] border border-cc-success-tint-border bg-cc-success-tint px-4 py-[15px] duration-200 ease-out fade-in slide-in-from-bottom-[6px]">
+        <Mail
+          size={17}
+          strokeWidth={2.1}
+          aria-hidden
+          className="mt-px shrink-0 text-cc-success-ink"
+        />
+        <div>
+          <div className="font-semibold text-[14px] text-cc-success-ink">
+            Check your inbox
+          </div>
+          <div className="mt-[3px] text-[12.5px] text-cc-ink2 leading-[1.5]">
             We sent a sign-in link to {sentTo}. It expires in 5 minutes.
-          </EmptyDescription>
-        </EmptyHeader>
-      </Empty>
+          </div>
+        </div>
+      </output>
     );
   }
 
   return (
     <form
+      className="mt-4"
+      // `type="email"` makes the browser refuse the submit and raise its own
+      // bubble, which is native chrome in a typeface and colour the design has
+      // no say over — and which meant `formSchema`'s message, the artboard's
+      // own "Enter a valid email address.", was unreachable in a real browser.
+      // Turning the native pass off routes a bad address to the designed line
+      // instead. The type attribute stays: it is what asks a phone for the
+      // right keyboard and what tells a password manager this is an address.
+      noValidate
       onSubmit={(event) => {
         event.preventDefault();
         void form.handleSubmit();
       }}
     >
-      <FieldGroup>
-        <form.Field name="email">
-          {(field) => {
-            const isInvalid =
-              field.state.meta.isTouched && !field.state.meta.isValid;
-            return (
-              <Field data-invalid={isInvalid}>
-                <FieldLabel htmlFor={field.name}>Email</FieldLabel>
-                <Input
-                  id={field.name}
-                  name={field.name}
-                  type="email"
-                  autoComplete="email"
-                  placeholder="your.email@kth.se"
-                  value={field.state.value}
-                  onBlur={field.handleBlur}
-                  onChange={(event) => field.handleChange(event.target.value)}
-                  aria-invalid={isInvalid}
-                />
-                {isInvalid && <FieldError errors={field.state.meta.errors} />}
-              </Field>
-            );
-          }}
-        </form.Field>
+      <form.Field name="email">
+        {(field) => {
+          const isInvalid =
+            field.state.meta.isTouched && !field.state.meta.isValid;
+          const message = isInvalid
+            ? firstError(field.state.meta.errors)
+            : null;
+          return (
+            <div>
+              <label
+                className="mb-1.5 block font-medium text-[12.5px] text-cc-ink2"
+                htmlFor={`${id}-email`}
+              >
+                Email
+              </label>
+              <input
+                id={`${id}-email`}
+                name={field.name}
+                type="email"
+                autoComplete="email"
+                placeholder="your.email@kth.se"
+                value={field.state.value}
+                onBlur={field.handleBlur}
+                onChange={(event) => field.handleChange(event.target.value)}
+                aria-invalid={isInvalid}
+                // Tied to the message rather than left to the visitor to find:
+                // the line below is the only thing that says what to fix, and
+                // a screen reader reaches the field first.
+                aria-describedby={message ? `${id}-email-error` : undefined}
+                className={FIELD}
+              />
+              {message ? (
+                <p
+                  id={`${id}-email-error`}
+                  role="alert"
+                  className="mt-2 text-[12.5px] text-cc-danger-ink"
+                >
+                  {message}
+                </p>
+              ) : null}
+            </div>
+          );
+        }}
+      </form.Field>
+      {/* 14px under the field, which is the gap the Landing artboard's own
+          email panel leaves between the address and the button that sends
+          to it. */}
+      <div className="mt-3.5">
         <form.Subscribe selector={(state) => state.isSubmitting}>
           {(isSubmitting) => (
-            <Button type="submit" disabled={isSubmitting} className="w-full">
-              {isSubmitting ? <Spinner data-icon="inline-start" /> : null}
+            <button type="submit" disabled={isSubmitting} className={SUBMIT}>
+              {isSubmitting ? <Spinner /> : null}
               Email me a sign-in link
-            </Button>
+            </button>
           )}
         </form.Subscribe>
-      </FieldGroup>
+      </div>
     </form>
   );
 }


### PR DESCRIPTION
Closes #164 once merged — not closing it from here.

`/auth` was shadcn's `login-02` block close to verbatim, and the only file
under `features/` with zero `--cc-*` classes. It is the route a signed-out
visitor sees before anything else, so it is where "the shadcn tokens map onto
`--cc-*`, therefore there is one visual system" stopped being true.

## The dark-theme surface inversion was real

The issue flagged this as inferred from token values and asked for it to be
confirmed on screen before being treated as a reason to act. It holds.

Read off the running page in dark theme, before the change:

| element | computed |
| --- | --- |
| `body` | `rgb(7, 24, 49)` — `--cc-pg` |
| page ground (`bg-muted`) | `rgba(244, 238, 226, 0.16)` |
| card (`bg-card`) | `rgb(11, 37, 76)` — `--cc-surface` |

`bg-muted` aliases to `--cc-pill`, which in dark is a 16% cream. Over
`--cc-pg` it composites to `#2d3a4d`, whose relative luminance is `0.042`
against the card's `0.019` — the ground was **2.2× lighter than the card
standing on it**, and a grey rather than the design's blue. Confirmed
visually too: the card read as a dark hole punched in a lighter page.

After: ground `rgb(7, 24, 49)`, card `rgb(11, 37, 76)`. Right way up.

## Metrics

All from the "Controls" row of
`docs/design_ref/2026-09-05/Course Community - Design System.dc.html`, which
is the only artboard that states these numbers. Measured in the browser
before and after.

| control | was | now | artboard |
| --- | --- | --- | --- |
| Google / GitHub buttons | 32px, r10, 14px text | **38px, r9, 13.5px** | "Secondary" — `height:38px;border-radius:9px;border:1px solid var(--rule3);background:var(--surface);font-size:13.5px;font-weight:500` |
| "Email me a sign-in link" | 32px, r10, 14px text | **38px, r9, 13.5px** | "Primary action" — `height:38px;border-radius:9px;background:var(--btn);color:var(--btnFg);font-size:13.5px;font-weight:600`, `.88` on hover |
| email field | 32px, r10 | **40px, r10, 14px** | "Field placeholder" — `height:40px;padding:0 14px;border-radius:10px;border:1px solid var(--rule3);background:var(--surface);font-size:14px` |
| page ground | `bg-muted` | `bg-cc-pg` | "Surfaces": `--pg` is the page background |
| card | bare shadcn `Card` | `bg-cc-surface`, `border-cc-rule2`, r14 | `--surface` is "cards, fields, menus"; `RULES` names `--rule2` the card border. Radius 14 and the resting shadow `0 4px 20px rgba(20,30,45,.08)` from `Course Community - Review Card Options.dc.html` |
| divider | `after:border-t`, label repainting the card behind itself | two `bg-cc-rule` hairlines around an eyebrow label | `--rule` is "hairline between rows"; the label is the Design System "Type" row's eyebrow (11px / 600 / .09em / uppercase / `--dim`) |
| error banner | shadcn `Alert` | `bg-cc-danger-tint` + `border-cc-danger-tint-border` + `text-cc-danger-ink` | `BANNERS` names that trio "Error banner" |
| sent confirmation | shadcn `Empty` | the success trio, same shape `feedback-form.tsx` already uses | `BANNERS`, "Upload success banner" |

Type follows the same artboard: 19/600/1.25 title, 13.5/1.55 `--muted` body,
11/600/.09em uppercase eyebrow.

Responsive is a container query on the card rather than a viewport breakpoint
(`grid-cols-1 @xs:grid-cols-2`), because the card is 400px wide on a 1440px
display — the window's width was never what decided whether "Google" and
"GitHub" fit side by side. Verified live: `171px 171px` at the card's full
width, one column once the card drops under 20rem.

## Copy

The header is `REASONS["log-in"]` from
`docs/design_ref/2026-09-05/Course Community - Landing.dc.html` — "Welcome
back" / "Log in to Course Community" / "Browsing never needs an account …",
the same three lines `AuthReasonDialog` renders — in place of shadcn's
"Welcome!". Written out rather than shared with the dialog: that map is keyed
by *why* a protected action interrupted somebody, and `/auth` is reached with
no such reason.

`?error=` on this route means one thing — Better Auth refused a magic link —
and the artboard has words for exactly that state (its `isDotExpired`
branch): "This link no longer works" / "Private links expire after a short
while, and each one can be used once. Request a new link to try again."
Rendered as a banner above both ways in rather than as the artboard's
whole-panel takeover, since Google, GitHub and a fresh link all still work
underneath it.

The artboard's own button labels are **not** adopted. It offers "Continue
with KTH account"; `server/auth.ts` configures no KTH IdP, and naming a
provider that does not exist is the one way this page could lie to a
first-time visitor. `auth.spec.tsx` asserts no such button ships.

## What I left alone in the auth flow

PR #180's return-to work is untouched. `requestedReturnTo()` still feeds
`callbackURL` on both the social and the magic-link path, `errorCallbackURL`
is still `"/auth"`, and `lib/return-to.ts` is not modified. It now has
component-level regression coverage on both paths — `?next=` carried through,
`/search` as the fallback, and `https://evil.example`, `//evil.example` and a
backslash-prefixed path all refused — so a future styling pass cannot quietly
undo it the way the original hardcoded `"/search"` did.

Also left alone, and reported rather than changed:

- **`errorCallbackURL: "/auth"` drops `?next=`.** After an expired link the
  visitor lands back on `/auth` with no destination, so the retry goes to
  `/search` even though the first attempt knew better. A real gap in #180's
  promise, but it is the auth flow, which this issue puts out of scope.
  Worth its own issue.
- Better Auth configuration, the provider set, and the magic link's
  five-minute expiry: untouched.

## Two things the pass turned up

- **`type="email"` made the designed error unreachable.** The browser refused
  the submit and raised its own bubble, so `formSchema`'s message — the
  artboard's own "Enter a valid email address." — never rendered in a real
  browser. Confirmed on the running page (`input.validity.valid` false,
  submit swallowed, no message in the DOM). The form now sets `noValidate`,
  the way `feedback-form.tsx` already does and for the reason recorded there,
  and the field points at the message with `aria-describedby`. The `email`
  type stays — it is what asks a phone for the right keyboard.
- **`justify-center` put the card's top out of reach.** A flex item centred
  by justification overflows both ends of a container it outgrows, and the
  top end is the one nothing scrolls back to. This card grows: the
  expired-link banner adds most of a hundred pixels. Auto margins instead.

## Files I did not own

None reached into. `app/globals.css`, `components/ui/**`, `features/**`
outside `auth`, and `server/**` are untouched, and **no token was added** —
everything here consumes `--cc-*` tokens that already exist.

The only thing I wanted and did not have was a resting-card shadow token.
`0 4px 20px rgba(20,30,45,.08)` is a literal here because the palette has no
shadow tokens at all, and adding the first one is a `globals.css` decision
rather than mine. `reviewer-card.tsx` and `unreviewed-card.tsx` already carry
their own shadow literals for the same reason, so this is consistent with the
repo rather than new.

## A cross-surface difference worth naming

`features/landing/components/find-your-dot.tsx` is the other place in this
repo that asks for an email address and mails a link back, and it implements
the Landing artboard's own panel: a 40px field at a **9px** radius and a
**40px** submit at 9px. `/auth` here is 40px/**10px** and **38px**/9px,
because the Design System artboard states those and the Landing panel is a
different artboard with its own numbers.

That is a real difference between two neighbouring surfaces, and it is the
artboards' rather than mine. Reconciling it means deciding which of the two
the design intends to win, which is a design question and not this issue's.
Both files now agree on everything the artboards *do* agree on: `noValidate`,
`--cc-danger` for an invalid border, the message under it in the same colour,
and `aria-describedby` tying the two together.

## Validation

- `bun run lint` — clean (8 warnings, all pre-existing unused imports in
  `server/db/schema.ts`)
- `bun run typecheck` — exit 0
- `bun run test:web` — 82 files, 1084 tests passing; `features/auth` goes
  from 22 tests to 53
- Rendered at `localhost` in both themes, with and without `?error=`, and
  every metric in the table above read back off the live page rather than
  assumed
- New specs hold under React Strict Mode's double mount

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017EAUKDDo2BkQTFELyvV3v8
