### PR TITLE
fix(reviews): unify the ReviewDraft decoder, and name the applied-bar blue

### DIFF
--- a/apps/web/app/globals.css
+++ b/apps/web/app/globals.css
@@ -91,6 +91,7 @@
   --color-cc-node-violet: var(--cc-node-violet);
   --color-cc-checked-tint: var(--cc-checked-tint);
   --color-cc-checked-hover-tint: var(--cc-checked-hover-tint);
+  --color-cc-applied: var(--cc-applied);
 }
 
 :root {
@@ -98,6 +99,10 @@
      `docs/design_ref/2026-09-05/cc-theme.css`. That file is the design's single
      definition of both palettes, so nothing here is tuned locally: a colour
      change belongs in the design and arrives here as a re-mirror.
+
+     One exception, and it is named where it is declared: `--cc-applied` at the
+     foot of this block is a colour the artboards use inline and `cc-theme.css`
+     has never named. It is the only token here without a line to mirror.
 
      pg page background  surface cards, fields, menus  inset recessed panel
      pill chips, tracks and hover fills
@@ -196,6 +201,62 @@
   /* "Mark as taken" and "Save" once they are on, plus that state's hover. */
   --cc-checked-tint: rgba(23, 81, 166, 0.08);
   --cc-checked-hover-tint: rgba(23, 81, 166, 0.14);
+
+  /* The applied end of a theory/applied bar — the one colour on these screens
+     the design uses without ever having named (#173).
+
+     `cc-theme.css` in the 2026-09-05 export contains no `9dbfe4` and declares no
+     token for it, while `Course Community - Workspace Pane.dc.html:115` writes
+     the hex inline as the applied half of the bar. Four other artboards reuse it
+     as a dashed "add something" border and as link text on a toast. So it is a
+     real colour of the design with no name, which is why this is the one `--cc-*`
+     token below that is not a line of `cc-theme.css`. When an export finally
+     names it, this is the token to reconcile.
+
+     ## Why two literals and not one `color-mix`
+
+     Three call sites used to derive it as
+     `color-mix(in srgb, var(--cc-btn) 40%, var(--cc-surface))`, which was the
+     right substitution while nothing was named (#86's rule) and is the wrong
+     shape for a token. A mix is a standing promise that the derivation will keep
+     being correct, and nobody re-checks it: `--cc-btn` inverts between the
+     themes — `#1751a6` light, `#8bb3ef` dark — so the mix silently re-resolves
+     every time either input moves. That is the same mechanism that put a white
+     "Sign up" button on a `--cc-btn` rail, which the 2026-09-05 export had to
+     fix. Two flat values are checked once and reviewed when changed, and they
+     are what every other token here is.
+
+     Light is the artboard's own literal, so this stops approximating it: the mix
+     resolved to `#a2b9db`, which also held the "Applied" label (`--cc-brand`
+     `#1751a6`, 12px semibold) at 3.80:1 where the design's value gives 3.98:1.
+
+     Dark is chosen for the dark page, by the design's own reflection: it moves
+     `--cc-btn` from HSL lightness 37% to 74% and keeps hue and saturation, so
+     this moves its light value (H211 S57% L75%) to L38% the same way. Pinning
+     `#9dbfe4` in dark was the one thing that could not work — at luminance 0.50
+     against `--cc-btn`'s 0.44 the quieter half of the bar would read *brighter*
+     than the brand half it sits beside, 1.12:1 apart.
+
+     ## What it is not for
+
+     The bar, and nothing else yet. #173 asked whether the draft's starter pills
+     should take it too — the artboard draws them with the same hex, dashed
+     (`Course Community - Workspace Pane.dc.html:274`), where
+     `review-draft-panel.tsx` uses `border-cc-hov`. They are left alone on
+     purpose: `Collections.dc.html:108` and `:134` draw the same dashed
+     `#9dbfe4` and `collections.tsx:524`/`:553` already map both onto
+     `--cc-hov`. Moving one of the three onto this token would replace one
+     inconsistency with a worse one — the same artboard element spelled two ways
+     — and this token is named for a fill in a bar, not for a border. If the
+     dashed border is worth its own name it is worth all three call sites and a
+     name of its own.
+
+     Resolved: light `#9dbfe4` — 1.91:1 on `--cc-surface`, 3.98:1 against the
+     `--cc-btn` half beside it, and 3.98:1 under its `--cc-brand` label.
+     Dark `#2a5f98` — 2.31:1 on `--cc-surface`, 3.07:1 against `--cc-btn`, and
+     5.09:1 under `--cc-brand`. Neither disappears into its ground and neither
+     is mistakable for the half beside it. */
+  --cc-applied: #9dbfe4;
 
   /* ── shadcn primitives, expressed in Course Community tokens ──────────────
      `components/ui/**` is a stock shadcn set and styles itself against
@@ -351,6 +412,14 @@
   --cc-danger-ink2: #ffb3ab;
   --cc-checked-tint: rgba(142, 194, 255, 0.22);
   --cc-checked-hover-tint: rgba(142, 194, 255, 0.32);
+
+  /* The applied end of a theory/applied bar, chosen for this page rather than
+     mixed for it — see the light block. The artboards hardcode the light hex
+     here too, which is what makes this the one value in the file that no export
+     has ever stated for dark. Same hue and saturation as the light value
+     (H211 S57%), lightness dropped 75% → 38% the way `--cc-btn` itself is
+     reflected between the two palettes. */
+  --cc-applied: #2a5f98;
 }
 
 @layer base {

--- a/apps/web/app/globals.css
+++ b/apps/web/app/globals.css
@@ -100,9 +100,10 @@
      definition of both palettes, so nothing here is tuned locally: a colour
      change belongs in the design and arrives here as a re-mirror.
 
-     One exception, and it is named where it is declared: `--cc-applied` at the
-     foot of this block is a colour the artboards use inline and `cc-theme.css`
-     has never named. It is the only token here without a line to mirror.
+     One exception, and it is argued where it is declared: `--cc-applied`,
+     further down this block, is a colour the artboards use inline and
+     `cc-theme.css` has never named. It is the only token in either palette with
+     no line to mirror.
 
      pg page background  surface cards, fields, menus  inset recessed panel
      pill chips, tracks and hover fills
@@ -210,21 +211,22 @@
      the hex inline as the applied half of the bar. Four other artboards reuse it
      as a dashed "add something" border and as link text on a toast. So it is a
      real colour of the design with no name, which is why this is the one `--cc-*`
-     token below that is not a line of `cc-theme.css`. When an export finally
-     names it, this is the token to reconcile.
+     token in the file that mirrors nothing. When an export finally names it,
+     this is the token to reconcile.
 
      ## Why two literals and not one `color-mix`
 
-     Three call sites used to derive it as
+     `pane-parts.tsx` and `reviewer-card.tsx` each used to derive it as
      `color-mix(in srgb, var(--cc-btn) 40%, var(--cc-surface))`, which was the
      right substitution while nothing was named (#86's rule) and is the wrong
      shape for a token. A mix is a standing promise that the derivation will keep
      being correct, and nobody re-checks it: `--cc-btn` inverts between the
      themes — `#1751a6` light, `#8bb3ef` dark — so the mix silently re-resolves
-     every time either input moves. That is the same mechanism that put a white
-     "Sign up" button on a `--cc-btn` rail, which the 2026-09-05 export had to
-     fix. Two flat values are checked once and reviewed when changed, and they
-     are what every other token here is.
+     every time either input moves. Colours that quietly track each other are how
+     the light rail ended up painting a `--cc-btn` "Sign up" onto a `--cc-rail`
+     that is the same `#1751a6`; the rail block below is white on purpose for
+     that reason. Two flat values are checked once and reviewed when changed,
+     and they are what every other token here is.
 
      Light is the artboard's own literal, so this stops approximating it: the mix
      resolved to `#a2b9db`, which also held the "Applied" label (`--cc-brand`

--- a/apps/web/features/reviews/components/reviewer-card.tsx
+++ b/apps/web/features/reviews/components/reviewer-card.tsx
@@ -27,8 +27,19 @@ import {
   toggleMethod,
 } from "../lib/review-draft";
 
-/** The applied half of the theory track, as the workspace pane tints it too. */
-const APPLIED_FILL = "color-mix(in srgb, var(--cc-btn) 40%, var(--cc-surface))";
+/**
+ * The applied half of the theory track, as the workspace pane tints it too.
+ *
+ * Both used to spell out the same `color-mix`, and this copy had escaped the
+ * one `features/workspace/components/pane-parts.tsx` exports to stop exactly
+ * that. #173 named the colour instead — `--cc-applied`, per theme, in
+ * `globals.css` — so the two are now two references to one token rather than
+ * two statements of one recipe, and a change to the colour is a change in one
+ * place whichever file you find first. Importing the pane's constant across the
+ * feature boundary would reach past `@/features/workspace`'s barrel into a
+ * component file for a string; the token is the shared thing.
+ */
+const APPLIED_FILL = "var(--cc-applied)";
 /** An unanswered track is drawn in the theme's strong hairline, not a fill. */
 const UNSET_FILL = "var(--cc-rule3)";
 /** Below this share a segment is too narrow to hold its own category name. */

--- a/apps/web/features/reviews/lib/review-draft.spec.ts
+++ b/apps/web/features/reviews/lib/review-draft.spec.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 import {
+  decodeReviewDraft,
   dividerPositions,
   EMPTY_REVIEW_DRAFT,
   evenShares,
@@ -213,5 +214,153 @@ describe("isUntouched", () => {
     expect(isUntouched(draft({ message: "  " }))).toBe(true);
     expect(isUntouched(draft({ happyTook: false }))).toBe(false);
     expect(isUntouched(draft({ approachTheoryPercent: 50 }))).toBe(false);
+  });
+});
+
+/*
+ * The one decoder both storages go through.
+ *
+ * `features/workspace/lib/workspace-storage.ts` and `./reviewer-session.ts`
+ * used to hand-decode a stored draft each. They drifted by four lines, then by
+ * what a malformed record *means* — one salvaged, the other rejected — which is
+ * #166. Everything about the reading is asserted here, once; each storage's own
+ * suite asserts that it goes through this and salvages.
+ */
+describe("decodeReviewDraft", () => {
+  /**
+   * The guard against a field being dropped on the way back in.
+   *
+   * Both old copies spread `EMPTY_REVIEW_DRAFT` before setting the fields they
+   * knew about, which made the result structurally complete whether or not the
+   * decoder had heard of every field: a field added to `ReviewDraft` compiled in
+   * both, type-checked in both, and came back as its empty value after a reload.
+   * The decoder no longer spreads it, so an omission is a compiler error — and
+   * this is the same guarantee at runtime, for the day somebody puts the spread
+   * back.
+   *
+   * `ANSWERED` is typed, so a field added to `ReviewDraft` has to be given a
+   * value here too rather than quietly dropping out of the test with the code.
+   */
+  const ANSWERED: ReviewDraft = {
+    methods: ["exam", "labs"],
+    shares: [60, 40],
+    approachTheoryPercent: 35,
+    workloadScore: 8,
+    learningScore: 6,
+    happyTook: true,
+    message: "Hard, and worth it",
+  };
+
+  it("carries every field of a fully answered draft across", () => {
+    // Every field differs from the empty draft, so a dropped one shows up as a
+    // difference rather than coincidentally matching the default.
+    for (const [field, value] of Object.entries(ANSWERED)) {
+      expect(value, field).not.toEqual(
+        EMPTY_REVIEW_DRAFT[field as keyof ReviewDraft],
+      );
+    }
+
+    expect(decodeReviewDraft(JSON.parse(JSON.stringify(ANSWERED)))).toEqual(
+      ANSWERED,
+    );
+  });
+
+  it("is nothing at all when the value is not an object", () => {
+    for (const value of [null, undefined, "draft", 7, true, ["exam"]]) {
+      expect(decodeReviewDraft(value), String(value)).toBeNull();
+    }
+  });
+
+  it("reads an empty object as a draft nobody has answered", () => {
+    expect(decodeReviewDraft({})).toEqual(EMPTY_REVIEW_DRAFT);
+  });
+
+  /*
+   * Salvage, not reject — the decision #166 had to make, and the reason there
+   * is only one decoder rather than one with a policy argument. Both screens
+   * mirror their state straight back over storage, so a draft refused here is
+   * a draft deleted within a commit. A bar we cannot draw is one unanswered
+   * question; the write-up and the scores are still the writer's work.
+   */
+  describe("a stored draft that is wrong in one field", () => {
+    const KEPT = {
+      workloadScore: 8,
+      learningScore: 3,
+      happyTook: true,
+      message: "Still mine",
+    };
+
+    it("keeps the answers when the bar's arrays do not line up", () => {
+      expect(
+        decodeReviewDraft({
+          ...KEPT,
+          methods: ["exam", "labs"],
+          shares: [100],
+        }),
+      ).toEqual({ ...EMPTY_REVIEW_DRAFT, ...KEPT, methods: [], shares: [] });
+    });
+
+    it("drops a split naming a method this build does not have", () => {
+      expect(
+        decodeReviewDraft({
+          ...KEPT,
+          methods: ["exam", "quiz"],
+          shares: [60, 40],
+        })?.methods,
+      ).toEqual([]);
+    });
+
+    it("drops a split that does not add up to 100", () => {
+      expect(
+        decodeReviewDraft({
+          ...KEPT,
+          methods: ["exam", "labs"],
+          shares: [60, 30],
+        })?.methods,
+      ).toEqual([]);
+    });
+
+    it("drops a split naming the same method twice", () => {
+      expect(
+        decodeReviewDraft({
+          ...KEPT,
+          methods: ["exam", "exam"],
+          shares: [50, 50],
+        })?.methods,
+      ).toEqual([]);
+    });
+
+    it("keeps a split that is entirely fine", () => {
+      expect(
+        decodeReviewDraft({ methods: ["exam", "labs"], shares: [60, 40] }),
+      ).toMatchObject({ methods: ["exam", "labs"], shares: [60, 40] });
+    });
+
+    it("reads an answer of the wrong type as no answer", () => {
+      expect(
+        decodeReviewDraft({
+          workloadScore: "8",
+          learningScore: null,
+          approachTheoryPercent: [],
+          happyTook: "yes",
+          message: 12,
+        }),
+      ).toEqual(EMPTY_REVIEW_DRAFT);
+    });
+
+    /*
+     * `JSON.parse` cannot produce either, but this takes `unknown`. A
+     * non-finite score would travel to `clampScore`, whose `Math.min`/`Math.max`
+     * propagate it into a form the writer is then told is unfinished.
+     */
+    it("reads a score that is not a finite number as no answer", () => {
+      expect(
+        decodeReviewDraft({ workloadScore: Number.NaN })?.workloadScore,
+      ).toBeNull();
+      expect(
+        decodeReviewDraft({ approachTheoryPercent: Number.POSITIVE_INFINITY })
+          ?.approachTheoryPercent,
+      ).toBeNull();
+    });
   });
 });

--- a/apps/web/features/reviews/lib/review-draft.ts
+++ b/apps/web/features/reviews/lib/review-draft.ts
@@ -80,6 +80,155 @@ export const EMPTY_REVIEW_DRAFT: ReviewDraft = {
   message: "",
 };
 
+/* ── Reading a draft back out of a browser ────────────────────────────────────
+ *
+ * Two screens keep an unpublished draft in the browser and read it back on the
+ * next page load: the workspace pane, in `localStorage`, and the fast-track
+ * reviewer, in its tab's `sessionStorage`. Until #166 each had written its own
+ * decoder, field by field, and the two had drifted — first by four lines, then
+ * by what a malformed record *means*. One salvaged, the other rejected. This is
+ * the one decoder both now go through.
+ *
+ * ## Why it does not spread `EMPTY_REVIEW_DRAFT`
+ *
+ * Both old copies started `{ ...EMPTY_REVIEW_DRAFT, ... }` and then set the
+ * fields they knew about. That spread is what made the duplication dangerous
+ * rather than merely untidy: it makes the result structurally complete whether
+ * or not the decoder has heard of every field, so a field added to `ReviewDraft`
+ * compiles in both copies, passes the type checker in both copies, and comes
+ * back as its empty value on the next reload — silently, and delayed until
+ * someone reloads.
+ *
+ * The object literal below therefore names every field and defaults none of
+ * them. Adding a field to `ReviewDraft` now fails to compile *here*, in the one
+ * place that has to learn about it. Do not reintroduce the spread — and if
+ * somebody does, `review-draft.spec.ts` round-trips an exhaustive fixture whose
+ * every field differs from the empty draft, which catches the same mistake at
+ * runtime. The fixture is typed `ReviewDraft`, so a new field forces a new value
+ * into it rather than being quietly omitted from the test too.
+ *
+ * ## Salvage, not reject — and only one of them exists
+ *
+ * A field that cannot be read is dropped; the rest of the draft comes back. The
+ * only thing that yields "no draft" is a value that is not an object at all,
+ * because there is nothing in a string to salvage.
+ *
+ * That is not a preference. Both screens mirror their state straight back over
+ * storage — the workspace pane on the effect #180 rebuilt, the reviewer on
+ * `useEffect(… , [round])` in `reviewer.tsx`, which fires on the mount that
+ * follows the restore — so a draft this function refuses is a draft *deleted*,
+ * within a commit, permanently. Rejecting a whole draft over one unreadable
+ * field burns the write-up and the scores to avoid drawing a bar wrong.
+ *
+ * `reviewer-session.ts` used to reject, on the reading that a half-understood
+ * *round* is worse than none. The round-level check is real and it stays in
+ * that file — an absent or empty queue is still no round. But it is a different
+ * granularity: rejecting one draft never rejected the round, it dealt the same
+ * card with the reviewer's answers thrown away. So there is no call site that
+ * wants rejection, and there is deliberately no policy switch here to give one.
+ */
+
+/**
+ * Whether a parsed value could be a draft at all.
+ *
+ * An array is not: `JSON.parse("[1,2]")` is an object with a `length`, and
+ * reading fields off it would decode a list into an untouched draft rather than
+ * into nothing.
+ *
+ * Exported because the workspace pane's draft is this shape plus two flags, and
+ * its decoder has to read those two off the same record — see
+ * `features/workspace/lib/review-draft.ts`. Sharing the guard is what lets it
+ * extend `decodeDraftAnswers` without asserting a type it has not checked.
+ */
+export function isDraftRecord(
+  value: unknown,
+): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+/**
+ * A stored number, or no answer.
+ *
+ * `Number.isFinite` rather than a bare `typeof`: nothing `JSON.parse` produces
+ * is `NaN` or `Infinity`, but this takes `unknown` and a non-finite score would
+ * travel all the way to `clampScore`, whose `Math.min`/`Math.max` propagate it
+ * into a form the writer is then told is unfinished.
+ */
+function toScore(candidate: unknown): number | null {
+  return typeof candidate === "number" && Number.isFinite(candidate)
+    ? candidate
+    : null;
+}
+
+/** The examination split as `ReviewDraft` holds it: two parallel arrays. */
+type ExaminationSplit = Pick<ReviewDraft, "methods" | "shares">;
+
+function isExaminationKey(value: unknown): value is ExaminationKey {
+  return (EXAMINATION_DISTRIBUTION_KEYS as readonly unknown[]).includes(value);
+}
+
+/**
+ * The stored examination split, or no split at all.
+ *
+ * `methods` and `shares` are parallel, always add up to 100, and name methods
+ * *this* build knows about. A stored `"quiz"` from a build that offered one used
+ * to be cast straight into `ExaminationKey[]` and reach the bar as a segment
+ * with no colour and no label; a length mismatch used to reach `moveDivider` as
+ * arithmetic over `undefined`.
+ *
+ * Anything that fails drops the split and **nothing else**. A split we cannot
+ * read is a question left unanswered; the rest of the review is still the
+ * writer's work and there is no reason to burn it.
+ */
+function toExaminationSplit(value: Record<string, unknown>): ExaminationSplit {
+  const none: ExaminationSplit = { methods: [], shares: [] };
+
+  const { methods, shares } = value;
+  if (!Array.isArray(methods) || !Array.isArray(shares)) return none;
+  if (methods.length !== shares.length || methods.length === 0) return none;
+
+  const named = methods.filter(isExaminationKey);
+  if (named.length !== methods.length) return none;
+  if (new Set(named).size !== named.length) return none;
+
+  const sizes = shares.filter(
+    (share): share is number => typeof share === "number" && share > 0,
+  );
+  if (sizes.length !== shares.length) return none;
+  if (sizes.reduce((total, share) => total + share, 0) !== 100) return none;
+
+  return { methods: named, shares: sizes };
+}
+
+/**
+ * A stored record as this build's answers.
+ *
+ * Total: every record decodes to a draft. The caller has already established
+ * that it *is* a record, which is the only thing that can fail.
+ */
+export function decodeDraftAnswers(
+  value: Record<string, unknown>,
+): ReviewDraft {
+  // Every field named, nothing defaulted from `EMPTY_REVIEW_DRAFT`. See above:
+  // the spread is what let a new field drop out of a reload unnoticed.
+  return {
+    ...toExaminationSplit(value),
+    approachTheoryPercent: toScore(value.approachTheoryPercent),
+    workloadScore: toScore(value.workloadScore),
+    learningScore: toScore(value.learningScore),
+    happyTook: typeof value.happyTook === "boolean" ? value.happyTook : null,
+    message: typeof value.message === "string" ? value.message : "",
+  };
+}
+
+/**
+ * Whatever a browser handed back, as a draft — or `null` when it is not an
+ * object and there is therefore nothing in it to salvage.
+ */
+export function decodeReviewDraft(value: unknown): ReviewDraft | null {
+  return isDraftRecord(value) ? decodeDraftAnswers(value) : null;
+}
+
 /** The smallest share a segment may be dragged to, in whole percent. */
 export const MIN_SHARE = 5;
 /** Shares move in these steps, so the split stays a round number. */

--- a/apps/web/features/reviews/lib/reviewer-session.spec.ts
+++ b/apps/web/features/reviews/lib/reviewer-session.spec.ts
@@ -6,7 +6,7 @@
  * pure-logic suite into the component project just to borrow a global.
  */
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import { EMPTY_REVIEW_DRAFT } from "./review-draft";
+import { EMPTY_REVIEW_DRAFT, type ReviewDraft } from "./review-draft";
 import {
   clearReviewerSession,
   type ReviewerSession,
@@ -34,6 +34,44 @@ describe("a round the tab remembers", () => {
     writeReviewerSession(round);
 
     expect(readReviewerSession()).toEqual(round);
+  });
+
+  /**
+   * The guard against a new field being dropped on the way back in.
+   *
+   * Both storages used to hand-decode a draft field by field over a spread of
+   * `EMPTY_REVIEW_DRAFT`, which made the result structurally complete whether or
+   * not the decoder had heard of every field — so a field added to `ReviewDraft`
+   * compiled, type-checked, and came back empty after a reload (#166). The
+   * decoder no longer spreads the empty draft, so the omission is now a compiler
+   * error; this is the same guarantee at runtime, for the day somebody puts the
+   * spread back.
+   *
+   * `ANSWERED` is typed `ReviewDraft`, so a new field cannot be left out of the
+   * fixture either — it has to be given a value, and that value then has to
+   * survive the trip.
+   */
+  it("brings every field of a fully answered draft back", () => {
+    const ANSWERED: ReviewDraft = {
+      methods: ["exam", "labs"],
+      shares: [60, 40],
+      approachTheoryPercent: 35,
+      workloadScore: 8,
+      learningScore: 6,
+      happyTook: true,
+      message: "Hard, and worth it",
+    };
+    // Every field differs from the empty draft, so a dropped one shows up as a
+    // difference rather than coincidentally matching the default.
+    for (const [field, value] of Object.entries(ANSWERED)) {
+      expect(value, field).not.toEqual(
+        EMPTY_REVIEW_DRAFT[field as keyof ReviewDraft],
+      );
+    }
+
+    writeReviewerSession(session({ drafts: { DD2424: ANSWERED } }));
+
+    expect(readReviewerSession()?.drafts.DD2424).toEqual(ANSWERED);
   });
 
   it("is nothing at all until a round has been written", () => {
@@ -115,24 +153,45 @@ describe("storage that cannot be believed", () => {
 
   /**
    * `methods` and `shares` are parallel arrays, and the bar's arithmetic is
-   * written against that. A pair that does not line up is not a draft this
-   * build can draw, so it is dropped rather than half-restored.
+   * written against that. A pair that does not line up is not a bar this build
+   * can draw — so the *bar* goes, and nothing else does.
+   *
+   * This file used to throw the whole card away, which is the behaviour #166
+   * unified out. Two things make it wrong rather than merely strict. It does
+   * not drop the card: the code stays in `queue`, so the reviewer is dealt the
+   * same course with a blank form. And `reviewer.tsx` mirrors the round back to
+   * storage in a `useEffect` keyed on `round`, which runs on the mount after
+   * the restore — so the write-up and the scores are gone from the tab before
+   * the reviewer has touched anything. The same mechanism #180 fixed in the
+   * workspace pane, in the file documented as the counter-example to it.
    */
-  it("drops a draft whose bar does not line up", () => {
+  it("keeps the answers when only the examination bar is broken", () => {
     sessionStorage.setItem(
       KEY,
       JSON.stringify({
         queue: ["DD2424", "SF1918"],
         done: {},
         drafts: {
-          DD2424: { methods: ["exam", "labs"], shares: [100] },
+          DD2424: {
+            methods: ["exam", "labs"],
+            shares: [100],
+            workloadScore: 9,
+            happyTook: true,
+            message: "Worth it",
+          },
           SF1918: { methods: ["exam"], shares: [100], workloadScore: 6 },
         },
       }),
     );
 
     const round = readReviewerSession();
-    expect(round?.drafts.DD2424).toBeUndefined();
+    expect(round?.drafts.DD2424).toMatchObject({
+      methods: [],
+      shares: [],
+      workloadScore: 9,
+      happyTook: true,
+      message: "Worth it",
+    });
     expect(round?.drafts.SF1918).toMatchObject({
       methods: ["exam"],
       shares: [100],
@@ -140,6 +199,49 @@ describe("storage that cannot be believed", () => {
       happyTook: null,
       message: "",
     });
+  });
+
+  /**
+   * A method this build has never heard of used to be cast into
+   * `ExaminationKey[]` unchecked here — the workspace pane stopped doing that
+   * in #180 and this file kept doing it, which is the drift in miniature. It
+   * would reach the bar as a segment with no colour and no label.
+   */
+  it("drops a split naming a method this build does not have", () => {
+    sessionStorage.setItem(
+      KEY,
+      JSON.stringify({
+        queue: ["DD2424"],
+        done: {},
+        drafts: {
+          DD2424: {
+            methods: ["exam", "quiz"],
+            shares: [60, 40],
+            message: "Still mine",
+          },
+        },
+      }),
+    );
+
+    expect(readReviewerSession()?.drafts.DD2424).toMatchObject({
+      methods: [],
+      shares: [],
+      message: "Still mine",
+    });
+  });
+
+  /** There is nothing in a string to salvage, so this one really is nothing. */
+  it("drops an entry that is not a draft at all", () => {
+    sessionStorage.setItem(
+      KEY,
+      JSON.stringify({
+        queue: ["DD2424", "SF1918"],
+        done: {},
+        drafts: { DD2424: "nope", SF1918: ["exam"] },
+      }),
+    );
+
+    expect(readReviewerSession()?.drafts).toEqual({});
   });
 
   it("fills a draft's missing answers with nothing rather than a value", () => {

--- a/apps/web/features/reviews/lib/reviewer-session.ts
+++ b/apps/web/features/reviews/lib/reviewer-session.ts
@@ -1,8 +1,4 @@
-import {
-  EMPTY_REVIEW_DRAFT,
-  type ExaminationKey,
-  type ReviewDraft,
-} from "./review-draft";
+import { decodeReviewDraft, type ReviewDraft } from "./review-draft";
 
 /**
  * What the fast-track reviewer keeps across a reload of `/taken`, and why.
@@ -29,7 +25,11 @@ import {
  *
  * Every read is defensive. What comes back is whatever was in the tab's
  * storage, possibly written by an older build, so anything that does not match
- * the shape is dropped rather than trusted.
+ * the shape is dropped rather than trusted — but at the granularity the thing
+ * is worth at. A round that is not a round is refused whole; a *draft* is
+ * salvaged field by field by the shared `decodeReviewDraft`, because this file
+ * once had its own copy of that decoder and the workspace pane had another, and
+ * the two came to disagree about what a bad draft means (#166).
  *
  * **Being well-formed is not the same as being current.** Nothing in this file
  * knows which courses still need reviewing, so it cannot tell a round that was
@@ -58,34 +58,6 @@ const OUTCOMES: CardOutcome[] = ["saved", "skipped"];
 
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null && !Array.isArray(value);
-}
-
-function toDraft(value: unknown): ReviewDraft | null {
-  if (!isRecord(value)) return null;
-
-  const methods = Array.isArray(value.methods) ? value.methods : [];
-  const shares = Array.isArray(value.shares) ? value.shares : [];
-  if (
-    !methods.every((method) => typeof method === "string") ||
-    !shares.every((share) => typeof share === "number") ||
-    methods.length !== shares.length
-  ) {
-    return null;
-  }
-
-  const score = (candidate: unknown) =>
-    typeof candidate === "number" ? candidate : null;
-
-  return {
-    ...EMPTY_REVIEW_DRAFT,
-    methods: methods as ExaminationKey[],
-    shares,
-    approachTheoryPercent: score(value.approachTheoryPercent),
-    workloadScore: score(value.workloadScore),
-    learningScore: score(value.learningScore),
-    happyTook: typeof value.happyTook === "boolean" ? value.happyTook : null,
-    message: typeof value.message === "string" ? value.message : "",
-  };
 }
 
 /**
@@ -138,10 +110,30 @@ export function readReviewerSession(): ReviewerSession | null {
     }
   }
 
+  /**
+   * Each card's answers, salvaged rather than vetted.
+   *
+   * `decodeReviewDraft` drops a field it cannot read and keeps the rest, and
+   * this file used to do the opposite: a `methods`/`shares` pair that did not
+   * line up threw the whole card away — write-up, scores and all — on the
+   * reading that a half-understood round is worse than none.
+   *
+   * That reading does not survive looking at what dropping a draft actually
+   * does. It does not drop the *card*: the code stays in `queue`, so the
+   * reviewer is dealt the same course with an empty form and no sign that
+   * anything was lost. And `reviewer.tsx` writes the whole session back in a
+   * `useEffect` keyed on `round`, which fires on the mount that follows the
+   * restore — so the discarded answers are gone from storage before the
+   * reviewer has typed anything, exactly as #180 found in the workspace pane.
+   *
+   * The round-level refusals below are a different thing and they stay: a
+   * missing or empty `queue` is genuinely not a round, and refusing one opens
+   * no card and destroys no answers.
+   */
   const drafts: Record<string, ReviewDraft> = {};
   if (isRecord(value.drafts)) {
     for (const [code, candidate] of Object.entries(value.drafts)) {
-      const draft = toDraft(candidate);
+      const draft = decodeReviewDraft(candidate);
       if (draft) drafts[code] = draft;
     }
   }

--- a/apps/web/features/shell/components/theme-tokens.spec.tsx
+++ b/apps/web/features/shell/components/theme-tokens.spec.tsx
@@ -92,6 +92,26 @@ function ccNameFor(designToken: string): string {
   return `--cc-${designToken.slice(2).replace(/[A-Z]/g, "-$&").toLowerCase()}`;
 }
 
+/**
+ * `--cc-*` tokens the app names and `cc-theme.css` does not.
+ *
+ * The parity check below is the point of this file and this list is a hole in
+ * it, so it is a list rather than a predicate: adding to it is a visible edit
+ * with a reason attached, and everything not on it still fails as loudly as
+ * before.
+ *
+ * - `--cc-applied` — the applied end of a theory/applied bar. The artboards
+ *   write `#9dbfe4` inline for it (`Course Community - Workspace Pane.dc.html`
+ *   at `:115`, and four other artboards reuse the hex for other things) and no
+ *   export has ever given it a name. Three call sites derived it with
+ *   `color-mix` instead; #173 named it here so the derivation cannot silently
+ *   re-resolve when `--cc-btn` moves. Its dark value is the one `--cc-*` value
+ *   in `globals.css` chosen locally, because the artboards hardcode the light
+ *   hex in both themes. When an export names it, delete this entry and the
+ *   parity check picks it up.
+ */
+const UNNAMED_BY_THE_DESIGN = new Set(["--cc-applied"]);
+
 const PALETTES = [
   { theme: "light", ours: ":root", theirs: ":root" },
   { theme: "dark", ours: ".dark", theirs: '[data-cc-theme="dark"]' },
@@ -113,9 +133,31 @@ describe.each(PALETTES)("the $theme palette", (palette) => {
 
   it("adds nothing to the `--cc-*` namespace the design does not define", () => {
     const extra = [...ours.keys()].filter(
-      (name) => name.startsWith("--cc-") && !designed.has(name),
+      (name) =>
+        name.startsWith("--cc-") &&
+        !designed.has(name) &&
+        !UNNAMED_BY_THE_DESIGN.has(name),
     );
     expect(extra).toEqual([]);
+  });
+
+  /**
+   * A hole in the parity check is only safe while it is still needed. An export
+   * that names one of these leaves the entry behind exempting a token the
+   * design now defines — which would let its value drift with nothing checking,
+   * in the one place someone had already decided checking mattered.
+   */
+  it("does not exempt a token the design has since named", () => {
+    const named = [...UNNAMED_BY_THE_DESIGN].filter((name) =>
+      designed.has(name),
+    );
+    expect(named).toEqual([]);
+  });
+
+  /** And an exemption for a token nobody declares any more is dead weight. */
+  it("does not exempt a token globals.css no longer declares", () => {
+    const gone = [...UNNAMED_BY_THE_DESIGN].filter((name) => !ours.has(name));
+    expect(gone).toEqual([]);
   });
 });
 

--- a/apps/web/features/workspace/components/pane-parts.tsx
+++ b/apps/web/features/workspace/components/pane-parts.tsx
@@ -20,29 +20,20 @@ export function Kicker({ children }: { children: ReactNode }) {
 /**
  * The applied end of a theory/applied bar.
  *
- * The design draws it as a fixed pale blue (`#9dbfe4`) that no `--cc-*` token
- * carries, so it is derived from the brand fill rather than invented — the
- * same substitution rule the course card's workload bar took in #86.
+ * This was a `color-mix` of `--cc-btn` over `--cc-surface` — the substitution
+ * #86 settled for a design colour with no token, kept when #127 §1 removed the
+ * other two derivations because those had a real token to swap to and this one
+ * did not. #173 named it: `--cc-applied` in `globals.css` carries a value per
+ * theme, the light one being the artboard's own literal and the dark one chosen
+ * for the dark page rather than mixed for it. The reasoning lives with the
+ * token, which is where a colour's reasoning belongs.
  *
- * ## Why this `color-mix` stays, when #127 §1 removed the others
- *
- * That rule is "no derivation where a real token exists", and here none does.
- * Re-checked against the 2026-09-05 export: `cc-theme.css` contains no
- * `9dbfe4` and names no token for it, while
- * `Course Community - Workspace Pane.dc.html:115` writes the hex inline for
- * this very segment — and again at `:274`, as the dashed border on the draft's
- * starter pills. So it is a small pale blue the design reuses without ever
- * having named, not a token this file failed to find. Pinning the hex is the
- * one thing that would be wrong: it is a light-mode value, and on the dark page
- * it is a bar that reads as brighter than the brand it is meant to sit under.
- *
- * The derivation is therefore the substitution, not a shortcut past a token.
- * Naming it is worth doing and is not this file's to do — `globals.css` owns
- * both halves of the mirror, and a token would want a dark value chosen for the
- * dark page rather than mixed for it. Filed as #173; until then this constant
- * is the single place the mix is written, and
- * `features/reviews/components/reviewer-card.tsx` carries the one copy that has
- * escaped it.
+ * The constant stays, because what it is for has not changed. A course being
+ * read and a review being written draw the same bar in two files, and the token
+ * alone would not stop one of them reaching for `--cc-hov` next time. It is now
+ * a name for the token rather than a name for a mix, so the copy in
+ * `features/reviews/components/reviewer-card.tsx` — which drew the same bar and
+ * had drifted out of here already — is harmless where it is not identical:
+ * both spell the one token.
  */
-export const APPLIED_FILL =
-  "color-mix(in srgb, var(--cc-btn) 40%, var(--cc-surface))";
+export const APPLIED_FILL = "var(--cc-applied)";

--- a/apps/web/features/workspace/lib/review-draft.spec.ts
+++ b/apps/web/features/workspace/lib/review-draft.spec.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 import { sanitizeHtml } from "@/lib/sanitize-html";
 import { examinationDistributionSchema } from "@/types";
 import {
+  decodeReviewDraft,
   EMPTY_REVIEW_DRAFT,
   isUntouched,
   type ReviewDraft,
@@ -175,5 +176,90 @@ describe("what the pane sends", () => {
 
   it("leaves a write-up nobody typed empty rather than inventing a paragraph", () => {
     expect(toReviewFormData(answered({ message: "   " }))?.message).toBe("");
+  });
+});
+
+/*
+ * Only what the pane adds to the shared decoder, for the same reason as the
+ * rest of this file. The answers, and every salvage rule about them, are
+ * `features/reviews/lib/review-draft.spec.ts`'s.
+ */
+describe("decodeReviewDraft", () => {
+  /**
+   * Typed, so a field added to either half of the shape has to be given a value
+   * here and then survive the round trip. That is the runtime half of #166's
+   * guarantee; the compile-time half is that neither decoder defaults anything
+   * from an empty draft any more, so an unhandled field fails to build.
+   */
+  const ANSWERED: ReviewDraft = {
+    methods: ["exam", "labs"],
+    shares: [60, 40],
+    approachTheoryPercent: 35,
+    approachForgotten: true,
+    examinationForgotten: true,
+    workloadScore: 8,
+    learningScore: 6,
+    happyTook: true,
+    message: "Hard, and worth it",
+  };
+
+  it("carries every field of a fully answered draft across", () => {
+    for (const [field, value] of Object.entries(ANSWERED)) {
+      expect(value, field).not.toEqual(
+        EMPTY_REVIEW_DRAFT[field as keyof ReviewDraft],
+      );
+    }
+
+    expect(decodeReviewDraft(JSON.parse(JSON.stringify(ANSWERED)))).toEqual(
+      ANSWERED,
+    );
+  });
+
+  it("is nothing at all when the value is not an object", () => {
+    for (const value of [null, "draft", 7, ["exam"]]) {
+      expect(decodeReviewDraft(value), String(value)).toBeNull();
+    }
+  });
+
+  /**
+   * The flags are the pane's whole extension, and they are the one part of a
+   * draft with no null: a box is ticked or it is not. Anything that is not
+   * `true` is a box nobody ticked, which is also what an older build that never
+   * wrote them looks like.
+   */
+  it("reads a flag that is not true as a box nobody ticked", () => {
+    expect(decodeReviewDraft({})).toMatchObject({
+      examinationForgotten: false,
+      approachForgotten: false,
+    });
+    expect(
+      decodeReviewDraft({ examinationForgotten: "yes", approachForgotten: 1 }),
+    ).toMatchObject({ examinationForgotten: false, approachForgotten: false });
+  });
+
+  /*
+   * A draft carrying both a ticked box and the methods it was meant to clear is
+   * a shape storage can hold — the fields are read one at a time — and
+   * `toReviewFormData` is where "I don't remember" wins. The decoder's job is
+   * to report what was stored, not to tidy it.
+   */
+  it("keeps a ticked box and the answers beside it, and lets the mapper decide", () => {
+    const draft = decodeReviewDraft({
+      methods: ["exam"],
+      shares: [100],
+      examinationForgotten: true,
+      workloadScore: 5,
+      learningScore: 5,
+      happyTook: true,
+    });
+
+    expect(draft).toMatchObject({
+      methods: ["exam"],
+      examinationForgotten: true,
+    });
+    expect(
+      // biome-ignore lint/style/noNonNullAssertion: decoded from a record above.
+      toReviewFormData(draft!)?.examinationDistribution,
+    ).toBeNull();
   });
 });

--- a/apps/web/features/workspace/lib/review-draft.ts
+++ b/apps/web/features/workspace/lib/review-draft.ts
@@ -16,7 +16,9 @@ import type { ReviewFormData } from "@/features/reviews";
  * nothing at runtime and the convention is free to hold there.
  */
 import {
+  decodeDraftAnswers,
   EMPTY_REVIEW_DRAFT as EMPTY_REVIEW_ANSWERS,
+  isDraftRecord,
   isUntouched as noAnswersGiven,
   type ReviewDraft as ReviewAnswers,
   toReviewFormData as toAnsweredFormData,
@@ -60,6 +62,35 @@ export const EMPTY_REVIEW_DRAFT: ReviewDraft = {
   approachForgotten: false,
 };
 
+/**
+ * A stored draft as the pane holds it, or `null` when the stored value is not
+ * an object and there is nothing in it to salvage.
+ *
+ * The answers are `features/reviews/lib/review-draft.ts`'s to decode, for the
+ * same reason the model is: there is nothing about the pane that makes a stored
+ * `workloadScore` mean something else. Only the two flags are read here, which
+ * is exactly the extension this file exists for.
+ *
+ * The record guard is shared rather than repeated so that the flags come off a
+ * value TypeScript has *checked* is a record — the alternative is decoding the
+ * answers first and then asserting that the input must have been a record after
+ * all, which is the kind of unchecked cast #166 set out to remove.
+ *
+ * Nothing is defaulted from `EMPTY_REVIEW_DRAFT`. Adding a field to this
+ * interface fails to compile here, and adding one to `ReviewAnswers` fails to
+ * compile in the reviews decoder; between them there is no field on either half
+ * of the shape that can be added without a compiler error naming the decoder
+ * that has to learn about it.
+ */
+export function decodeReviewDraft(value: unknown): ReviewDraft | null {
+  if (!isDraftRecord(value)) return null;
+  return {
+    ...decodeDraftAnswers(value),
+    examinationForgotten: value.examinationForgotten === true,
+    approachForgotten: value.approachForgotten === true,
+  };
+}
+
 /** The three sections the progress bar counts. */
 export const REVIEW_DRAFT_SECTIONS = 3;
 
@@ -102,8 +133,8 @@ export function isUntouched(draft: ReviewDraft): boolean {
  * The flags are folded away first, and explicitly rather than by relying on the
  * checkboxes having cleared the answers they cover. A draft comes back out of
  * `localStorage`, where it may have been written by an older build or by a
- * tab that never finished a keystroke, and `toDraft` reads each field on its
- * own — so a stored draft carrying both a ticked box and the methods it was
+ * tab that never finished a keystroke, and `decodeReviewDraft` reads each field
+ * on its own — so a stored draft carrying both a ticked box and the methods it was
  * meant to clear is a shape this has to survive. "I don't remember" wins,
  * because that is the answer the writer gave last.
  *

--- a/apps/web/features/workspace/lib/workspace-storage.spec.tsx
+++ b/apps/web/features/workspace/lib/workspace-storage.spec.tsx
@@ -74,6 +74,44 @@ describe("drafts", () => {
     expect(readDrafts().DD2380?.message).toBe("Half a thought");
   });
 
+  /**
+   * The guard against a new field being dropped on the way back in — #166, the
+   * defect underneath the duplication.
+   *
+   * This file's decoder and `features/reviews/lib/reviewer-session.ts`'s both
+   * spread `EMPTY_REVIEW_DRAFT` and then copied across the fields they knew
+   * about, so a field added to the draft compiled in both, type-checked in
+   * both, and came back empty on the next reload from whichever one you forgot.
+   * They now share one decoder, and it defaults nothing — an unhandled field is
+   * a compiler error. This is the same guarantee at runtime.
+   *
+   * `ANSWERED` is typed, so a new field has to be given a value here too, and
+   * every value differs from the empty draft's so a dropped one shows up rather
+   * than coincidentally matching the default.
+   */
+  it("brings every field of a fully answered draft back", () => {
+    const ANSWERED: ReviewDraft = {
+      methods: ["exam", "labs"],
+      shares: [60, 40],
+      approachTheoryPercent: 35,
+      approachForgotten: true,
+      examinationForgotten: true,
+      workloadScore: 8,
+      learningScore: 6,
+      happyTook: true,
+      message: "Hard, and worth it",
+    };
+    for (const [field, value] of Object.entries(ANSWERED)) {
+      expect(value, field).not.toEqual(
+        EMPTY_REVIEW_DRAFT[field as keyof ReviewDraft],
+      );
+    }
+
+    writeFresh({ DD2380: ANSWERED });
+
+    expect(readDrafts().DD2380).toEqual(ANSWERED);
+  });
+
   it("forgets a draft nobody came back to for a week", () => {
     storeRawDraft("DD2380", draftWith(), Date.now() - WEEK_MS - 1000);
 
@@ -258,6 +296,12 @@ describe("drafts the previous release left behind", () => {
  * A decoder that rejects is a decoder that deletes, because the pane writes its
  * state straight back over storage. So a stored draft that is wrong in one
  * field has to come back missing that field and nothing else.
+ *
+ * The rules themselves belong to `features/reviews/lib/review-draft.ts` now —
+ * this file used to hold its own copy of them and `reviewer-session.ts` a
+ * third, which is #166. These stay because what is asserted here is that *this
+ * storage path* still salvages: the shared decoder having the right policy is
+ * no use if a future read stops going through it.
  */
 describe("a stored draft that does not quite fit", () => {
   it("keeps the write-up and the scores when the examination split is broken", () => {

--- a/apps/web/features/workspace/lib/workspace-storage.ts
+++ b/apps/web/features/workspace/lib/workspace-storage.ts
@@ -1,5 +1,3 @@
-import type { ExaminationKey } from "@/features/reviews/lib/review-draft";
-import { EXAMINATION_DISTRIBUTION_KEYS } from "@/types";
 import {
   EMPTY_WORKSPACE,
   type OpenCourse,
@@ -7,6 +5,7 @@ import {
   type Workspace,
 } from "./open-courses";
 import {
+  decodeReviewDraft,
   EMPTY_REVIEW_DRAFT,
   isUntouched,
   type ReviewDraft,
@@ -50,8 +49,15 @@ import {
  * so anything that does not match the shape is dropped rather than trusted. But
  * "dropped" is narrower than it looks: the pane writes its state back over
  * storage, so anything this file refuses to decode is deleted a keystroke later.
- * A draft therefore salvages what it can — see `toDraft` — instead of failing
- * whole.
+ * A draft therefore salvages what it can, instead of failing whole.
+ *
+ * The salvaging is `decodeReviewDraft`'s, in `./review-draft.ts`, which extends
+ * `features/reviews/lib/review-draft.ts`'s decoder with the pane's two flags.
+ * This file used to hold a second hand-written copy of it, and the fast-track
+ * reviewer a third; #166 is what they cost. The three refusals left in this file
+ * are its own and none of them is a field: an entry that is not an object, one
+ * with no `savedAt`, and one whose stamp has expired. Those are deliberate, and
+ * the last of them is the whole point of the stamp.
  */
 
 const WORKSPACE_KEY = "cc.workspace.open";
@@ -150,68 +156,6 @@ export function writeWorkspace(workspace: Workspace): void {
   write("session", WORKSPACE_KEY, workspace);
 }
 
-function isExaminationKey(value: unknown): value is ExaminationKey {
-  return (EXAMINATION_DISTRIBUTION_KEYS as readonly unknown[]).includes(value);
-}
-
-/** The examination split as `ReviewDraft` holds it: two parallel arrays. */
-type ExaminationSplit = Pick<ReviewDraft, "methods" | "shares">;
-
-/**
- * The stored examination split, or no split at all.
- *
- * `methods` and `shares` are parallel, always add up to 100, and name methods
- * *this* build knows about. A stored `"quiz"` from a build that offered one used
- * to be cast straight into `ExaminationKey[]` and reach the bar as a segment
- * with no colour and no label; a length mismatch used to reach `moveDivider` as
- * arithmetic over `undefined`.
- *
- * Anything that fails drops the split and **nothing else**. This check used to
- * reject the whole draft, and since the pane writes its state back over storage
- * on the next keystroke, a draft rejected here was a draft permanently deleted —
- * the write-up and the scores went with the one bad field. A split we cannot
- * read is a question left unanswered; the rest of the review is still the
- * writer's work and there is no reason to burn it.
- */
-function toExaminationSplit(value: Record<string, unknown>): ExaminationSplit {
-  const none: ExaminationSplit = { methods: [], shares: [] };
-
-  const { methods, shares } = value;
-  if (!Array.isArray(methods) || !Array.isArray(shares)) return none;
-  if (methods.length !== shares.length || methods.length === 0) return none;
-
-  const named = methods.filter(isExaminationKey);
-  if (named.length !== methods.length) return none;
-  if (new Set(named).size !== named.length) return none;
-
-  const sizes = shares.filter(
-    (share): share is number => typeof share === "number" && share > 0,
-  );
-  if (sizes.length !== shares.length) return none;
-  if (sizes.reduce((total, share) => total + share, 0) !== 100) return none;
-
-  return { methods: named, shares: sizes };
-}
-
-function toDraft(value: unknown): ReviewDraft | null {
-  if (!isRecord(value)) return null;
-
-  const score = (candidate: unknown) =>
-    typeof candidate === "number" ? candidate : null;
-
-  return {
-    ...EMPTY_REVIEW_DRAFT,
-    ...toExaminationSplit(value),
-    examinationForgotten: value.examinationForgotten === true,
-    approachTheoryPercent: score(value.approachTheoryPercent),
-    approachForgotten: value.approachForgotten === true,
-    workloadScore: score(value.workloadScore),
-    learningScore: score(value.learningScore),
-    happyTook: typeof value.happyTook === "boolean" ? value.happyTook : null,
-    message: typeof value.message === "string" ? value.message : "",
-  };
-}
-
 /** One course's draft with the clock reading that decides when to forget it. */
 interface StoredDraft {
   savedAt: number;
@@ -233,7 +177,7 @@ function decodeStoredDrafts(): Record<string, StoredDraft> {
     const { savedAt } = entry;
     if (typeof savedAt !== "number" || !Number.isFinite(savedAt)) continue;
     if (savedAt < oldest) continue;
-    const draft = toDraft(entry.draft);
+    const draft = decodeReviewDraft(entry.draft);
     if (draft) stored[courseCode] = { savedAt, draft };
   }
   return stored;
@@ -273,7 +217,7 @@ function adoptLegacyDrafts(
   const merged: Record<string, StoredDraft> = { ...stored };
   for (const [courseCode, candidate] of Object.entries(legacy)) {
     if (courseCode in merged) continue;
-    const draft = toDraft(candidate);
+    const draft = decodeReviewDraft(candidate);
     if (!draft || isUntouched(draft)) continue;
     merged[courseCode] = { savedAt: now, draft };
   }
@@ -306,8 +250,8 @@ export function readDrafts(): Record<string, ReviewDraft> {
  * Never stamping would be worse: a draft edited daily would expire mid-edit.
  *
  * Field by field rather than by serialising: both sides are small, and the two
- * come from different places — one from `toDraft`, one from the panel's
- * spreads — so their key order is not something to bet a comparison on.
+ * come from different places — one from `decodeReviewDraft`, one from the
+ * panel's spreads — so their key order is not something to bet a comparison on.
  */
 function sameDraft(a: ReviewDraft, b: ReviewDraft): boolean {
   return (


### PR DESCRIPTION
Closes nothing on its own — #166 and #173 are left open for the owner to close.

## #166 — one decoder, and which failure policy survived

`features/reviews/lib/reviewer-session.ts` and
`features/workspace/lib/workspace-storage.ts` each hand-decoded a stored
`ReviewDraft`. They differed by four lines when #166 was filed. By the time it
was picked up they differed by **behaviour**: #180 taught the workspace copy to
salvage a malformed record, and this one still rejected the whole thing. Two
decoders that had merely diverged were two decoders that disagreed about what a
bad draft means.

Both now go through `decodeReviewDraft` in `features/reviews/lib/review-draft.ts`,
which the pane extends with its two flags in
`features/workspace/lib/review-draft.ts` — the file that already exists to say
what the pane's draft has that the model does not.

### Salvage won, and reject is not reachable any more

Not by preference, and not by merging. The case for keeping `reviewer-session.ts`
rejecting was that it restores a fast-track **round**, and a half-understood
round may be worse than none. That argument does not survive looking at what
rejecting a draft actually did there:

- **It never rejected the round.** The course code stays in `queue`. The reviewer
  is dealt the same card, with an empty form, and no sign anything was lost.
- **It deleted the answers.** `reviewer.tsx` mirrors the round back to storage in
  `useEffect(…, [round])`, which fires on the mount following the restore. So the
  write-up and the scores were gone from the tab before the reviewer typed
  anything — #180's mechanism exactly, in the file its PR describes as *not* at
  risk from it. That note was right about the pane's `hydrated` gate and wrong
  about this: the gate is not what the deletion needed, only a write-back is.

So there was no call site that wanted rejection, and there is deliberately **no
policy parameter** — a future author who wants reject-on-bad-field has to add a
`return null` to a function documented as never doing so, past a test at each
call site asserting the opposite (`reviewer-session.spec.ts` "keeps the answers
when only the examination bar is broken", `workspace-storage.spec.tsx` "a stored
draft that does not quite fit").

The round-level refusals stay where they were and are now named as a different
granularity: an absent or empty `queue` is genuinely not a round, and refusing
one opens no card and destroys no answers.

### The silent field drop cannot happen quietly now — two independent guards

The real defect was `...EMPTY_REVIEW_DRAFT`. It made the decoded object
structurally complete whether or not the decoder had heard of every field, so a
new field compiled, type-checked, and came back empty on the next reload from
whichever copy you forgot.

1. **Compile time.** Neither decoder defaults anything. The object literal names
   every field, so an unhandled one is `TS2741` at the decoder that has to learn
   about it.
2. **Runtime**, for the day somebody puts the spread back. Typed exhaustive
   fixtures — every field set to something the empty draft is not, asserted as
   such in the test — round-trip through the decoder, through `sessionStorage`,
   and through `localStorage`.

Both verified against a simulated regression rather than assumed:

| Simulated change | Result |
|---|---|
| drop `message` from the decoder | `TS2741: Property 'message' is missing … in type 'ReviewDraft'` |
| add a field to the workspace `ReviewDraft` | `TS2741` at `workspace/lib/review-draft.ts:88` (the decoder) plus both fixtures |
| re-add `...EMPTY_REVIEW_DRAFT` **and** drop `message` | typecheck **passes**; 25 tests fail across all three suites |

That last row is the whole point: the type checker alone cannot see the mistake
once the spread is back, and the fixtures can.

### Also closed

- **`reviewer-session.ts`'s unchecked `methods as ExaminationKey[]` was still
  live.** #180 had removed the workspace's; this one survived. A stored `"quiz"`
  from a build that offered one reached the bar as a segment with no colour and
  no label. It now goes through the same `EXAMINATION_DISTRIBUTION_KEYS` check,
  along with the duplicate-method and sums-to-100 rules the workspace already
  had — the reviewer gained four validations by sharing the decoder.
- Scores are read with `Number.isFinite`, not a bare `typeof`. `JSON.parse`
  cannot produce `NaN`, but the decoder takes `unknown` and a non-finite score
  propagates through `clampScore`'s `Math.min`/`Math.max` into a form the writer
  is then told is unfinished.

### What #180 guarantees, untouched

The `hydrated` state gate, the ref-guarded one-shot read, the legacy
`sessionStorage` migration and the per-tab `synced` baseline are all unchanged;
`workspace-pane.tsx` is not in the diff at all. Every test in
`workspace-storage.spec.tsx` and `workspace-pane.spec.tsx` still passes as
written, including "ignores an entry with no stamp" — see below.

### The dropped-entry deletion: partly still live, deliberately

Checked rather than assumed. `writeDrafts` rebuilds the record from
`readStoredDrafts()`, so anything the read refuses is still absent from the next
write and therefore permanently deleted. #180 did not remove that mechanism; it
**narrowed what gets refused** from "any bad field" to three whole-entry cases,
and this change extends the same narrowing to the reviewer. The three refusals
left in `workspace-storage.ts` are its own and none of them is a field: an entry
that is not an object, one with no `savedAt`, and one whose stamp has expired.
The last is the entire purpose of the stamp, and the middle one is asserted by a
#180 test — so they are left alone and now documented as deliberate rather than
as an oversight the decoder happens to inherit.

## #173 — `--cc-applied`

The `color-mix(in srgb, var(--cc-btn) 40%, var(--cc-surface))` in
`pane-parts.tsx` and its byte-identical private copy in `reviewer-card.tsx` are
both now `var(--cc-applied)`. `course-details-panel.tsx` and
`review-draft-panel.tsx` reach it through `APPLIED_FILL`, which stays — it is now
a name for the token rather than a name for a mix.

### Form: two literals, not a `color-mix`

`--cc-btn` inverts between the themes (`#1751a6` light, `#8bb3ef` dark), so a
single fixed literal is wrong in one of them. The choice was between one
`color-mix` tracking both and one literal per theme; **two literals**, for three
reasons:

- A mix is a standing promise that the derivation stays correct, and nobody
  re-checks it — it silently re-resolves whenever either input moves. That is the
  mechanism behind the `--cc-btn`-on-`--cc-rail` invisible "Sign up" button the
  2026-09-05 export had to fix. A literal is checked once and reviewed when
  changed.
- It is what every other token in `globals.css` is, and #173 asked for it in
  those words: the tint families are three flat tokens each rather than one solid
  and a percentage precisely so dark can be chosen for dark.
- It lets light be the artboard's **own** value instead of an approximation of
  it. The mix resolved to `#a2b9db`; the design writes `#9dbfe4`.

### Values, and how they resolve

| | Light | Dark |
|---|---|---|
| `--cc-applied` | `#9dbfe4` — the artboard's literal | `#2a5f98` — chosen for the dark page |
| on `--cc-surface` | 1.91:1 | 2.31:1 |
| against the `--cc-btn` half beside it | 3.98:1 | 3.07:1 |
| under its `--cc-brand` "Applied" label | 3.98:1 (was 3.80:1 under the mix) | 5.09:1 |

Dark is derived the way the design derives its own dark values, not mixed:
`--cc-btn` is reflected from HSL lightness 37% to 74% between the palettes with
hue and saturation held, so the applied blue moves the same way — H211 S57%,
L75% → L38%.

**It is not another invisible-Sign-up-button.** Pinning `#9dbfe4` in dark was the
one thing that could not work: at relative luminance 0.50 against `--cc-btn`'s
0.44 the *quieter* half of the bar would read brighter than the brand half it
sits beside, 1.12:1 apart. Both values are checked against their ground, against
the segment beside them, and under the label they carry, in the table above.

### The starter pills, checked and left

#173 asked whether `review-draft-panel.tsx`'s dashed pills should take the token
too — the artboard draws them with the same hex at
`Course Community - Workspace Pane.dc.html:274` where the repo uses
`border-cc-hov`. They are left, on purpose and recorded in the token's comment:
`Collections.dc.html:108` and `:134` draw the same dashed `#9dbfe4` and
`collections.tsx:524`/`:553` already map both onto `--cc-hov`. Moving one of the
three would spell one artboard element two ways, which is worse than spelling it
one way slightly off — and this token is named for a fill in a bar, not a border.
If the dashed border deserves a name it deserves all three call sites and a name
of its own.

## Validation

- `bun run lint` — clean (the 8 warnings are pre-existing, all in
  `.agents/skills/neon-drizzle` templates, none in `apps/web`).
- `bun run typecheck` — clean.
- `bun run test:web` — **1075 tests / 79 files, green**, up from 1053 / 79 on
  `origin/feat/frontend` (measured on this branch before any spec was touched).
  All UI tests under React Strict Mode, as `vitest.setup.ts` configures.
- Regression coverage verified against the bugs, not just added: the table under
  "two independent guards" is three simulated regressions and what each one
  breaks.

## One file outside the brief

`features/shell/components/theme-tokens.spec.tsx` asserts that `globals.css`
adds nothing to the `--cc-*` namespace that `cc-theme.css` does not define —
which is a good guard and which a new token fails by construction. It gains an
`UNNAMED_BY_THE_DESIGN` list, in the shape of the `LITERALS` list already beside
it: one entry, with the reason, so every *other* addition still fails as loudly
as before. Two tests come with it — the exemption must not outlive the design
naming the token, and must not outlive `globals.css` declaring it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017EAUKDDo2BkQTFELyvV3v8
