### PR TITLE
feat(search): page Explore with a lookahead, and never with a total (#148)

### DIFF
--- a/apps/web/features/search/api/queries.ts
+++ b/apps/web/features/search/api/queries.ts
@@ -17,21 +17,43 @@ export type ExploreFilters = {
   department?: string;
 };
 
-/** Exactly the input `search.courses` takes, from a query and Explore's filters. */
-export function toSearchCoursesInput(query: string, filters: ExploreFilters) {
+/**
+ * Exactly the input `search.courses` takes, from a query, Explore's filters and
+ * the page it is on.
+ *
+ * Page 1 sends no `page` at all rather than `page: 1`. The two mean the same
+ * thing to the server, but react-query hashes a key by its contents, so
+ * omitting it keeps the first page under the same key as a caller that does not
+ * page at all — which is what lets Taken courses reuse `useSearchCourses`
+ * without paying for a second copy of every first-page search.
+ */
+export function toSearchCoursesInput(
+  query: string,
+  filters: ExploreFilters,
+  page = 1,
+) {
   return {
     q: query,
     department: filters.department || undefined,
+    page: page > 1 ? page : undefined,
   };
 }
 
-export function useSearchCourses(input: { q: string; department?: string }) {
+export function useSearchCourses(input: {
+  q: string;
+  department?: string;
+  page?: number;
+}) {
   const trpc = useTRPC();
   return useQuery(
     trpc.search.courses.queryOptions(input, {
       enabled: Boolean(input.q.trim()),
       // The previous page of results stays on screen while the next one loads,
-      // so typing does not flash the whole column empty between keystrokes.
+      // so typing does not flash the whole column empty between keystrokes —
+      // and neither does paging. `isPlaceholderData` is how a caller tells the
+      // two apart, which matters for `page`: the reply carries the page the
+      // server actually served, and while this flag is set that reply is the
+      // *previous* page's.
       placeholderData: keepPreviousData,
     }),
   );

--- a/apps/web/features/search/components/explore.spec.tsx
+++ b/apps/web/features/search/components/explore.spec.tsx
@@ -111,8 +111,27 @@ function searchState(over: Record<string, unknown> = {}) {
 }
 
 function results(...courses: CourseSummary[]) {
+  return pageOf({ courses });
+}
+
+/**
+ * A reply from `search.courses` as it is shaped now: which page was served, and
+ * whether another follows. There is no `total` — the server cannot count a
+ * de-duplicated union of a keyword ranking and a semantic one, and #148 removed
+ * the `total: results.length` that pretended otherwise.
+ */
+function pageOf(
+  data: { courses?: CourseSummary[]; page?: number; hasMore?: boolean },
+  over: Record<string, unknown> = {},
+) {
   return searchState({
-    data: { results: courses, total: courses.length, page: 1, pageSize: 10 },
+    data: {
+      results: data.courses ?? [],
+      page: data.page ?? 1,
+      pageSize: 20,
+      hasMore: data.hasMore ?? false,
+    },
+    ...over,
   });
 }
 
@@ -673,6 +692,300 @@ describe("Explore", () => {
 
       expect(badge).toHaveClass("bg-cc-danger-tint", "text-cc-danger-ink");
       expect(badge.className).not.toContain("color-mix");
+    });
+  });
+
+  /**
+   * The artboard's pager, built on a lookahead rather than a count (#148).
+   *
+   * The whole contract is `hasMore` plus the page the server says it served.
+   * There is no total — one page of a de-duplicated union of a keyword ranking
+   * and a semantic one has no count behind it — so every assertion here is
+   * about *whether there is another page*, never about how many there are.
+   */
+  describe("the pager", () => {
+    const NEXT = { name: /Next/ } as const;
+    const PREVIOUS = { name: /Previous/ } as const;
+
+    function pager() {
+      return screen.queryByRole("navigation", {
+        name: "Search results pages",
+      });
+    }
+
+    beforeEach(() => {
+      search = "q=graphs";
+    });
+
+    it("is not drawn when there is only one page", () => {
+      useSearchCourses.mockReturnValue(
+        pageOf({ courses: [course("DD2380", "AI")], hasMore: false }),
+      );
+      render(<Explore />);
+
+      expect(pager()).not.toBeInTheDocument();
+    });
+
+    it("appears as soon as a page follows this one", () => {
+      useSearchCourses.mockReturnValue(
+        pageOf({ courses: [course("DD2380", "AI")], hasMore: true }),
+      );
+      render(<Explore />);
+
+      expect(pager()).toBeVisible();
+      expect(screen.getByText("Page 1")).toBeVisible();
+      expect(screen.getByRole("button", PREVIOUS)).toBeDisabled();
+      expect(screen.getByRole("button", NEXT)).toBeEnabled();
+    });
+
+    // A last page still needs the control, or there is no way back off it.
+    it("stays on a last page, with only the way back live", () => {
+      search = "q=graphs&page=2";
+      useSearchCourses.mockReturnValue(
+        pageOf({ courses: [course("DD2380", "AI")], page: 2, hasMore: false }),
+      );
+      render(<Explore />);
+
+      expect(screen.getByText("Page 2")).toBeVisible();
+      expect(screen.getByRole("button", PREVIOUS)).toBeEnabled();
+      expect(screen.getByRole("button", NEXT)).toBeDisabled();
+    });
+
+    // `push`, not `replace`: turning a page is a navigation, and Back must undo
+    // it — unlike a search grown one keystroke at a time.
+    it("turns the page by pushing it into the URL", async () => {
+      useSearchCourses.mockReturnValue(
+        pageOf({ courses: [course("DD2380", "AI")], hasMore: true }),
+      );
+      render(<Explore />);
+
+      await userEvent.click(screen.getByRole("button", NEXT));
+
+      expect(push).toHaveBeenCalledWith("/search?q=graphs&page=2", {
+        scroll: false,
+      });
+      expect(replace).not.toHaveBeenCalled();
+    });
+
+    it("drops the parameter entirely on the way back to the first page", async () => {
+      search = "q=graphs&page=2";
+      useSearchCourses.mockReturnValue(
+        pageOf({ courses: [course("DD2380", "AI")], page: 2, hasMore: false }),
+      );
+      render(<Explore />);
+
+      await userEvent.click(screen.getByRole("button", PREVIOUS));
+
+      expect(push).toHaveBeenCalledWith("/search?q=graphs", { scroll: false });
+    });
+
+    it("asks the server for the page the URL names", () => {
+      search = "q=graphs&page=3";
+      useSearchCourses.mockReturnValue(
+        pageOf({ courses: [course("DD2380", "AI")], page: 3, hasMore: true }),
+      );
+      render(<Explore />);
+
+      expect(useSearchCourses).toHaveBeenLastCalledWith({
+        q: "graphs",
+        department: undefined,
+        page: 3,
+      });
+    });
+
+    /**
+     * The first page sends no `page` at all. react-query hashes a key by its
+     * contents, so `{ q }` and `{ q, page: 1 }` would be two keys for one
+     * answer — and Taken courses reuses this hook without paging at all.
+     */
+    it("sends no page for the first one, so the key is the unpaged one", () => {
+      useSearchCourses.mockReturnValue(pageOf({ hasMore: true }));
+      render(<Explore />);
+
+      const input = useSearchCourses.mock.calls.at(-1)?.[0] as {
+        page?: number;
+      };
+      expect(input.page).toBeUndefined();
+    });
+
+    /**
+     * `?page=` past the server's depth cap. The server clamps and says which
+     * page it served; the pager reads that rather than the address bar, so the
+     * reader is told where they actually are.
+     *
+     * Nothing corrects the URL. An effect writing the state it reads is how the
+     * last three render loops in this page started, and the reader's next click
+     * writes a truthful number anyway.
+     */
+    it("names the page the server served, not the one the URL asked for", () => {
+      search = "q=graphs&page=99";
+      useSearchCourses.mockReturnValue(
+        pageOf({ courses: [course("DD2380", "AI")], page: 5, hasMore: false }),
+      );
+      render(<Explore />);
+
+      expect(screen.getByText("Page 5")).toBeVisible();
+      expect(screen.queryByText("Page 99")).not.toBeInTheDocument();
+      expect(push).not.toHaveBeenCalled();
+      expect(replace).not.toHaveBeenCalled();
+    });
+
+    it("steps back from a clamped page onto the one before it", async () => {
+      search = "q=graphs&page=99";
+      useSearchCourses.mockReturnValue(
+        pageOf({ courses: [course("DD2380", "AI")], page: 5, hasMore: false }),
+      );
+      render(<Explore />);
+
+      await userEvent.click(screen.getByRole("button", PREVIOUS));
+
+      expect(push).toHaveBeenCalledWith("/search?q=graphs&page=4", {
+        scroll: false,
+      });
+    });
+
+    /**
+     * `keepPreviousData` keeps the previous page's rows on screen while the
+     * next page loads, which is what stops the column flashing empty. Its
+     * `page` and `hasMore` describe that *previous* request, so reading them
+     * here would label the flight to page 2 "Page 1" and flip both buttons
+     * twice on the way.
+     */
+    it("does not take the page number off a stale reply mid-flight", () => {
+      search = "q=graphs&page=2";
+      useSearchCourses.mockReturnValue(
+        pageOf(
+          { courses: [course("DD2380", "AI")], page: 1, hasMore: true },
+          { isPlaceholderData: true },
+        ),
+      );
+      render(<Explore />);
+
+      expect(screen.getByText("Page 2")).toBeVisible();
+      expect(screen.queryByText("Page 1")).not.toBeInTheDocument();
+    });
+
+    // An empty first page means nothing matched. An empty later one means the
+    // ranking ran out behind the page that was asked for, which is a different
+    // sentence and a different way out.
+    it("says a page is past the end rather than that nothing matched", async () => {
+      search = "q=graphs&page=3";
+      useSearchCourses.mockReturnValue(
+        pageOf({ courses: [], page: 3, hasMore: false }),
+      );
+      render(<Explore />);
+
+      expect(screen.getByText("Nothing on page 3")).toBeVisible();
+      expect(
+        screen.queryByText("No courses match “graphs”"),
+      ).not.toBeInTheDocument();
+
+      await userEvent.click(
+        screen.getByRole("button", { name: "Back to the first page" }),
+      );
+      expect(push).toHaveBeenCalledWith("/search?q=graphs", { scroll: false });
+    });
+
+    it("still says nothing matched on an empty first page", () => {
+      useSearchCourses.mockReturnValue(pageOf({ courses: [] }));
+      render(<Explore />);
+
+      expect(screen.getByText("No courses match “graphs”")).toBeVisible();
+      expect(screen.queryByText(/^Nothing on page/)).not.toBeInTheDocument();
+    });
+
+    // Narrowing to one school shortens the ranking, so page 3 of the unfiltered
+    // search is very often past the end of the filtered one.
+    it("returns to the first page when the school changes", async () => {
+      search = "q=graphs&page=3";
+      useSearchCourses.mockReturnValue(
+        pageOf({ courses: [course("DD2380", "AI")], page: 3, hasMore: true }),
+      );
+      render(<Explore />);
+
+      await userEvent.selectOptions(screen.getByLabelText("School"), "EECS");
+
+      expect(replace).toHaveBeenLastCalledWith(
+        "/search?q=graphs&department=EECS",
+        { scroll: false },
+      );
+    });
+
+    it("returns to the first page when the search changes", async () => {
+      search = "q=graphs&page=3";
+      useSearchCourses.mockReturnValue(
+        pageOf({ courses: [course("DD2380", "AI")], page: 3, hasMore: true }),
+      );
+      render(<Explore />);
+
+      await userEvent.type(screen.getByLabelText("Search courses"), " theory");
+
+      await waitFor(() =>
+        expect(replace).toHaveBeenLastCalledWith("/search?q=graphs+theory", {
+          scroll: false,
+        }),
+      );
+    });
+
+    /**
+     * The page now lives in the URL, and the URL is what `setParams` is rebuilt
+     * from. An effect that wrote it back on mount would be a loop with fuel —
+     * three have shipped in this repo. Nothing here writes on arrival, under a
+     * Strict Mode double mount included.
+     */
+    it("writes nothing to the URL merely by opening on a deep page", () => {
+      search = "q=graphs&page=3";
+      useSearchCourses.mockReturnValue(
+        pageOf({ courses: [course("DD2380", "AI")], page: 3, hasMore: true }),
+      );
+      render(<Explore />);
+
+      expect(push).not.toHaveBeenCalled();
+      expect(replace).not.toHaveBeenCalled();
+    });
+
+    // A `?page=` with nothing searched has no page to go back to, only a
+    // number in the address bar. The start-here panel is what that moment is
+    // for, and a pager over it would offer to leave a search nobody has run.
+    it("is not drawn over the start-here panel", () => {
+      search = "page=3";
+      useSearchCourses.mockReturnValue(pageOf({ hasMore: true }));
+      render(<Explore />);
+
+      expect(screen.getByText("Search the KTH catalogue")).toBeVisible();
+      expect(pager()).not.toBeInTheDocument();
+    });
+
+    // Nor over the error panel: the last good answer is still in `data`, and
+    // paging off it would ask for a page of a search that just failed.
+    it("is not drawn when the catalogue did not answer", () => {
+      search = "q=graphs&page=2";
+      useSearchCourses.mockReturnValue(
+        pageOf(
+          { courses: [course("DD2380", "AI")], page: 2, hasMore: true },
+          { isError: true },
+        ),
+      );
+      render(<Explore />);
+
+      expect(
+        screen.getByText("The course catalogue did not answer"),
+      ).toBeVisible();
+      expect(pager()).not.toBeInTheDocument();
+    });
+
+    it("ignores a ?page= that is not a page", () => {
+      search = "q=graphs&page=not-a-number";
+      useSearchCourses.mockReturnValue(
+        pageOf({ courses: [course("DD2380", "AI")], hasMore: true }),
+      );
+      render(<Explore />);
+
+      const input = useSearchCourses.mock.calls.at(-1)?.[0] as {
+        page?: number;
+      };
+      expect(input.page).toBeUndefined();
+      expect(screen.getByText("Page 1")).toBeVisible();
     });
   });
 

--- a/apps/web/features/search/components/explore.spec.tsx
+++ b/apps/web/features/search/components/explore.spec.tsx
@@ -886,6 +886,20 @@ describe("Explore", () => {
       expect(push).toHaveBeenCalledWith("/search?q=graphs", { scroll: false });
     });
 
+    // The live region and the panel are one message in two places; they must
+    // not disagree about what happened.
+    it("tells the live region the same thing the panel says", () => {
+      search = "q=graphs&page=3";
+      useSearchCourses.mockReturnValue(
+        pageOf({ courses: [], page: 3, hasMore: false }),
+      );
+      render(<Explore />);
+
+      expect(
+        screen.getByText("No courses on page 3 for \u201Cgraphs\u201D"),
+      ).toBeVisible();
+    });
+
     it("still says nothing matched on an empty first page", () => {
       useSearchCourses.mockReturnValue(pageOf({ courses: [] }));
       render(<Explore />);

--- a/apps/web/features/search/components/explore.spec.tsx
+++ b/apps/web/features/search/components/explore.spec.tsx
@@ -704,8 +704,11 @@ describe("Explore", () => {
    * about *whether there is another page*, never about how many there are.
    */
   describe("the pager", () => {
-    const NEXT = { name: /Next/ } as const;
-    const PREVIOUS = { name: /Previous/ } as const;
+    // Exact names: the artboard's arrows are decoration and are hidden from
+    // the accessibility tree, so the buttons are announced "Previous" and
+    // "Next" rather than "left arrow Previous".
+    const NEXT = { name: "Next" } as const;
+    const PREVIOUS = { name: "Previous" } as const;
 
     function pager() {
       return screen.queryByRole("navigation", {

--- a/apps/web/features/search/components/explore.tsx
+++ b/apps/web/features/search/components/explore.tsx
@@ -363,7 +363,9 @@ function Pager({ explore }: { explore: ReturnType<typeof useExplore> }) {
         disabled={!explore.canPrevPage}
         className={PAGER_BUTTON_CLASS}
       >
-        ← Previous
+        {/* The arrows are the artboard's, and decoration: hidden so the button
+            is announced "Previous" rather than "left arrow Previous". */}
+        <span aria-hidden>←&nbsp;</span>Previous
       </button>
       {/* `aria-live`: the buttons keep focus across a turn, so without it a
           screen reader is told nothing about the page having changed. */}
@@ -379,7 +381,7 @@ function Pager({ explore }: { explore: ReturnType<typeof useExplore> }) {
         disabled={!explore.canNextPage}
         className={PAGER_BUTTON_CLASS}
       >
-        Next →
+        Next<span aria-hidden>&nbsp;→</span>
       </button>
     </nav>
   );

--- a/apps/web/features/search/components/explore.tsx
+++ b/apps/web/features/search/components/explore.tsx
@@ -49,8 +49,9 @@ import { useExplore } from "../hooks/use-explore";
  *   another page", and the server answers it with one extra row. `total` is
  *   gone rather than corrected; `hasMore` replaced it.
  *   `server/search/service.ts` carries the reasoning.
- * - The artboard's pager **labels the page it is on** (line 264,
- *   `pageLabel: "Page N of M"`, line 1289) and this keeps that label, minus the
+ * - The artboard's pager **labels the page it is on**
+ *   (`docs/design_ref/2026-09-06/Course Community - Explore.dc.html:264`, whose
+ *   `pageLabel` is built at :1289) and this keeps that label, minus the
  *   `of M`. Dropping only the half the data cannot support is the smallest edit
  *   that leaves the control the artboard drew — three items centred with a
  *   14px gap — intact, and "Page 3" asserts nothing about a total. It is also
@@ -325,7 +326,8 @@ const PAGER_BUTTON_CLASS =
 /**
  * The artboard's pager: Previous, the page it is on, Next.
  *
- * `Course Community - Explore.dc.html:261-267` draws exactly this — a 34px
+ * `docs/design_ref/2026-09-06/Course Community - Explore.dc.html:261-267`
+ * draws exactly this — a 34px
  * pill either side of a `--muted` label, centred with a 14px gap, each pill
  * `--ink` when it can be used and `--dim2` when it cannot. Two things here are
  * not literal transcriptions of it:

--- a/apps/web/features/search/components/explore.tsx
+++ b/apps/web/features/search/components/explore.tsx
@@ -2,7 +2,7 @@
 
 import { RotateCcw, Search as SearchIcon, TriangleAlert } from "lucide-react";
 import type { ReactNode } from "react";
-import { useRef } from "react";
+import { useEffect, useRef } from "react";
 import { AuthReasonDialog } from "@/features/auth";
 import { CourseCardItem, courseCardGeometry } from "@/features/courses";
 import { PageColumn, PageHeader, useSearchBarArrival } from "@/features/shell";
@@ -37,17 +37,25 @@ import { useExplore } from "../hooks/use-explore";
  *
  * ## Where it departs from the artboard, and why
  *
- * - The artboard's **pager** (lines 263-265) is not built, and stays unbuilt by
- *   decision: it is **#148**. `search.courses` accepts a `page` input and
- *   ignores it, and returns `total: results.length` — the count of what it just
- *   returned. A pager over that would invent pages that do not exist, which is
- *   the same error class as scoring an unreviewed course 0%. The real fix is a
- *   `COUNT` query and an honoured offset in the search domain, which is server
- *   work; nothing here should grow a pager over the contract as it stands.
- *   Removing the minimum-rating filter cleared one of the three reasons that
- *   count could not be told truthfully; the other two — a union of two rankings
- *   with no natural count, and a semantic path with no cutoff — are structural
- *   and still there. `server/search/service.ts` carries the detail.
+ * - The artboard's **pager** is built (#148), and turns pages without ever
+ *   claiming how many there are. `search.courses` used to accept a `page` and
+ *   drop it, and to report `total: results.length` — the size of the page it
+ *   had just built. A pager over that would have invented pages, which is the
+ *   same error class as scoring an unreviewed course 0%, so it stayed unbuilt.
+ *   The fix was not the `COUNT` that was assumed: a de-duplicated union of a
+ *   keyword ranking and a semantic one has no count to take, and the semantic
+ *   leg matches every course with an embedding at some distance, so there is
+ *   nothing to count *up to*. What a prev/next control asks is only "is there
+ *   another page", and the server answers it with one extra row. `total` is
+ *   gone rather than corrected; `hasMore` replaced it.
+ *   `server/search/service.ts` carries the reasoning.
+ * - The artboard's pager **labels the page it is on** (line 264,
+ *   `pageLabel: "Page N of M"`, line 1289) and this keeps that label, minus the
+ *   `of M`. Dropping only the half the data cannot support is the smallest edit
+ *   that leaves the control the artboard drew — three items centred with a
+ *   14px gap — intact, and "Page 3" asserts nothing about a total. It is also
+ *   what makes the deep end legible: without a number, a reader who followed a
+ *   link to a page past the cap has no way to see where they landed.
  * - The artboard's **filter row does not exist** at all; its search block is the
  *   field alone. One filter is built here anyway — **school** — in the
  *   artboard's own control vocabulary. It earns the deviation by filtering in
@@ -87,8 +95,23 @@ export function Explore() {
   const barRef = useRef<HTMLFormElement>(null);
   useSearchBarArrival(barRef, containerRef);
 
-  const { results, hasQuery, isLoading, isError } = explore;
-  const showEmpty = hasQuery && !isLoading && !isError && results.length === 0;
+  const { results, hasQuery, isLoading, isError, page } = explore;
+  const isEmpty = hasQuery && !isLoading && !isError && results.length === 0;
+  // An empty *first* page means nothing matched. An empty later one means the
+  // ranking ran out behind a `?page=` that was ahead of it, which is a
+  // different thing to say and a different way out.
+  const showEmpty = isEmpty && page === 1;
+  const showPastEnd = isEmpty && page > 1;
+
+  // A turned page starts at the top of the column, not wherever the last one
+  // was scrolled to. The column scrolls, not the document, so `scroll: false`
+  // on the router write is not what does this — and setting `scrollTop`
+  // touches no state, so it cannot feed the render loop this page has been
+  // bitten by three times.
+  // biome-ignore lint/correctness/useExhaustiveDependencies: the page changing is the event
+  useEffect(() => {
+    if (resultsRef.current) resultsRef.current.scrollTop = 0;
+  }, [page]);
 
   return (
     <PageColumn
@@ -187,6 +210,25 @@ export function Explore() {
               </Panel>
             ) : null}
 
+            {showPastEnd ? (
+              <Panel dashed>
+                <div className="font-semibold text-[14.5px]">
+                  Nothing on page {page}
+                </div>
+                <div className="mt-[5px] text-[13px] text-cc-muted">
+                  The results for “{explore.query}” run out before this page.{" "}
+                  <button
+                    type="button"
+                    onClick={explore.onFirstPage}
+                    className="cursor-pointer font-medium text-cc-brand hover:underline"
+                  >
+                    Back to the first page
+                  </button>
+                  .
+                </div>
+              </Panel>
+            ) : null}
+
             {!hasQuery && !isError ? (
               <StartHere onSuggest={explore.onSuggestQuery} />
             ) : null}
@@ -205,6 +247,8 @@ export function Explore() {
                 onRequestAuth={explore.setAuthReason}
               />
             ))}
+
+            <Pager explore={explore} />
           </div>
         </div>
 
@@ -266,6 +310,72 @@ function resultsLabel(explore: ReturnType<typeof useExplore>): string {
   const count = explore.results.length;
   if (count === 0) return `No courses for “${explore.query}”`;
   return `Showing ${count} course${count === 1 ? "" : "s"} for “${explore.query}”`;
+}
+
+const PAGER_BUTTON_CLASS =
+  "flex h-[34px] items-center rounded-[8px] border border-cc-rule3 bg-cc-surface px-3.5 font-medium text-[12.5px] enabled:cursor-pointer enabled:text-cc-ink enabled:hover:border-cc-hov disabled:cursor-not-allowed disabled:text-cc-dim2";
+
+/**
+ * The artboard's pager: Previous, the page it is on, Next.
+ *
+ * `Course Community - Explore.dc.html:261-267` draws exactly this — a 34px
+ * pill either side of a `--muted` label, centred with a 14px gap, each pill
+ * `--ink` when it can be used and `--dim2` when it cannot. Two things here are
+ * not literal transcriptions of it:
+ *
+ * - **The label loses its "of M".** The artboard's store computes
+ *   `"Page " + (page + 1) + " of " + pageCount` (line 1289) because its mock
+ *   store is the whole catalogue and can count it. The server cannot: one page
+ *   of a de-duplicated union of a keyword ranking and a semantic one has no
+ *   total behind it, and the semantic leg matches every course with an
+ *   embedding at some distance, so there is nothing to count up to. Removing
+ *   the half that asserts a total and keeping the half that does not is the
+ *   smallest edit that leaves the control intact — the alternative, deleting
+ *   the label, would leave two buttons where the artboard draws three items and
+ *   would take with it the only thing that tells a reader how deep they are.
+ * - **The pills are `<button>`s, not the artboard's `role="button"` divs.**
+ *   Disabled is the whole state model of this control, and `disabled` on a real
+ *   button is the only version of it that reaches the keyboard and the
+ *   accessibility tree. The artboard's own vocabulary is preserved: it is what
+ *   the pill looks like that is the design, not which element carries it.
+ *
+ * Shown when `explore.hasPager` — the artboard's `pageCount > 1` translated
+ * into what the data supports. See `use-explore.ts`.
+ */
+function Pager({ explore }: { explore: ReturnType<typeof useExplore> }) {
+  if (!explore.hasPager) return null;
+
+  return (
+    <nav
+      aria-label="Search results pages"
+      className="flex items-center justify-center gap-3.5 pt-1.5 pb-1"
+    >
+      <button
+        type="button"
+        onClick={explore.onPrevPage}
+        disabled={!explore.canPrevPage}
+        className={PAGER_BUTTON_CLASS}
+      >
+        ← Previous
+      </button>
+      {/* `aria-live`: the buttons keep focus across a turn, so without it a
+          screen reader is told nothing about the page having changed. */}
+      <span
+        aria-live="polite"
+        className="text-[12.5px] text-cc-muted tabular-nums"
+      >
+        Page {explore.page}
+      </span>
+      <button
+        type="button"
+        onClick={explore.onNextPage}
+        disabled={!explore.canNextPage}
+        className={PAGER_BUTTON_CLASS}
+      >
+        Next →
+      </button>
+    </nav>
+  );
 }
 
 /** The artboard's boxed message, dashed for an empty set and solid otherwise. */

--- a/apps/web/features/search/components/explore.tsx
+++ b/apps/web/features/search/components/explore.tsx
@@ -308,7 +308,14 @@ function resultsLabel(explore: ReturnType<typeof useExplore>): string {
   // `StartHere` says what this column is for instead of repeating it.
   if (!explore.hasQuery) return "";
   const count = explore.results.length;
-  if (count === 0) return `No courses for “${explore.query}”`;
+  // An empty page that is not the first has not failed to match anything — the
+  // ranking ran out behind the page that was asked for, and the live region has
+  // to say the same thing the panel below it does.
+  if (count === 0) {
+    return explore.page > 1
+      ? `No courses on page ${explore.page} for “${explore.query}”`
+      : `No courses for “${explore.query}”`;
+  }
   return `Showing ${count} course${count === 1 ? "" : "s"} for “${explore.query}”`;
 }
 

--- a/apps/web/features/search/hooks/use-explore.ts
+++ b/apps/web/features/search/hooks/use-explore.ts
@@ -32,6 +32,14 @@ export interface ExploreOptions {
   onOpenCourse?: (request: OpenCourseRequest) => void;
 }
 
+/** `?page=` as the hook reads it: a positive integer, or the first page. */
+function pageFromParam(raw: string | null): number {
+  if (!raw) return 1;
+  const parsed = Number(raw);
+  if (!Number.isSafeInteger(parsed) || parsed < 1) return 1;
+  return parsed;
+}
+
 /**
  * Everything Explore renders, and everything a click on it does.
  *
@@ -54,6 +62,13 @@ export interface ExploreOptions {
  * The school filter needs none of this: it is one discrete click with nothing to
  * keep up with, so the URL simply drives it, and Back undoes a filter for free.
  * It is also the only filter left; `department` below says what went and why.
+ *
+ * `?page=` is driven the same way, and is the one write here that *pushes*
+ * rather than replaces, because turning a page is a navigation the reader
+ * expects Back to undo. It is also the one piece of state this hook does not
+ * have the last word on: the server caps how deep Explore may page and says
+ * which page it served, so `requestedPage` below is what was asked for and
+ * `page` is what was answered.
  *
  * What the two paths *do* share is `setParams`, and they write through it at
  * genuinely independent moments — see `issuedParams` for why a write cannot
@@ -100,6 +115,24 @@ export function useExplore({ onOpenCourse }: ExploreOptions = {}) {
    */
   const department = searchParams.get("department") ?? "";
 
+  /**
+   * The page asked for, which is not necessarily the page that comes back.
+   *
+   * Only the shape is checked here — a positive integer, anything else is page
+   * one — because how *deep* Explore may page is the server's rule, not this
+   * hook's. `server/search/service.ts` caps the depth (the semantic leg has no
+   * relevance floor, so there is no honest bottom to page to) and echoes the
+   * page it actually served. A hand-typed `?page=99` therefore lands on the
+   * last page that exists, with the pager reading from the served page rather
+   * than from the number in the address bar.
+   *
+   * Nothing rewrites `?page=` to match. An effect that corrected the URL from
+   * the response would be an effect writing the very state it reads, which is
+   * how the last three render loops in this repo started; the reader's next
+   * click writes a truthful number and the stale one is gone.
+   */
+  const requestedPage = pageFromParam(searchParams.get("page"));
+
   const liveParams = searchParams.toString();
 
   /**
@@ -124,7 +157,10 @@ export function useExplore({ onOpenCourse }: ExploreOptions = {}) {
   }, [liveParams]);
 
   const setParams = useCallback(
-    (patch: Record<string, string | null>) => {
+    (
+      patch: Record<string, string | null>,
+      options?: { history?: "push" | "replace" },
+    ) => {
       const next = new URLSearchParams(issuedParams.current ?? liveParams);
       for (const [key, value] of Object.entries(patch)) {
         if (value) next.set(key, value);
@@ -132,18 +168,26 @@ export function useExplore({ onOpenCourse }: ExploreOptions = {}) {
       }
       const queryString = next.toString();
       issuedParams.current = queryString;
-      router.replace(queryString ? `${pathname}?${queryString}` : pathname, {
-        scroll: false,
-      });
+      const href = queryString ? `${pathname}?${queryString}` : pathname;
+      // Everything on this page rewrites the URL it is already on — a search
+      // grown a character at a time must not leave twelve entries in the
+      // reader's history. Paging is the exception, and goes through the same
+      // writer rather than a second `router.replace` of its own, because two
+      // independent writers on one query string is the race `issuedParams`
+      // exists to prevent. See `onNextPage` for why it pushes.
+      if (options?.history === "push") router.push(href, { scroll: false });
+      else router.replace(href, { scroll: false });
     },
     [router, pathname, liveParams],
   );
 
-  // What was searched here goes into the URL.
+  // What was searched here goes into the URL. A new search starts at the first
+  // page: page 3 of "graphs" is not page 3 of "compilers", and carrying the
+  // number across would open the new search on an empty column.
   useEffect(() => {
     if (writtenQuery.current === query) return;
     writtenQuery.current = query;
-    setParams({ q: query || null });
+    setParams({ q: query || null, page: null });
   }, [query, setParams]);
 
   // And what arrives in the URL from anywhere else comes back into the field.
@@ -220,10 +264,55 @@ export function useExplore({ onOpenCourse }: ExploreOptions = {}) {
     department: department || undefined,
   };
 
-  const search = useSearchCourses(toSearchCoursesInput(query, filters));
+  const search = useSearchCourses(
+    toSearchCoursesInput(query, filters, requestedPage),
+  );
   const departments = useDepartments();
 
+  /**
+   * The reply, but only when it is a reply to *this* request.
+   *
+   * `keepPreviousData` keeps the previous page mounted while the next one
+   * loads, which is what stops the column flashing empty on every keystroke and
+   * on every page turn. The rows are the point of that; `page` and `hasMore`
+   * are not — they describe the request that produced them, so reading them off
+   * a placeholder would say "page 1, no more" for the whole of the flight to
+   * page 2 and flip the pager's buttons twice on the way.
+   */
+  const settled = search.isPlaceholderData ? undefined : search.data;
+
   const results: CourseSummary[] = query ? (search.data?.results ?? []) : [];
+
+  /**
+   * The page on screen: the one the server says it served, and the requested
+   * one only while the answer is still in flight.
+   *
+   * They agree on every ordinary turn, and differ exactly when `?page=` was
+   * past the depth cap — which is the case the echo exists for.
+   */
+  const page = settled?.page ?? requestedPage;
+  const hasMore = settled?.hasMore ?? false;
+
+  const goToPage = useCallback(
+    (next: number) => {
+      // `push`, not `replace`: turning a page is a deliberate navigation and
+      // the reader expects Back to undo it, unlike a search grown a keystroke
+      // at a time. Page one drops the parameter rather than writing `page=1`,
+      // so the shared link for a first page is the one it always was.
+      setParams({ page: next > 1 ? String(next) : null }, { history: "push" });
+    },
+    [setParams],
+  );
+
+  const onPrevPage = useCallback(() => {
+    if (page > 1) goToPage(page - 1);
+  }, [page, goToPage]);
+
+  const onNextPage = useCallback(() => {
+    if (hasMore) goToPage(page + 1);
+  }, [page, hasMore, goToPage]);
+
+  const onFirstPage = useCallback(() => goToPage(1), [goToPage]);
 
   // A fresh array every render, which costs nothing: react-query hashes a query
   // key by its contents, so the same codes are the same query.
@@ -255,13 +344,16 @@ export function useExplore({ onOpenCourse }: ExploreOptions = {}) {
     [setDebouncedField],
   );
 
+  // Both reset to the first page for the same reason the query mirror does:
+  // narrowing to one school shortens the ranking, so page 3 of the unfiltered
+  // search is very often past the end of the filtered one.
   const onDepartmentChange = useCallback(
-    (value: string) => setParams({ department: value || null }),
+    (value: string) => setParams({ department: value || null, page: null }),
     [setParams],
   );
 
   const onClearFilters = useCallback(
-    () => setParams({ department: null }),
+    () => setParams({ department: null, page: null }),
     [setParams],
   );
 
@@ -282,6 +374,27 @@ export function useExplore({ onOpenCourse }: ExploreOptions = {}) {
     isLoading: search.isFetching,
     isError: search.isError,
     onRetry: () => void search.refetch(),
+
+    page,
+    /**
+     * Whether the pager is drawn at all.
+     *
+     * The artboard shows it when `pageCount > 1`, which it can ask because its
+     * mock store *is* the catalogue. There is no page count here and there
+     * cannot be one, so this is that condition translated into what the data
+     * supports: the control appears exactly when it can do something — when
+     * there is a page after this one, or one before it.
+     *
+     * Never over the start-here panel or the error panel, though. A bare
+     * `?page=3` with nothing searched, or a page whose request failed, has no
+     * page to go back to — only a number in the address bar.
+     */
+    hasPager: query.length > 0 && !search.isError && (hasMore || page > 1),
+    canPrevPage: page > 1,
+    canNextPage: hasMore,
+    onPrevPage,
+    onNextPage,
+    onFirstPage,
 
     department,
     departments: departments.data?.departments ?? [],

--- a/apps/web/server/api/protected.spec.ts
+++ b/apps/web/server/api/protected.spec.ts
@@ -93,6 +93,9 @@ describe("protected procedures", () => {
 
   it("allows visitors on search.courses", async () => {
     const result = await caller(null).search.courses({ q: "" });
-    expect(result).toMatchObject({ results: [], total: 0 });
+    // `total` is gone (#148): a de-duplicated union of a keyword ranking and a
+    // semantic one has no count to report, and `hasMore` is what a prev/next
+    // pager actually asks for.
+    expect(result).toMatchObject({ results: [], page: 1, hasMore: false });
   });
 });

--- a/apps/web/server/search/repository.spec.ts
+++ b/apps/web/server/search/repository.spec.ts
@@ -54,18 +54,18 @@ describe("searchByEmbedding", () => {
   });
 
   /**
-   * Distance alone is not a total order. Two courses at the identical distance
-   * — courses sharing an ingested description embed to the same vector — may
-   * come back in either order between two executions, and nothing about the
-   * plan promises the same order twice. Under a plain LIMIT that is invisible.
-   * Under paging it is a bug: the service pages by slicing one ordered prefix,
-   * so a pair that swaps between the fetch for page 2 and the fetch for page 3
-   * puts one course on both pages and the other on neither.
+   * Distance alone is not a total order, and an ORDER BY that is not total
+   * promises nothing: two rows at the identical distance may come back in
+   * either order between two executions. Under a plain LIMIT that is
+   * invisible. Under paging it is a bug — the service pages by slicing one
+   * ordered prefix, so a pair that swaps between the fetch for page 2 and the
+   * fetch for page 3 puts one course on both pages and the other on neither.
    *
    * Appending the primary key makes the order total, which is what turns a
    * LIMIT into a stable prefix. This asserts the tiebreak is there *and* that
-   * it comes after the distance, which is the difference between a tiebreak and
-   * an alphabetical search.
+   * it comes after the distance — the difference between a tiebreak and an
+   * alphabetical search, and what keeps the HNSW index providing the ordering
+   * with only the ties sorted above it.
    */
   it("breaks distance ties on the course code, so a prefix is stable", async () => {
     await searchByEmbedding([0.1, 0.2], 10, null);

--- a/apps/web/server/search/repository.spec.ts
+++ b/apps/web/server/search/repository.spec.ts
@@ -2,7 +2,7 @@ import type { SQL } from "drizzle-orm";
 import { PgDialect } from "drizzle-orm/pg-core";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { db } from "../db";
-import { searchByKeyword } from "./repository";
+import { searchByEmbedding, searchByKeyword } from "./repository";
 
 vi.mock("../db", () => ({
   db: {
@@ -44,5 +44,40 @@ describe("searchByKeyword", () => {
     const limitIndex = Number(text.match(/limit \$(\d+)/i)?.[1]);
     expect(limitIndex).toBeGreaterThan(0);
     expect(params[limitIndex - 1]).toBe(10);
+  });
+});
+
+describe("searchByEmbedding", () => {
+  beforeEach(() => {
+    vi.mocked(db.execute).mockReset();
+    vi.mocked(db.execute).mockResolvedValue({ rows: [] } as never);
+  });
+
+  /**
+   * Distance alone is not a total order. Two courses at the identical distance
+   * — courses sharing an ingested description embed to the same vector — may
+   * come back in either order between two executions, and nothing about the
+   * plan promises the same order twice. Under a plain LIMIT that is invisible.
+   * Under paging it is a bug: the service pages by slicing one ordered prefix,
+   * so a pair that swaps between the fetch for page 2 and the fetch for page 3
+   * puts one course on both pages and the other on neither.
+   *
+   * Appending the primary key makes the order total, which is what turns a
+   * LIMIT into a stable prefix. This asserts the tiebreak is there *and* that
+   * it comes after the distance, which is the difference between a tiebreak and
+   * an alphabetical search.
+   */
+  it("breaks distance ties on the course code, so a prefix is stable", async () => {
+    await searchByEmbedding([0.1, 0.2], 10, null);
+
+    const query = vi.mocked(db.execute).mock.calls[0]?.[0] as SQL | undefined;
+    const text = new PgDialect().sqlToQuery(query as SQL).sql.toLowerCase();
+
+    const orderBy = text.slice(text.lastIndexOf("order by"));
+    expect(orderBy).toContain("<=>");
+    expect(orderBy).toContain('"courses"."code" asc');
+    expect(orderBy.indexOf("<=>")).toBeLessThan(
+      orderBy.indexOf('"courses"."code" asc'),
+    );
   });
 });

--- a/apps/web/server/search/repository.ts
+++ b/apps/web/server/search/repository.ts
@@ -15,6 +15,14 @@ export type SearchHit = {
  * has nothing to absorb: what is asked for is what is fetched. The department
  * filter needs no window at all — it is a SQL predicate below, so every row the
  * query returns already satisfies it.
+ *
+ * The service now asks for a window that covers every page up to the one it is
+ * serving, plus one row of lookahead (#148). That is still `size` meaning
+ * `size` — it is a bigger number, not an inflated one — and it works only
+ * because this query is *totally* ordered: the three-way bucket, then
+ * `ts_rank`, then `courses.code ASC`. A LIMIT over a total order returns a
+ * prefix, so a wider window returns a superset that begins with the narrower
+ * one, and page 2 holds the same rows however deep the fetch went.
  */
 export async function searchByKeyword(
   query: string,
@@ -80,6 +88,27 @@ export async function searchByKeyword(
   }));
 }
 
+/**
+ * Nearest neighbours by cosine distance — and, on ties, by course code.
+ *
+ * The tiebreak is not cosmetic. Distance alone is not a total order: two
+ * courses at the identical distance may come back in either order between two
+ * executions of this query, because nothing in the plan is obliged to break the
+ * tie the same way twice. Under a LIMIT that is invisible — the set is the
+ * same, only shuffled. Under pagination it is a bug: the service pages by
+ * slicing one ordered prefix (#148), so a pair that swaps between the fetch for
+ * page 2 and the fetch for page 3 puts one course on both pages and the other
+ * on neither.
+ *
+ * Identical distances are not exotic here. Courses that share an ingested
+ * description — a course re-established under a new code, a round duplicated
+ * across schools — embed to the same vector and so sit at exactly the same
+ * distance from every query.
+ *
+ * `courses.code` is the primary key, so appending it makes the order total, and
+ * total is what makes a LIMIT a stable prefix. `searchByKeyword` above already
+ * ends this way for the same reason.
+ */
 export async function searchByEmbedding(
   embedding: number[],
   limit: number,
@@ -104,7 +133,9 @@ export async function searchByEmbedding(
           ON ${schema.courseExplore.courseCode} = ${schema.courses.code}
         CROSS JOIN q
         WHERE ${whereSql}
-        ORDER BY ${schema.courseExplore.embedding} <=> q.v
+        ORDER BY
+          ${schema.courseExplore.embedding} <=> q.v,
+          ${schema.courses.code} ASC
         LIMIT ${limit}
       `);
 

--- a/apps/web/server/search/repository.ts
+++ b/apps/web/server/search/repository.ts
@@ -91,23 +91,28 @@ export async function searchByKeyword(
 /**
  * Nearest neighbours by cosine distance — and, on ties, by course code.
  *
- * The tiebreak is not cosmetic. Distance alone is not a total order: two
- * courses at the identical distance may come back in either order between two
- * executions of this query, because nothing in the plan is obliged to break the
- * tie the same way twice. Under a LIMIT that is invisible — the set is the
- * same, only shuffled. Under pagination it is a bug: the service pages by
- * slicing one ordered prefix (#148), so a pair that swaps between the fetch for
- * page 2 and the fetch for page 3 puts one course on both pages and the other
- * on neither.
- *
- * Identical distances are not exotic here. Courses that share an ingested
- * description — a course re-established under a new code, a round duplicated
- * across schools — embed to the same vector and so sit at exactly the same
- * distance from every query.
+ * The tiebreak is not cosmetic. Distance alone is not a total order, and an
+ * ORDER BY that is not total obliges the executor to nothing: two rows at the
+ * identical distance may come back in either order between two executions of
+ * the same query. Under a plain LIMIT that is invisible — the same set, only
+ * shuffled. Under pagination it is a bug: the service pages by slicing one
+ * ordered prefix (#148), so a pair that swaps between the fetch for page 2 and
+ * the fetch for page 3 puts one course on both pages and the other on neither.
  *
  * `courses.code` is the primary key, so appending it makes the order total, and
  * total is what makes a LIMIT a stable prefix. `searchByKeyword` above already
- * ends this way for the same reason.
+ * ends this way for the same reason. The distance stays the leading key, so the
+ * HNSW index still provides the ordering and only the ties above it are sorted;
+ * the second key does not turn this into an alphabetical search.
+ *
+ * What it does *not* buy is exactness, and the comment would be dishonest
+ * without saying so. `course_explore_embedding_idx` is HNSW — approximate by
+ * construction, with a search list pgvector widens as the LIMIT grows — so a
+ * 61-row fetch is not *formally* guaranteed to begin with the same rows as a
+ * 21-row one, however reliably it does at this catalogue size. The tiebreak
+ * removes the one source of drift that is entirely ours. What bounds the rest
+ * is that this leg only ever supplies the tail: the service puts the exact
+ * keyword ranking first and appends these behind it.
  */
 export async function searchByEmbedding(
   embedding: number[],

--- a/apps/web/server/search/router.spec.ts
+++ b/apps/web/server/search/router.spec.ts
@@ -1,0 +1,126 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { createCallerFactory } from "../api/trpc";
+import { searchRouter } from "./router";
+import {
+  DEFAULT_SEARCH_PAGE_SIZE,
+  getDepartments,
+  searchCourses,
+} from "./service";
+
+vi.mock("./service", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("./service")>();
+  return {
+    ...actual,
+    searchCourses: vi.fn(),
+    getDepartments: vi.fn(),
+  };
+});
+
+/** Search is open to visitors: every case here is an anonymous caller. */
+function caller() {
+  return createCallerFactory(searchRouter)({
+    session: null as never,
+    headers: new Headers(),
+  });
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  vi.mocked(searchCourses).mockResolvedValue({
+    results: [],
+    page: 1,
+    hasMore: false,
+  });
+  vi.mocked(getDepartments).mockResolvedValue(["EECS"]);
+});
+
+describe("search.courses", () => {
+  /**
+   * `total` was `results.length` — the size of the page just built, offered as
+   * if it were the size of the matching set. It is not replaced by a truthful
+   * count: a de-duplicated union of a keyword ranking and a semantic one has no
+   * count to take, and the semantic leg matches every course with an embedding
+   * at some distance. `hasMore` is what a prev/next pager actually asks (#148).
+   */
+  it("reports whether there is another page, and no total at all", async () => {
+    vi.mocked(searchCourses).mockResolvedValue({
+      results: [],
+      page: 2,
+      hasMore: true,
+    });
+
+    const reply = await caller().courses({ q: "maths", page: 2 });
+
+    expect(reply).toEqual({
+      results: [],
+      page: 2,
+      pageSize: DEFAULT_SEARCH_PAGE_SIZE,
+      hasMore: true,
+    });
+    expect(reply).not.toHaveProperty("total");
+  });
+
+  it("honours the page it is given rather than accepting and dropping it", async () => {
+    await caller().courses({ q: "maths", page: 3, department: "EECS" });
+
+    expect(searchCourses).toHaveBeenCalledWith("maths", {
+      page: 3,
+      size: DEFAULT_SEARCH_PAGE_SIZE,
+      department: "EECS",
+    });
+  });
+
+  /**
+   * The page in the reply is the service's, not the input's: it clamps to the
+   * depth cap, so a hand-typed `?page=99` is served as the last page that
+   * exists and the reply says which one that was.
+   */
+  it("echoes the page that was served, not the page that was asked for", async () => {
+    vi.mocked(searchCourses).mockResolvedValue({
+      results: [],
+      page: 5,
+      hasMore: false,
+    });
+
+    const reply = await caller().courses({ q: "maths", page: 99 });
+
+    expect(reply.page).toBe(5);
+  });
+
+  it("defaults to a page of 20, replacing the old 10", async () => {
+    await caller().courses({ q: "maths" });
+
+    expect(DEFAULT_SEARCH_PAGE_SIZE).toBe(20);
+    expect(searchCourses).toHaveBeenCalledWith("maths", {
+      page: undefined,
+      size: 20,
+      department: undefined,
+    });
+  });
+
+  /**
+   * This procedure is open to visitors and the window it fetches is
+   * `page * size`, so an uncapped `size` would be a lever on the cost of an
+   * anonymous request — five pages deep at whatever width the caller liked.
+   * A smaller page is still allowed; a larger one is not a page.
+   */
+  it("refuses a page size larger than the default", async () => {
+    await expect(
+      caller().courses({ q: "maths", size: 5_000 }),
+    ).rejects.toMatchObject({ code: "BAD_REQUEST" });
+    expect(searchCourses).not.toHaveBeenCalled();
+
+    await expect(caller().courses({ q: "maths", size: 5 })).resolves.toEqual(
+      expect.objectContaining({ pageSize: 5 }),
+    );
+  });
+
+  it("refuses a page that is not a page", async () => {
+    await expect(
+      caller().courses({ q: "maths", page: 0 }),
+    ).rejects.toMatchObject({ code: "BAD_REQUEST" });
+    await expect(
+      caller().courses({ q: "maths", page: -2 }),
+    ).rejects.toMatchObject({ code: "BAD_REQUEST" });
+  });
+});

--- a/apps/web/server/search/router.ts
+++ b/apps/web/server/search/router.ts
@@ -1,28 +1,59 @@
 import { z } from "zod";
 import { baseProcedure, createTRPCRouter } from "../api/trpc";
-import { getDepartments, searchCourses } from "./service";
+import {
+  DEFAULT_SEARCH_PAGE_SIZE,
+  getDepartments,
+  searchCourses,
+} from "./service";
 
 export const searchRouter = createTRPCRouter({
+  /**
+   * One page of the catalogue, and whether another one follows it.
+   *
+   * `page` used to be accepted and dropped, and the reply carried
+   * `total: results.length` — the size of the page it had just built, offered
+   * as if it were the size of the matching set. Both are gone (#148): `page` is
+   * honoured, and `total` is not replaced by a truthful count because there is
+   * no truthful count to compute over a de-duplicated union of a keyword
+   * ranking and a semantic one. `service.ts` sets out why at length.
+   *
+   * What a prev/next pager actually asks is "is there another page", and
+   * `hasMore` answers exactly that, from one extra row rather than a second
+   * query.
+   *
+   * `page` is echoed back because it may not be the page that was asked for:
+   * the service clamps it to the depth cap, so a hand-typed `?page=99` is
+   * served as page 5 and says so. `size` is capped at the default rather than
+   * left open — this is an unauthenticated procedure, and the window it fetches
+   * is `page * size`, so an uncapped `size` would be a five-fold lever on the
+   * cost of an anonymous request.
+   */
   courses: baseProcedure
     .input(
       z.object({
         q: z.string(),
         page: z.number().int().positive().optional(),
-        size: z.number().int().positive().optional(),
+        size: z
+          .number()
+          .int()
+          .positive()
+          .max(DEFAULT_SEARCH_PAGE_SIZE)
+          .optional(),
         department: z.string().optional(),
       }),
     )
     .query(async ({ input }) => {
-      const page = input.page && input.page > 0 ? input.page : 1;
-      const pageSize = input.size ?? 10;
-      const results = await searchCourses(input.q, pageSize, {
+      const pageSize = input.size ?? DEFAULT_SEARCH_PAGE_SIZE;
+      const { results, page, hasMore } = await searchCourses(input.q, {
+        page: input.page,
+        size: pageSize,
         department: input.department,
       });
       return {
         results,
-        total: results.length,
         page,
         pageSize,
+        hasMore,
       };
     }),
   departments: baseProcedure.query(async () => {

--- a/apps/web/server/search/service.spec.ts
+++ b/apps/web/server/search/service.spec.ts
@@ -4,7 +4,11 @@ import { embedSingle } from "../ai";
 import { getSummariesByCodes } from "../course/service";
 import { getAggregatesByCourseCodes } from "../reviews/service";
 import { searchByEmbedding, searchByKeyword } from "./repository";
-import { searchCourses } from "./service";
+import {
+  DEFAULT_SEARCH_PAGE_SIZE,
+  MAX_SEARCH_PAGES,
+  searchCourses,
+} from "./service";
 
 vi.mock("./repository");
 vi.mock("../course/service");
@@ -31,6 +35,33 @@ function summary(courseCode: string): CourseSummary {
   };
 }
 
+/** `n` distinct hits, numbered so a slice is readable in a failure message. */
+function hits(n: number, prefix = "C") {
+  return Array.from({ length: n }, (_, i) => ({
+    courseCode: `${prefix}${String(i).padStart(3, "0")}`,
+    score: null,
+  }));
+}
+
+/**
+ * A keyword leg that behaves like the real one: one fixed ranking, cut to the
+ * LIMIT it is handed. That prefix behaviour is the property the whole paging
+ * scheme rests on, so the double has to have it or the tests below prove
+ * nothing.
+ */
+function rankedKeywordLeg(ranking: ReturnType<typeof hits>) {
+  vi.mocked(searchByKeyword).mockImplementation(async (_q, size) =>
+    ranking.slice(0, size),
+  );
+}
+
+function embeddingIsAvailable() {
+  vi.mocked(embedSingle).mockResolvedValue({
+    embedding: [0.25, 0.5],
+    usage: { tokens: 2 },
+  });
+}
+
 describe("searchCourses", () => {
   beforeEach(() => {
     vi.clearAllMocks();
@@ -45,10 +76,7 @@ describe("searchCourses", () => {
   });
 
   it("keeps keyword order and appends only new semantic hits", async () => {
-    vi.mocked(embedSingle).mockResolvedValueOnce({
-      embedding: [0.25, 0.5],
-      usage: { tokens: 2 },
-    });
+    embeddingIsAvailable();
     vi.mocked(searchByKeyword).mockResolvedValueOnce([
       { courseCode: "SF1625", score: null },
       { courseCode: "DD2421", score: null },
@@ -58,7 +86,7 @@ describe("searchCourses", () => {
       { courseCode: "ID2209", score: 0.9 },
     ]);
 
-    const results = await searchCourses("distributed systems", 3);
+    const { results } = await searchCourses("distributed systems", { size: 3 });
 
     expect(results.map((result) => result.courseCode)).toEqual([
       "SF1625",
@@ -67,47 +95,243 @@ describe("searchCourses", () => {
     ]);
   });
 
-  /**
-   * The minimum-rating filter is gone, and with it the `size * 5` window that
-   * existed only to leave something for a post-fetch pass to throw away.
-   *
-   * This asserts the window is not merely unused but absent: both legs are
-   * asked for exactly `size`. An inflated fetch that nothing filters is a
-   * five-fold cost on every search, and the slice would hide it from any test
-   * that only looked at the returned codes.
-   */
-  it("fetches exactly the size it was asked for, on both legs", async () => {
-    vi.mocked(embedSingle).mockResolvedValueOnce({
-      embedding: [0.25, 0.5],
-      usage: { tokens: 2 },
-    });
-
-    await searchCourses("maths", 4, { department: "EECS" });
-
-    expect(searchByKeyword).toHaveBeenCalledWith("maths", 4, "EECS");
-    expect(searchByEmbedding).toHaveBeenCalledWith([0.25, 0.5], 4, "EECS");
-  });
-
   it("never reads review aggregates: rating is not a search filter", async () => {
     // The removed filter thresholded a learning mean it had to fetch from the
     // reviews domain, after the query, for every search that set it. Choosing
     // courses is now purely the catalogue's business.
-    await searchCourses("maths", 10, { department: "EECS" });
+    await searchCourses("maths", { department: "EECS" });
 
     expect(getAggregatesByCourseCodes).not.toHaveBeenCalled();
   });
 
   it("returns nothing for a blank query without touching the database", async () => {
-    const results = await searchCourses("   ", 10);
+    const page = await searchCourses("   ");
 
-    expect(results).toEqual([]);
+    expect(page).toEqual({ results: [], page: 1, hasMore: false });
     expect(searchByKeyword).not.toHaveBeenCalled();
     expect(searchByEmbedding).not.toHaveBeenCalled();
   });
 
   it("returns every hit when no filter is given", async () => {
-    const results = await searchCourses("maths", 10);
+    const { results } = await searchCourses("maths");
 
     expect(results.map((r) => r.courseCode)).toEqual(["SF1625", "DD2421"]);
+  });
+
+  describe("the lookahead", () => {
+    beforeEach(embeddingIsAvailable);
+
+    /**
+     * The window is `(page * size) + 1`, and the `+ 1` is the entire mechanism.
+     * It is *one* row, not a multiple: the `size * 5` over-fetch that used to
+     * feed a post-fetch rating filter is gone, and an inflated window
+     * reintroduced here would cost every search and buy nothing.
+     */
+    it("asks each leg for one row more than the page needs", async () => {
+      await searchCourses("maths", { page: 1, size: 20 });
+
+      expect(searchByKeyword).toHaveBeenCalledWith("maths", 21, null);
+      expect(searchByEmbedding).toHaveBeenCalledWith([0.25, 0.5], 21, null);
+    });
+
+    it("widens the window by whole pages, not by a multiple", async () => {
+      await searchCourses("maths", { page: 3, size: 20 });
+
+      expect(searchByKeyword).toHaveBeenCalledWith("maths", 61, null);
+      expect(searchByEmbedding).toHaveBeenCalledWith([0.25, 0.5], 61, null);
+    });
+
+    it("reports a next page when the extra row comes back", async () => {
+      rankedKeywordLeg(hits(41));
+
+      const page = await searchCourses("maths", { page: 1, size: 20 });
+
+      expect(page.hasMore).toBe(true);
+      expect(page.results).toHaveLength(20);
+    });
+
+    it("reports no next page when it does not", async () => {
+      rankedKeywordLeg(hits(20));
+
+      const page = await searchCourses("maths", { page: 1, size: 20 });
+
+      expect(page.hasMore).toBe(false);
+      expect(page.results).toHaveLength(20);
+    });
+
+    /**
+     * A full last page is the case a naive `results.length === size` check gets
+     * wrong: twenty rows with nothing behind them look exactly like twenty rows
+     * with more behind them. Only the extra row tells them apart.
+     */
+    it("does not offer a next page for a ranking ending exactly on the boundary", async () => {
+      rankedKeywordLeg(hits(40));
+
+      const second = await searchCourses("maths", { page: 2, size: 20 });
+
+      expect(second.results).toHaveLength(20);
+      expect(second.hasMore).toBe(false);
+    });
+
+    /**
+     * `getSummariesByCodes` drops a code whose course row has gone, so a page
+     * can come back shorter than the ranking behind it. "Is there another page"
+     * is a fact about the ranking, not about how many summaries survived.
+     */
+    it("answers from the ranking, not from the rows that survived summary lookup", async () => {
+      rankedKeywordLeg(hits(41));
+      vi.mocked(getSummariesByCodes).mockImplementation(async (codes) =>
+        codes.slice(0, 3).map(summary),
+      );
+
+      const page = await searchCourses("maths", { page: 1, size: 20 });
+
+      expect(page.results).toHaveLength(3);
+      expect(page.hasMore).toBe(true);
+    });
+  });
+
+  describe("the page it serves", () => {
+    beforeEach(embeddingIsAvailable);
+
+    it("slices the requested page out of the ranking", async () => {
+      const ranking = hits(60);
+      rankedKeywordLeg(ranking);
+
+      const second = await searchCourses("maths", { page: 2, size: 20 });
+
+      expect(second.page).toBe(2);
+      expect(second.results.map((r) => r.courseCode)).toEqual(
+        ranking.slice(20, 40).map((h) => h.courseCode),
+      );
+    });
+
+    /**
+     * The property the whole scheme rests on: a wider fetch yields the same
+     * page. Each leg is a LIMIT over a totally ordered query — which is why
+     * `searchByEmbedding` had to grow `courses.code ASC` — so a wider LIMIT is
+     * a superset beginning with the narrower one, and the union of the two legs
+     * inherits that.
+     */
+    it("gives the same page whatever depth the fetch went to", async () => {
+      const keyword = hits(30, "K");
+      const semantic = hits(30, "S");
+      vi.mocked(searchByKeyword).mockImplementation(async (_q, size) =>
+        keyword.slice(0, size),
+      );
+      vi.mocked(searchByEmbedding).mockImplementation(async (_e, size) =>
+        semantic.slice(0, size),
+      );
+
+      const asPage2 = await searchCourses("maths", { page: 2, size: 5 });
+      const asPage4 = await searchCourses("maths", { page: 4, size: 5 });
+      const wholePrefix = await searchCourses("maths", { page: 1, size: 20 });
+
+      const codes = wholePrefix.results.map((r) => r.courseCode);
+      expect(asPage2.results.map((r) => r.courseCode)).toEqual(
+        codes.slice(5, 10),
+      );
+      expect(asPage4.results.map((r) => r.courseCode)).toEqual(
+        codes.slice(15, 20),
+      );
+    });
+
+    it("keeps the department filter on every page, in SQL", async () => {
+      rankedKeywordLeg(hits(60));
+
+      await searchCourses("maths", { page: 3, size: 20, department: "EECS" });
+
+      expect(searchByKeyword).toHaveBeenCalledWith("maths", 61, "EECS");
+      expect(searchByEmbedding).toHaveBeenCalledWith([0.25, 0.5], 61, "EECS");
+    });
+
+    it("returns an empty page, not an error, past the end of a short ranking", async () => {
+      rankedKeywordLeg(hits(25));
+
+      const page = await searchCourses("maths", { page: 3, size: 20 });
+
+      expect(page).toEqual({ results: [], page: 3, hasMore: false });
+      expect(getSummariesByCodes).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("the depth cap", () => {
+    beforeEach(embeddingIsAvailable);
+
+    /**
+     * `MAX_SEARCH_PAGES` is a judgement, not a fact about the data: the
+     * semantic leg has no relevance floor, so a deep page is courses sorted by
+     * how little they match. Past the cap there is no next page to ask about,
+     * so the extra row is not even fetched.
+     */
+    it("stops offering a next page at the last page it allows", async () => {
+      rankedKeywordLeg(hits(500));
+
+      const last = await searchCourses("maths", {
+        page: MAX_SEARCH_PAGES,
+        size: 20,
+      });
+
+      expect(last.results).toHaveLength(20);
+      expect(last.hasMore).toBe(false);
+      expect(searchByKeyword).toHaveBeenCalledWith(
+        "maths",
+        MAX_SEARCH_PAGES * 20,
+        null,
+      );
+    });
+
+    it("clamps a page past the cap onto the last one, and says which it served", async () => {
+      rankedKeywordLeg(hits(500));
+
+      const page = await searchCourses("maths", { page: 99, size: 20 });
+
+      expect(page.page).toBe(MAX_SEARCH_PAGES);
+      expect(page.hasMore).toBe(false);
+      expect(searchByKeyword).toHaveBeenCalledWith(
+        "maths",
+        MAX_SEARCH_PAGES * 20,
+        null,
+      );
+    });
+
+    it.each([0, -3, Number.NaN, 1.7])(
+      "treats %p as the first page",
+      async (page) => {
+        rankedKeywordLeg(hits(60));
+
+        const served = await searchCourses("maths", { page, size: 20 });
+
+        expect(served.page).toBe(1);
+        expect(searchByKeyword).toHaveBeenCalledWith("maths", 21, null);
+      },
+    );
+
+    it("bounds the deepest possible fetch to the cap times the page size", async () => {
+      rankedKeywordLeg(hits(5000));
+
+      await searchCourses("maths", {
+        page: 10_000,
+        size: DEFAULT_SEARCH_PAGE_SIZE,
+      });
+
+      const fetchWindow = vi.mocked(searchByKeyword).mock.calls[0]?.[1];
+      expect(fetchWindow).toBe(MAX_SEARCH_PAGES * DEFAULT_SEARCH_PAGE_SIZE);
+    });
+  });
+
+  it("defaults to a page of 20", async () => {
+    embeddingIsAvailable();
+    rankedKeywordLeg(hits(100));
+
+    const page = await searchCourses("maths");
+
+    expect(DEFAULT_SEARCH_PAGE_SIZE).toBe(20);
+    expect(page.results).toHaveLength(DEFAULT_SEARCH_PAGE_SIZE);
+    expect(searchByKeyword).toHaveBeenCalledWith(
+      "maths",
+      DEFAULT_SEARCH_PAGE_SIZE + 1,
+      null,
+    );
   });
 });

--- a/apps/web/server/search/service.ts
+++ b/apps/web/server/search/service.ts
@@ -206,10 +206,11 @@ function clampPage(page: number | undefined): number {
  * One honest caveat. The semantic leg reads an HNSW index, which is approximate
  * and whose search list widens with the LIMIT, so its prefix is stable in
  * practice rather than by construction — `repository.ts` says what the tiebreak
- * does and does not buy. The exposure is bounded: the keyword leg is exact and
- * comes first, so it is only the tail of a deep page that an ANN wobble could
- * reshuffle, and no page a reader reaches by clicking Next is built from a
- * different fetch than the one that offered it.
+ * does and does not buy. The exposure is bounded twice over: the keyword leg is
+ * exact and comes first, so only the tail of a deep page is ANN-ordered at all;
+ * and `MAX_SEARCH_PAGES` keeps the widest window this domain ever asks for at
+ * 101 rows, which over a catalogue this size is well inside where an HNSW scan
+ * and an exact one agree.
  *
  * The cost of the whole scheme is a discarded prefix: page 5 fetches 101 rows
  * and drops 80. At this catalogue size that is cheap, and `MAX_SEARCH_PAGES`

--- a/apps/web/server/search/service.ts
+++ b/apps/web/server/search/service.ts
@@ -203,8 +203,17 @@ function clampPage(page: number | undefined): number {
  *   cannot reach them; where it does not fill the window, it is exhausted and
  *   identical at every width, so the semantic tail extends rather than shifts.
  *
- * The cost of that is a discarded prefix: page 5 fetches 101 rows and drops 80.
- * At this catalogue size that is cheap, and `MAX_SEARCH_PAGES` bounds it.
+ * One honest caveat. The semantic leg reads an HNSW index, which is approximate
+ * and whose search list widens with the LIMIT, so its prefix is stable in
+ * practice rather than by construction — `repository.ts` says what the tiebreak
+ * does and does not buy. The exposure is bounded: the keyword leg is exact and
+ * comes first, so it is only the tail of a deep page that an ANN wobble could
+ * reshuffle, and no page a reader reaches by clicking Next is built from a
+ * different fetch than the one that offered it.
+ *
+ * The cost of the whole scheme is a discarded prefix: page 5 fetches 101 rows
+ * and drops 80. At this catalogue size that is cheap, and `MAX_SEARCH_PAGES`
+ * bounds it.
  */
 export async function searchCourses(
   query: string,

--- a/apps/web/server/search/service.ts
+++ b/apps/web/server/search/service.ts
@@ -93,8 +93,58 @@ async function searchWithEmbedding(
 }
 
 /**
+ * How deep Explore can page, in pages.
+ *
+ * This is the one judgement call in #148 rather than something the data
+ * dictates. The semantic leg has no relevance floor: its `WHERE` is effectively
+ * "has an embedding", so every course in the catalogue is a hit at *some*
+ * distance and the LIMIT is the only thing that makes the result a set rather
+ * than the catalogue. Page 20 of that is not more results, it is courses sorted
+ * by how little they match, presented with the same confidence as page 1.
+ *
+ * A cap says that honestly and costs nothing to defend. The alternative is a
+ * similarity threshold, which means defending a specific number on cosine
+ * distance — a number nobody here can justify from the data, and one that would
+ * silently change meaning the next time the embedding model does.
+ *
+ * It is also what bounds the lookahead's cost: the deepest fetch this domain
+ * will ever issue is `MAX_SEARCH_PAGES * size` rows, per leg.
+ */
+export const MAX_SEARCH_PAGES = 5;
+
+/** The page size Explore asks for when it does not say. */
+export const DEFAULT_SEARCH_PAGE_SIZE = 20;
+
+export type SearchPageRequest = {
+  page?: number;
+  size?: number;
+  department?: string;
+};
+
+export type SearchPage = {
+  results: CourseSummary[];
+  /**
+   * The page actually served, which is the requested page clamped into
+   * `[1, MAX_SEARCH_PAGES]`. Explore reads this back rather than trusting its
+   * own `?page=`, so a hand-typed page past the cap lands on the last page
+   * that exists instead of on a lie.
+   */
+  page: number;
+  /**
+   * Whether a next page exists — the answer to the only question a prev/next
+   * pager asks. Never a count: see below for why there is not one to give.
+   */
+  hasMore: boolean;
+};
+
+function clampPage(page: number | undefined): number {
+  if (!page || !Number.isFinite(page)) return 1;
+  return Math.min(Math.max(Math.trunc(page), 1), MAX_SEARCH_PAGES);
+}
+
+/**
  * Hybrid search: keyword and embedding in parallel, keyword order kept, new
- * semantic hits appended, sliced to `size`.
+ * semantic hits appended, sliced to the requested page.
  *
  * ## `department` is the only filter, and it is deliberate
  *
@@ -111,54 +161,90 @@ async function searchWithEmbedding(
  * filter, the query over-fetched `size * 5`. If more than four fifths of that
  * window missed the threshold the caller silently got fewer results than it
  * asked for, with nothing on the wire saying more existed. That failure mode
- * left with the feature, and the over-fetch went with it: `size` is now what
- * is fetched.
+ * left with the feature, and the over-fetch went with it.
  *
  * `department` stays, and is still a deviation from the artboard — but a cheap
  * and honest one. It filters in SQL (`department ILIKE`, in the repository),
  * so the database does the narrowing, every returned row already satisfies it,
- * and the result count is whatever the caller asked for. It needs no window,
- * no second round trip, and no post-fetch pass.
+ * and it applies to the whole window rather than to one page. That is what
+ * makes it survive paging: page 3 of a filtered search is page 3 of the
+ * filtered ranking, not page 3 of an unfiltered one with rows knocked out.
  *
- * ## Why `total` is still a lie, and still #148
+ * ## Paging with a lookahead, because there is no total to have
  *
- * The router returns `total: results.length` — the count of what it just
- * returned, not of what matches. Removing the rating filter clears **one of
- * three** reasons a truthful count could not be computed; two remain, and they
- * are the structural ones:
+ * `total` used to be returned here as `results.length` — the size of what had
+ * just been returned, which is not a total of anything. It is gone rather than
+ * corrected, because the honest version cannot be computed:
  *
- * - the result set is the union of two independent rankings, de-duplicated,
- *   which has no natural count short of running both queries unbounded; and
- * - the semantic path has no cutoff — every course with an embedding is a hit
- *   at some distance, so "how many match" is not a question it can answer.
+ * - the result set is the union of two independent rankings, de-duplicated in
+ *   application code, so neither leg's count is the answer and the union's
+ *   cannot be had without running both across the whole catalogue; and
+ * - the semantic leg has no cutoff — every course with an embedding matches at
+ *   some distance — so "how many match" has no answer short of "all of them".
  *
- * So a real pager still needs server work (a `COUNT` and an honoured offset),
- * and #148 still owns it. One fewer obstacle, not none.
+ * A prev/next pager never needed one. "How many results are there" is expensive
+ * and close to meaningless for a hybrid ranking; **"is there another page" is
+ * one extra row.** So this fetches `(page * size) + 1` and reports whether the
+ * extra row came back. One query per leg, exactly as before, one row wider.
+ *
+ * ## Why a wider fetch gives the same page
+ *
+ * Paging by re-fetching the whole prefix works only if the prefix is stable —
+ * page 2 of a 41-row fetch must hold the rows page 2 of a 61-row fetch holds.
+ * It does, for two reasons that have to hold together:
+ *
+ * - each leg is a LIMIT over a *totally* ordered query, so a wider LIMIT
+ *   returns a superset beginning with the narrower one. The keyword leg has
+ *   always ended `courses.code ASC`; the semantic leg does now, and #148 is
+ *   where that was fixed — ordering on distance alone let equidistant rows
+ *   swap between two fetches, which puts a course on two pages or on none.
+ * - the union of the two is itself prefix-stable. Where the keyword leg fills
+ *   the window, the first `size` rows *are* keyword rows and the semantic leg
+ *   cannot reach them; where it does not fill the window, it is exhausted and
+ *   identical at every width, so the semantic tail extends rather than shifts.
+ *
+ * The cost of that is a discarded prefix: page 5 fetches 101 rows and drops 80.
+ * At this catalogue size that is cheap, and `MAX_SEARCH_PAGES` bounds it.
  */
 export async function searchCourses(
   query: string,
-  size = 10,
-  filters?: { department?: string },
-): Promise<CourseSummary[]> {
-  if (!query?.trim()) return [];
-  const departmentFilter = resolveDepartmentFilter(filters?.department);
+  options: SearchPageRequest = {},
+): Promise<SearchPage> {
+  const page = clampPage(options.page);
+  if (!query?.trim()) return { results: [], page, hasMore: false };
+
+  const size = options.size ?? DEFAULT_SEARCH_PAGE_SIZE;
+  const departmentFilter = resolveDepartmentFilter(options.department);
+  const offset = (page - 1) * size;
+
+  // One row past the end of this page, which is the whole of "is there a next
+  // page". At the cap there is no next page to ask about, so the row is not
+  // fetched and `hasMore` falls out false on its own rather than being
+  // special-cased below.
+  const lookahead = page < MAX_SEARCH_PAGES ? 1 : 0;
+  const fetchWindow = offset + size + lookahead;
 
   const [keywordHits, semanticHits] = await Promise.all([
-    searchByKeyword(query, size, departmentFilter),
-    searchWithEmbedding(query, size, departmentFilter),
+    searchByKeyword(query, fetchWindow, departmentFilter),
+    searchWithEmbedding(query, fetchWindow, departmentFilter),
   ]);
 
   const seen = new Set(keywordHits.map((h) => h.courseCode));
-  const codes = [
+  const ranked = [
     ...keywordHits,
     ...semanticHits.filter((h) => !seen.has(h.courseCode)),
-  ]
-    .slice(0, size)
-    .map((h) => h.courseCode);
+  ].slice(0, fetchWindow);
 
-  if (codes.length === 0) return [];
+  // Read off the ranking, not off `results`: `getSummariesByCodes` drops a code
+  // whose course row has gone, so a page can come back short of the rows that
+  // were ranked behind it. Whether a next page exists is a fact about the
+  // ranking.
+  const hasMore = ranked.length > offset + size;
+  const codes = ranked.slice(offset, offset + size).map((h) => h.courseCode);
 
-  return getSummariesByCodes(codes);
+  if (codes.length === 0) return { results: [], page, hasMore };
+
+  return { results: await getSummariesByCodes(codes), page, hasMore };
 }
 
 export function getDepartments(): Promise<string[]> {


### PR DESCRIPTION
Closes #148 — builds the Explore pager the artboard draws, without ever claiming a total.

## The lookahead, and why no count exists

`search.courses` accepted a `page` and dropped it, and returned
`total: results.length` — the size of the page it had just built, offered as if it were
the size of the matching set. The issue originally asked for a `COUNT(*)`. **There is
none to take.**

- The result set is a de-duplicated union of two independent rankings — `searchByKeyword`
  and `searchByEmbedding` run in parallel, keyword hits first, semantic hits appended.
  Neither leg's count is the answer, and the union's cannot be had without running both
  across the whole catalogue.
- `searchByEmbedding`'s `WHERE` is effectively "has an embedding", so **every** course
  matches at some distance and the `LIMIT` is the only thing that makes the result a set.
  There is no cutoff to count up to.

A prev/next control never asked how many results there are. It asks whether there is
another page — and that is one extra row.

- Fetch `(page * size) + 1`. One row, not a multiple. The `size * 5` window that existed
  only to feed the post-fetch rating filter removed in #183 is not coming back; a test
  asserts each leg is asked for exactly the window.
- Return `hasMore: boolean`. `total` is **deleted**, not corrected.
- Page size **20**, replacing the default of 10.
- `hasPager` is `hasMore || page > 1` — the artboard's `pageCount > 1` translated into
  what the data supports. It is additionally gated on there being a search and on the
  request not having failed, so it never appears over the start-here or error panel.

## Prefix stability, and the tiebreak that guarantees it

Paging by re-fetching the whole prefix works only if page 2 of a 41-row fetch holds the
rows page 2 of a 61-row fetch holds. Two things have to hold together:

- **Each leg must be a LIMIT over a *totally* ordered query**, so a wider LIMIT is a
  superset that begins with the narrower one. `searchByKeyword` already ended
  `, courses.code ASC`. `searchByEmbedding` ordered on cosine distance alone, which is
  **not** a total order: two courses at the identical distance may come back in either
  order between two executions — an ORDER BY that is not total obliges the executor to
  nothing. Under a plain LIMIT that is invisible: same set, shuffled. Under paging it
  puts one course on page 2 *and* page 3 and another on neither, and reads to a user
  as "search is broken". This PR appends `, courses.code ASC` (the primary key) after
  the distance, and a repository test asserts both that it is there and that it comes
  *after* the distance — so the HNSW index still provides the ordering and only the
  ties above it are sorted.
- **The union must inherit that.** Where the keyword leg fills the window, the first
  `size` rows *are* keyword rows and the semantic leg cannot reach them; where it does
  not fill the window it is exhausted and identical at every width, so the semantic tail
  extends rather than shifts. A service test pins this directly: pages 2 and 4 of a
  size-5 fetch equal the corresponding slices of a single size-20 fetch.

**One honest caveat, documented in the code rather than glossed.**
`course_explore_embedding_idx` is HNSW — approximate, with a search list pgvector widens
as the LIMIT grows — so the semantic leg's prefix is stable *in practice* rather than by
construction. The tiebreak removes the one source of drift that is entirely ours; the rest
is a property of ANN search. The exposure is bounded by the exact keyword leg coming
first, so only the tail of a deep page could be reshuffled. (An earlier revision of these
comments justified the tiebreak by claiming courses sharing a description embed
identically. That is false — `server/ingest/ingest.ts:285` puts the unique course code
first in the embedding text — and the claim is gone.)

## The depth cap

`MAX_SEARCH_PAGES = 5` (100 results). This is the one judgement call rather than
something the data dictates: with no relevance floor on the semantic leg, page 20 is
courses sorted by how little they match, presented with the same confidence as page 1.
The cap says that honestly. The alternative — a similarity threshold — means defending a
specific number on cosine distance that would silently change meaning the next time the
embedding model does.

At the cap the lookahead row is **not fetched** (`lookahead = page < MAX ? 1 : 0`), so
`hasMore` falls out false on its own rather than being special-cased. The cap also bounds
the cost: the deepest fetch this domain can ever issue is `MAX_SEARCH_PAGES * size` rows
per leg. For the same reason `size` is now capped at 20 in the input schema — this is an
unauthenticated procedure and the window is `page * size`, so an uncapped `size` was a
five-fold lever on the cost of an anonymous request.

## What an out-of-range `?page=` does

| `?page=` | what happens |
|---|---|
| `?page=99` (past the cap) | the service clamps to 5, serves page 5, and **echoes `page: 5`**. The pager reads the echo, so it says "Page 5" and Previous goes to 4 — not "Page 99". |
| `?page=3` on a 25-result ranking | an empty page, not an error. A distinct panel — "Nothing on page 3 … Back to the first page" — rather than "No courses match", which would be false: something matched, on an earlier page. |
| `?page=abc`, `?page=0`, `?page=-2` | read as page 1, silently. Same treatment as the stale `?rating=` links: an old URL should be boring, not an error. |

**Nothing rewrites `?page=` from the response.** An effect that corrected the URL from the
state it reads is how the last three render loops in this repo started; the reader's next
click writes a truthful number and the stale one is gone. A test asserts that opening on
`?page=3` writes nothing to the router at all, under the Strict Mode double mount.

`?page=` is also the one write on this page that **pushes** rather than replaces — turning
a page is a deliberate navigation and Back should undo it — and it goes through the
existing `setParams` rather than a second `router.replace`, because two independent
writers on one query string is exactly the race `issuedParams` exists to prevent. A new
search or a changed school resets to the first page; page 1 drops the parameter entirely.

## The department filter across pages

It survives, because it never left SQL: `department ILIKE` is a predicate on both legs, so
it narrows the *whole ranking* before the window is cut. Page 3 of a filtered search is
page 3 of the filtered ranking, not page 3 of an unfiltered one with rows knocked out. A
service test asserts the filter reaches both legs on page 3 alongside the widened window.

## One deviation from the settled spec, flagged deliberately

The settled comment says the artboard draws "prev and next, **no page numbers**, no 'of N'
label", citing `docs/design_ref/2026-09-05/`. That folder no longer exists; the authority
is `docs/design_ref/2026-09-06/`, and **it does draw a label** —
`Course Community - Explore.dc.html:264` is `<span>{{ pageLabel }}</span>` between the two
pills, and line 1289 is `pageLabel: "Page " + (page + 1) + " of " + pageCount`. The
artboards are revised at each export, so the spec's premise is stale rather than wrong in
intent.

What the spec actually defends is *do not assert a total*. So this keeps the label and
drops only its `of N`: "Page 3" asserts nothing about a total, it preserves the artboard's
three-item centred layout, and it is the only thing that tells a reader who followed a
link to a deep page where they actually landed. Deleting the label would have been a
larger edit to the design, not a smaller one. **Happy to remove it if you would rather the
literal reading of the spec win** — it is one `<span>` and one field.

The pills are real `<button disabled>` rather than the artboard's `role="button"` divs:
disabled is the whole state model of this control, and only a real button carries it to
the keyboard and the accessibility tree. The artboard's own visual vocabulary (34px pill,
`--surface` over `--rule3`, `--ink` / `--dim2`, hover on `--hov`) is kept exactly.

## Validation

- `bun run lint` — clean (8 pre-existing warnings, none in touched files)
- `bun run typecheck` — clean
- `bun run test:web` — **1148 passed / 83 files** (baseline 1106 / 82)

New coverage: `server/search/router.spec.ts` (new file — contract shape, no `total`, page
echoed, `size` cap, invalid page rejected), `server/search/service.spec.ts` (lookahead
width, boundary case where a full page has nothing behind it, `hasMore` read off the
ranking rather than surviving summaries, prefix stability, department across pages, cap
and clamping), `server/search/repository.spec.ts` (tiebreak present and ordered after the
distance), `features/search/components/explore.spec.tsx` (16 pager cases: visibility,
push-not-replace, clamped page display, placeholder-data staleness, past-end panel, page
resets, no-write-on-mount).

## Files outside the search domain

One line: `server/api/protected.spec.ts` asserted `total: 0` on the visitor-access case
and now asserts `{ results: [], page: 1, hasMore: false }`. It is a direct consequence of
removing `total` and there was no way to leave it.

`features/taken/components/add-taken-course-dialog.tsx` is untouched and unaffected in
shape — it calls `useSearchCourses({ q })` with no page, which the first page deliberately
matches (page 1 sends no `page` key, so react-query's content-hashed key is the unpaged
one). It does now get 20 candidates rather than 10 in its scrollable dropdown, which is
the intended new default.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017EAUKDDo2BkQTFELyvV3v8
