### PR TITLE
fix(landing): put the hero copy and search bar back on the artboard

### DIFF
--- a/apps/web/features/landing/components/landing.tsx
+++ b/apps/web/features/landing/components/landing.tsx
@@ -382,12 +382,15 @@ export function Landing() {
           />
         </motion.div>
 
-        <div className="relative z-[1] flex min-h-[480px] @lg:min-h-[600px] flex-col items-center justify-center px-4 py-14 @lg:px-7">
+        <div className="relative z-[1] flex min-h-[480px] @lg:min-h-[600px] flex-col items-center justify-center px-4 @lg:px-7">
           <div className="flex w-full max-w-[720px] flex-col items-center text-center">
+            {/* The artboard's 70px, and it is load-bearing: it grows the
+                centred column at the top, which is what sits the hero copy
+                where the artboard has it rather than 64px higher. */}
             <motion.p
               variants={HERO_EXIT}
               data-hero-clear
-              className="m-0 font-semibold text-[11px] text-cc-dim uppercase tracking-[0.09em]"
+              className="mt-[70px] mb-0 font-semibold text-[11px] text-cc-dim uppercase tracking-[0.09em]"
             >
               Run by students at KTH
             </motion.p>
@@ -402,7 +405,22 @@ export function Landing() {
 
             {/* The one element that stays. It carries `data-hero-clear` for the
                 graph's keep-out and no `variants` for the exit, which is the
-                whole difference between the two sets. */}
+                whole difference between the two sets.
+
+                `Course Community - Landing.dc.html` pins this bar out of flow,
+                at `top:400px` from the page top, floating over an empty 97px
+                spacer. That is not a layout decision to copy: there the bar is
+                one element that *transitions* `top` between the hero and
+                Explore's header (`barTop`, `barTween`), and `top` does not
+                animate in flow. Here the departure is a route change that
+                measures the bar's box at submit time, so the bar can stay in
+                flow — and the artboard's 97px is the space it occupies plus its
+                margins, split around it rather than stacked above it.
+
+                19 + 42 + 36 = 97. The sum has to hold, or the centred column
+                changes height and every line in the hero moves; the 19 is what
+                puts the bar's top back on the artboard's 400px, 334px below the
+                header. Both measured against the artboard, not derived. */}
             <form
               ref={barRef}
               data-hero-clear
@@ -410,7 +428,7 @@ export function Landing() {
                 event.preventDefault();
                 submitSearch(query);
               }}
-              className="mt-6 @lg:mt-[97px] flex h-[42px] w-full @lg:max-w-[560px] items-center gap-2.5 rounded-[10px] border border-cc-rule3 bg-cc-surface px-3.5"
+              className="mt-4 @lg:mt-[19px] flex h-[42px] w-full @lg:max-w-[560px] items-center gap-2.5 rounded-[10px] border border-cc-rule3 bg-cc-surface px-3.5"
             >
               <Search
                 size={16}
@@ -431,7 +449,7 @@ export function Landing() {
             <motion.div
               variants={HERO_EXIT}
               data-hero-clear
-              className="mt-4 flex flex-wrap items-center justify-center gap-[7px]"
+              className="mt-6 @lg:mt-[36px] flex flex-wrap items-center justify-center gap-[7px]"
             >
               <span className="text-[12px] text-cc-dim">Try</span>
               {TRY.map((term) => (


### PR DESCRIPTION
The landing hero's vertical rhythm had drifted from `docs/design_ref/2026-09-06/Course Community - Landing.dc.html`. Measured against the artboard at 1440px+:

| | artboard | before | after |
|---|---|---|---|
| header bottom → bar top | **334px** | ~350px | 334.52px |
| headline bottom | 380.52 | ~319 | 381.52 |
| headline → bar gap | 19.48px | 97px | 19px |
| kicker top | 257.48 | ~193 | 258.48 |

The copy sat ~64px high and the bar ~16px low.

## What caused it

**The kicker lost its `margin-top:70px`** (artboard line 61) to `m-0`. That margin grows the vertically-centred column at the top, so dropping it lifts every line in the hero — it is doing real work, not decoration.

**The artboard's 97px hero spacer became the bar's own `mt-[97px]`.** That is not what the 97px is. The artboard pins the bar out of flow at `top:400px` (`const centre = 400`, line 1462/1546) and the 97px spacer (line 68) is the hole it floats in. Stacking it above the bar instead both moved the bar down and added 42px to the column's height.

## Why the fix keeps the bar in flow

The absolute positioning is a prototype artifact, not a design decision. In the artboard the bar is a single element that *transitions* `top` between the hero and Explore's header (`barTop`, `barTween` at line 1455) — and `top` will not animate in flow, so it had to leave.

Here the departure is a real route change, and the morph measures the box live:

```ts
const from = barRef.current?.getBoundingClientRect();   // landing.tsx:217
stashSearchBarHandoff(from);
```

So the layout mechanism is invisible to the animation. Porting `top:400px` would import the constraint without its reason, and hand us a magic `400` that breaks silently if the header height or the headline's wrap changes — the artboard's pin and its centred copy only agree at one content height.

Instead the 97 is split around the bar rather than stacked above it: **19 + 42 + 36 = 97**. The sum has to hold or the centred column changes height and everything moves; the 19 is what puts the bar's top back on 400px.

Also drops `py-14` from the hero box, which the artboard doesn't have (`padding:0 28px`) and which positions nothing — content never fills the box at either breakpoint.

## Mobile

The two values were reversed. The artboard gives the mobile bar `margin-top:16px` (line 63) and the gap below it `24px`; this had 24 above and 16 below.

## Verification

Measured in Chrome by rendering the artboard's own hero markup against `cc-theme.css` and Geist, then the post-fix layout under Tailwind's `border-box` reset — not derived by hand. The 17/38 split I first estimated from arithmetic was wrong; the measured split is 19.48/35.52.

Residual is ≤1px on every line, and it all traces to one thing left alone deliberately: the chips are 28px here under Tailwind's `border-box` against the artboard's 30px (it sets `height:28px` with a 1px border and no box-sizing reset). That makes the column 2px shorter and shifts it 1px. Fixing it means deciding whether the artboard means a 28px chip or a 30px one, which is a separate question from this spacing and would change how the chips look — worth a follow-up if you want it exact.

`bun run lint` clean on the touched file (8 pre-existing warnings elsewhere in the drizzle schema, untouched), `typecheck` exit 0, `test:web` 1183 passed / 85 files. No test churn — `landing.spec.tsx` asserts behaviour, not classes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0138hrzfV9YRwECtr8ageG3F
