### PR TITLE
fix(landing): re-land the hero spacing, with more room above the search bar

### DIFF
--- a/apps/web/features/landing/components/landing.tsx
+++ b/apps/web/features/landing/components/landing.tsx
@@ -386,11 +386,17 @@ export function Landing() {
           <div className="flex w-full max-w-[720px] flex-col items-center text-center">
             {/* The artboard's 70px, and it is load-bearing: it grows the
                 centred column at the top, which is what sits the hero copy
-                where the artboard has it rather than 64px higher. */}
+                where the artboard has it rather than 64px higher.
+
+                Desktop takes 58 instead — 12 off the top, given back to the
+                bar's own margin below. A deliberate divergence: the artboard's
+                19px headline-to-bar gap read too tight once built, and this is
+                the half of the trade that moves the copy up. Mobile keeps the
+                70, along with its own untouched 16px gap. */}
             <motion.p
               variants={HERO_EXIT}
               data-hero-clear
-              className="mt-[70px] mb-0 font-semibold text-[11px] text-cc-dim uppercase tracking-[0.09em]"
+              className="mt-[70px] @lg:mt-[58px] mb-0 font-semibold text-[11px] text-cc-dim uppercase tracking-[0.09em]"
             >
               Run by students at KTH
             </motion.p>
@@ -420,7 +426,14 @@ export function Landing() {
                 19 + 42 + 36 = 97. The sum has to hold, or the centred column
                 changes height and every line in the hero moves; the 19 is what
                 puts the bar's top back on the artboard's 400px, 334px below the
-                header. Both measured against the artboard, not derived. */}
+                header. Both measured against the artboard, not derived.
+
+                Desktop now runs 31 + 42 + 36 = 109, with the extra 12 taken off
+                the kicker's top margin above. That keeps the column the same
+                height and the bar on the same 400px — only the copy above it
+                moves, which is the point: the artboard's 19 read too tight in
+                the built page. The 97 is still what the artboard says, and this
+                is knowingly 12 off it. */}
             <form
               ref={barRef}
               data-hero-clear
@@ -428,7 +441,7 @@ export function Landing() {
                 event.preventDefault();
                 submitSearch(query);
               }}
-              className="mt-4 @lg:mt-[19px] flex h-[42px] w-full @lg:max-w-[560px] items-center gap-2.5 rounded-[10px] border border-cc-rule3 bg-cc-surface px-3.5"
+              className="mt-4 @lg:mt-[31px] flex h-[42px] w-full @lg:max-w-[560px] items-center gap-2.5 rounded-[10px] border border-cc-rule3 bg-cc-surface px-3.5"
             >
               <Search
                 size={16}

--- a/apps/web/features/landing/components/landing.tsx
+++ b/apps/web/features/landing/components/landing.tsx
@@ -382,12 +382,15 @@ export function Landing() {
           />
         </motion.div>
 
-        <div className="relative z-[1] flex min-h-[480px] @lg:min-h-[600px] flex-col items-center justify-center px-4 py-14 @lg:px-7">
+        <div className="relative z-[1] flex min-h-[480px] @lg:min-h-[600px] flex-col items-center justify-center px-4 @lg:px-7">
           <div className="flex w-full max-w-[720px] flex-col items-center text-center">
+            {/* The artboard's 70px, and it is load-bearing: it grows the
+                centred column at the top, which is what sits the hero copy
+                where the artboard has it rather than 64px higher. */}
             <motion.p
               variants={HERO_EXIT}
               data-hero-clear
-              className="m-0 font-semibold text-[11px] text-cc-dim uppercase tracking-[0.09em]"
+              className="mt-[70px] mb-0 font-semibold text-[11px] text-cc-dim uppercase tracking-[0.09em]"
             >
               Run by students at KTH
             </motion.p>
@@ -402,7 +405,22 @@ export function Landing() {
 
             {/* The one element that stays. It carries `data-hero-clear` for the
                 graph's keep-out and no `variants` for the exit, which is the
-                whole difference between the two sets. */}
+                whole difference between the two sets.
+
+                `Course Community - Landing.dc.html` pins this bar out of flow,
+                at `top:400px` from the page top, floating over an empty 97px
+                spacer. That is not a layout decision to copy: there the bar is
+                one element that *transitions* `top` between the hero and
+                Explore's header (`barTop`, `barTween`), and `top` does not
+                animate in flow. Here the departure is a route change that
+                measures the bar's box at submit time, so the bar can stay in
+                flow — and the artboard's 97px is the space it occupies plus its
+                margins, split around it rather than stacked above it.
+
+                19 + 42 + 36 = 97. The sum has to hold, or the centred column
+                changes height and every line in the hero moves; the 19 is what
+                puts the bar's top back on the artboard's 400px, 334px below the
+                header. Both measured against the artboard, not derived. */}
             <form
               ref={barRef}
               data-hero-clear
@@ -410,7 +428,7 @@ export function Landing() {
                 event.preventDefault();
                 submitSearch(query);
               }}
-              className="mt-6 @lg:mt-[97px] flex h-[42px] w-full @lg:max-w-[560px] items-center gap-2.5 rounded-[10px] border border-cc-rule3 bg-cc-surface px-3.5"
+              className="mt-4 @lg:mt-[19px] flex h-[42px] w-full @lg:max-w-[560px] items-center gap-2.5 rounded-[10px] border border-cc-rule3 bg-cc-surface px-3.5"
             >
               <Search
                 size={16}
@@ -431,7 +449,7 @@ export function Landing() {
             <motion.div
               variants={HERO_EXIT}
               data-hero-clear
-              className="mt-4 flex flex-wrap items-center justify-center gap-[7px]"
+              className="mt-6 @lg:mt-[36px] flex flex-wrap items-center justify-center gap-[7px]"
             >
               <span className="text-[12px] text-cc-dim">Try</span>
               {TRY.map((term) => (


### PR DESCRIPTION
Re-lands #195, which was merged and then reverted in #196 because the headline sat too close to the search bar. Two commits: the revert-of-the-revert, then the spacing change — so the diff against what was reverted is exactly the fix.

## The change

The headline-to-bar gap goes from the artboard's **19px to 31px** on desktop. The 12px comes off the kicker's top margin (`70 → 58` at `@lg`) and is given to the bar's own margin (`19 → 31`), so the centred column keeps its height and the bar keeps the artboard's 400px position. Only the copy above it moves.

| | before | after |
|---|---|---|
| kicker `margin-top` (`@lg`) | 70px | 58px |
| headline → bar gap (`@lg`) | 19px | 31px |
| bar top from page | 400.52px | 400.94px |

**Mobile is untouched.** The kicker's `70px` gains an `@lg` variant rather than changing outright, and the 16px gap below the headline stays. It has much less vertical room to give, and the complaint was not about it.

## This is a deliberate divergence from the design ref

Worth being explicit, since #195 existed precisely to put these numbers *on* the artboard. `Course Community - Landing.dc.html` says 19px; this says 31px. It reads too tight in the built page, and that judgement is recorded in the component next to the numbers rather than left looking like the drift #195 fixed. The artboard's own `19 + 42 + 36 = 97` sum is still written down beside it, with the note that desktop now runs 109 and why.

If the preference is to keep the artboard authoritative and change it at source instead, this should wait on that.

## Verification

Measured in the running app at both ends of the container query, not derived:

- 1536px container: kicker 58px, bar margin 31px, gap 31px, bar top 400.94px
- container narrowed to 400px: kicker 70px, bar margin 16px — unchanged

`bun run test:web` on `features/landing` 130 passed · `tsc --noEmit` clean · `bun run lint` at the 8 pre-existing warnings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RAUnEjgKvSqyiJxi3GWbWg
