### PR TITLE
fix(landing): fit the landing page to a laptop viewport

### DIFF
--- a/apps/web/features/landing/components/landing.tsx
+++ b/apps/web/features/landing/components/landing.tsx
@@ -281,11 +281,11 @@ export function Landing() {
     <motion.div
       initial={false}
       animate={leavingFor ? "leaving" : "at-rest"}
-      className="scrollbar-subtle @container cc-theme min-h-dvh bg-cc-pg text-cc-ink text-sm lg:h-dvh lg:overflow-y-auto"
+      className="scrollbar-subtle @container cc-theme min-h-dvh bg-cc-pg text-cc-ink text-sm lg:flex lg:h-dvh lg:flex-col lg:overflow-y-auto"
     >
       <motion.header
         variants={HERO_EXIT}
-        className="relative z-10 flex h-[66px] items-center justify-between gap-5 border-cc-rule border-b bg-cc-pg px-4 @lg:px-7"
+        className="relative z-10 flex h-[66px] shrink-0 items-center justify-between gap-5 border-cc-rule border-b bg-cc-pg px-4 @lg:px-7"
       >
         <Link
           href="/"
@@ -360,7 +360,7 @@ export function Landing() {
 
       <section
         data-hero
-        className="relative min-h-[480px] @lg:min-h-[600px] overflow-hidden"
+        className="relative min-h-[480px] lg:min-h-[400px] lg:flex-1 overflow-hidden"
       >
         {/* The graph clears with everything else. It is the backdrop the bar is
             leaving, and a still canvas sitting behind a page that has faded out
@@ -382,7 +382,7 @@ export function Landing() {
           />
         </motion.div>
 
-        <div className="relative z-[1] flex min-h-[480px] @lg:min-h-[600px] flex-col items-center justify-center px-4 @lg:px-7">
+        <div className="relative z-[1] flex min-h-[480px] lg:h-full lg:min-h-0 flex-col items-center justify-center px-4 @lg:px-7">
           <div className="flex w-full max-w-[720px] flex-col items-center text-center">
             {/* The artboard's 70px, and it is load-bearing: it grows the
                 centred column at the top, which is what sits the hero copy
@@ -502,7 +502,7 @@ export function Landing() {
 
       <motion.section
         variants={HERO_EXIT}
-        className="border-cc-rule border-t bg-cc-surface px-4 py-[34px] @lg:px-7"
+        className="border-cc-rule border-t bg-cc-surface px-4 py-[34px] @lg:px-7 lg:shrink-0"
       >
         <div className="mx-auto flex max-w-[960px] flex-col gap-[22px] @lg:grid @lg:grid-cols-3">
           {SECTIONS.map((section) => (


### PR DESCRIPTION
The landing page scrolled on an ordinary laptop. The hero was a fixed 600px band, so the content summed to a constant regardless of screen height:

```
header                      66.00
hero band                  600.00   ← fixed
"Search / Read / Review"   177.98
                          ───────
                           843.98   vs. a 730px viewport → 114px of overflow
```

730px is not a small screen — that's a 1920×1080 panel at 125% scaling, minus browser chrome. The document itself never scrolled; the root is `lg:h-dvh lg:overflow-y-auto`, so it scrolled internally.

## The change

The band takes what's left instead of a fixed 600. Five class edits in `landing.tsx`:

```
root    + lg:flex lg:flex-col       (already had lg:h-dvh lg:overflow-y-auto)
header  + shrink-0
hero      min-h-[480px] lg:min-h-[400px] lg:flex-1   (dropped @lg:min-h-[600px])
inner     min-h-[480px] lg:h-full lg:min-h-0
strip   + lg:shrink-0
```

## Measured in the browser

| viewport | header | hero | strip | scrolls? | header→bar | h1→bar |
|---|---|---|---|---|---|---|
| 1000 | 66 | 756 | 178 | no | 413 | 31 |
| 900 | 66 | 656 | 178 | no | 363 | 31 |
| 800 | 66 | 556 | 178 | no | 313 | 31 |
| **730** | 66 | **485.6** | 178 | **no** | 277.8 | 31 |

66 + 485.6 + 178 = 729.6 at a 730px viewport — zero overflow, and the copy (357.6px) sits clear of the band with no clipping.

Two bugs the measurements caught that reading the diff would not have:

- Making the root a flex column let the **header collapse from 66px to 35.3px** — flex items shrink by default. Hence `shrink-0` on the header and the strip.
- **`@lg:min-h-[600px]` outranks `lg:min-h-[400px]`** in Tailwind's cascade — container-query variants win over media-query ones. While both existed the hero could not shrink and the page still scrolled. The hero's height is now a viewport concern only; `@lg` keeps type and padding.

## Three deliberate costs

**The search bar leaves the artboard's 400px, and can't keep it.** Fitting the viewport shrinks the band, and the copy is centred in it, so the bar rises — 277.8 below the header at 730, 413 at 1000. Holding 400 would require the strip below to shrink from 178px to 64px. The bar's position is now viewport-dependent by design. The internal rhythm is untouched: **headline→bar is 31px at every height**, exactly as #197 left it.

**Viewports 512–1023px wide get a 480px hero instead of 600.** Fallout from moving height off the container query to resolve the cascade conflict. Narrow screens still scroll, as intended.

**Below a 644px viewport it scrolls again** (66 + the 400px floor + 178). That's what the floor is for — without it the band shrinks under the copy and the hero's `overflow-hidden` clips it. This number is arithmetic, not measurement: the browser window would not shrink below the physical screen, so I could not verify it empirically. Worth a manual check on a short window.

`lint` clean on the touched file (8 pre-existing warnings elsewhere), `typecheck` 0, `test:web` 1183 passed / 85 files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0138hrzfV9YRwECtr8ageG3F
