### PR TITLE
docs(comments): audit the comments against #191's rubric

### DIFF
--- a/apps/web/app/(public)/layout.tsx
+++ b/apps/web/app/(public)/layout.tsx
@@ -2,10 +2,9 @@ import type { ReactNode } from "react";
 import { AppShell } from "@/features/shell";
 
 /**
- * The public pages render in the same frame as the rest of the app. They used to
- * switch chrome on the session — a rail for members, a wordmark bar for everyone
- * else — but the designed rail carries its own signed-out state, so there is one
- * frame now and visitors keep the whole of it.
+ * The public pages render in the same frame as the rest of the app: the designed
+ * rail carries its own signed-out state, so there is one frame and a visitor
+ * keeps the whole of it rather than being given different chrome.
  */
 export default function PublicLayout({ children }: { children: ReactNode }) {
   return <AppShell>{children}</AppShell>;

--- a/apps/web/app/api/user/transcript/route.spec.ts
+++ b/apps/web/app/api/user/transcript/route.spec.ts
@@ -80,7 +80,7 @@ describe("a signed-out visitor", () => {
   /**
    * The change this route exists to make. The artboard has a guest read a
    * transcript and meet the account at the *keep* step
-   * (`docs/design_ref/2026-09-06/Course Community - Taken Courses.dc.html:1305`),
+   * (`docs/design_ref/2026-09-06/Course Community - Taken Courses.dc.html`),
    * which needs a parse that answers without a session — and which is safe only
    * because this route writes nothing.
    */

--- a/apps/web/app/api/user/transcript/route.ts
+++ b/apps/web/app/api/user/transcript/route.ts
@@ -71,7 +71,7 @@ const UNATTRIBUTED = "unattributed";
  * **A signed-out visitor may parse, and may not write.** The artboard has a
  * guest drop a transcript in, read what came out, and meet the account at the
  * *keep* step — "Sign in to keep this list"
- * (`docs/design_ref/2026-09-06/Course Community - Taken Courses.dc.html:1305-1308`)
+ * (`docs/design_ref/2026-09-06/Course Community - Taken Courses.dc.html`)
  * — and that flow is implementable only because parsing and writing are two
  * calls. This one is open; `transcript.confirm` stays a `protectedProcedure`
  * and is the only thing in the flow that touches a row. Nothing a signed-out

--- a/apps/web/app/globals.css
+++ b/apps/web/app/globals.css
@@ -137,25 +137,23 @@
   --cc-btn-fg: #ffffff;
   --cc-info: rgba(23, 81, 166, 0.07);
 
-  /* `--cc-warn-*` is the **review draft** family. It used to be documented here
-     as "the nudge to write a review", which #127 §4 flags as wrong: #88 showed
-     the actual nudge is `--cc-btn` on `--cc-surface`, and nothing amber appears
-     on it.
+  /* `--cc-warn-*` is the **review draft** family, not "the nudge to write a
+     review" — the nudge is `--cc-btn` on `--cc-surface` and nothing amber
+     appears on it.
 
      The tint half is the draft's header. The Design System artboard names
-     `--warn` "Review draft header" in both `TINTS` and `BANNERS`, and
-     `Course Community - Workspace Pane.dc.html` paints exactly it in its
-     `isReview` branch — `--warn` behind the draft's title block, `--warnInk` on
-     its "Review draft" eyebrow, and `--warnBorder` + `--warnSolid` as the
-     border and opaque backing of the progress row that sticks beneath it.
+     `--warn` "Review draft header" in both `TINTS` and `BANNERS`, and the
+     Workspace Pane artboard paints exactly it in its `isReview` branch —
+     `--warn` behind the draft's title block, `--warnInk` on its "Review draft"
+     eyebrow, and `--warnBorder` + `--warnSolid` as the border and opaque
+     backing of the progress row that sticks beneath it.
 
-     `--cc-warn-btn`/`--cc-warn-btn-fg` are a separate pair, and the one place
-     the old wording was not wrong: the Design System demos them under "Status
-     text & buttons" as a **"Write a review"** button. They are an accent, not a
-     banner tint — the filled progress segments and the submit button in
-     `review-draft-panel.tsx`, and the Review Card's accent for a review that
-     was not happy (`Review Card.dc.html:51`). Neither appears anywhere in the
-     Workspace Pane's `isReview` branch. */
+     `--cc-warn-btn`/`--cc-warn-btn-fg` are a separate pair: the Design System
+     demos them under "Status text & buttons" as a **"Write a review"** button.
+     They are an accent, not a banner tint — the filled progress segments and
+     the submit button in `review-draft-panel.tsx`, and the Review Card's accent
+     for a review that was not happy. Neither appears anywhere in the Workspace
+     Pane's `isReview` branch. */
   --cc-warn: #fdf7ea;
   --cc-warn-border: #f0e6d2;
   --cc-warn-ink: #7a5309;
@@ -174,12 +172,11 @@
      six tokens are the client half of that contract and the palette can be
      re-skinned here without a data migration.
 
-     Mirrored, like everything above: the revised `cc-theme.css` names all six
+     Mirrored, like everything above: `cc-theme.css` names all six
      (`--nodeAurora` … `--nodeViolet`), and the Design System artboard renders
      them under "Community graph nodes". They are *unassigned* rather than
      absent — #68 §3 settled that a node with no configured appearance is
-     `--cc-brand`, and these are the palette personalisation will draw from once
-     a tier writer exists. */
+     `--cc-brand`, and these are the palette personalisation draws from. */
   --cc-node-aurora: #2f9e8e;
   --cc-node-ember: #c96a4a;
   --cc-node-frost: #2f5fa8;
@@ -190,9 +187,8 @@
   /* The panel-tint families. A tint, its border and its ink are three separate
      tokens because a banner needs all three and none of them is derivable from
      `--cc-success` / `--cc-danger`: dark states them as alpha over the page,
-     light as flat mixes that are not a percentage of anything. Anything
-     deriving one with `color-mix` is reading the palette from before these
-     existed (#127 §1). */
+     light as flat mixes that are not a percentage of anything. Do not derive
+     one with `color-mix`. */
   --cc-success-tint: #e9f3ef;
   --cc-success-tint-border: #cfe4de;
   --cc-success-ink: #1c6b60;
@@ -209,71 +205,61 @@
 
      `--cc-focus` is `--cc-brand`, which is also `--cc-rail` — so a ring drawn in
      it on a sidebar control is the same colour as its background and cannot be
-     seen. That is the third instance of one pattern: `--cc-btn` on `--cc-rail`
-     gave an invisible Sign up button before the 2026-09-05 export fixed it. The
-     design answers it as a rule rather than a case, and so does this. */
+     seen. Every brand-blue token has this problem on the rail; the design
+     answers it as a rule rather than a case, and so does this. */
   --cc-focus: #1751a6;
   --cc-focus-ring: rgba(23, 81, 166, 0.25);
   --cc-rail-focus: #ffffff;
   --cc-rail-focus-ring: rgba(255, 255, 255, 0.35);
 
   /* The rail's "Sign up". The export disagrees with itself — six artboards
-     draw it `#8bb3ef`/`#0a2449`, Landing:151 draws `#fff`/`#12417f` — and the
-     decision the `--sidebar-primary` note below deferred is settled per theme:
-     white here, the six artboards' blue on the dark rail. Not `--cc-btn`,
-     which is `--cc-rail` itself in light. */
+     draw it `#8bb3ef`/`#0a2449`, Landing draws `#fff`/`#12417f` — and it is
+     settled per theme: white here, the six artboards' blue on the dark rail.
+     Not `--cc-btn`, which is `--cc-rail` itself in light. */
   --cc-rail-btn: #ffffff;
   --cc-rail-btn-fg: var(--cc-rail);
 
   /* The applied end of a theory/applied bar — the one colour on these screens
-     the design uses without ever having named (#173).
+     the design uses without ever having named.
 
-     `cc-theme.css` in the 2026-09-05 export contains no `9dbfe4` and declares no
-     token for it, while `Course Community - Workspace Pane.dc.html:115` writes
-     the hex inline as the applied half of the bar. Four other artboards reuse it
-     as a dashed "add something" border and as link text on a toast. So it is a
-     real colour of the design with no name, which is why this is the one `--cc-*`
-     token in the file that mirrors nothing. When an export finally names it,
-     this is the token to reconcile.
+     `cc-theme.css` declares no token for `#9dbfe4`, while the Workspace Pane
+     artboard writes the hex inline as the applied half of the bar and four
+     others reuse it as a dashed "add something" border and as link text on a
+     toast. So it is a real colour of the design with no name, which is why this
+     is the one `--cc-*` token in the file that mirrors nothing. When an export
+     finally names it, this is the token to reconcile.
 
      ## Why two literals and not one `color-mix`
 
-     `pane-parts.tsx` and `reviewer-card.tsx` each used to derive it as
-     `color-mix(in srgb, var(--cc-btn) 40%, var(--cc-surface))`, which was the
-     right substitution while nothing was named (#86's rule) and is the wrong
-     shape for a token. A mix is a standing promise that the derivation will keep
-     being correct, and nobody re-checks it: `--cc-btn` inverts between the
+     Deriving it as `color-mix(in srgb, var(--cc-btn) 40%, var(--cc-surface))` is
+     the wrong shape for a token. A mix is a standing promise that the derivation
+     keeps being correct, and nobody re-checks it: `--cc-btn` inverts between the
      themes — `#1751a6` light, `#8bb3ef` dark — so the mix silently re-resolves
      every time either input moves. Colours that quietly track each other are how
-     the light rail ended up painting a `--cc-btn` "Sign up" onto a `--cc-rail`
-     that is the same `#1751a6`; the rail block below is white on purpose for
-     that reason. Two flat values are checked once and reviewed when changed,
-     and they are what every other token here is.
+     a `--cc-btn` "Sign up" can land on a `--cc-rail` that is the same
+     `#1751a6`; the rail block below is white on purpose for that reason. Two
+     flat values are checked once and reviewed when changed.
 
-     Light is the artboard's own literal, so this stops approximating it: the mix
-     resolved to `#a2b9db`, which also held the "Applied" label (`--cc-brand`
+     Light is the artboard's own literal rather than an approximation of it: the
+     mix resolved to `#a2b9db`, which held the "Applied" label (`--cc-brand`
      `#1751a6`, 12px semibold) at 3.80:1 where the design's value gives 3.98:1.
 
      Dark is chosen for the dark page, by the design's own reflection: it moves
      `--cc-btn` from HSL lightness 37% to 74% and keeps hue and saturation, so
      this moves its light value (H211 S57% L75%) to L38% the same way. Pinning
-     `#9dbfe4` in dark was the one thing that could not work — at luminance 0.50
-     against `--cc-btn`'s 0.44 the quieter half of the bar would read *brighter*
-     than the brand half it sits beside, 1.12:1 apart.
+     `#9dbfe4` in dark cannot work — at luminance 0.50 against `--cc-btn`'s 0.44
+     the quieter half of the bar would read *brighter* than the brand half it
+     sits beside, 1.12:1 apart.
 
      ## What it is not for
 
-     The bar, and nothing else yet. #173 asked whether the draft's starter pills
-     should take it too — the artboard draws them with the same hex, dashed
-     (`Course Community - Workspace Pane.dc.html:274`), where
-     `review-draft-panel.tsx` uses `border-cc-hov`. They are left alone on
-     purpose: `Collections.dc.html:108` and `:134` draw the same dashed
-     `#9dbfe4` and `collections.tsx:524`/`:553` already map both onto
-     `--cc-hov`. Moving one of the three onto this token would replace one
-     inconsistency with a worse one — the same artboard element spelled two ways
-     — and this token is named for a fill in a bar, not for a border. If the
-     dashed border is worth its own name it is worth all three call sites and a
-     name of its own.
+     The bar, and nothing else. The Workspace Pane artboard draws the draft's
+     starter pills with the same hex, dashed, where `review-draft-panel.tsx`
+     uses `border-cc-hov`; the Collections artboard draws the same dashed
+     `#9dbfe4` twice and `collections.tsx` maps both onto `--cc-hov`. Moving one
+     of the three onto this token would spell the same artboard element two
+     ways, and this token is named for a fill in a bar, not for a border. If the
+     dashed border is worth its own name it is worth all three call sites.
 
      Resolved: light `#9dbfe4` — 1.91:1 on `--cc-surface`, 3.98:1 against the
      `--cc-btn` half beside it, and 3.98:1 under its `--cc-brand` label.
@@ -284,17 +270,13 @@
 
   /* ── shadcn primitives, expressed in Course Community tokens ──────────────
      `components/ui/**` is a stock shadcn set and styles itself against
-     `--background`, `--card`, `--muted` and friends. Those used to be a second,
-     unrelated neutral palette sitting beside `--cc-*` and disagreeing with it:
-     light `--background` was the design's cream while dark `--background` was a
-     blue-grey nothing like `--cc-pg`, and `--card` was pure white against a
-     `#0f172a` dark. That is the whole reason dark "worked better" than light —
-     the design's dark palette is self-consistent, so it was only in light that
-     the two systems sat side by side and every seam showed.
+     `--background`, `--card`, `--muted` and friends. Left on their stock
+     values those are a second, unrelated neutral palette sitting beside
+     `--cc-*` and disagreeing with it, and every seam shows.
 
-     So every shadcn token is now an alias onto the `--cc-*` token that means
-     the same thing. There is one palette, and a dialog, popover or button
-     inherits the theme without knowing the design exists.
+     So every shadcn token is an alias onto the `--cc-*` token that means the
+     same thing. There is one palette, and a dialog, popover or button inherits
+     the theme without knowing the design exists.
 
      The aliases are declared once, here, rather than repeated under `.dark`. A
      custom property is substituted at computed-value time, so `var(--cc-pg)`
@@ -349,16 +331,12 @@
      values, so these mirror it — `.16` is the active nav item and `.20` the
      divider above the signed-out block.
 
-     `--sidebar-primary` is **not** the artboard's "Sign up", and this comment
-     used to claim it was. Six of the seven artboards that draw the rail give
-     that button `background:#8bb3ef; color:#0a2449`; the seventh, Landing,
-     gives it `#fff` / `#12417f`. Neither is white on `--cc-rail`. `bg-sidebar`
-     has no consumer, so nothing renders from these and nothing is wrong on
-     screen — but the note was being read as authority for what `rail.tsx`
-     paints, which is how it survived two passes. That decision is now settled
-     per theme in `--cc-rail-btn` above, which is what `rail.tsx` paints. These
-     aliases stay white because they are shadcn's `Sidebar` contract and still
-     have no consumer. */
+     `--sidebar-primary` is **not** the artboard's "Sign up". Six of the seven
+     artboards that draw the rail give that button `background:#8bb3ef;
+     color:#0a2449`; the seventh, Landing, gives it `#fff` / `#12417f`. Neither
+     is white on `--cc-rail`. What `rail.tsx` paints is `--cc-rail-btn` above;
+     these aliases stay white because they are shadcn's `Sidebar` contract and
+     have no consumer. Do not read them as authority for the rail's button. */
   --sidebar: var(--cc-rail);
   --sidebar-foreground: #ffffff;
   --sidebar-primary: #ffffff;
@@ -483,8 +461,8 @@
 
    `:focus-visible` and not `:focus`, so a mouse click does not ring the control
    it just pressed — that is what gets a focus style deleted again a week later.
-   `!important` because the artboards carry 22 inline `outline:none`
-   declarations and this has to beat every one of them, and because it must also
+   `!important` because the artboards carry inline `outline:none` declarations
+   throughout and this has to beat every one of them, and because it must also
    reach hand-rolled `role="button"` divs, which are not focusable by default and
    get no help from the shadcn primitives' own ring.
 
@@ -517,17 +495,16 @@
    it sets `tabIndex={0}` on the selected tab, so the tab that has focus is never
    the one this excludes.
 
-   ## Nine treatments removed, three kept
+   ## The hand-rolled treatments that remain
 
-   #167's residue was twelve hand-rolled treatments in `features/**`, not the
-   five this comment used to claim. Nine are gone. The three that remain are
-   deliberate and say so at their own call sites:
-   `review-draft-panel.tsx`'s checkbox ring (painted on a sibling of an
+   This rule is meant to be the only focus treatment in the app. Three call
+   sites in `features/**` still carry their own, and each says why at the call
+   site: `review-draft-panel.tsx`'s checkbox ring (painted on a sibling of an
    `sr-only` peer, which this rule cannot reach), `workspace-pane.tsx`'s
    `focus:bg-cc-pill` (a menu highlight, not a ring), and
-   `search/components/explore.tsx`'s dead `focus-visible:outline-cc-brand`,
-   which this rule already overrides and which is left for the PR that owns
-   that file. */
+   `search/components/explore.tsx`'s `focus-visible:outline-cc-brand`, which
+   this rule already overrides and which is therefore dead. Anything else added
+   in `features/**` is a duplicate of this rule. */
 :focus-visible:not([tabindex="-1"]) {
   /* biome-ignore lint/complexity/noImportantStyles: it has to beat the 22 inline `outline:none` declarations the artboards carry, and the shadcn primitives' own ring. Without it a focus style exists everywhere except where it is needed. */
   outline: 2px solid var(--cc-focus) !important;
@@ -549,9 +526,8 @@
 
    The convention is that a scroll container picks one of these two utilities
    deliberately. Neither is the same as picking nothing: a container with no
-   utility renders the browser's default bar, which is what the artboards do not
-   draw and what this pass corrected across ten surfaces. If you add
-   `overflow-auto` anywhere, add one of these with it.
+   utility renders the browser's default bar, which the artboards never draw. If
+   you add `overflow-auto` anywhere, add one of these with it.
 
    `--border` is mapped onto `--cc-rule2`, so this tracks the theme on its own. */
 @utility scrollbar-subtle {

--- a/apps/web/components/editor/editor-hooks/use-modal.tsx
+++ b/apps/web/components/editor/editor-hooks/use-modal.tsx
@@ -29,9 +29,8 @@ export function useEditorModal(): [
     return (
       <Dialog open={true} onOpenChange={onClose}>
         {/*
-          384px, stated rather than inherited: `DialogContent` used to clamp
-          every dialog to it and no longer does. This modal is one of the
-          two that were happy with the clamp, so it keeps it explicitly.
+          384px, stated rather than inherited: `DialogContent` has no width
+          opinion of its own, so a caller that wants one says so.
         */}
         <DialogContent className="sm:max-w-sm">
           <DialogHeader>

--- a/apps/web/components/editor/editor-hooks/use-modal.tsx
+++ b/apps/web/components/editor/editor-hooks/use-modal.tsx
@@ -30,7 +30,7 @@ export function useEditorModal(): [
       <Dialog open={true} onOpenChange={onClose}>
         {/*
           384px, stated rather than inherited: `DialogContent` used to clamp
-          every dialog to it and no longer does (#178). This modal is one of the
+          every dialog to it and no longer does. This modal is one of the
           two that were happy with the clamp, so it keeps it explicitly.
         */}
         <DialogContent className="sm:max-w-sm">

--- a/apps/web/components/ui/alert-dialog.tsx
+++ b/apps/web/components/ui/alert-dialog.tsx
@@ -28,21 +28,15 @@ function AlertDialogPortal({
 }
 
 /**
- * Nothing imports this file any more.
+ * A vendored shadcn primitive with no consumer: the app's delete confirmations
+ * are {@link import("./confirm-dialog").ConfirmDialog}, which is built on
+ * `Dialog`.
  *
- * Its four consumers were the app's delete confirmations, and they moved to
- * {@link import("./confirm-dialog").ConfirmDialog} — the artboard's own
- * confirmation — which is built on `Dialog`. That also leaves the
- * `overlayClassName` prop #178 added here without a caller.
- *
- * It is kept rather than deleted because "which vendored shadcn primitives
- * should this repo still carry" is one question about 37 files, not a decision
- * to take one file at a time; see the follow-up issue. If it does come back
- * into use, note the width trap recorded on `ConfirmDialog`:
- * `data-[size=default]:sm:max-w-sm` below sits in a different tailwind-merge
- * group from a plain `max-w-*`, so a caller asking for a width wider than 384px
- * silently does not get it. That is the same trap #178 removed from
- * `DialogContent` and it is still here.
+ * If it does come back into use, note the width trap recorded on
+ * `ConfirmDialog`: `data-[size=default]:sm:max-w-sm` below sits in a different
+ * tailwind-merge group from a plain `max-w-*`, so a caller asking for a width
+ * wider than 384px silently does not get it. `DialogContent` no longer carries
+ * that clamp; this still does.
  */
 function AlertDialogOverlay({
   className,
@@ -74,13 +68,12 @@ function AlertDialogContent({
    * Restyle the scrim — e.g. to drop the blur when what is behind must stay
    * legible, which is the usual reason to reach for it.
    *
-   * Parity with {@link DialogContent}, which has had this prop all along.
-   * Without it this primitive rendered an overlay no caller could reach, and
-   * #178 records what that cost: the two confirmations that needed the
-   * artboard's own scrim were built on `Dialog` instead, purely because only
-   * `Dialog` let them at it. Which primitive a confirmation uses should follow
-   * from whether the question is destructive enough to want `alertdialog`
-   * semantics, not from which one happens to expose a prop.
+   * Parity with {@link DialogContent}. Without it this primitive renders an
+   * overlay no caller can reach, and a confirmation that needs the artboard's
+   * own scrim is pushed onto `Dialog` purely because only `Dialog` lets it at
+   * one. Which primitive a confirmation uses should follow from whether the
+   * question is destructive enough to want `alertdialog` semantics, not from
+   * which one happens to expose a prop.
    */
   overlayClassName?: string;
 }) {

--- a/apps/web/components/ui/command.tsx
+++ b/apps/web/components/ui/command.tsx
@@ -53,7 +53,7 @@ function CommandDialog({
           /*
             384px, stated rather than inherited. `DialogContent` used to carry an
             `sm:max-w-sm` in its base classes, where it silently clamped every
-            caller that asked for something wider (#178). It is gone from there,
+            caller that asked for something wider. It is gone from there,
             so the palette — which does want 384px — says so itself.
           */
           "top-1/3 translate-y-0 overflow-hidden rounded-xl! p-0 sm:max-w-sm",

--- a/apps/web/components/ui/command.tsx
+++ b/apps/web/components/ui/command.tsx
@@ -51,10 +51,9 @@ function CommandDialog({
       <DialogContent
         className={cn(
           /*
-            384px, stated rather than inherited. `DialogContent` used to carry an
-            `sm:max-w-sm` in its base classes, where it silently clamped every
-            caller that asked for something wider. It is gone from there,
-            so the palette — which does want 384px — says so itself.
+            384px, stated rather than inherited: `DialogContent` has no width
+            opinion of its own, so the palette — which does want 384px — says so
+            itself.
           */
           "top-1/3 translate-y-0 overflow-hidden rounded-xl! p-0 sm:max-w-sm",
           className,

--- a/apps/web/components/ui/confirm-dialog.spec.tsx
+++ b/apps/web/components/ui/confirm-dialog.spec.tsx
@@ -78,11 +78,9 @@ describe("ConfirmDialog", () => {
     open();
     const classes = widthClasses();
 
-    // `My Page.dc.html` draws the confirmation at `width:440px`. This
-    // component used to state that twice — `w-[440px]` plus an
-    // `sm:max-w-[440px]` — because `DialogContent` carried an `sm:max-w-sm` that
-    // a plain width could not merge away. #178 removed the clamp, so the second
-    // statement went with it; this asserts the first one is now enough.
+    // `My Page.dc.html` draws the confirmation at `width:440px`, and stating it
+    // once has to be enough: a second `sm:max-w-[440px]` would only be needed if
+    // `DialogContent` carried a clamp a plain width could not merge away.
     expect(classes).toContain("w-[440px]");
     expect(classes.filter((name) => name.startsWith("sm:max-w-"))).toEqual([]);
     expect(classes.filter((name) => name.startsWith("max-w-"))).toEqual([

--- a/apps/web/components/ui/confirm-dialog.spec.tsx
+++ b/apps/web/components/ui/confirm-dialog.spec.tsx
@@ -78,7 +78,7 @@ describe("ConfirmDialog", () => {
     open();
     const classes = widthClasses();
 
-    // `My Page.dc.html:428` draws the confirmation at `width:440px`. This
+    // `My Page.dc.html` draws the confirmation at `width:440px`. This
     // component used to state that twice — `w-[440px]` plus an
     // `sm:max-w-[440px]` — because `DialogContent` carried an `sm:max-w-sm` that
     // a plain width could not merge away. #178 removed the clamp, so the second

--- a/apps/web/components/ui/confirm-dialog.tsx
+++ b/apps/web/components/ui/confirm-dialog.tsx
@@ -55,7 +55,7 @@ type Props = {
  *
  * ## Why this exists rather than `components/ui/alert-dialog`
  *
- * `Course Community - My Page.dc.html` lines 426-436 draw this dialog properly —
+ * `Course Community - My Page.dc.html` draws this dialog properly —
  * 440px, a 14px radius, 22px of padding, a brand eyebrow over a 19px/600 title,
  * an `rgba(20,30,45,.34)` scrim and 38px buttons. The stock `AlertDialogContent`
  * hands its buttons to `Button`'s variants and clamps its own width:

--- a/apps/web/components/ui/confirm-dialog.tsx
+++ b/apps/web/components/ui/confirm-dialog.tsx
@@ -37,21 +37,14 @@ type Props = {
  *
  * ## Why it lives here
  *
- * It was `features/collections/components/confirm-dialog.tsx`, and the barrel
- * that exported it said what would move it: *"when a third screen needs it, it
- * belongs in `components/ui/` instead."* Taken courses was the third screen and
- * built a near-verbatim copy instead — same 440px shell, same scrim, same button
- * pair, differing only in the eyebrow and a computed body, both of which
- * {@link ConfirmRequest} already models. Five more screens then wanted it. So it
- * is here.
+ * Seven screens ask a confirmation, and they differ only in the eyebrow and the
+ * body — which is what {@link ConfirmRequest} models. So the shell is one
+ * component. It is not a vendored shadcn primitive and does not pretend to be
+ * one; it is app UI that more than one feature needs and no single feature
+ * owns, which is the case `components/ui/` exists for.
  *
- * `RemoveTakenCourseDialog` still exists and is still worth having — it is now
- * only the thing that decides what to ask, because `bodyFor(row)` and its two
- * documented deviations are real. It is the duplicated *shell* that is gone.
- *
- * It is not a vendored shadcn primitive and does not pretend to be one; it is
- * app UI that more than one feature needs and no single feature owns, which is
- * the case `components/ui/` exists for.
+ * A wrapper like `RemoveTakenCourseDialog` is still worth having where it
+ * decides *what* to ask. It is the duplicated shell that must not come back.
  *
  * ## Why this exists rather than `components/ui/alert-dialog`
  *
@@ -61,10 +54,8 @@ type Props = {
  * hands its buttons to `Button`'s variants and clamps its own width:
  * `data-[size=default]:sm:max-w-sm` sits in a different tailwind-merge group
  * from a plain `max-w-*`, so a caller asking for 440px silently gets 384px from
- * the `sm` breakpoint up. That is the exact trap #178 took out of
- * `DialogContent`; it is still in `AlertDialogContent`, and removing it is a
- * change to a shared primitive that belongs in its own PR rather than riding
- * along with this one.
+ * the `sm` breakpoint up. `DialogContent` no longer carries that clamp;
+ * `AlertDialogContent` still does.
  *
  * So the shell is `Dialog`, and the semantics are restored by hand:
  * `role="alertdialog"` is what tells a screen reader this is a question that
@@ -106,12 +97,12 @@ export function ConfirmDialog({ request, onCancel, onConfirm }: Props) {
             `cc-theme` because the dialog is portalled to the body and would
             otherwise leave the subtree that defines the `--cc-*` tokens.
 
-            There used to be an `sm:max-w-[440px]` here too, to defeat an
-            `sm:max-w-sm` the primitive carried in its own base classes — a plain
-            `max-w-*` sits in a different tailwind-merge group and so did not
-            replace it. #178 took that clamp out of the primitive, which is where
-            the problem was, so the override is gone: `w-[440px]` now means
-            440px, and `max-w-[calc(100vw-2rem)]` is the only thing narrowing it.
+            No `sm:max-w-*` here, and none needed: `DialogContent` carries no
+            width of its own beyond the phone guard, so `w-[440px]` means 440px
+            and `max-w-[calc(100vw-2rem)]` is the only thing narrowing it. If a
+            responsive clamp ever comes back to the primitive, a plain `max-w-*`
+            here will not defeat it — tailwind-merge keeps the two in different
+            groups.
           */
           className="cc-theme w-[440px] max-w-[calc(100vw-2rem)] gap-0 rounded-[14px] bg-cc-surface p-[22px] text-cc-ink shadow-[0_18px_48px_rgba(20,30,45,0.24)] ring-0"
         >

--- a/apps/web/components/ui/dialog.tsx
+++ b/apps/web/components/ui/dialog.tsx
@@ -88,7 +88,7 @@ function DialogContent({
           /*
             `max-w-[calc(100%-2rem)]` is the phone guard, and it is the only
             opinion this primitive has about width. There used to be an
-            `sm:max-w-sm` beside it, and it was a trap (#178).
+            `sm:max-w-sm` beside it, and it was a trap.
 
             tailwind-merge keeps `sm:max-w-*` and plain `max-w-*` in different
             groups, so neither a caller's `w-[440px]` nor its `max-w-4xl`

--- a/apps/web/components/ui/dialog.tsx
+++ b/apps/web/components/ui/dialog.tsx
@@ -42,18 +42,13 @@ function DialogOverlay({
           The artboards' modal scrim, as the default rather than as an override
           each dialog remembers to pass.
 
-          `rgba(20,30,45,.34)` is what all eight artboards that draw a modal use
-          — Collections, Explore, Landing, My Page, Saved, Saved copy, Taken
-          Courses and Workspace Pane. It was shadcn's blurred `bg-black/10` here,
-          and six dialogs each carried an `overlayClassName` to get back to the
-          design; four of those six had copied Landing's one-off
-          `rgba(14,26,44,.34)` by mistake, which is how a single scrim became
-          four values in the app. A default nobody has to remember is what stops
-          that recurring.
+          `rgba(20,30,45,.34)` is what every artboard that draws a modal uses.
+          It is the default here rather than shadcn's blurred `bg-black/10`
+          because a scrim each dialog has to remember to pass is a scrim that
+          ends up spelled several ways.
 
           Flat, with no blur: what is behind a dialog is the thing the dialog is
-          about, and it has to stay readable while the reader decides. Every one
-          of those six overrides had already turned the blur off.
+          about, and it has to stay readable while the reader decides.
 
           Two scrims legitimately differ and still say so at the call site: the
           mobile drawer is `rgba(20,30,45,.4)` (`Mobile Preview.dc.html`) and
@@ -87,18 +82,16 @@ function DialogContent({
         className={cn(
           /*
             `max-w-[calc(100%-2rem)]` is the phone guard, and it is the only
-            opinion this primitive has about width. There used to be an
-            `sm:max-w-sm` beside it, and it was a trap.
+            opinion this primitive has about width. **Do not add a responsive
+            clamp beside it.**
 
             tailwind-merge keeps `sm:max-w-*` and plain `max-w-*` in different
             groups, so neither a caller's `w-[440px]` nor its `max-w-4xl`
-            replaced it: from the `sm` breakpoint up the dialog rendered at
-            384px, whatever it had asked for. Nothing errored and no test failed,
-            so it only showed up if someone measured — and two dialogs were wrong
-            on screen for it while two more carried an `sm:max-w-[440px]` to work
-            around a clamp that is invisible from the call site.
+            replaces one: from the `sm` breakpoint up the dialog renders at the
+            clamp's width, whatever it asked for. Nothing errors and no test
+            fails, so it only shows up if someone measures.
 
-            So a caller now states its own width and gets it. A caller that wants
+            A caller states its own width and gets it. A caller that wants
             a *cap* rather than a width overrides this class and takes the phone
             guard with it, so it should state both at once —
             `max-w-[min(56rem,calc(100vw-2rem))]`, the way `Review` does. The two

--- a/apps/web/components/ui/dialog.tsx
+++ b/apps/web/components/ui/dialog.tsx
@@ -56,9 +56,9 @@ function DialogOverlay({
           of those six overrides had already turned the blur off.
 
           Two scrims legitimately differ and still say so at the call site: the
-          mobile drawer is `rgba(20,30,45,.4)` (`Mobile Preview.dc.html:242`) and
+          mobile drawer is `rgba(20,30,45,.4)` (`Mobile Preview.dc.html`) and
           Find your dot is `rgba(14,26,44,.34)`, dropping to `.08` while the dot
-          is revealing (`Landing.dc.html:164,1493`).
+          is revealing (`Landing.dc.html`).
         */
         "fixed inset-0 isolate z-50 bg-[rgba(20,30,45,0.34)] duration-100 data-open:animate-in data-open:fade-in-0 data-closed:animate-out data-closed:fade-out-0",
         className,

--- a/apps/web/components/ui/sonner.tsx
+++ b/apps/web/components/ui/sonner.tsx
@@ -30,7 +30,7 @@ const Toaster = ({ ...props }: ToasterProps) => {
           "--normal-text": "var(--popover-foreground)",
           "--normal-border": "var(--border)",
           /*
-            10px, because `Course Community - My Page.dc.html:415` draws the
+            10px, because `Course Community - My Page.dc.html` draws the
             toast at `border-radius:10px`.
 
             It was `var(--radius)`, which is 0.625rem and therefore also 10px —

--- a/apps/web/components/ui/switch.tsx
+++ b/apps/web/components/ui/switch.tsx
@@ -20,7 +20,7 @@ function Switch({
         /*
           The artboard's switch: a 42×24 track at a 99px radius with 3px of
           inset, holding an 18px round thumb that travels 18px.
-          `Course Community - My Page.dc.html:324,331` draws both of them.
+          `Course Community - My Page.dc.html` draws both of them.
 
           The stock metrics were 32×18.4 with a 16px thumb and a
           `calc(100%-2px)` travel that worked out to 14px, so every number was

--- a/apps/web/data/course-card-sample.ts
+++ b/apps/web/data/course-card-sample.ts
@@ -41,7 +41,7 @@
  *   boolean to draw the branch where the reader is *not* naming a new
  *   collection. JSX writes that as a ternary on `creating`, so nothing ever
  *   read the inverse — it was computed by the mapper, carried in the type and
- *   never looked at (#134).
+ *   never looked at.
  * - The artboard's `comparisons` / `hasComparisons` / `onNewComparison` are its
  *   word for **collections**. `CONTEXT.md` bans "comparison" in identifiers and
  *   #68 settles the concept as Collection, so they are renamed here and

--- a/apps/web/data/course-card-sample.ts
+++ b/apps/web/data/course-card-sample.ts
@@ -39,9 +39,8 @@
  *   an artifact of the artboard's template language, not a piece of the card's
  *   model: `<sc-if>` has no `else`, so the artboard needs a second, inverted
  *   boolean to draw the branch where the reader is *not* naming a new
- *   collection. JSX writes that as a ternary on `creating`, so nothing ever
- *   read the inverse — it was computed by the mapper, carried in the type and
- *   never looked at.
+ *   collection. JSX writes that as a ternary on `creating`, so nothing reads
+ *   the inverse.
  * - The artboard's `comparisons` / `hasComparisons` / `onNewComparison` are its
  *   word for **collections**. `CONTEXT.md` bans "comparison" in identifiers and
  *   #68 settles the concept as Collection, so they are renamed here and

--- a/apps/web/features/auth/components/auth-providers.tsx
+++ b/apps/web/features/auth/components/auth-providers.tsx
@@ -20,7 +20,7 @@ import { requestedReturnTo } from "../lib/return-to";
  * `focus-visible:border-cc-hov` plus a `ring-2`, on the stated grounds that the
  * artboards drew no focus state — true when it was written, and not true since
  * the 2026-09-06 export, whose `cc-theme.css` defines one treatment for
- * everything (#167).
+ * everything.
  */
 const PROVIDER_BUTTON =
   "flex h-[38px] w-full cursor-pointer items-center justify-center gap-2 rounded-[9px] border border-cc-rule3 bg-cc-surface px-[15px] font-medium text-[13.5px] text-cc-ink outline-none hover:border-cc-hov disabled:cursor-not-allowed disabled:opacity-60 [&>svg]:size-4 [&>svg]:shrink-0";

--- a/apps/web/features/auth/components/auth-reason-dialog.tsx
+++ b/apps/web/features/auth/components/auth-reason-dialog.tsx
@@ -57,10 +57,10 @@ const REASONS: Record<
   },
   /**
    * The Taken Courses gate. Its kicker and title are the artboard's own —
-   * `docs/design_ref/2026-09-06/Course Community - Taken Courses.dc.html:58-59`
-   * draws "ONE STEP LEFT" over "Sign in to keep this list", and `:1305` puts
-   * the second of those on the confirm button that opens this. The body is the
-   * artboard's `authReturnLine` for a reader who has rows waiting (`:1245`).
+   * `docs/design_ref/2026-09-06/Course Community - Taken Courses.dc.html`
+   * draws "ONE STEP LEFT" over "Sign in to keep this list", and puts the second
+   * of those on the confirm button that opens this. The body is the artboard's
+   * `authReturnLine` for a reader who has rows waiting.
    */
   "keep-course-list": {
     kicker: "One step left",

--- a/apps/web/features/auth/components/auth.tsx
+++ b/apps/web/features/auth/components/auth.tsx
@@ -25,7 +25,7 @@ import { MagicLinkForm } from "./magic-link-form";
  * could lie to a first-time visitor, so the buttons keep the providers that do.
  *
  * Before this, `/auth` was shadcn's `login-02` block close to verbatim and the
- * only file under `features/` with no `--cc-*` class at all (#164). The visible
+ * only file under `features/` with no `--cc-*` class at all. The visible
  * cost was not only that it looked borrowed: `bg-muted` resolves through
  * `globals.css` to `--cc-pill`, which in dark theme is a 16% cream over
  * `--cc-pg` — a `#2d3a4d` grey ground standing behind the `#0b254c` card. The

--- a/apps/web/features/auth/components/magic-link-form.tsx
+++ b/apps/web/features/auth/components/magic-link-form.tsx
@@ -20,7 +20,7 @@ const formSchema = z.object({
  * text. shadcn's `Input` is 32px at a 10px radius, which is what this was.
  *
  * Focus is `globals.css`'s. The hand-rolled treatment that used to sit here
- * answered an export that drew no focus state; the 2026-09-06 one does (#167).
+ * answered an export that drew no focus state; the 2026-09-06 one does.
  *
  * The invalid border is `--cc-danger`, matching `find-your-dot.tsx`, which is
  * the other place in this repo that asks for an email address and mails a link

--- a/apps/web/features/auth/lib/return-to.ts
+++ b/apps/web/features/auth/lib/return-to.ts
@@ -2,12 +2,11 @@
  * Where a sign-in comes back to.
  *
  * Signing in is a round trip through somebody else's site, and Better Auth
- * needs to be told where to land afterwards. `AuthReasonDialog` has always told
- * it the truth — "You keep everything you were looking at" is a promise its
- * `callbackURL` keeps — while the two controls on `/auth` sent everyone to
- * `/search` regardless of where they came from. That is the difference between
- * a student returning to the draft they were writing and a student returning to
- * an empty search box, and it is the whole of what this file is for.
+ * needs to be told where to land afterwards. `AuthReasonDialog` promises "You
+ * keep everything you were looking at", and its `callbackURL` is what keeps
+ * that promise. The difference is a student returning to the draft they were
+ * writing rather than to an empty search box, and it is the whole of what this
+ * file is for.
  *
  * The route carries the destination in `?next=`, because the email path has no
  * other way to carry anything: the dialog navigates to `/auth`, `/auth` sends

--- a/apps/web/features/collections/components/collection-chip.spec.tsx
+++ b/apps/web/features/collections/components/collection-chip.spec.tsx
@@ -36,7 +36,7 @@ describe("CollectionChip", () => {
    * a `#fdf3ef` hover, which is `--cc-danger-ink` over `--cc-danger-tint`. The
    * chip used to derive that hover with
    * `color-mix(in srgb, var(--cc-danger) 12%, var(--cc-surface))` because the
-   * tint family did not exist yet (#127 §1) — and no mix of the solid colour
+   * tint family did not exist yet — and no mix of the solid colour
    * could have reached it in dark, where the design states the tint as alpha
    * over the page instead.
    *

--- a/apps/web/features/collections/components/collection-chip.tsx
+++ b/apps/web/features/collections/components/collection-chip.tsx
@@ -104,12 +104,10 @@ export function CollectionChip({
               Rename
             </button>
             {/* The artboard's own pair — `#a4402a` on a `#fdf3ef` hover — which
-                is `--cc-danger-ink` over `--cc-danger-tint` now that the tint
-                family exists. This used to derive the hover with `color-mix`
-                against `--cc-danger`, because when the chip was built the
-                palette stopped at the solid colour (#127 §1). The derivation
-                was never the design's: dark states the tint as alpha over the
-                page, so no percentage of the solid reaches it. */}
+                is `--cc-danger-ink` over `--cc-danger-tint`. Not a `color-mix`
+                against `--cc-danger`: dark states the tint as alpha over the
+                page, so no percentage of the solid reaches it. See the
+                panel-tint note in `globals.css`. */}
             <button
               type="button"
               role="menuitem"

--- a/apps/web/features/collections/components/collection-detail.tsx
+++ b/apps/web/features/collections/components/collection-detail.tsx
@@ -74,7 +74,7 @@ const MOVE_BUTTON =
  * string assembled from its mock store; `period` and `school` are not fields the
  * schema has, and the card renders the same course from data that does exist —
  * so the codebase wins, as #68 has it, and the design's remove affordance
- * survives as the card's own `removeLabel` button, which #86 built for this page.
+ * survives as the card's own `removeLabel` button.
  * The geometry arrives as a prop; see {@link Props.geo} for why this component
  * is the wrong place to decide it.
  *

--- a/apps/web/features/collections/components/collection-detail.tsx
+++ b/apps/web/features/collections/components/collection-detail.tsx
@@ -26,13 +26,13 @@ type Props = {
    * The card's collapse ramp, measured by whoever owns the column these rows
    * are laid out in.
    *
-   * This used to be `EXPANDED_CARD_GEOMETRY`, pinned here on the grounds that
-   * the page column had nothing competing for its width. That was true of
-   * `/collections` and false of `/saved`, which embeds this component inside the
-   * very column the workspace pane narrows — so one card collapsed or did not
-   * depending only on which of the page's two lists it was in, and the surplus
-   * was clipped rather than scrolled because that column is `overflow-x-hidden`
-   * (#159). The decision belongs to the host, and both hosts now measure.
+   * Measured, never pinned to `EXPANDED_CARD_GEOMETRY`. Nothing competes for
+   * the column's width on `/collections`, but `/saved` embeds this component
+   * inside the very column the workspace pane narrows — pin it and one card
+   * collapses or does not depending only on which of that page's two lists it
+   * is in, with the surplus clipped rather than scrolled because that column is
+   * `overflow-x-hidden`. The decision belongs to the host, and both hosts
+   * measure.
    *
    * It is the *column's* width, not the card's: each row spends 36px on the
    * reorder buttons before the card starts, so the ramp here runs about 36px

--- a/apps/web/features/collections/components/collection-tile.spec.tsx
+++ b/apps/web/features/collections/components/collection-tile.spec.tsx
@@ -35,7 +35,7 @@ describe("CollectionTile", () => {
   /**
    * Same pair as the chip's, from the same artboard rows — `--cc-danger-ink`
    * over a `--cc-danger-tint` hover. Both were `color-mix` derivations against
-   * `--cc-danger` before the tint family existed (#127 §1), and both are
+   * `--cc-danger` before the tint family existed, and both are
    * asserted separately because they are two components that happen to agree,
    * not one shared control.
    */

--- a/apps/web/features/collections/components/collection-tile.tsx
+++ b/apps/web/features/collections/components/collection-tile.tsx
@@ -114,10 +114,8 @@ export function CollectionTile({
                 Rename
               </button>
               {/* Same pair as the chip's Delete, and the artboard's own:
-                  `--cc-danger-ink` over a `--cc-danger-tint` hover. The
-                  `color-mix` this replaces predated the tint family (#127 §1)
-                  and could not have reproduced it — dark states the tint as
-                  alpha over the page, not as a share of the solid colour. */}
+                  `--cc-danger-ink` over a `--cc-danger-tint` hover. Not a
+                  `color-mix` — see `collection-chip.tsx`. */}
               <button
                 type="button"
                 role="menuitem"

--- a/apps/web/features/collections/components/collections.tsx
+++ b/apps/web/features/collections/components/collections.tsx
@@ -36,10 +36,8 @@ const COMPACT_HEADING_ID = "collections-section-heading";
  * compare." — and the "New collection" tile beside it reads "Group specific
  * courses and compare them side by side." Neither is true: there is no
  * comparison surface anywhere in the app, and #68's settled decision 1 is that
- * there is no AI-comparison feature to build one for. #91 already dropped the
- * promise from the tile; this is the same substitution finished, so the page
- * does not head itself with a promise its own tile has stopped making. The
- * wording is the tile's, so the two agree.
+ * there is no AI-comparison feature to build one for. So neither the heading
+ * nor the tile promises one, and both use the same wording.
  *
  * It is a copy change against the visual authority, which is the narrow case
  * `CLAUDE.md` allows: the design loses to the schema on what exists, and it is
@@ -107,7 +105,7 @@ type Props = {
    *
    * `/saved` embeds this inside the very column `WorkspacePaneHost` narrows, so
    * the geometry it computes for its own list is the geometry these cards need
-   * too — one card behaving two ways in one page is what #159 reports. Left
+   * too, or one card behaves two ways on one page. Left
    * out, this component measures the column it is standing in itself, which is
    * what the `/collections` route does; see {@link Collections} for why that is
    * a measurement there rather than the pinned expanded end.
@@ -136,11 +134,9 @@ type Props = {
  * ## Where it sits
  *
  * `Course Community - Saved.dc.html` imports the Collections artboard as a
- * section of the Saved page, in its `compact` variant. That embedding is Saved's
- * to build; this is the same component as a page of its own, so the
- * feature is reachable and usable before Saved exists. The `compact` chip row
- * is built and Saved is its caller — the sentence that used to stand here said
- * it had none, which stopped being true when #90 landed.
+ * section of the Saved page, in its `compact` variant. This is that same
+ * component as a page of its own, so the feature is reachable both ways. Saved
+ * is the caller of the `compact` chip row.
  *
  * ## What the writes do about failure
  *
@@ -156,8 +152,8 @@ type Props = {
  *
  * All three ways to delete a collection — the detail's button, the tile's menu
  * and the chip's menu — hand the collection to one confirmation rather than to
- * the mutation. The artboards confirm *after*, with a note; #155 settled that
- * they lose here, because what is destroyed cannot be put back. Restoring a
+ * the mutation. The artboards confirm *after*, with a note; a deliberate
+ * deviation, because what is destroyed cannot be put back. Restoring a
  * deleted collection means `create` and then one `addCourse` per course in
  * order — `reorderCollectionCourses` throws `NotFoundError` for a code that is
  * not already a member, so it can never add one — and `addCourseToCollection`

--- a/apps/web/features/collections/components/collections.tsx
+++ b/apps/web/features/collections/components/collections.tsx
@@ -137,7 +137,7 @@ type Props = {
  *
  * `Course Community - Saved.dc.html` imports the Collections artboard as a
  * section of the Saved page, in its `compact` variant. That embedding is Saved's
- * to build (#90); this is the same component as a page of its own, so the
+ * to build; this is the same component as a page of its own, so the
  * feature is reachable and usable before Saved exists. The `compact` chip row
  * is built and Saved is its caller — the sentence that used to stand here said
  * it had none, which stopped being true when #90 landed.
@@ -174,7 +174,7 @@ type Props = {
  * narrows a column, and the ramp's input is the width itself rather than the
  * reason for it. So this measures too rather than pinning the expanded end:
  * measuring *is* pinning whenever the column is wide, and unlike pinning it is
- * also right when the column is not (#159).
+ * also right when the column is not.
  */
 export function Collections({
   openCollectionId = null,

--- a/apps/web/features/collections/components/new-collection-dialog.spec.tsx
+++ b/apps/web/features/collections/components/new-collection-dialog.spec.tsx
@@ -7,9 +7,9 @@ import { NewCollectionDialog } from "./new-collection-dialog";
  *
  * jsdom computes no layout and there is no Tailwind stylesheet at test time, so
  * the class list is what a test can hold. It is the right surface anyway: the
- * string is `cn`'s output, and #178 was a `cn` bug — `DialogContent` carried an
- * `sm:max-w-sm`, tailwind-merge keeps that in a different group from a plain
- * `max-w-*` or a `w-*`, and so the caller's width did not replace it.
+ * string is `cn`'s output, and the failure this guards is a `cn` failure: a
+ * `sm:max-w-*` on `DialogContent` sits in a different tailwind-merge group from
+ * a plain `max-w-*` or a `w-*`, so the caller's width would not replace it.
  */
 function widthClasses() {
   const content = document.querySelector('[data-slot="dialog-content"]');
@@ -42,13 +42,11 @@ describe("NewCollectionDialog", () => {
     open();
     const classes = widthClasses();
 
-    // `Collections.dc.html` draws this dialog at `width:440px`. It rendered
-    // at 384px until #178, because the primitive's `sm:max-w-sm` outlived this
-    // `w-[440px]` from the `sm` breakpoint up.
+    // `Collections.dc.html` draws this dialog at `width:440px`.
     expect(classes).toContain("w-[440px]");
 
-    // Nothing narrows it above `sm` any more. The one cap left is the artboard's
-    // own gutter, which only bites below 472px.
+    // Nothing narrows it above `sm`. The one cap is the artboard's own gutter,
+    // which only bites below 472px.
     expect(classes.filter((name) => name.startsWith("sm:max-w-"))).toEqual([]);
     expect(classes.filter((name) => name.startsWith("max-w-"))).toEqual([
       "max-w-[calc(100vw-2rem)]",

--- a/apps/web/features/collections/components/new-collection-dialog.spec.tsx
+++ b/apps/web/features/collections/components/new-collection-dialog.spec.tsx
@@ -42,7 +42,7 @@ describe("NewCollectionDialog", () => {
     open();
     const classes = widthClasses();
 
-    // `Collections.dc.html:183` draws this dialog at `width:440px`. It rendered
+    // `Collections.dc.html` draws this dialog at `width:440px`. It rendered
     // at 384px until #178, because the primitive's `sm:max-w-sm` outlived this
     // `w-[440px]` from the `sm` breakpoint up.
     expect(classes).toContain("w-[440px]");

--- a/apps/web/features/collections/index.ts
+++ b/apps/web/features/collections/index.ts
@@ -3,7 +3,7 @@
  *
  * `Collections` is exported because it is not only a page: the Saved artboard
  * imports the Collections artboard as a section of itself, so whoever builds
- * Saved (#90) renders this component rather than a second copy of it. The route
+ * Saved renders this component rather than a second copy of it. The route
  * at `app/(service)/collections` renders it too — pages import from
  * `features/<name>/components`, so that import does not come through here.
  *
@@ -16,7 +16,7 @@ export { Collections } from "./components/collections";
  * `ConfirmDialog` used to be exported from here, because Saved asks the same
  * question about the same object — unsaving a course cascades it out of every
  * collection it was in, so it is destructive in exactly the way deleting a
- * collection is (#155).
+ * collection is.
  *
  * That export said what would end it: *"when a third screen needs it, it belongs
  * in `components/ui/` instead."* Seven screens now ask a confirmation, so it is

--- a/apps/web/features/collections/index.ts
+++ b/apps/web/features/collections/index.ts
@@ -13,14 +13,6 @@
 
 export { Collections } from "./components/collections";
 /*
- * `ConfirmDialog` used to be exported from here, because Saved asks the same
- * question about the same object — unsaving a course cascades it out of every
- * collection it was in, so it is destructive in exactly the way deleting a
- * collection is.
- *
- * That export said what would end it: *"when a third screen needs it, it belongs
- * in `components/ui/` instead."* Seven screens now ask a confirmation, so it is
- * `@/components/ui/confirm-dialog` and Saved imports it directly. Nothing
- * collection-shaped is exported twice, which is why this note replaces the
- * export rather than a re-export standing in for it.
+ * `ConfirmDialog` is `@/components/ui/confirm-dialog`, not a re-export from
+ * here: seven screens ask a confirmation and no feature owns it.
  */

--- a/apps/web/features/courses/components/course-card-item.tsx
+++ b/apps/web/features/courses/components/course-card-item.tsx
@@ -10,7 +10,9 @@ import type { CardGeometry } from "@/types";
 type Props = UseCourseCardOptions & {
   /**
    * The screen's, because the collapse ramp belongs to whatever owns the
-   * column's width: Explore interpolates it, Saved and Collections pin an end.
+   * column's width. See `features/courses/lib/card-geometry.ts`; do not name
+   * the screens that ramp and the screens that pin here, because that list has
+   * already drifted.
    */
   geo: CardGeometry;
   /** Opens the picker upwards, for a card near the bottom of a page. */

--- a/apps/web/features/courses/hooks/use-course-card.ts
+++ b/apps/web/features/courses/hooks/use-course-card.ts
@@ -133,7 +133,7 @@ export function useCourseCard({
    * A guest's save is not deferred behind sign-in any more: the Saved artboard
    * keeps a signed-out reader's list in the browser under its own key and
    * offers to move it into an account later
-   * (`docs/design_ref/2026-09-06/Course Community - Saved.dc.html:322`, and the
+   * (`docs/design_ref/2026-09-06/Course Community - Saved.dc.html`, and the
    * `pendingImport` row at 119-124). Interrupting a save to ask for an account
    * contradicted both that and the app's own line that browsing never needs
    * one.

--- a/apps/web/features/courses/index.ts
+++ b/apps/web/features/courses/index.ts
@@ -1,7 +1,7 @@
 /**
  * The cross-feature API of the courses feature.
  *
- * What Explore (#89), Saved (#90) and Collections (#91) need in order to render
+ * What Explore, Saved and Collections need in order to render
  * a course card, and to manage the collections a card can be put into. The
  * card's mapper and its formatting helpers stay inside the feature, reachable
  * through `CourseCardItem` — a barrel that exports its own internals turns each
@@ -14,7 +14,7 @@
  *
  * `useTakenCourses` and `useMarkCourseTaken` are here for the same reason. The
  * card reads the viewer's taken courses to tick its Taken control and writes
- * one with `taken.add`; Taken courses (#92) reads the same list and builds its
+ * one with `taken.add`; Taken courses reads the same list and builds its
  * other three writes on the same invalidation, so both surfaces share one query
  * key and one `taken.add`.
  */

--- a/apps/web/features/courses/index.ts
+++ b/apps/web/features/courses/index.ts
@@ -41,8 +41,8 @@ export { CourseCard } from "./components/course-card";
 export { CourseCardItem } from "./components/course-card-item";
 export type { UseCourseCardOptions } from "./hooks/use-course-card";
 /**
- * The collapse ramp. The parent owns it: Explore interpolates from its results
- * column, Saved and Collections pin an end.
+ * The collapse ramp. The parent owns it — a screen that measures its column
+ * interpolates, one that cannot pins an end. See `lib/card-geometry.ts`.
  */
 export {
   CARD_RAMP_CEILING,

--- a/apps/web/features/courses/lib/card-geometry.ts
+++ b/apps/web/features/courses/lib/card-geometry.ts
@@ -7,12 +7,10 @@
  * end of the ramp instead. That split is the reason the card is one component
  * and not two.
  *
- * This used to name Saved and Collections as the two that pin, and Saved has
- * not pinned since #90's decision was reversed — `saved.tsx` ramps from its own
- * results width, and says so at length. Naming screens here is how the two
- * comments came to state opposite things about the same page, so the list is
- * gone: `courseCardGeometry`'s callers are who ramps, and the two pinned
- * constants below are who does not.
+ * **Do not name the screens that pin here.** Doing so is how this comment and
+ * `saved.tsx` came to state opposite things about the same page.
+ * `courseCardGeometry`'s callers are who ramps, and the two pinned constants
+ * below are who does not.
  *
  * Every number here is the artboard's:
  * `docs/design_ref/2026-09-06/Course Community - Explore.dc.html` computes exactly this ramp,
@@ -127,10 +125,10 @@ export function courseCardGeometry(
  * yield to starts from.
  *
  * Saved's own artboard passes a fully expanded geometry with a taller
- * `summaryMax` (57px, three lines) than this ramp ever reaches, which #68's body
- * — saying Saved pins the *collapsed* end — also disagrees with. Both ends are
- * exported so #90 can settle that against its own artboard; nothing here
- * forecloses either.
+ * `summaryMax` (57px, three lines) than this ramp ever reaches, which #68's
+ * body — saying Saved pins the *collapsed* end — also disagrees with. Both ends
+ * are exported so that disagreement can be settled against the artboard;
+ * nothing here forecloses either.
  */
 export const EXPANDED_CARD_GEOMETRY = courseCardGeometry(
   Number.POSITIVE_INFINITY,

--- a/apps/web/features/feedback/components/feedback-form.spec.tsx
+++ b/apps/web/features/feedback/components/feedback-form.spec.tsx
@@ -74,7 +74,7 @@ describe("FeedbackForm", () => {
     /**
      * The panel was built when the palette had no green and borrowed
      * `--cc-info` with `--cc-brand` ink, which read as information rather than
-     * success. The tint family exists now (#127 §1) and its three tokens are
+     * success. The tint family exists now and its three tokens are
      * the artboard's three hexes exactly, so the panel says "this worked" in
      * the design's own colours in both themes.
      *

--- a/apps/web/features/feedback/components/feedback-form.tsx
+++ b/apps/web/features/feedback/components/feedback-form.tsx
@@ -61,7 +61,7 @@ const LABEL = "mb-1.5 block font-medium text-[12.5px] text-cc-ink2";
  * Focus is `globals.css`'s. This file is where the app's hand-rolled focus
  * border started, on the correct reading that the artboards then drew no focus
  * state at all; the 2026-09-06 export draws one, so the local treatment is gone
- * and the whole app follows the same ring (#167).
+ * and the whole app follows the same ring.
  */
 const CONTROL =
   "w-full rounded-[9px] border border-cc-rule3 bg-cc-surface text-[14px] text-cc-ink outline-none";
@@ -110,7 +110,7 @@ export function FeedbackForm() {
       // ink and the PR reported the gap. The gap is closed: those three hexes
       // are now `--cc-success-tint`, `--cc-success-tint-border` and
       // `--cc-success-ink` verbatim, and the Design System artboard's `BANNERS`
-      // names this exact combination "Upload success banner" (#127 §1). The
+      // names this exact combination "Upload success banner". The
       // tick stays, because a colour is not what should carry "this worked".
       <output className="mt-4 flex animate-in items-start gap-[11px] rounded-[12px] border border-cc-success-tint-border bg-cc-success-tint px-4 py-[15px] duration-200 ease-out fade-in slide-in-from-bottom-[6px]">
         <CircleCheck
@@ -213,7 +213,7 @@ export function FeedbackForm() {
         </button>
         {/* The artboard's `#a3452a` is `--cc-danger-ink` exactly. It had no
             token when this was written, so the line borrowed `--cc-warn-ink`;
-            it has one now (#127 §1), and `--cc-warn-*` turns out to mean the
+            it has one now, and `--cc-warn-*` turns out to mean the
             review draft rather than anything that failed. `role="alert"` is
             still what carries the message — the hue only agrees with it. */}
         {error ? (

--- a/apps/web/features/landing/components/landing.tsx
+++ b/apps/web/features/landing/components/landing.tsx
@@ -44,7 +44,7 @@ import { HeroNetwork } from "./hero-network";
  * of the way over 130ms, the hero graph stops so the only thing moving is the
  * layout, and the navigation is fired by that exit *finishing* rather than by a
  * timer guessing when it will have. `Course Community - Landing.dc.html`'s
- * `toExplore()` (line 501) sketches the same departure with a blind
+ * `toExplore()` sketches the same departure with a blind
  * `setTimeout(130)`; this is the one place in the app authorised to improve on
  * the artboard, and that timer is most of the reason why.
  */

--- a/apps/web/features/landing/lib/hero-keepout.ts
+++ b/apps/web/features/landing/lib/hero-keepout.ts
@@ -2,11 +2,8 @@
  * The hero's keep-out: where the landing copy is, how far a pixel is from it,
  * and where a thing drawn behind it has to go instead.
  *
- * This file used to place a synthetic field of drifting dots as well — an
- * illustration of a community rather than the community. That is retired: the
- * hero draws the real community graph and nothing else, so all that is left
- * here is geometry. Nothing in it knows what a **Node** is; it answers "how far
- * is this pixel from the headline" and stops there.
+ * Geometry only. Nothing in it knows what a **Node** is; it answers "how far is
+ * this pixel from the headline" and stops there.
  *
  * The rule it exists to enforce is the artboard's, and it is a *guarantee*
  * rather than a fade. `docs/design_ref/2026-09-06/Course Community -

--- a/apps/web/features/landing/lib/neighbourhood-view.ts
+++ b/apps/web/features/landing/lib/neighbourhood-view.ts
@@ -15,14 +15,11 @@
  * screenY = (node.y - centre.y) * scale + anchorY
  * ```
  *
- * The bug this file was written against — two members standing in the same
- * region of the graph seeing different pictures of it — was the **scale**. It
- * used to be fitted to the viewer's own neighbourhood extent, so the same two
- * dots rendered at different zooms for two different people. It is a constant
- * now, `VIEW_SCALE`, and it is not a function of anything.
+ * The **scale** is a constant, `VIEW_SCALE`, and not a function of anything —
+ * fit it to the viewer's own neighbourhood extent and two members standing in
+ * the same region of the graph see the same two dots at different zooms.
  *
- * The anchor was removed at the same time and that was collateral damage. It
- * is back, because it is provably not the same kind of thing:
+ * The **anchor** is provably not the same kind of thing:
  *
  * ```
  * screen(p) − screen(q) = (p − q) · s
@@ -273,11 +270,10 @@ const ANCHOR_STEPS = 12;
  * a padded rect puts the whole reveal about 50px from anything a reader is
  * looking at.
  *
- * The version of this function that was deleted in `2ca7f52` scored raw
- * distance instead, and the two ends of that are both wrong. Measured against
- * the rendered hero: on a 1920x600 frame it maximised out into a corner, and on
- * a 360x480 one — where the whole frame is close to the copy and no candidate
- * scores much — the centrality pull won outright and the anchor landed *inside
+ * Scoring raw distance instead is wrong at both ends, measured against the
+ * rendered hero: on a 1920x600 frame it maximises out into a corner, and on a
+ * 360x480 one — where the whole frame is close to the copy and no candidate
+ * scores much — the centrality pull wins outright and the anchor lands *inside
  * the headline*, `clearAt` 0.00. Saturating fixes both.
  */
 const ANCHOR_COMFORT = 25;
@@ -304,8 +300,7 @@ const ANCHOR_PULL = 0.35;
  * handed to `pushClear`, which is what turns "the best of eleven-by-eleven
  * guesses" into "actually clear", and which hands it back untouched when the
  * copy leaves nowhere within `MAX_PUSH` to stand — a hero whose copy covers its
- * whole frame therefore falls back to the middle of it, which is where this used
- * to be unconditionally.
+ * whole frame therefore falls back to the middle of it.
  *
  * **What is and is not promised across sessions.** For a given frame size and a
  * given copy layout this is deterministic, so a returning member finds their own

--- a/apps/web/features/my-page/api/queries.ts
+++ b/apps/web/features/my-page/api/queries.ts
@@ -6,15 +6,10 @@ import type { AppRouter } from "@/server/api/root";
 import { type RouterOutputs, useTRPC } from "@/trpc/client";
 
 /**
- * The viewer's taken courses and the shape of one, both re-exported rather than
- * re-declared.
- *
- * This file used to hold a byte-identical copy of `useTakenCourses`, and that
- * was not a tidiness problem: `features/courses/index.ts` exports the hook
- * *specifically* so "both surfaces share one query key", and a second
- * declaration is a second `useQuery` call site building its own cache entry. My
- * Page and the course card were fetching `taken.list` twice and could disagree
- * about the answer.
+ * The viewer's taken courses and the shape of one, re-exported rather than
+ * re-declared: a second declaration is a second `useQuery` call site with its
+ * own cache entry, so My Page and the course card would fetch `taken.list`
+ * twice and could disagree about the answer.
  *
  * Both imports go to the module rather than the feature barrel, for the reason
  * `../../reviews/api/queries.ts` records: `@/features/courses` reaches the
@@ -35,17 +30,16 @@ export type { TakenCourse } from "@/features/taken/lib/taken-rows";
  * code and a viewer, and the viewer is only used to fill in `userVote`. So the
  * page reads the list once and differences it in the browser.
  *
- * That is a real cost and it is stated plainly rather than hidden: the whole
- * `reviews` table crosses the wire, carrying each review's author id. The
- * author id is already public on this procedure — the course page's own list
- * has always returned it — so this adds no exposure, only volume, and the fix
- * is an author/vote filter on `reviews.list`, which is server work outside
- * #93. Do not paper over it with a second client-side cache.
+ * That is a real cost, stated plainly rather than hidden: the whole `reviews`
+ * table crosses the wire, carrying each review's author id. The author id is
+ * already public on this procedure, so this adds volume and no exposure. The
+ * fix is an author/vote filter on `reviews.list`; do not paper over it with a
+ * second client-side cache.
  *
  * One list rather than one per course is what makes the upvoted set possible at
- * all: `userVote` comes back on every row, so "reviews I upvoted" is a real
- * server-side fact here instead of the `localStorage` array `cc-store.js`
- * keeps. There is no local vote state on this page.
+ * all: `userVote` comes back on every row, so "reviews I upvoted" is a
+ * server-side fact here rather than local state. There is no local vote state
+ * on this page.
  */
 export function useAllReviews(enabled: boolean) {
   const trpc = useTRPC();
@@ -79,9 +73,10 @@ export function useNodePersonalization(enabled: boolean) {
 /**
  * The app user has no row the tier could be derived from.
  *
- * #82 gives every account a graph node, so this is not the state a normal
- * account sits in; it is what an account deleted mid-session looks like, and
- * the "My dot" tab says so rather than drawing tier 0 as if it were measured.
+ * Every account is given a graph node at sign-up, so this is not the state a
+ * normal account sits in; it is what an account deleted mid-session looks like,
+ * and the "My dot" tab says so rather than drawing tier 0 as if it were
+ * measured.
  */
 export function isTierUnavailable(error: unknown): boolean {
   return (

--- a/apps/web/features/my-page/components/account-settings.tsx
+++ b/apps/web/features/my-page/components/account-settings.tsx
@@ -24,7 +24,7 @@ import type { TakenCourse } from "../api/queries";
  * Both are deliberate deviations from the artboard, which removes and then
  * offers a note: `user.delete` cascades across taken courses, collections,
  * reviews and votes, and clearing grades drops every value read from a
- * transcript. Neither has an undo to offer once it has run (#155).
+ * transcript. Neither has an undo to offer once it has run.
  */
 const CONFIRMATIONS: Record<"grades" | "account", ConfirmRequest> = {
   grades: {

--- a/apps/web/features/my-page/components/my-page.spec.tsx
+++ b/apps/web/features/my-page/components/my-page.spec.tsx
@@ -662,7 +662,7 @@ describe("MyPage my dot", () => {
   });
 
   /**
-   * The signed-out panel, which `My Page.dc.html:73-90` draws inside the shell
+   * The signed-out panel, which `My Page.dc.html` draws inside the shell
    * rather than as a redirect. It was unreachable until `/profile` stopped
    * being redirected away and this page stopped calling `useRequireSession`.
    */

--- a/apps/web/features/my-page/components/my-page.tsx
+++ b/apps/web/features/my-page/components/my-page.tsx
@@ -92,10 +92,10 @@ type OpenEditor = { review: EditableReview; courseCode: string };
  *
  * `useUnreviewedTakenCourses` fetches one `reviews.list` per taken course;
  * `useAllReviews` fetches the unfiltered list once. They overlap, and the
- * overlap is deliberate — #93 forbids a second unreviewed-courses derivation,
- * and the upvoted column cannot be built from per-course lists of courses the
- * viewer happens to have taken. `useAllReviews` says what the unfiltered read
- * costs and what would fix it.
+ * overlap is deliberate: there is one derivation of "unreviewed" and this page
+ * does not get a second, while the upvoted column cannot be built from
+ * per-course lists of courses the viewer happens to have taken. `useAllReviews`
+ * says what the unfiltered read costs and what would fix it.
  */
 export function MyPage() {
   const router = useRouter();
@@ -564,7 +564,7 @@ function LoadFailed({ onRetry }: { onRetry: () => void }) {
   );
 }
 
-/** #97 settled the substitution: members, never students — it is app users who vote. */
+/** Members, never students: it is app users who vote, not everyone at KTH. */
 function upvoteNote(upvotes: number): string {
   if (upvotes === 0) return "no upvotes yet";
   return upvotes === 1

--- a/apps/web/features/my-page/components/my-page.tsx
+++ b/apps/web/features/my-page/components/my-page.tsx
@@ -344,7 +344,7 @@ export function MyPage() {
                     a course and the URL carries it — `?review=<CODE>` — because
                     the row's whole contract is "open the reviewer on this one",
                     and a parameter that could only say "open the reviewer"
-                    discarded the course the reader named (#157). The button,
+                    discarded the course the reader named. The button,
                     which names no course, still writes the original
                     `?review=1`.
                   */

--- a/apps/web/features/my-page/components/my-page.tsx
+++ b/apps/web/features/my-page/components/my-page.tsx
@@ -451,7 +451,7 @@ export function MyPage() {
 }
 
 /**
- * The artboard's signed-out panel (`… - My Page.dc.html:73-90`).
+ * The artboard's signed-out panel (`… - My Page.dc.html`).
  *
  * Two controls, as it draws: Sign up on `--btn`, Log in outlined beside it.
  * Both go to the same place — the artboard wires both of its own to `onSignIn`

--- a/apps/web/features/my-page/components/my-page.tsx
+++ b/apps/web/features/my-page/components/my-page.tsx
@@ -188,12 +188,9 @@ export function MyPage() {
   }
 
   // Signed out, which is a state this page renders rather than a state it
-  // refuses. `My Page.dc.html:73` draws it: the panel below, inside the shell,
-  // with the rail beside it carrying its own guest banner. This page is no
-  // no longer redirected away by a proxy and no longer calls
-  // `useRequireSession`, so a guest arrives here instead of at `/auth` — and so
-  // does the stale-cookie case that used to be the only way to reach this
-  // branch.
+  // refuses. The My Page artboard draws it: the panel below, inside the shell,
+  // with the rail beside it carrying its own guest banner. Nothing gates the
+  // route, so a visitor arrives here rather than at `/auth`.
   if (!isSessionLoading && !isAuthenticated) {
     return (
       <PageColumn>

--- a/apps/web/features/my-page/hooks/use-average-preference.ts
+++ b/apps/web/features/my-page/hooks/use-average-preference.ts
@@ -21,8 +21,7 @@ const storageKeyFor = (userId: string) => `cc:myPage:showAverage:${userId}`;
  * about a viewer's data changes when it is flipped.
  *
  * It follows that the switch does not sync across devices, which the page says
- * out loud rather than implying otherwise. A `users` column would fix that and
- * is server work, outside #93.
+ * out loud rather than implying otherwise. A `users` column would fix that.
  *
  * The default is on, which is the artboard's own initial state. Reads and
  * writes are wrapped because storage can be unavailable — a private window, or

--- a/apps/web/features/my-page/lib/personalization-tiers.ts
+++ b/apps/web/features/my-page/lib/personalization-tiers.ts
@@ -11,7 +11,7 @@
  * *same* `PERSONALIZATION_AXES` — offering an option the server would refuse is
  * exactly what a second copy would produce.
  *
- * Two rules govern the numbers, both from `CONTEXT.md` and #93.
+ * Two rules govern the numbers, both from `CONTEXT.md`.
  *
  * **What may be edited is the effective tier.** `users.personalization_tier_
  * earned` holds the highest tier ever reached and is never lowered;
@@ -22,9 +22,8 @@
  * anything and it is never phrased as a loss. It exists here so that an axis
  * somebody earned and has gone quiet on reads as **Dormant** — its pick still
  * stored, waiting — rather than as **Locked**, which would tell them they had
- * lost something the database still holds. This tab used to collapse the two
- * because `graph.effectiveTier` returned a single number; it returns both now,
- * and the limitation is gone rather than documented.
+ * lost something the database still holds. Telling the two apart needs both
+ * numbers, which is why `graph.personalization` returns both.
  */
 
 import {

--- a/apps/web/features/reviews/api/queries.ts
+++ b/apps/web/features/reviews/api/queries.ts
@@ -31,9 +31,9 @@ export type { TakenCourse };
  * A taken course with no review, and the catalogue title to draw it with.
  *
  * The title is part of the answer rather than each screen's to fetch:
- * `user_taken_courses` stores only a code, so a host that forgot the lookup
- * rendered the code twice — which is exactly what My Page did. There is
- * one host fewer to remember now, and no second place for the join to diverge.
+ * `user_taken_courses` stores only a code, so a host that forgets the lookup
+ * renders the code twice. Answering with the title is one host fewer to
+ * remember, and no second place for the join to diverge.
  *
  * `null` while `course.summary` is still in flight, or when it failed. The card
  * falls back to the code for it, which is why nothing here waits on a title:
@@ -56,7 +56,7 @@ export function useReviewList(courseCode: string | undefined) {
  * `UnreviewedCard` renders, shared by Taken courses and My Page.
  *
  * The difference is worked out here, in the client, deliberately: it is a
- * per-user set of at most a few dozen rows and #88 rules out a server procedure
+ * per-user set of at most a few dozen rows, and there is no server procedure
  * for it. That costs one `reviews.list` per taken course, in the same shape
  * Saved already uses for `course.summary`. The cheaper-looking alternative —
  * one unfiltered `reviews.list` — was rejected: `reviews.list` has no author

--- a/apps/web/features/reviews/api/queries.ts
+++ b/apps/web/features/reviews/api/queries.ts
@@ -32,7 +32,7 @@ export type { TakenCourse };
  *
  * The title is part of the answer rather than each screen's to fetch:
  * `user_taken_courses` stores only a code, so a host that forgot the lookup
- * rendered the code twice — which is exactly what My Page did (#157). There is
+ * rendered the code twice — which is exactly what My Page did. There is
  * one host fewer to remember now, and no second place for the join to diverge.
  *
  * `null` while `course.summary` is still in flight, or when it failed. The card
@@ -72,7 +72,7 @@ export function useReviewList(courseCode: string | undefined) {
  *
  * The catalogue title comes back with each course for the same reason the
  * difference does: it is the same join on both screens, and the host that had
- * to remember it was the host that forgot (#157).
+ * to remember it was the host that forgot.
  */
 export function useUnreviewedTakenCourses(): {
   courses: UnreviewedTakenCourse[];

--- a/apps/web/features/reviews/components/review.spec.tsx
+++ b/apps/web/features/reviews/components/review.spec.tsx
@@ -31,8 +31,8 @@ const EDITING = {
  * jsdom computes no layout — `getBoundingClientRect` is zeros and no Tailwind
  * stylesheet exists at test time — so the class list is the surface a test can
  * hold. It is not a proxy for the real thing either: this string is the output
- * of `cn`, which is where #178's bug lived, so a `sm:max-w-*` creeping back into
- * `DialogContent`'s base classes shows up here exactly as it would on screen.
+ * of `cn`, so a `sm:max-w-*` creeping back into `DialogContent`'s base classes
+ * shows up here exactly as it would on screen.
  */
 function widthClasses() {
   const content = document.querySelector('[data-slot="dialog-content"]');
@@ -82,7 +82,7 @@ describe("Review, as the edit-review dialog", () => {
       ),
     ).toBe(true);
 
-    // #178: `DialogContent` must contribute no width of its own. If it does, it
+    // `DialogContent` must contribute no width of its own. If it does, it
     // arrives as an `sm:max-w-*` — a different tailwind-merge group from the
     // `max-w-*` above, so it would not replace it and would silently win from
     // 640px up.

--- a/apps/web/features/reviews/components/review.tsx
+++ b/apps/web/features/reviews/components/review.tsx
@@ -113,7 +113,7 @@ type ReviewProps = {
   /**
    * Renders no trigger button of its own, leaving the opening to `openOnLoad`.
    *
-   * Taken courses (#92) walks a queue of unreviewed courses and mounts one of
+   * Taken courses walks a queue of unreviewed courses and mounts one of
    * these per course; the row the reader clicked is the trigger, so a second
    * "Add Review" button sitting under the list would open a dialog that is
    * already open. `editing` implies this — a review being rewritten is opened
@@ -207,12 +207,11 @@ export function Review({
         )}
         {/*
           The width is one `max-w-*` that already carries its own viewport
-          guard. It used to be `max-w-4xl min-w-3xl`, and the floor was the bug
-          (#165): `min-w-3xl` is 768px, min-width beats max-width in CSS, and it
-          therefore beat `DialogContent`'s own `max-w-[calc(100%-2rem)]` too — so
-          on any phone the dialog was wider than the screen and the page scrolled
-          sideways. This is reachable: it is the edit-review dialog, opened from
-          My Page.
+          guard. Do not add a `min-w-*` floor beside it: `min-w-3xl` is 768px,
+          min-width beats max-width in CSS, and it therefore beats
+          `DialogContent`'s own `max-w-[calc(100%-2rem)]` too — so on any phone
+          the dialog is wider than the screen and the page scrolls sideways.
+          This is reachable: it is the edit-review dialog, opened from My Page.
 
           `w-full` is what supplies the floor now, and it cannot fight the
           viewport the way a fixed `min-w-*` could: the element is `fixed`, so it

--- a/apps/web/features/reviews/components/unreviewed-card.tsx
+++ b/apps/web/features/reviews/components/unreviewed-card.tsx
@@ -90,7 +90,7 @@ function CourseRowContent({ course }: { course: UnreviewedCourse }) {
  * artboard makes the same choice.
  *
  * The card is deliberately incurious about the set. It takes a list and renders
- * it, so Taken courses (#92) and My Page (#93) can each hand it a differently
+ * it, so Taken courses and My Page can each hand it a differently
  * derived list — and so nothing here is tempted to show a satisfaction state
  * for a course that has no review to carry one.
  */

--- a/apps/web/features/reviews/lib/review-draft.ts
+++ b/apps/web/features/reviews/lib/review-draft.ts
@@ -29,13 +29,12 @@ import { fromPlainText } from "./review-text";
  *
  * ## The workspace pane writes through this model too
  *
- * `features/workspace/lib/review-draft.ts` used to carry a near-identical copy
- * of everything below — the same shape, the same bar arithmetic under the same
- * names. It no longer does: it now holds only the two flags that are genuinely
- * the pane's, `examinationForgotten` and `approachForgotten`, and extends this
- * shape with them. The pane draws explicit "I don't remember" checkboxes where
- * this card leaves the question alone, which is the one real difference between
- * the two surfaces.
+ * `features/workspace/lib/review-draft.ts` holds only the two flags that are
+ * genuinely the pane's, `examinationForgotten` and `approachForgotten`, and
+ * extends this shape with them. The pane draws explicit "I don't remember"
+ * checkboxes where this card leaves the question alone, which is the one real
+ * difference between the two surfaces. Everything else — the shape, the bar
+ * arithmetic — is here, once.
  *
  * That is why `toggleMethod`, `moveDivider` and `nudgeDivider` are generic over
  * the draft rather than typed to this exact shape. Each of them replaces
@@ -84,20 +83,16 @@ export const EMPTY_REVIEW_DRAFT: ReviewDraft = {
  *
  * Two screens keep an unpublished draft in the browser and read it back on the
  * next page load: the workspace pane, in `localStorage`, and the fast-track
- * reviewer, in its tab's `sessionStorage`. Until #166 each had written its own
- * decoder, field by field, and the two had drifted — first by four lines, then
- * by what a malformed record *means*. One salvaged, the other rejected. This is
- * the one decoder both now go through.
+ * reviewer, in its tab's `sessionStorage`. This is the one decoder both go
+ * through, so they cannot drift about what a malformed record means.
  *
  * ## Why it does not spread `EMPTY_REVIEW_DRAFT`
  *
- * Both old copies started `{ ...EMPTY_REVIEW_DRAFT, ... }` and then set the
- * fields they knew about. That spread is what made the duplication dangerous
- * rather than merely untidy: it makes the result structurally complete whether
- * or not the decoder has heard of every field, so a field added to `ReviewDraft`
- * compiles in both copies, passes the type checker in both copies, and comes
- * back as its empty value on the next reload — silently, and delayed until
- * someone reloads.
+ * `{ ...EMPTY_REVIEW_DRAFT, ... }` followed by the fields the decoder knows
+ * about makes the result structurally complete whether or not it has heard of
+ * every field — so a field added to `ReviewDraft` compiles, passes the type
+ * checker, and comes back as its empty value on the next reload, silently, and
+ * delayed until somebody reloads.
  *
  * The object literal below therefore names every field and defaults none of
  * them. Adding a field to `ReviewDraft` now fails to compile *here*, in the one
@@ -114,18 +109,17 @@ export const EMPTY_REVIEW_DRAFT: ReviewDraft = {
  * because there is nothing in a string to salvage.
  *
  * That is not a preference. Both screens mirror their state straight back over
- * storage — the workspace pane on the effect #180 rebuilt, the reviewer on
+ * storage — the workspace pane on its write effect, the reviewer on
  * `useEffect(… , [round])` in `reviewer.tsx`, which fires on the mount that
  * follows the restore — so a draft this function refuses is a draft *deleted*,
  * within a commit, permanently. Rejecting a whole draft over one unreadable
  * field burns the write-up and the scores to avoid drawing a bar wrong.
  *
- * `reviewer-session.ts` used to reject, on the reading that a half-understood
- * *round* is worse than none. The round-level check is real and it stays in
- * that file — an absent or empty queue is still no round. But it is a different
- * granularity: rejecting one draft never rejected the round, it dealt the same
- * card with the reviewer's answers thrown away. So there is no call site that
- * wants rejection, and there is deliberately no policy switch here to give one.
+ * Rejection at the *round* level is a different granularity and it is real:
+ * `reviewer-session.ts` still treats an absent or empty queue as no round.
+ * Rejecting one draft never rejects the round — it deals the same card with the
+ * reviewer's answers thrown away — so no call site wants it, and there is
+ * deliberately no policy switch here to give one.
  */
 
 /**
@@ -171,10 +165,10 @@ function isExaminationKey(value: unknown): value is ExaminationKey {
  * The stored examination split, or no split at all.
  *
  * `methods` and `shares` are parallel, always add up to 100, and name methods
- * *this* build knows about. A stored `"quiz"` from a build that offered one used
- * to be cast straight into `ExaminationKey[]` and reach the bar as a segment
- * with no colour and no label; a length mismatch used to reach `moveDivider` as
- * arithmetic over `undefined`.
+ * *this* build knows about. All three are checked rather than asserted: a
+ * stored `"quiz"` from a build that offered one would otherwise reach the bar
+ * as a segment with no colour and no label, and a length mismatch would reach
+ * `moveDivider` as arithmetic over `undefined`.
  *
  * Anything that fails drops the split and **nothing else**. A split we cannot
  * read is a question left unanswered; the rest of the review is still the

--- a/apps/web/features/reviews/lib/reviewer-session.spec.ts
+++ b/apps/web/features/reviews/lib/reviewer-session.spec.ts
@@ -42,7 +42,7 @@ describe("a round the tab remembers", () => {
    * Both storages used to hand-decode a draft field by field over a spread of
    * `EMPTY_REVIEW_DRAFT`, which made the result structurally complete whether or
    * not the decoder had heard of every field — so a field added to `ReviewDraft`
-   * compiled, type-checked, and came back empty after a reload (#166). The
+   * compiled, type-checked, and came back empty after a reload. The
    * decoder no longer spreads the empty draft, so the omission is now a compiler
    * error; this is the same guarantee at runtime, for the day somebody puts the
    * spread back.

--- a/apps/web/features/reviews/lib/reviewer-session.ts
+++ b/apps/web/features/reviews/lib/reviewer-session.ts
@@ -30,7 +30,7 @@ import { decodeReviewDraft, type ReviewDraft } from "./review-draft";
  * is worth at. A round that is not a round is refused whole; a *draft* is
  * salvaged field by field by the shared `decodeReviewDraft`, because this file
  * once had its own copy of that decoder and the workspace pane had another, and
- * the two came to disagree about what a bad draft means (#166).
+ * the two came to disagree about what a bad draft means.
  *
  * **Being well-formed is not the same as being current.** Nothing in this file
  * knows which courses still need reviewing, so it cannot tell a round that was

--- a/apps/web/features/reviews/lib/reviewer-session.ts
+++ b/apps/web/features/reviews/lib/reviewer-session.ts
@@ -16,21 +16,21 @@ import { decodeReviewDraft, type ReviewDraft } from "./review-draft";
  * still being there next week. Nothing kept here is data — an unsaved card has no
  * row — which is exactly why the browser is the right place for it.
  *
- * That file's *draft* has since moved to `localStorage`, and the difference is
- * worth naming rather than copying by habit: the workspace throws a guest out of
- * the tab to sign in, and the magic-link path lands them in a new one. Nothing
- * here does that. `/taken` opens to a signed-out visitor now, but a round is
- * dealt from *taken* courses and a guest has none — every card in this queue
- * belongs to an account that was already signed in when the round started, so
- * the tab they started in is the tab they finish in.
+ * That file's *draft* is in `localStorage` instead, and the difference is worth
+ * naming rather than copying by habit: the workspace sends a visitor out of the
+ * tab to sign in, and the magic-link path lands them in a new one. Nothing here
+ * does that. `/taken` opens to a signed-out visitor, but a round is dealt from
+ * *taken* courses and a visitor has none — every card in this queue belongs to
+ * an account that was already signed in when the round started, so the tab they
+ * started in is the tab they finish in.
  *
  * Every read is defensive. What comes back is whatever was in the tab's
  * storage, possibly written by an older build, so anything that does not match
  * the shape is dropped rather than trusted — but at the granularity the thing
  * is worth at. A round that is not a round is refused whole; a *draft* is
- * salvaged field by field by the shared `decodeReviewDraft`, because this file
- * once had its own copy of that decoder and the workspace pane had another, and
- * the two came to disagree about what a bad draft means.
+ * salvaged field by field by the shared `decodeReviewDraft`, which is the one
+ * decoder both storage surfaces go through so they cannot disagree about what a
+ * bad draft means.
  *
  * **Being well-formed is not the same as being current.** Nothing in this file
  * knows which courses still need reviewing, so it cannot tell a round that was
@@ -114,20 +114,16 @@ export function readReviewerSession(): ReviewerSession | null {
   /**
    * Each card's answers, salvaged rather than vetted.
    *
-   * `decodeReviewDraft` drops a field it cannot read and keeps the rest, and
-   * this file used to do the opposite: a `methods`/`shares` pair that did not
-   * line up threw the whole card away — write-up, scores and all — on the
-   * reading that a half-understood round is worse than none.
+   * `decodeReviewDraft` drops a field it cannot read and keeps the rest. Do not
+   * make it throw the whole card away instead: dropping a draft does not drop
+   * the *card* — the code stays in `queue`, so the reviewer is dealt the same
+   * course with an empty form and no sign that anything was lost — and
+   * `reviewer.tsx` writes the whole session back in a `useEffect` keyed on
+   * `round`, which fires on the mount that follows the restore, so the
+   * discarded answers are gone from storage before the reviewer has typed
+   * anything.
    *
-   * That reading does not survive looking at what dropping a draft actually
-   * does. It does not drop the *card*: the code stays in `queue`, so the
-   * reviewer is dealt the same course with an empty form and no sign that
-   * anything was lost. And `reviewer.tsx` writes the whole session back in a
-   * `useEffect` keyed on `round`, which fires on the mount that follows the
-   * restore — so the discarded answers are gone from storage before the
-   * reviewer has typed anything, exactly as #180 found in the workspace pane.
-   *
-   * The round-level refusals below are a different thing and they stay: a
+   * The round-level refusals above are a different thing and they stay: a
    * missing or empty `queue` is genuinely not a round, and refusing one opens
    * no card and destroys no answers.
    */

--- a/apps/web/features/saved/components/guest-saves-import-banner.tsx
+++ b/apps/web/features/saved/components/guest-saves-import-banner.tsx
@@ -18,12 +18,12 @@ type Props = {
  * The hand-off from browser to account, above the saved list.
  *
  * Four rows, one at a time, from
- * `docs/design_ref/2026-09-06/Course Community - Saved.dc.html:100-124`: the
+ * `docs/design_ref/2026-09-06/Course Community - Saved.dc.html`: the
  * offer (`pendingImport`), and the three `aria-live` results above it —
  * `importRunning`, `importDone`, `importDupes`.
  *
  * The offer shows only for a signed-in reader who still has codes in this
- * browser, which is the artboard's own condition at line 751 (`member &&
+ * browser, which is the artboard's own condition (`member &&
  * v.localSaves.length > 0 && v.importState !== "running"`). A guest sees
  * nothing here: their list *is* the page, and there is no account to move it
  * into yet.

--- a/apps/web/features/saved/components/saved.spec.tsx
+++ b/apps/web/features/saved/components/saved.spec.tsx
@@ -235,7 +235,7 @@ describe("Saved", { timeout: 20_000 }, () => {
       ).toBeNull();
     });
 
-    // The artboard's own heading and line (lines 129-131). The line is what
+    // The artboard's own heading and line. The line is what
     // distinguishes this section from the `h1` of the same words above it.
     it("heads the list the way the artboard heads it", () => {
       saved("DD2380");
@@ -320,7 +320,7 @@ describe("Saved", { timeout: 20_000 }, () => {
   });
 
   /**
-   * `Course Community - Saved.dc.html` line 82 imports the Collections artboard
+   * `Course Community - Saved.dc.html` imports the Collections artboard
    * with `compact`. That embedding is the design's only way in to collections —
    * the artboard's rail has no entry for them — so it is part of this page
    * rather than a link away from it.
@@ -617,7 +617,7 @@ describe("Saved", { timeout: 20_000 }, () => {
    * The page a signed-out reader gets.
    *
    * `Saved.dc.html` draws this as a working page rather than a locked one: the
-   * list is the browser's (line 322, 517) and the hand-off into an account is
+   * list is the browser's and the hand-off into an account is
    * offered afterwards (119-124). Until this, `/saved` redirected a guest to
    * `/auth` from two places at once and none of it was reachable.
    */

--- a/apps/web/features/saved/components/saved.tsx
+++ b/apps/web/features/saved/components/saved.tsx
@@ -46,11 +46,10 @@ const SAVED_HEADING_ID = "saved-courses-heading";
  * pane with the same contract Explore uses, and computes the card's
  * `geo` from what the pane leaves of the row exactly as Explore
  * does. So the geometry is measured here rather than pinned: with no tab open
- * the column is wide and the ramp lands on its expanded end, which is the fixed
- * object this page used to hand out, and with a tab open the cards collapse
- * instead of overflowing a column that just lost 504px. #90's "Saved pins the
- * card's `geo` to the fully collapsed end" was decided when this page had no
- * pane to yield to; it has one now, and the artboard interpolates.
+ * the column is wide and the ramp lands on its expanded end, and with a tab
+ * open the cards collapse instead of overflowing a column that just lost 504px.
+ * Pinning either end here — as a page with no pane to yield to could — is what
+ * the artboard's interpolation replaces.
  *
  * **Unsaving removes the save and its collection memberships, and nothing
  * else.** The trash control calls `saved.unsave`, whose repository deletes one
@@ -66,8 +65,8 @@ const SAVED_HEADING_ID = "saved-courses-heading";
  *
  * **Collections is a section of this page, not a link away from it.** The
  * artboard imports the Collections artboard with `compact`, which is
- * the design's only way in to collections — its rail has no entry for them, and
- * #91's stopgap rail link went when this landed. Opening a collection from the
+ * the design's only way in to collections — its rail has no entry for them.
+ * Opening a collection from the
  * chips opens its detail *here*, and the saved list gets out of its way, which
  * is the artboard's own `showSavedSection: !collectionsOpenDetail`. It is also
  * why a course opened from inside a collection comes back to this route as
@@ -78,11 +77,10 @@ const SAVED_HEADING_ID = "saved-courses-heading";
  * takes nothing out of this list, and a course may be in several at once. The
  * chips above **narrow** the list — opening one swaps this list for that
  * collection's — rather than relocating anything out of it. The artboard says
- * the same thing: `savedCards` over every saved code and
- * `hasSaved` where the previous export had `unorganized` and `hasUnorganized`,
- * and no "Every saved course is in a collection" panel, because there is no
- * state in which this list can be empty while saves exist. #156 settled it;
- * #90's deferral and the split it deferred are both gone.
+ * the same thing: `savedCards` over every saved code and `hasSaved`, with no
+ * "Every saved course is in a collection" panel, because there is no state in
+ * which this list can be empty while saves exist. There is deliberately no
+ * organized/unorganized split.
  *
  * The `h2` comes back with the subtitle that earns it. It repeats the `h1`, and
  * that is the artboard's own doing — but the section under it is now one of two
@@ -154,17 +152,13 @@ export function Saved({ openCollectionId = null, openCourse = null }: Props) {
   /**
    * The request this page has already acted on, so it acts on it exactly once.
    *
-   * This used to be load-bearing, and said so. `openCourse` was not idempotent
-   * at the state level — re-opening a tab that was already open and already in
-   * front still returned a *new* workspace — so every run of the effect below
-   * re-rendered this component, and any dependency whose identity is not stable
-   * across that render sent the effect round again immediately. `router` is
-   * exactly such a dependency. That was an unbounded loop allocating a workspace
-   * per turn, and it surfaced as an out-of-memory crash rather than as a failed
-   * assertion. #154 fixed it at the value: a no-op open now returns the very
-   * same `Workspace`, `useState` bails out, and the loop has no fuel.
+   * The unbounded render loop this could feed is closed at the value instead:
+   * `openCourse` returns the very same `Workspace` for a no-op open, so
+   * `useState` bails out rather than re-rendering this component and sending the
+   * effect below round again through a dependency — `router` — whose identity is
+   * not stable. See `features/workspace/lib/open-courses.ts`.
    *
-   * The guard stays, demoted to belt-and-braces. What it still defends against
+   * The guard is belt-and-braces. What it defends against
    * is a *second* instruction rather than the loop — the same `?open=` surviving
    * one more render before `router.replace` has taken it back out of the URL
    * would reopen a tab the reader may already have closed. Next's `router` is
@@ -341,9 +335,9 @@ export function Saved({ openCollectionId = null, openCourse = null }: Props) {
               className="flex flex-col gap-3.5 pt-[18px] pb-5 @max-[440px]:gap-3 @max-[440px]:pt-3"
             >
               {/*
-                The artboard's own heading and line. The line is
-                the whole of what #156 settled, said to the reader: a collection
-                groups saved courses, it does not take them out of this list.
+                The artboard's own heading and line. The line says the rule to
+                the reader: a collection groups saved courses, it does not take
+                them out of this list.
               */}
               <div>
                 <h2

--- a/apps/web/features/saved/components/saved.tsx
+++ b/apps/web/features/saved/components/saved.tsx
@@ -62,7 +62,7 @@ const SAVED_HEADING_ID = "saved-courses-heading";
  * collection it was in and out of each of their orders. That is what the
  * confirmation below names, and now that this list shows organized courses too
  * it is a thing a reader can do without ever opening the collection they are
- * emptying (#155).
+ * emptying.
  *
  * **Collections is a section of this page, not a link away from it.** The
  * artboard imports the Collections artboard with `compact`, which is
@@ -317,7 +317,7 @@ export function Saved({ openCollectionId = null, openCourse = null }: Props) {
                 An open collection's cards sit in this very column, so they get
                 the ramp this page already measured for its own list. Without it
                 they pinned the expanded end and were clipped by the column the
-                pane had just narrowed (#159).
+                pane had just narrowed.
               */
               geo={geo}
             />
@@ -457,7 +457,7 @@ export function Saved({ openCollectionId = null, openCourse = null }: Props) {
       ) : null}
 
       {/*
-        Asked before the write, not confirmed after it (#155). The body names
+        Asked before the write, not confirmed after it. The body names
         the one thing an unsave really does take with it — the course's place in
         every collection holding it, cascaded off `user_saved_courses` — and
         says nothing about reviews or taken history, which have no foreign key

--- a/apps/web/features/saved/components/saved.tsx
+++ b/apps/web/features/saved/components/saved.tsx
@@ -410,15 +410,14 @@ export function Saved({ openCollectionId = null, openCourse = null }: Props) {
                             workspace.open(course.courseCode, "review")
                           }
                           /*
-                            Every picker on this page opens upwards. The
-                            2026-09-05 artboard dropped its `picker-above` from
-                            this import, but the reason it was passed is a
-                            property of the page rather than of the drawing: the
-                            saved list is a single scrolling column, and a panel
-                            dropping out of the last card falls out of a box that
-                            is `overflow-x-hidden`. Following the removal would
-                            reintroduce that; it is recorded here rather than
-                            silently kept.
+                            A deliberate deviation: the Saved artboard leaves
+                            the Course Card's `pickerAbove` at its default, and
+                            this page passes it anyway. The reason is a property
+                            of the page rather than of the drawing — the saved
+                            list is a single scrolling column, and a panel
+                            dropping out of the last card falls out of a box
+                            that is `overflow-x-hidden`. Matching the artboard
+                            here would reintroduce that.
                           */
                           pickerAbove
                           onRequestAuth={setAuthReason}

--- a/apps/web/features/saved/components/saved.tsx
+++ b/apps/web/features/saved/components/saved.tsx
@@ -43,8 +43,8 @@ const SAVED_HEADING_ID = "saved-courses-heading";
  * about it are worth knowing before changing anything here.
  *
  * **It hosts the workspace pane, so its cards ramp.** The artboard imports the
- * pane at line 161 with the same contract Explore uses, and computes the card's
- * `geo` from what the pane leaves of the row (line 836) exactly as Explore
+ * pane with the same contract Explore uses, and computes the card's
+ * `geo` from what the pane leaves of the row exactly as Explore
  * does. So the geometry is measured here rather than pinned: with no tab open
  * the column is wide and the ramp lands on its expanded end, which is the fixed
  * object this page used to hand out, and with a tab open the cards collapse
@@ -65,7 +65,7 @@ const SAVED_HEADING_ID = "saved-courses-heading";
  * emptying (#155).
  *
  * **Collections is a section of this page, not a link away from it.** The
- * artboard imports the Collections artboard at line 82 with `compact`, which is
+ * artboard imports the Collections artboard with `compact`, which is
  * the design's only way in to collections — its rail has no entry for them, and
  * #91's stopgap rail link went when this landed. Opening a collection from the
  * chips opens its detail *here*, and the saved list gets out of its way, which
@@ -78,7 +78,7 @@ const SAVED_HEADING_ID = "saved-courses-heading";
  * takes nothing out of this list, and a course may be in several at once. The
  * chips above **narrow** the list — opening one swaps this list for that
  * collection's — rather than relocating anything out of it. The artboard says
- * the same thing at lines 129-135: `savedCards` over every saved code and
+ * the same thing: `savedCards` over every saved code and
  * `hasSaved` where the previous export had `unorganized` and `hasUnorganized`,
  * and no "Every saved course is in a collection" panel, because there is no
  * state in which this list can be empty while saves exist. #156 settled it;
@@ -96,7 +96,7 @@ const SAVED_HEADING_ID = "saved-courses-heading";
  * does the same job exactly rather than approximately — and, decisively, keeps
  * an open collection's detail scrollable. A fixed-height block above a row that
  * owns the page's only scroll would clip a long collection instead.
- * `resultsMax` (line 962) is computed by the artboard and never read by its
+ * `resultsMax` is computed by the artboard and never read by its
  * markup, so there is nothing to follow.
  */
 type Props = {
@@ -216,7 +216,7 @@ export function Saved({ openCollectionId = null, openCourse = null }: Props) {
    *
    * For a guest, the browser's own list. These are the artboard's `acctSaves`
    * and `localSaves`, and `savedVals` picks between them by exactly this test
-   * (`… - Saved.dc.html:517`). They are never merged for display: a reader who
+   * (`… - Saved.dc.html`). They are never merged for display: a reader who
    * has just signed in sees their account, and the banner above offers them the
    * browser list separately rather than showing a total that is not stored
    * anywhere.
@@ -341,7 +341,7 @@ export function Saved({ openCollectionId = null, openCourse = null }: Props) {
               className="flex flex-col gap-3.5 pt-[18px] pb-5 @max-[440px]:gap-3 @max-[440px]:pt-3"
             >
               {/*
-                The artboard's own heading and line, at lines 129-131. The line is
+                The artboard's own heading and line. The line is
                 the whole of what #156 settled, said to the reader: a collection
                 groups saved courses, it does not take them out of this list.
               */}

--- a/apps/web/features/saved/hooks/use-guest-saves.ts
+++ b/apps/web/features/saved/hooks/use-guest-saves.ts
@@ -30,8 +30,7 @@ export function useGuestSaves(): readonly string[] {
 /**
  * How far the hand-off from browser to account has got.
  *
- * The four states are the Saved artboard's own, at
- * `docs/design_ref/2026-09-06/Course Community - Saved.dc.html:747-752`:
+ * The four states are the Saved artboard's own:
  * `pending` is its `pendingImport` row, and `running` / `done` / `dupes` are
  * the three `aria-live` banners above it. `dupes` is a state rather than a
  * flavour of `done` because it says something different — nothing was added,
@@ -55,8 +54,8 @@ type ImportOptions = {
  * Moves the guest list into the account, once the reader asks.
  *
  * **Asked, not automatic.** The artboard auto-runs this only in its own
- * scenario poser (line 578, seeding a preview fixture); the control a reader
- * actually sees is the `pendingImport` row's "Add to my account" button. That
+ * scenario poser, seeding a preview fixture; the control a reader actually
+ * sees is the `pendingImport` row's "Add to my account" button. That
  * is also the safer of the two: signing in is not consent to write a list of
  * courses to an account, and somebody who signed in on a shared browser should
  * not silently inherit whatever the last person saved on it.
@@ -78,11 +77,11 @@ type ImportOptions = {
  * **Every snapshotted code is written, including ones the account looks like it
  * already has.** `accountCodes` is the `user.me` cache behind the page, and
  * that cache is optimistic: `useSetCourseSaved` puts a code into it before the
- * account has answered and takes it back out if the write is rejected. A run
- * that read the cache as proof retired the browser's copy of such a code
- * without writing anything of its own — and when the earlier write then rolled
- * back, the course was in neither place. So the cache decides only the number
- * the banner reports, never what leaves the browser. `saved.save` is idempotent
+ * account has answered and takes it back out if the write is rejected. Treating
+ * the cache as proof would retire the browser's copy of such a code without
+ * writing anything of its own, and a rolled-back earlier write then leaves the
+ * course in neither place. So the cache decides only the number the banner
+ * reports, never what leaves the browser. `saved.save` is idempotent
  * (`insertSavedCourse` uses `onConflictDoNothing`), so a redundant write costs
  * one request and changes nothing, which is a great deal cheaper than the
  * course it was losing.

--- a/apps/web/features/saved/lib/guest-saves.ts
+++ b/apps/web/features/saved/lib/guest-saves.ts
@@ -6,7 +6,7 @@
  * Browsing never needs an account, and neither does saving: the Saved artboard
  * models `localSaves` and `acctSaves` as two lists behind one page, and says
  * why — *"Guest saves have nowhere else to live, so they are kept under our own
- * key"* (`docs/design_ref/2026-09-06/Course Community - Saved.dc.html:322`).
+ * key"* (`docs/design_ref/2026-09-06/Course Community - Saved.dc.html`).
  *
  * It holds course *codes* and nothing else. A code is the one thing about a
  * course this app can re-fetch everything else from, so a stored list cannot go
@@ -16,9 +16,9 @@
  *
  * ## One key per course, not one key holding a list
  *
- * The artboard keeps its list as a JSON array under a single key, and this did
- * too until review found the consequence. A list under one key makes *every*
- * change a read-modify-write: to add one course you read the array, append, and
+ * The artboard keeps its list as a JSON array under a single key. This does
+ * not, and the reason is a deliberate deviation. A list under one key makes
+ * *every* change a read-modify-write: to add one course you read the array, append, and
  * write the whole thing back. `localStorage` is shared by every tab on the
  * origin and offers no compare-and-swap and no transaction, so two tabs doing
  * that at once lose whichever read first — and the write that loses is
@@ -191,8 +191,8 @@ export function setGuestSave(courseCode: string, saved: boolean): void {
  *
  * Called once the account writes have landed — the artboard's `runImport`
  * clears local storage in the same step that commits the merge, and comments
- * the ordering: *"the browser hand-off is cleared only now"* (line 594).
- * Clearing first would lose the list outright if the write then failed.
+ * the ordering: *"the browser hand-off is cleared only now"*. Clearing first
+ * would lose the list outright if the write then failed.
  *
  * **Named saves, not the whole list**, and one `removeItem` each. The artboard
  * can afford a wholesale `removeItem` there because its `localSaves` is
@@ -219,19 +219,17 @@ export function setGuestSave(courseCode: string, saved: boolean): void {
  * keeping, never the only copy of anything.
  *
  * That second bound is a fact about the caller, not about this function, and it
- * has been false once already: `useGuestSavesImport` used to retire a code on
- * the strength of the `user.me` cache listing it, and that cache is optimistic,
- * so a rejected write took the account's copy away after the browser's had
- * gone. The premise is stated in `useGuestSavesImport` and pinned by its tests
- * for that reason. If a caller ever hands this function a code without a
- * resolved write behind it, the bound is gone and so is the argument for
- * leaving the window open; the answer then is IndexedDB's transactions, not a
- * lock. Closing it needs mutual exclusion that every writer takes,
- * which means `navigator.locks` and an async `setGuestSave` reaching every Save
- * button in the app; that is both the lock this layout was chosen to do without
- * and the shape review already rejected upstream in this file, because where
- * the API is missing — older browsers, and jsdom, so every test here — the
- * fallback is this code with none of the locked path exercised.
+ * is easy to break: retiring a code on the strength of the optimistic `user.me`
+ * cache listing it means a rejected write takes the account's copy away after
+ * the browser's has gone. The premise is stated in `useGuestSavesImport` and
+ * pinned by its tests for that reason. If a caller ever hands this function a
+ * code without a resolved write behind it, the bound is gone and so is the
+ * argument for leaving the window open; the answer then is IndexedDB's
+ * transactions, not a lock. A lock needs mutual exclusion that every writer
+ * takes — `navigator.locks` and an async `setGuestSave` reaching every Save
+ * button in the app — and where that API is missing (older browsers, and jsdom,
+ * so every test here) the fallback is this code with none of the locked path
+ * exercised.
  */
 export function retireGuestSaves(saves: readonly GuestSave[]): void {
   if (!saves.length) return;

--- a/apps/web/features/search/components/explore.spec.tsx
+++ b/apps/web/features/search/components/explore.spec.tsx
@@ -680,7 +680,7 @@ describe("Explore", () => {
      * pair the Design System artboard names as the error banner. It used to
      * derive the fill with
      * `color-mix(in srgb, var(--cc-danger) 12%, var(--cc-surface))` under a
-     * comment claiming no error surface token existed (#127 §1). It did, the
+     * comment claiming no error surface token existed. It did, the
      * mix landed on a pink rather than the token's warm peach, and no mix of
      * the solid could have reached it in dark, where the design states the tint
      * as alpha over the page instead.
@@ -702,7 +702,7 @@ describe("Explore", () => {
   });
 
   /**
-   * The artboard's pager, built on a lookahead rather than a count (#148).
+   * The artboard's pager, built on a lookahead rather than a count.
    *
    * The whole contract is `hasMore` plus the page the server says it served.
    * There is no total — one page of a de-duplicated union of a keyword ranking

--- a/apps/web/features/search/components/explore.spec.tsx
+++ b/apps/web/features/search/components/explore.spec.tsx
@@ -675,7 +675,7 @@ describe("Explore", () => {
     });
 
     /**
-     * `Course Community - Explore.dc.html:243` draws the panel's badge as
+     * `Course Community - Explore.dc.html` draws the panel's badge as
      * `#a3452a` over `#fbeceb` — `--cc-danger-ink` over `--cc-danger-tint`, the
      * pair the Design System artboard names as the error banner. It used to
      * derive the fill with

--- a/apps/web/features/search/components/explore.tsx
+++ b/apps/web/features/search/components/explore.tsx
@@ -37,7 +37,7 @@ import { useExplore } from "../hooks/use-explore";
  *
  * ## Where it departs from the artboard, and why
  *
- * - The artboard's **pager** is built (#148), and turns pages without ever
+ * - The artboard's **pager** is built, and turns pages without ever
  *   claiming how many there are. `search.courses` used to accept a `page` and
  *   drop it, and to report `total: results.length` — the size of the page it
  *   had just built. A pager over that would have invented pages, which is the
@@ -294,7 +294,7 @@ export function Explore() {
  * its own mock store. The server cannot answer that question: `search.courses`
  * returns one page and reports `total` as the length of that page, and that
  * page is a de-duplicated union of a keyword ranking and a semantic one, which
- * has no count short of running both unbounded (#74). "Showing" is the smallest
+ * has no count short of running both unbounded. "Showing" is the smallest
  * edit that keeps the sentence true.
  *
  * The rating filter used to be a third reason — it thresholded rows *after* the

--- a/apps/web/features/search/components/explore.tsx
+++ b/apps/web/features/search/components/explore.tsx
@@ -24,7 +24,7 @@ import { useExplore } from "../hooks/use-explore";
  *
  * - **It owns the course card's collapse ramp.** `courseCardGeometry` turns the
  *   measured results-column width into the card's `geo`; the artboard computes
- *   the same ramp off the width the workspace pane leaves behind (line 1061).
+ *   the same ramp off the width the workspace pane leaves behind.
  *   The card measures nothing, which is why the geometry is a prop.
  * - **It is where a course opens.** #68 §5 retired the course page, so
  *   `/course/<code>` now redirects here carrying `?open=<code>&kind=…` and the
@@ -50,7 +50,7 @@ import { useExplore } from "../hooks/use-explore";
  *   gone rather than corrected; `hasMore` replaced it.
  *   `server/search/service.ts` carries the reasoning.
  * - The artboard's pager **labels the page it is on**
- *   (`docs/design_ref/2026-09-06/Course Community - Explore.dc.html:264`, whose
+ *   (`docs/design_ref/2026-09-06/Course Community - Explore.dc.html`, whose
  *   `pageLabel` is built at :1289) and this keeps that label, minus the
  *   `of M`. Dropping only the half the data cannot support is the smallest edit
  *   that leaves the control the artboard drew — three items centred with a
@@ -65,12 +65,12 @@ import { useExplore } from "../hooks/use-explore";
  *   removed: it had no design behind it and could only be applied after the
  *   query, which made searches silently return short.
  * - The artboard narrows its **search bar** by 236px while tabs are open
- *   (`searchBarMargin`, line 1351) so the field stays centred over the results
+ *   (`searchBarMargin`) so the field stays centred over the results
  *   rather than over the whole row. Not built: the bar is centred inside a
  *   `max-w-[560px]` box that is already narrower than the results column at
  *   every width the pane can open at, so the correction has nothing to correct.
  * - The artboard's **shared-element handoff from the landing hero** (its
- *   `pickUpSharedBar()`, line 856) *is* built, and is the one place in the app
+ *   `pickUpSharedBar()`) *is* built, and is the one place in the app
  *   authorised to improve on the artboard rather than match it.
  *   `useSearchBarArrival` below is the receiving end: when this mount is
  *   continuing a search the reader submitted on `/`, the bar animates out of the
@@ -326,14 +326,14 @@ const PAGER_BUTTON_CLASS =
 /**
  * The artboard's pager: Previous, the page it is on, Next.
  *
- * `docs/design_ref/2026-09-06/Course Community - Explore.dc.html:261-267`
+ * `docs/design_ref/2026-09-06/Course Community - Explore.dc.html`
  * draws exactly this — a 34px
  * pill either side of a `--muted` label, centred with a 14px gap, each pill
  * `--ink` when it can be used and `--dim2` when it cannot. Two things here are
  * not literal transcriptions of it:
  *
  * - **The label loses its "of M".** The artboard's store computes
- *   `"Page " + (page + 1) + " of " + pageCount` (line 1289) because its mock
+ *   `"Page " + (page + 1) + " of " + pageCount` because its mock
  *   store is the whole catalogue and can count it. The server cannot: one page
  *   of a de-duplicated union of a keyword ranking and a semantic one has no
  *   total behind it, and the semantic leg matches every course with an
@@ -452,14 +452,14 @@ function StartHere({ onSuggest }: { onSuggest: (query: string) => void }) {
  * This comment used to claim `cc-theme.css` carried no error surface and mix
  * the fill from `--cc-danger` at 12%; that was wrong twice over. The Design
  * System artboard names `--dangerTint` as *the* error banner surface
- * (`Course Community - Design System.dc.html:175-177`, alongside its border and
+ * (`Course Community - Design System.dc.html`, alongside its border and
  * its ink), and none of the three is derivable from the solid — dark states
  * them as alpha over the page, light as flat mixes that are not a percentage of
  * anything (`globals.css:182-187`, #127 §1). In light the difference showed:
  * the mix landed on a pink, the token is a warm peach.
  *
  * The icon takes `--cc-danger-ink` for the same reason, and it is also literally
- * what the artboard draws — `Course Community - Explore.dc.html:243` strokes it
+ * what the artboard draws — `Course Community - Explore.dc.html` strokes it
  * `#a3452a`, which is the ink, over the tint. Neither hex is pinned here: both
  * are light-mode values that would go invisible on the dark page.
  */

--- a/apps/web/features/search/components/explore.tsx
+++ b/apps/web/features/search/components/explore.tsx
@@ -37,21 +37,15 @@ import { useExplore } from "../hooks/use-explore";
  *
  * ## Where it departs from the artboard, and why
  *
- * - The artboard's **pager** is built, and turns pages without ever
- *   claiming how many there are. `search.courses` used to accept a `page` and
- *   drop it, and to report `total: results.length` — the size of the page it
- *   had just built. A pager over that would have invented pages, which is the
- *   same error class as scoring an unreviewed course 0%, so it stayed unbuilt.
- *   The fix was not the `COUNT` that was assumed: a de-duplicated union of a
+ * - The artboard's **pager** is built, and turns pages without ever claiming
+ *   how many there are. There is no count to claim: a de-duplicated union of a
  *   keyword ranking and a semantic one has no count to take, and the semantic
  *   leg matches every course with an embedding at some distance, so there is
  *   nothing to count *up to*. What a prev/next control asks is only "is there
- *   another page", and the server answers it with one extra row. `total` is
- *   gone rather than corrected; `hasMore` replaced it.
+ *   another page", and the server answers that with one extra row.
  *   `server/search/service.ts` carries the reasoning.
- * - The artboard's pager **labels the page it is on**
- *   (`docs/design_ref/2026-09-06/Course Community - Explore.dc.html`, whose
- *   `pageLabel` is built at :1289) and this keeps that label, minus the
+ * - The artboard's pager **labels the page it is on** (its `pageLabel`) and this
+ *   keeps that label, minus the
  *   `of M`. Dropping only the half the data cannot support is the smallest edit
  *   that leaves the control the artboard drew — three items centred with a
  *   14px gap — intact, and "Page 3" asserts nothing about a total. It is also
@@ -60,10 +54,9 @@ import { useExplore } from "../hooks/use-explore";
  * - The artboard's **filter row does not exist** at all; its search block is the
  *   field alone. One filter is built here anyway — **school** — in the
  *   artboard's own control vocabulary. It earns the deviation by filtering in
- *   SQL, so it is cheap, exact, and does not distort the result count. A
- *   minimum-rating dropdown was built beside it for #89 and has since been
- *   removed: it had no design behind it and could only be applied after the
- *   query, which made searches silently return short.
+ *   SQL, so it is cheap, exact, and does not distort the result count. A filter
+ *   that cannot be expressed in SQL does not belong beside it — see
+ *   `server/search/service.ts`.
  * - The artboard narrows its **search bar** by 236px while tabs are open
  *   (`searchBarMargin`) so the field stays centred over the results
  *   rather than over the whole row. Not built: the bar is centred inside a
@@ -292,15 +285,9 @@ export function Explore() {
  *
  * The artboard says "12 courses match “x”", counting the whole catalogue behind
  * its own mock store. The server cannot answer that question: `search.courses`
- * returns one page and reports `total` as the length of that page, and that
- * page is a de-duplicated union of a keyword ranking and a semantic one, which
- * has no count short of running both unbounded. "Showing" is the smallest
- * edit that keeps the sentence true.
- *
- * The rating filter used to be a third reason — it thresholded rows *after* the
- * fetch, so the page could come back shorter than the window it was cut from.
- * It is gone, and the sentence is no less true for it: the school filter runs
- * in SQL and removes nothing after the fact.
+ * returns one page and no total, because the page is a de-duplicated union of a
+ * keyword ranking and a semantic one, which has no count short of running both
+ * unbounded. "Showing" is the smallest edit that keeps the sentence true.
  */
 function resultsLabel(explore: ReturnType<typeof useExplore>): string {
   if (explore.isError) return "Catalogue unavailable";
@@ -449,14 +436,12 @@ function StartHere({ onSuggest }: { onSuggest: (query: string) => void }) {
  * The artboard's error panel.
  *
  * Its tinted circle is the danger tint family, not a derivation of the solid.
- * This comment used to claim `cc-theme.css` carried no error surface and mix
- * the fill from `--cc-danger` at 12%; that was wrong twice over. The Design
- * System artboard names `--dangerTint` as *the* error banner surface
- * (`Course Community - Design System.dc.html`, alongside its border and
- * its ink), and none of the three is derivable from the solid — dark states
- * them as alpha over the page, light as flat mixes that are not a percentage of
- * anything (`globals.css:182-187`, #127 §1). In light the difference showed:
- * the mix landed on a pink, the token is a warm peach.
+ * The Design System artboard names `--dangerTint` as *the* error banner surface
+ * (`Course Community - Design System.dc.html`, alongside its border and its
+ * ink), and none of the three is derivable from the solid — dark states them as
+ * alpha over the page, light as flat mixes that are not a percentage of
+ * anything; see the panel-tint note in `globals.css`. In light the difference
+ * is visible: a `--cc-danger` mix lands on a pink, the token is a warm peach.
  *
  * The icon takes `--cc-danger-ink` for the same reason, and it is also literally
  * what the artboard draws — `Course Community - Explore.dc.html` strokes it
@@ -540,11 +525,11 @@ const SELECT_CLASS =
  * native control is keyboard- and screen-reader-correct on every platform
  * without a portal.
  *
- * A "Minimum rating" select stood beside it until it was removed. It was in no
- * artboard, and unlike school it could not be pushed into SQL — the scores live
- * in the reviews domain — so it was applied after the query over an inflated
- * window, and a search could come back short with nothing saying so. School
- * stays because `department ILIKE` runs in the query itself.
+ * School is the only filter this page can honestly offer, because
+ * `department ILIKE` runs in the query itself. A filter over review scores
+ * cannot — those live in the reviews domain, so it would be applied after the
+ * query over an inflated window and a search could come back short with nothing
+ * saying so.
  */
 function Filters({ explore }: { explore: ReturnType<typeof useExplore> }) {
   return (

--- a/apps/web/features/search/hooks/use-explore.ts
+++ b/apps/web/features/search/hooks/use-explore.ts
@@ -103,15 +103,11 @@ export function useExplore({ onOpenCourse }: ExploreOptions = {}) {
   /**
    * School, the only filter.
    *
-   * `?rating=` used to be read here too, into a minimum-star threshold. The
-   * artboard drew no filter row at all, so that control was invented; it is
-   * gone, along with the post-fetch filtering in `server/search/service.ts`
-   * that made it quietly return short pages.
-   *
-   * Nothing replaces the read, and nothing strips the parameter: an old shared
-   * `?rating=4` link is simply a parameter this page does not look at. It opens
-   * on unfiltered results, with no error and no warning — a link someone sent
-   * last month should still work, just without a filter that no longer exists.
+   * `?rating=` is deliberately not read, and deliberately not stripped either:
+   * an old shared `?rating=4` link is simply a parameter this page ignores. It
+   * opens on unfiltered results, with no error and no warning — a link somebody
+   * sent months ago should still work, just without a filter this app does not
+   * have. `server/search/service.ts` says why it does not have one.
    */
   const department = searchParams.get("department") ?? "";
 
@@ -227,16 +223,12 @@ export function useExplore({ onOpenCourse }: ExploreOptions = {}) {
   /**
    * The request this hook has already spent, so it spends it exactly once.
    *
-   * This used to be load-bearing. `setParams` is rebuilt whenever the URL
-   * changes and whenever `router` changes identity, and the handler above
-   * re-renders the host — and `openCourse` returned a new workspace even for a
-   * tab that was already open and already in front, so those facts closed a
-   * loop that allocated on every turn and ended in an out-of-memory crash
-   * rather than a failed assertion. #154 fixed that at the value: a no-op open
-   * now returns the very same `Workspace`, `useState` bails out, and the fuel
-   * is gone.
+   * The render loop this once fed is closed at the value instead: `openCourse`
+   * returns the very same `Workspace` for a no-op open, so `useState` bails out
+   * rather than re-rendering the host, rebuilding `setParams` and re-running
+   * the effect. See `features/workspace/lib/open-courses.ts`.
    *
-   * The guard stays, demoted to belt-and-braces. It defends against a *second*
+   * The guard is belt-and-braces. It defends against a *second*
    * instruction rather than against the loop — the same `?open=` surviving one
    * more render before `router.replace` has taken it back out of the URL would
    * reopen a tab the reader may already have closed. Next's `router` is stable

--- a/apps/web/features/search/hooks/use-explore.ts
+++ b/apps/web/features/search/hooks/use-explore.ts
@@ -48,7 +48,7 @@ function pageFromParam(raw: string | null): number {
  * The field owns what is being typed, because an input driven from the URL
  * cannot keep up with a keystroke. `?q=` owns what is being *searched*: it seeds
  * the field on arrival, so a link shared out of Explore — or handed over by the
- * landing page's hero — opens on the search it names rather than empty (#95),
+ * landing page's hero — opens on the search it names rather than empty,
  * and the debounced value is written back to it so the address bar always names
  * the results on screen. `router.replace` rather than `push`: a search that grew
  * a character at a time must not leave twelve entries in the reader's history.

--- a/apps/web/features/search/index.ts
+++ b/apps/web/features/search/index.ts
@@ -3,7 +3,7 @@
  *
  * `Explore` is the workspace. `useSearchCourses` and `useDebouncedQuery` cross
  * the boundary because a second surface looks courses up in the catalogue:
- * Taken courses (#92) has to find the course a reader is adding by hand, and
+ * Taken courses has to find the course a reader is adding by hand, and
  * `search.courses` is the only procedure that finds one by code or name. It
  * reuses this hook rather than wrapping the procedure again, so both surfaces
  * share one query key and one debounce.

--- a/apps/web/features/shell/components/rail.tsx
+++ b/apps/web/features/shell/components/rail.tsx
@@ -19,12 +19,10 @@ import { cn } from "@/lib/utils";
  * The rail: the blue column every page renders beside.
  *
  * It is `--cc-rail` in both themes, but that token is **not** one colour in
- * both: `cc-theme.css` now calls it "the sidebar (darkens with the theme)" and
- * gives it `#1751a6` in light and `#0d2e5e` in dark. #85 was told the opposite
- * — "brand blue in both themes" — and #127 §2 corrects it. Nothing here changes
- * as a result; the token already swaps and the rail already reads it. Against
- * the revised dark page (`--cc-pg` `#071831`) the darker rail is still the
- * lighter of the two, so the column still separates from the content beside it
+ * both: `cc-theme.css` calls it "the sidebar (darkens with the theme)" and gives
+ * it `#1751a6` in light and `#0d2e5e` in dark. It is not brand blue in both.
+ * Against the dark page (`--cc-pg` `#071831`) the darker rail is still the
+ * lighter of the two, so the column separates from the content beside it
  * without the light theme's full brand blue glaring out of a dark screen.
  *
  * Its foreground is fixed even though its background is not. There is no
@@ -61,22 +59,16 @@ type NavItem = {
 };
 
 /**
- * "Taken courses" is back, which #85 deferred only because `/taken` did not
- * exist yet and it would not ship a link that 404s. #92 built the route, so the
- * rail is the artboard's four items again.
+ * The artboard's four items, in the artboard's order. "Taken courses" is
+ * **fourth**, after "My Page": `Course Community - Explore.dc.html` and
+ * `Course Community - Taken Courses.dc.html` both order the group Explore,
+ * Saved courses, My Page, Taken courses.
  *
- * It is **fourth**, after "My Page", which is where the artboards draw it —
- * `Course Community - Explore.dc.html` and `Course Community - Taken
- * Courses.dc.html` both order the group Explore, Saved courses, My Page, Taken
- * courses. #85's note said "third in the list" in the same breath as calling it
- * "the rail's fourth link"; the artboards settle it.
- */
-/**
- * "Collections" is deliberately *not* here, and #91's stopgap entry for it was
- * removed by #90. The artboard's rail has no such link: `Saved.dc.html` reaches
- * Collections by importing that artboard as a section of itself, and Saved now
- * does the same, so the design's own way in exists. `/collections` stays as the
- * route a `?collection=` permalink resolves to; nothing needs a second door.
+ * "Collections" is deliberately *not* here. The artboard's rail has no such
+ * link: `Saved.dc.html` reaches Collections by importing that artboard as a
+ * section of itself, and Saved does the same, so the design's own way in
+ * exists. `/collections` stays as the route a `?collection=` permalink resolves
+ * to; nothing needs a second door.
  */
 const NAV: readonly NavItem[] = [
   { href: "/search", label: "Explore", icon: Search, strokeWidth: 2.4 },

--- a/apps/web/features/shell/components/theme-toggle.tsx
+++ b/apps/web/features/shell/components/theme-toggle.tsx
@@ -15,7 +15,7 @@ import { useEffect, useState } from "react";
  * **The icon is chosen by CSS, not by React.** Nothing about the resolved theme
  * is knowable on the server, so a component that renders one glyph has to pick
  * the light one and correct itself after mount — a moon visibly flipping to a
- * sun on every dark-theme page load, which is the flash #127 asks about.
+ * sun on every dark-theme page load.
  * Rendering *both* glyphs and letting the `dark:` variant hide one moves the
  * decision into the stylesheet, and `next-themes` writes `.dark` onto `<html>`
  * from a blocking script before first paint, so the right glyph is the only one

--- a/apps/web/features/shell/components/theme-tokens.spec.tsx
+++ b/apps/web/features/shell/components/theme-tokens.spec.tsx
@@ -101,11 +101,11 @@ function ccNameFor(designToken: string): string {
  * before.
  *
  * - `--cc-applied` — the applied end of a theory/applied bar. The artboards
- *   write `#9dbfe4` inline for it (`Course Community - Workspace Pane.dc.html`
- *   at `:115`, and four other artboards reuse the hex for other things) and no
- *   export has ever given it a name. Three call sites derived it with
- *   `color-mix` instead; #173 named it here so the derivation cannot silently
- *   re-resolve when `--cc-btn` moves. Its dark value is the one `--cc-*` value
+ *   write `#9dbfe4` inline for it (the Workspace Pane artboard, and four others
+ *   that reuse the hex for other things) and no export has ever given it a
+ *   name. It is named here rather than derived with `color-mix` so the
+ *   derivation cannot silently re-resolve when `--cc-btn` moves; see
+ *   `globals.css`. Its dark value is the one `--cc-*` value
  *   in `globals.css` chosen locally, because the artboards hardcode the light
  *   hex in both themes. When an export names it, delete this entry and the
  *   parity check picks it up.

--- a/apps/web/features/shell/lib/page-title.ts
+++ b/apps/web/features/shell/lib/page-title.ts
@@ -42,7 +42,6 @@ const TITLES: ReadonlyArray<readonly [string, string]> = [
   ["/taken", "Taken courses"],
   // Routes the design does not key, titled after the page's own heading.
   ["/collections", "Collections"],
-  // #96 owns About and Contact if it wants different words.
   ["/contact", "Contact"],
   ["/about", "About"],
 ];

--- a/apps/web/features/shell/lib/search-morph.ts
+++ b/apps/web/features/shell/lib/search-morph.ts
@@ -16,9 +16,9 @@
  * else, which is what lets it be a genuine move instead of a dissolve pretending
  * to be one.
  *
- * `Course Community - Landing.dc.html`'s `toExplore()` (line 501) stashes the
+ * `Course Community - Landing.dc.html`'s `toExplore()` stashes the
  * rect under this same key and `Course Community - Explore.dc.html`'s
- * `pickUpSharedBar()` (line 855) reads it back, so the key and the shape are the
+ * `pickUpSharedBar()` reads it back, so the key and the shape are the
  * artboards'. What is not the artboards' is how the two ends are driven — see
  * `components/search-morph.tsx`.
  *

--- a/apps/web/features/taken/components/remove-taken-course-dialog.tsx
+++ b/apps/web/features/taken/components/remove-taken-course-dialog.tsx
@@ -35,16 +35,12 @@ function bodyFor(row: TakenRow): string {
  * Confirming the removal of a taken course.
  *
  * The dialog itself is {@link ConfirmDialog} — this only decides what it asks.
- * It used to render its own copy of that component: the same 440px shell at a
- * 14px radius, the same scrim, the same 38px button pair, differing only in the
- * eyebrow and the computed body, which is exactly what {@link ConfirmRequest}
- * models. The barrel that used to export `ConfirmDialog` had already named the
- * rule this broke — *"when a third screen needs it, it belongs in
- * `components/ui/`"* — and this was the third screen.
+ * Do not give it a shell of its own: the 440px frame, the scrim and the button
+ * pair belong to the shared component, and the eyebrow and body are what
+ * {@link ConfirmRequest} models.
  *
  * Two deliberate departures from
- * `docs/design_ref/2026-09-06/Course Community - My Page.dc.html`, both
- * recorded on the PR that made them.
+ * `docs/design_ref/2026-09-06/Course Community - My Page.dc.html`.
  *
  * **It confirms before the write, not after.** The artboard removes on the click
  * and offers a note; #155 settled that destructive actions confirm first, and of

--- a/apps/web/features/taken/components/remove-taken-course-dialog.tsx
+++ b/apps/web/features/taken/components/remove-taken-course-dialog.tsx
@@ -43,7 +43,7 @@ function bodyFor(row: TakenRow): string {
  * `components/ui/`"* — and this was the third screen.
  *
  * Two deliberate departures from
- * `docs/design_ref/2026-09-06/Course Community - My Page.dc.html:426-438`, both
+ * `docs/design_ref/2026-09-06/Course Community - My Page.dc.html`, both
  * recorded on the PR that made them.
  *
  * **It confirms before the write, not after.** The artboard removes on the click

--- a/apps/web/features/taken/components/taken-courses.spec.tsx
+++ b/apps/web/features/taken/components/taken-courses.spec.tsx
@@ -1216,9 +1216,9 @@ describe("arriving with ?review=…", () => {
  * The signed-out flow the artboard draws, and the two halves that make it safe.
  *
  * `docs/design_ref/2026-09-06/Course Community - Taken Courses.dc.html`
- * poses a guest on the **empty** screen rather than on a locked page, and
- * `:1305-1308` puts the account at the *keep* step: the confirm reads "Sign in
- * to keep this list", and the confirm is resumed once they are in. Everything
+ * poses a guest on the **empty** screen rather than on a locked page, and puts
+ * the account at the *keep* step: the confirm reads "Sign in to keep this
+ * list", and the confirm is resumed once they are in. Everything
  * up to that button is a read — `POST /api/user/transcript` stores nothing —
  * and everything past it is `transcript.confirm`, which is a
  * `protectedProcedure` and is not called here.

--- a/apps/web/features/taken/components/taken-courses.spec.tsx
+++ b/apps/web/features/taken/components/taken-courses.spec.tsx
@@ -1215,7 +1215,7 @@ describe("arriving with ?review=…", () => {
 /**
  * The signed-out flow the artboard draws, and the two halves that make it safe.
  *
- * `docs/design_ref/2026-09-06/Course Community - Taken Courses.dc.html:767`
+ * `docs/design_ref/2026-09-06/Course Community - Taken Courses.dc.html`
  * poses a guest on the **empty** screen rather than on a locked page, and
  * `:1305-1308` puts the account at the *keep* step: the confirm reads "Sign in
  * to keep this list", and the confirm is resumed once they are in. Everything

--- a/apps/web/features/taken/components/taken-courses.spec.tsx
+++ b/apps/web/features/taken/components/taken-courses.spec.tsx
@@ -176,7 +176,7 @@ function takenCourse(overrides: Partial<TakenCourse> = {}): TakenCourse {
 /**
  * One unreviewed course as the hook now hands it over: the taken row plus the
  * catalogue title. The lookup moved into `useUnreviewedTakenCourses` so neither
- * host has to remember it, and My Page was the host that forgot (#157).
+ * host has to remember it, and My Page was the host that forgot.
  */
 function unreviewedCourse(
   overrides: Partial<TakenCourse> = {},
@@ -527,7 +527,7 @@ describe("adding by hand", () => {
 /**
  * Everything on a taken row is self-reported — `CONTEXT.md` says so — and a
  * transcript re-read is the only cheap way back, so the mutation waits behind a
- * confirmation (#155). The artboard confirms after; the product owner settled
+ * confirmation. The artboard confirms after; the product owner settled
  * on before for every destructive action.
  */
 describe("removing", () => {
@@ -1155,7 +1155,7 @@ describe("arriving with ?review=…", () => {
   });
 
   /**
-   * The defect this contract was widened for (#157): a row on My Page's prompt
+   * The defect this contract was widened for: a row on My Page's prompt
    * names a course, and the round has to start on it rather than on whatever
    * the unreviewed set happens to list first.
    */

--- a/apps/web/features/taken/components/taken-courses.tsx
+++ b/apps/web/features/taken/components/taken-courses.tsx
@@ -292,7 +292,7 @@ export function TakenCourses() {
    * **The parameter carries a course.** `?review=<CODE>` starts the round on
    * that course with the rest dealt behind it, which is what a row on My Page's
    * prompt means and what it could not say while the parameter was the bare
-   * flag `1` (#157). `1` still means what it always did — open the reviewer, on
+   * flag `1`. `1` still means what it always did — open the reviewer, on
    * no particular course — so links already in the wild keep working;
    * `parseReviewDeepLink` is the whole contract.
    *
@@ -660,7 +660,7 @@ export function TakenCourses() {
    * nowhere but here, and the only cheap way back is reading a transcript
    * again — which cannot restore a hand-entered course at all. The artboard
    * confirms *after*, with a note; the product owner settled on confirming
-   * before for every destructive action, and this is one of them (#155).
+   * before for every destructive action, and this is one of them.
    *
    * The note stays anyway. Confirming before is about not removing the wrong
    * row; Undo is about the row it was right to remove and wrong to lose.

--- a/apps/web/features/taken/components/taken-courses.tsx
+++ b/apps/web/features/taken/components/taken-courses.tsx
@@ -163,7 +163,7 @@ function importedSummary(added: number, filled: number): string {
  * poses a guest on the empty screen rather than on a locked page
  * (`… - Taken Courses.dc.html`), lets them read a transcript, and asks for
  * the account at the *keep* step: the confirm button reads "Sign in to keep
- * this list" and the confirm is resumed once they are in (`:1305-1308`). That
+ * this list" and the confirm is resumed once they are in. That
  * is implementable only because parsing and writing are two calls —
  * `POST /api/user/transcript` parses and stores nothing, and
  * `transcript.confirm` is a `protectedProcedure` that nothing here weakens. The

--- a/apps/web/features/taken/components/taken-courses.tsx
+++ b/apps/web/features/taken/components/taken-courses.tsx
@@ -161,7 +161,7 @@ function importedSummary(added: number, filled: number): string {
  *
  * **A signed-out visitor gets the whole flow except the write.** The artboard
  * poses a guest on the empty screen rather than on a locked page
- * (`… - Taken Courses.dc.html:767`), lets them read a transcript, and asks for
+ * (`… - Taken Courses.dc.html`), lets them read a transcript, and asks for
  * the account at the *keep* step: the confirm button reads "Sign in to keep
  * this list" and the confirm is resumed once they are in (`:1305-1308`). That
  * is implementable only because parsing and writing are two calls —
@@ -331,7 +331,7 @@ export function TakenCourses() {
 
   /**
    * Picks up the transcript a signed-out reader left behind on their way to
-   * sign in — the artboard's `pending: "confirm"` (`… - Taken Courses.dc.html:1307`).
+   * sign in — the artboard's `pending: "confirm"` (`… - Taken Courses.dc.html`).
    *
    * **Only for the sign-in that left it.** The record is claimable only by an
    * arrival carrying its handoff token, which the confirm below put in the
@@ -516,7 +516,7 @@ export function TakenCourses() {
    * Opens the by-hand form, or asks for the account it would write to.
    *
    * The artboard offers "Add courses manually instead" on the same empty screen
-   * it poses a guest on (`… - Taken Courses.dc.html:95`, `:767`), and its own
+   * it poses a guest on (`… - Taken Courses.dc.html`), and its own
    * handler just opens the form — its mock has no server to refuse the save.
    * Ours does: `taken.add` is a `protectedProcedure`. So a guest gets the
    * sign-in prompt here instead of a form whose Save cannot work.
@@ -952,7 +952,7 @@ export function TakenCourses() {
 
       {/*
         The artboard draws this gate as a screen of the page (`isAuth`,
-        `… - Taken Courses.dc.html:56-68`). It is a dialog here because that is
+        `… - Taken Courses.dc.html`). It is a dialog here because that is
         what the sign-in surface is everywhere else in this app — `auth.tsx`
         records that the design's own sign-in is "a panel over the page it
         interrupted" — and because `AuthReasonDialog` already carries the two

--- a/apps/web/features/taken/components/transcript-proposal.tsx
+++ b/apps/web/features/taken/components/transcript-proposal.tsx
@@ -61,7 +61,7 @@ function unmatchedTitle(count: number): string {
  * **Signed out, the button asks for the account instead of writing.**
  * `confirmCta: s.signedIn ? "Looks right" : "Sign in to keep this list"` is the
  * artboard's own line (`docs/design_ref/2026-09-06/Course Community - Taken
- * Courses.dc.html:1305`), and it is the whole shape of the guest flow: the
+ * Courses.dc.html`), and it is the whole shape of the guest flow: the
  * transcript is read, the rows are shown, and the account is asked for at the
  * step that would keep them. Nothing on this screen has been stored either way.
  */

--- a/apps/web/features/taken/lib/guest-proposal.spec.ts
+++ b/apps/web/features/taken/lib/guest-proposal.spec.ts
@@ -69,7 +69,7 @@ describe("holding a proposal across a sign-in", () => {
 
   /**
    * The grades switch off means "no grade of yours is stored anywhere"
-   * (`docs/design_ref/2026-09-06/Course Community - Taken Courses.dc.html:1296`),
+   * (`docs/design_ref/2026-09-06/Course Community - Taken Courses.dc.html`),
    * and `planTranscriptImport` drops them at confirm time anyway. Writing them
    * down for the sake of data the confirm will discard would make that copy
    * false for the one storage the reader cannot see.

--- a/apps/web/features/taken/lib/guest-proposal.ts
+++ b/apps/web/features/taken/lib/guest-proposal.ts
@@ -13,8 +13,7 @@ import type {
  * PDF in, reads what came out, and the confirm button says "Sign in to keep
  * this list" — then `{ screen: "auth", returnTo: "list", pending: "confirm" }`,
  * and after the sign-in "the action that asked for the account finishes itself"
- * (`docs/design_ref/2026-09-06/Course Community - Taken Courses.dc.html`,
- * `:1247-1250`).
+ * (`docs/design_ref/2026-09-06/Course Community - Taken Courses.dc.html`).
  *
  * In the artboard that resume is free, because its sign-in is a `setState`. Ours
  * is a round trip through somebody else's site: Google and GitHub redirect the
@@ -54,9 +53,8 @@ import type {
  * never finishes signing in, person B signs in on the same browser profile
  * inside the half hour, and a record keyed on nothing at all is A's course list
  * — and A's grades, if A had the switch on — sitting on B's screen under
- * "Looks right". An earlier revision of this comment argued from the writer to
- * conclude "there is no second account's data to keep apart"; that does not
- * follow, and it was wrong.
+ * "Looks right". "Only a guest writes one, so there is no second account's data
+ * to keep apart" does not follow: it argues from the writer about the reader.
  *
  * So the record carries a `handoff` token, minted at write time and handed to
  * the caller, which puts it in the return-to the sign-in round trip carries

--- a/apps/web/features/taken/lib/guest-proposal.ts
+++ b/apps/web/features/taken/lib/guest-proposal.ts
@@ -13,7 +13,7 @@ import type {
  * PDF in, reads what came out, and the confirm button says "Sign in to keep
  * this list" — then `{ screen: "auth", returnTo: "list", pending: "confirm" }`,
  * and after the sign-in "the action that asked for the account finishes itself"
- * (`docs/design_ref/2026-09-06/Course Community - Taken Courses.dc.html:1305-1308`,
+ * (`docs/design_ref/2026-09-06/Course Community - Taken Courses.dc.html`,
  * `:1247-1250`).
  *
  * In the artboard that resume is free, because its sign-in is a `setState`. Ours
@@ -38,7 +38,7 @@ import type {
  * **Grades are dropped unless the reader asked to keep them.** With the grades
  * switch off, `planTranscriptImport` throws the grades away at confirm time
  * anyway, and the artboard's own copy for that state is "no grade of yours is
- * stored anywhere" (`… - Taken Courses.dc.html:1296`). Carrying them through a
+ * stored anywhere" (`… - Taken Courses.dc.html`). Carrying them through a
  * sign-in would make that false for the sake of data the confirm is going to
  * discard, so they are stripped before the write rather than after the read.
  *

--- a/apps/web/features/taken/lib/review-deep-link.ts
+++ b/apps/web/features/taken/lib/review-deep-link.ts
@@ -5,7 +5,7 @@
  * thing it can say about a course the reader picked is what it puts in the URL.
  * The parameter used to be the bare flag `1`, which could say "open the
  * reviewer" and nothing else, so a row and the "Fast track all N" button
- * deep-linked to the very same place and the named course was discarded (#157).
+ * deep-linked to the very same place and the named course was discarded.
  */
 
 /**

--- a/apps/web/features/taken/lib/review-deep-link.ts
+++ b/apps/web/features/taken/lib/review-deep-link.ts
@@ -3,15 +3,15 @@
  *
  * My Page has no reviewer of its own — `/taken` owns the queue — so the only
  * thing it can say about a course the reader picked is what it puts in the URL.
- * The parameter used to be the bare flag `1`, which could say "open the
- * reviewer" and nothing else, so a row and the "Fast track all N" button
- * deep-linked to the very same place and the named course was discarded.
+ * The parameter therefore carries a course code, not just a flag: with only the
+ * flag, a row and the "Fast track all N" button deep-link to the same place and
+ * the named course is discarded.
  */
 
 /**
- * `review=1` — the original contract. It still means what it always meant: open
- * the reviewer, on no particular course. Kept so a link somebody bookmarked,
- * or a tab left open across this deploy, still lands where it used to.
+ * `review=1` — open the reviewer, on no particular course. It is also the older
+ * spelling of this parameter, so it stays understood: a bookmarked link or a
+ * long-open tab still lands where it expects to.
  */
 export const REVIEW_ALL = "1";
 

--- a/apps/web/features/workspace/components/review-draft-panel.tsx
+++ b/apps/web/features/workspace/components/review-draft-panel.tsx
@@ -706,7 +706,7 @@ export function ReviewDraftPanel({
             the tick. This used to derive the fill from `--cc-success` at 12%
             and take the *solid* for the text; neither is reachable that way,
             because dark states the tint as alpha over the page and light as a
-            flat mix that is not a percentage of anything (#127 §1). */}
+            flat mix that is not a percentage of anything. */}
         {justPublished && (
           <p className="flex items-center gap-2.5 border-cc-rule border-b bg-cc-success-tint px-5 py-2.5 text-[12.5px] text-cc-success-ink">
             Published. Thanks — your review is live on the course.

--- a/apps/web/features/workspace/components/review-draft-panel.tsx
+++ b/apps/web/features/workspace/components/review-draft-panel.tsx
@@ -90,10 +90,10 @@ function ForgotCheckbox({
         aria-hidden="true"
         className={cn(
           /*
-            **Do not remove this ring as a duplicate of `globals.css`'s.** #167
-            deleted nine hand-rolled focus treatments that the global
-            `:focus-visible` rule had made redundant; this is the one that is
-            not, and the reason is not visible from the class list.
+            **Do not remove this ring as a duplicate of `globals.css`'s.** Most
+            hand-rolled focus treatments in `features/**` are redundant against
+            the global `:focus-visible` rule. This one is not, and the reason is
+            not visible from the class list.
 
             The focusable element here is the `peer` input above, which is
             `sr-only` — clipped to a 1px box. The global rule draws its outline

--- a/apps/web/features/workspace/components/review-draft-panel.tsx
+++ b/apps/web/features/workspace/components/review-draft-panel.tsx
@@ -654,14 +654,14 @@ export function ReviewDraftPanel({
       </div>
 
       {/* The artboard's footer has two controls: a bordered "Save draft" beside
-          the post button (`Course Community - Workspace Pane.dc.html:301-303`).
+          the post button (`Course Community - Workspace Pane.dc.html`).
           Only the post button is here, deliberately.
 
           There is no unsaved state for a "Save draft" to resolve. Every
           keystroke goes `onDraftChange` → `patchDraft` → the `writeDrafts`
           effect in `workspace-pane.tsx`, so the button would either be a no-op
           or imply the draft had been at risk. The artboard's own reassurance is
-          kept: its `savedLabel` (`:170`, defined at `:645`) is the "Not saved
+          kept: its `savedLabel` is the "Not saved
           yet" / "Saved just now" line in this panel's header, word for word.
 
           Recorded because a deviation nobody wrote down is a deviation the next
@@ -701,7 +701,7 @@ export function ReviewDraftPanel({
           </p>
         )}
         {/* The success tint family, which is what the artboard draws:
-            `Course Community - Workspace Pane.dc.html:296-297` paints this
+            `Course Community - Workspace Pane.dc.html` paints this
             banner `var(--successTint)` with `var(--successInk)` on the text and
             the tick. This used to derive the fill from `--cc-success` at 12%
             and take the *solid* for the text; neither is reachable that way,

--- a/apps/web/features/workspace/components/workspace-pane-host.spec.tsx
+++ b/apps/web/features/workspace/components/workspace-pane-host.spec.tsx
@@ -63,7 +63,7 @@ function host(openCourses: OpenCourse[]) {
 }
 
 /**
- * Explore and Saved mount the same column (#127 §3), so what it does with no
+ * Explore and Saved mount the same column, so what it does with no
  * open courses, and how wide it starts, is asserted once here rather than in
  * each host's screen test.
  */

--- a/apps/web/features/workspace/components/workspace-pane.spec.tsx
+++ b/apps/web/features/workspace/components/workspace-pane.spec.tsx
@@ -471,7 +471,7 @@ describe("the review draft tab", () => {
       message: "<p>Hard but worth it.</p>",
     });
     /*
-     * `Course Community - Workspace Pane.dc.html:296-297` paints this banner
+     * `Course Community - Workspace Pane.dc.html` paints this banner
      * `var(--successTint)` with `var(--successInk)`. It used to derive the fill
      * from `--cc-success` at 12% in an inline `style` and take the solid for
      * the text, which no mix could reach in dark, where the design states the

--- a/apps/web/features/workspace/components/workspace-pane.spec.tsx
+++ b/apps/web/features/workspace/components/workspace-pane.spec.tsx
@@ -41,8 +41,8 @@ vi.mock("@/features/courses", () => ({
   useCourseSummaries: (codes: string[]) => useCourseSummaries(codes),
 }));
 
-// `ReviewList` is the reviews feature's own list of designed Review Cards
-// (#87). The pane's job is to hand it the course and its reviews, which is
+// `ReviewList` is the reviews feature's own list of designed Review Cards.
+// The pane's job is to hand it the course and its reviews, which is
 // what this asserts; how a card draws itself is that feature's test.
 // The palette and the review-draft model are the real ones — the pane draws
 // the same examination bar the Review Card does, and since the pane's draft
@@ -475,7 +475,7 @@ describe("the review draft tab", () => {
      * `var(--successTint)` with `var(--successInk)`. It used to derive the fill
      * from `--cc-success` at 12% in an inline `style` and take the solid for
      * the text, which no mix could reach in dark, where the design states the
-     * tint as alpha over the page (#127 §1). Classes rather than computed
+     * tint as alpha over the page. Classes rather than computed
      * colours: jsdom runs no Tailwind, so what is assertable is the token the
      * component asked for — and that the derivation is not back in a `style`.
      */

--- a/apps/web/features/workspace/components/workspace-pane.tsx
+++ b/apps/web/features/workspace/components/workspace-pane.tsx
@@ -270,10 +270,10 @@ export function WorkspacePane({
                       `focus:bg-cc-pill` is the menu *highlight*, not a focus
                       ring — Radix moves DOM focus between items as the pointer
                       or the arrow keys travel, and this is the wash that follows
-                      it. It survived #167's sweep of hand-rolled focus
-                      treatments for that reason: it sets a background, which the
-                      global `:focus-visible` rule does not touch, and removing
-                      it would leave the menu with no highlight at all.
+                      it. **Do not remove it as a duplicate of `globals.css`'s
+                      focus rule.** It sets a background, which that rule does
+                      not touch, and removing it would leave the menu with no
+                      highlight at all.
                     */
                     "gap-2.5 rounded-[7px] px-2.5 py-[7px] text-[12.5px] focus:bg-cc-pill",
                     entry.id === active.id

--- a/apps/web/features/workspace/index.ts
+++ b/apps/web/features/workspace/index.ts
@@ -1,7 +1,7 @@
 /**
  * The cross-feature API of the workspace feature.
  *
- * The **workspace pane** is the column Explore (#89) and Saved (#90) mount
+ * The **workspace pane** is the column Explore and Saved mount
  * beside their results: it holds every course the user has opened, one tab
  * each, either as course details or as a review draft. Since #68 §5 retired
  * `/course/<code>` it is the *only* place a course opens, so both hosts mount

--- a/apps/web/features/workspace/lib/open-courses.ts
+++ b/apps/web/features/workspace/lib/open-courses.ts
@@ -111,16 +111,16 @@ function openCourseId(courseCode: string, kind: OpenCourseKind): string {
  *
  * ## Opening an already-front tab returns the *same object*
  *
- * Not merely an equal one. Three separate unbounded render loops have shipped
- * on this branch, and every one of them was an effect that called into the
- * workspace and then re-ran because something it depended on had been rebuilt.
- * A transition that hands back a fresh `Workspace` for a no-op is the fuel:
- * `useState` bails out of a re-render when the next state is `Object.is`-equal
- * to the current one, and a spread is never that, so "open the course that is
- * already open and already in front" used to re-render every host of this
- * state — which rebuilds `setParams`, which re-runs the effect, which opens the
- * course again. The guards in `use-explore.ts` and `saved.tsx` each stop that
- * loop one caller at a time; this stops it at the value.
+ * Not merely an equal one, and this is load-bearing. Every unbounded render
+ * loop this workspace has produced was an effect that called in here and then
+ * re-ran because something it depended on had been rebuilt. A transition that
+ * hands back a fresh `Workspace` for a no-op is the fuel: `useState` bails out
+ * of a re-render only when the next state is `Object.is`-equal to the current
+ * one, and a spread never is — so "open the course that is already open and
+ * already in front" would re-render every host of this state, which rebuilds
+ * `setParams`, which re-runs the effect, which opens the course again. The
+ * guards in `use-explore.ts` and `saved.tsx` each stop that loop one caller at
+ * a time; this stops it at the value.
  *
  * The bail-out is deliberately narrow. Bringing a *background* tab forward is a
  * real change and still allocates, because `activeId` genuinely differs.

--- a/apps/web/features/workspace/lib/review-draft.ts
+++ b/apps/web/features/workspace/lib/review-draft.ts
@@ -30,11 +30,9 @@ import {
  *
  * The model itself — the picked methods, the parallel shares, the scores, the
  * write-up — and every piece of the examination bar's arithmetic live in
- * `features/reviews/lib/review-draft.ts`. This file used to carry a second copy
- * of all of it. It no longer does, because there is nothing about the pane that
- * makes a divider move differently: a review draft is one concept with two
- * presentations, and the model belongs to the feature that owns reviews rather
- * than to whichever screen was built first.
+ * `features/reviews/lib/review-draft.ts`. Nothing about the pane makes a
+ * divider move differently: a review draft is one concept with two
+ * presentations, and the model belongs to the feature that owns reviews.
  *
  * ## What is genuinely the pane's
  *
@@ -74,7 +72,7 @@ export const EMPTY_REVIEW_DRAFT: ReviewDraft = {
  * The record guard is shared rather than repeated so that the flags come off a
  * value TypeScript has *checked* is a record — the alternative is decoding the
  * answers first and then asserting that the input must have been a record after
- * all, which is the kind of unchecked cast #166 set out to remove.
+ * all, which is an unchecked cast.
  *
  * Nothing is defaulted from `EMPTY_REVIEW_DRAFT`. Adding a field to this
  * interface fails to compile here, and adding one to `ReviewAnswers` fails to

--- a/apps/web/features/workspace/lib/workspace-storage.ts
+++ b/apps/web/features/workspace/lib/workspace-storage.ts
@@ -74,11 +74,10 @@ import {
  *
  * The salvaging is `decodeReviewDraft`'s, in `./review-draft.ts`, which extends
  * `features/reviews/lib/review-draft.ts`'s decoder with the pane's two flags.
- * This file used to hold a second hand-written copy of it, and the fast-track
- * reviewer a third; #166 is what they cost. The three refusals left in this file
- * are its own and none of them is a field: an entry that is not an object, one
- * with no `savedAt`, and one whose stamp has expired. Those are deliberate, and
- * the last of them is the whole point of the stamp.
+ * Do not hand-write a second copy of it here. The three refusals this file does
+ * own are not fields: an entry that is not an object, one with no `savedAt`, and
+ * one whose stamp has expired. Those are deliberate, and the last of them is the
+ * whole point of the stamp.
  */
 
 const WORKSPACE_KEY = "cc.workspace.open";
@@ -259,12 +258,10 @@ function decodeBuckets(): DraftBuckets {
 /**
  * Drafts the previous release left in `sessionStorage`, brought across once.
  *
- * The release this replaces wrote `{ [courseCode]: ReviewDraft }` under the
- * same key in the tab's storage. Without this, shipping the fix is itself the
- * data loss it fixes: every student with a half-written review open at deploy
- * time reloads into a blank form, and their tab still had the draft — it was
- * simply being looked for in the wrong place. A migration is cheap and the
- * alternative is a one-off outage of exactly the thing this PR is about.
+ * An earlier release wrote `{ [courseCode]: ReviewDraft }` under the same key in
+ * the tab's storage. Without this, every student with a half-written review open
+ * at deploy time reloads into a blank form while their tab still holds the
+ * draft — it is simply being looked for in the wrong place.
  *
  * They arrive unowned, so they land in the anonymous bucket and are claimed by
  * the first account to read them. The tab knew who was typing; the storage it

--- a/apps/web/next.config.ts
+++ b/apps/web/next.config.ts
@@ -25,10 +25,10 @@ const nextConfig: NextConfig = {
    * Routes that have been renamed, and the links already out in the world that
    * point at their old names.
    *
-   * `/favorites` was the Saved courses page until #90 moved it to `/saved`,
-   * closing the last of the three names ADR 0003 recorded for one concept.
-   * Bookmarks, history entries and anything anyone has shared still say
-   * `/favorites`, and without an entry here they land on the 404 page.
+   * `/favorites` was the Saved courses page before `/saved`, and it is the last
+   * of the three names ADR 0003 recorded for one concept. Bookmarks, history
+   * entries and anything anyone has shared still say `/favorites`, and without
+   * an entry here they land on the 404 page.
    *
    * `permanent` is a 308, which is what a rename is: the old path is not coming
    * back, and `CONTEXT.md` retires the word rather than freeing it for reuse.

--- a/apps/web/server/api/protected.spec.ts
+++ b/apps/web/server/api/protected.spec.ts
@@ -93,7 +93,7 @@ describe("protected procedures", () => {
 
   it("allows visitors on search.courses", async () => {
     const result = await caller(null).search.courses({ q: "" });
-    // `total` is gone (#148): a de-duplicated union of a keyword ranking and a
+    // `total` is gone: a de-duplicated union of a keyword ranking and a
     // semantic one has no count to report, and `hasMore` is what a prev/next
     // pager actually asks for.
     expect(result).toMatchObject({ results: [], page: 1, hasMore: false });

--- a/apps/web/server/graph/placement.ts
+++ b/apps/web/server/graph/placement.ts
@@ -13,10 +13,11 @@
  * is re-exported here because placement writes the unconfigured state on join
  * and every existing importer of these names came through this module.
  *
- * **Nobody is assigned a colour.** Placement used to hash every app user onto a
- * palette name, which gave everyone a colour nobody chose, and a node profile is
- * personalisation: a colour is chosen, never dealt out. `graph.setAppearance` is
- * the only writer of a chosen value, and it is driven by a member clicking one.
+ * **Nobody is assigned a colour.** Placement writes the unconfigured state and
+ * never hashes an app user onto a palette name: a node profile is
+ * personalisation, so a colour is chosen, never dealt out. `graph.setAppearance`
+ * is the only writer of a chosen value, and it is driven by a member clicking
+ * one.
  */
 export {
   DEFAULT_NODE_COLOR,

--- a/apps/web/server/graph/repository.ts
+++ b/apps/web/server/graph/repository.ts
@@ -269,9 +269,9 @@ export function findReviewedCourses(
 /**
  * The courses this app user got from a transcript import.
  *
- * `transcript_imported_at is not null` is the whole test, and it is the one
- * #161 names: a course typed in by hand carries no import stamp and cannot earn
- * tier 2 or 3. The primary key on `(user_id, course_code)` leads with
+ * `transcript_imported_at is not null` is the whole test, and it is the one the
+ * ladder names (ADR 0005): a course typed in by hand carries no import stamp
+ * and cannot earn tier 2 or 3. The primary key on `(user_id, course_code)` leads with
  * `user_id`, so this read is indexed.
  *
  * It reads `user_taken_courses`, which belongs to the taken domain, and it is
@@ -334,7 +334,7 @@ export async function findTierCandidateUserIds(
  * what makes it hold under concurrency: two contributions landing at once
  * cannot have the slower one write a stale, smaller number over the faster
  * one's, and a recompute that answers 2 where the column already says 3 — which
- * #161's ladder allows, because tier 3's condition stops holding the moment a
+ * the ladder allows, because tier 3's condition stops holding the moment a
  * further transcript is imported — is a no-op rather than a demotion. The `<`
  * in the `WHERE` only spares the row a write it does not need; delete it and
  * the column is still correct.

--- a/apps/web/server/graph/service.ts
+++ b/apps/web/server/graph/service.ts
@@ -188,11 +188,10 @@ export async function joinCommunityGraphOnSignUp(
  * An app user without a node is placed rather than refused, so this read can
  * write on its first call for them.
  *
- * It returns a window and nothing else. It used to carry the effective
- * personalization tier as well, from a time when it was read only if somebody
- * opened **Find your dot**; the landing draws the graph on load now, so that
- * would be two extra queries on every visit for a number this page does not
- * use. `graph.effectiveTier` is where My Page asks for it.
+ * It returns a window and nothing else — no personalization tier. The landing
+ * draws the graph on load, so carrying the tier here would be two extra queries
+ * on every visit for a number this page does not use. `graph.effectiveTier` is
+ * where My Page asks for it.
  */
 export async function getNeighbourhood(userId: string): Promise<GraphWindow> {
   // Sign-up placement is the primary pathway, but it cannot cover everyone:
@@ -235,12 +234,12 @@ export type NodePersonalization = {
 /**
  * Both personalization tier numbers for an app user.
  *
- * **Two numbers, not one, and that is the point.** This read used to answer with
- * the effective tier alone, which left My Page unable to tell a *dormant* axis —
- * earned, decayed, pick still stored — from a *locked* one that was never
- * earned. The artboard has three badges and the UI could only draw two, so it
- * collapsed dormant into "Locked" and told members they had lost something the
- * database still holds. The earned number closes that and does nothing else.
+ * **Two numbers, not one, and that is the point.** The effective tier alone
+ * cannot tell a *dormant* axis — earned, decayed, pick still stored — from a
+ * *locked* one that was never earned, and the artboard draws three badges. With
+ * one number the UI can only draw two, and it collapses dormant into "Locked",
+ * telling members they have lost something the database still holds. The earned
+ * number closes that and does nothing else.
  *
  * Read-only by construction: the earned tier is the highest ever reached and
  * decay is derived from it, never written back.
@@ -386,10 +385,10 @@ const TIER_BACKFILL_PAGE = 200;
 /**
  * Give every app user who already contributed the tier they already earned.
  *
- * The writer above only fires on a *new* review or a *new* import, so on the
- * day this ships, everybody who reviewed or imported before it exists is still
- * at the column default and still sees three locked axes until they contribute
- * again. This is the one-off that fixes that, and it is safe to run whenever
+ * The writer above only fires on a *new* review or a *new* import, so anybody
+ * who reviewed or imported before it existed sits at the column default and
+ * sees three locked axes until they contribute again. This is the one-off that
+ * fixes that, and it is safe to run whenever
  * anybody doubts the column: it derives from the same `deriveEarnedTier`, it
  * raises through the same `greatest`, so a second run is a no-op and a run
  * racing a live contribution cannot lower anything.
@@ -398,7 +397,8 @@ const TIER_BACKFILL_PAGE = 200;
  * `findTierCandidateUserIds` — and pages on the user id, so a review published
  * mid-run cannot make it skip somebody. One app user at a time rather than a
  * single statement, because the rule that decides a tier is TypeScript and
- * expressing it again in SQL is exactly the second definition #161 forbids.
+ * expressing it again in SQL would be a second definition that can disagree
+ * with the first (ADR 0005).
  *
  * Unlike the per-contribution path this does **not** swallow: a backfill that
  * half-ran and reported success is worse than one that stops and says where.
@@ -456,7 +456,7 @@ export async function backfillEarnedPersonalizationTiers(
  * a lower tier true, and the column does not go down, so there is nothing to
  * write. Removing an imported course can also complete a transcript and make
  * tier 3 true; that raise waits for the next contribution rather than putting a
- * tier write on a delete path, and #161 settles the ladder, not its latency.
+ * tier write on a delete path.
  */
 export async function recordEarnedPersonalizationTierOnContribution(
   userId: string,

--- a/apps/web/server/graph/tier.ts
+++ b/apps/web/server/graph/tier.ts
@@ -13,9 +13,9 @@ import { selectUnreviewedCourses } from "../reviews/unreviewed";
  * touching a service or a query. They are one policy seen from two ends —
  * earning and decay — which is why they share a file rather than a layer.
  *
- * The rule itself is #161's settled ladder, and the two halves are deliberately
- * asymmetric: see `deriveEarnedTier` on why a non-monotonic condition still
- * produces a column that only ever rises.
+ * The ladder is settled in `docs/adr/0005-personalization-tier-earning.md`, and
+ * the two halves are deliberately asymmetric: see `deriveEarnedTier` on why a
+ * non-monotonic condition still produces a column that only ever rises.
  */
 
 /** Complete months of inactivity that cost one tier step. */
@@ -42,7 +42,7 @@ export type EarnedTierInputs = {
 /**
  * The tier an app user's contributions have earned, right now.
  *
- * The ladder, settled in #161:
+ * The ladder, settled in ADR 0005:
  *
  * - **1** — they have published a review. The 0→1 step, and the contribution
  *   the product most wants.
@@ -79,7 +79,9 @@ export function deriveEarnedTier(inputs: EarnedTierInputs): number {
   const hasImported = inputs.transcriptImportedCourses.length > 0;
   // The one definition of "unreviewed", narrowed to imported courses. Tier 3
   // falls out of the same arithmetic the "Fast track all N" count uses; a
-  // second version of it written in SQL is exactly the duplication #161 forbids.
+  // second version written in SQL could disagree with the UI in the worst
+  // possible place — telling a member they had finished while the tier said
+  // they had not.
   const unreviewedImported = selectUnreviewedCourses(
     inputs.transcriptImportedCourses,
     inputs.reviews,

--- a/apps/web/server/http/rate-limit.ts
+++ b/apps/web/server/http/rate-limit.ts
@@ -6,7 +6,7 @@
  * request contains. It exists because `/api/user/transcript` now answers a
  * signed-out visitor — the Taken Courses artboard has a guest upload a
  * transcript and asks for the account at the *keep* step
- * (`docs/design_ref/2026-09-06/Course Community - Taken Courses.dc.html:1305`)
+ * (`docs/design_ref/2026-09-06/Course Community - Taken Courses.dc.html`)
  * — and a route that runs a PDF parser for anyone who asks needs a ceiling
  * that an account no longer provides.
  *

--- a/apps/web/server/ingest/transcript/service.ts
+++ b/apps/web/server/ingest/transcript/service.ts
@@ -141,7 +141,7 @@ export async function confirmTranscriptImport(
       ? await fillTranscriptCourseFields(userId, fillInputs)
       : 0;
 
-  // The other moment #161's ladder can move: an import earns tier 2, and it
+  // The other moment the personalization ladder can move: an import earns 2, and it
   // earns tier 3 outright for somebody who had already reviewed everything on
   // it. It runs even when nothing was inserted, because a confirmation that
   // only filled fields still tells us the stored rows are worth re-reading, and

--- a/apps/web/server/reviews/service.ts
+++ b/apps/web/server/reviews/service.ts
@@ -104,8 +104,9 @@ export async function createReview(
     );
   }
 
-  // Publishing a first review is one of the two moments #161's ladder can move:
-  // it earns tier 1 outright, and it is what completes a transcript for tier 3.
+  // Publishing a first review is one of the two moments the personalization
+  // ladder can move (ADR 0005): it earns tier 1 outright, and it is what
+  // completes a transcript for tier 3.
   // The recompute reads the row this call just committed, raises the column and
   // never lowers it, and swallows its own failures — a review that was
   // published stays published even if the tier write does not land.

--- a/apps/web/server/reviews/unreviewed.ts
+++ b/apps/web/server/reviews/unreviewed.ts
@@ -16,8 +16,7 @@ import type { Review } from "@/types";
  * figure. The server asks the same question of transcript-imported courses to
  * decide personalization tier 3 (`server/graph/tier.ts`). If those two ever
  * disagreed, a member would be told they had finished while the tier said they
- * had not. That is the shape of the duplicated `ReviewDraft` decoder the #134
- * audit found, and one function is how it stays impossible.
+ * had not. One function is how that stays impossible.
  */
 
 /**

--- a/apps/web/server/search/repository.ts
+++ b/apps/web/server/search/repository.ts
@@ -17,7 +17,7 @@ export type SearchHit = {
  * query returns already satisfies it.
  *
  * The service now asks for a window that covers every page up to the one it is
- * serving, plus one row of lookahead (#148). That is still `size` meaning
+ * serving, plus one row of lookahead. That is still `size` meaning
  * `size` — it is a bigger number, not an inflated one — and it works only
  * because this query is *totally* ordered: the three-way bucket, then
  * `ts_rank`, then `courses.code ASC`. A LIMIT over a total order returns a
@@ -96,7 +96,7 @@ export async function searchByKeyword(
  * identical distance may come back in either order between two executions of
  * the same query. Under a plain LIMIT that is invisible — the same set, only
  * shuffled. Under pagination it is a bug: the service pages by slicing one
- * ordered prefix (#148), so a pair that swaps between the fetch for page 2 and
+ * ordered prefix, so a pair that swaps between the fetch for page 2 and
  * the fetch for page 3 puts one course on both pages and the other on neither.
  *
  * `courses.code` is the primary key, so appending it makes the order total, and

--- a/apps/web/server/search/repository.ts
+++ b/apps/web/server/search/repository.ts
@@ -8,21 +8,16 @@ export type SearchHit = {
 };
 
 /**
- * `size` is the LIMIT, exactly. It used to be inflated to `size * 5` whenever a
- * minimum-rating filter was set, because the service thresholded ratings in
- * application code after the query and needed a window wide enough to survive
- * that pass. The rating filter is gone (it was in no artboard), so the window
- * has nothing to absorb: what is asked for is what is fetched. The department
- * filter needs no window at all — it is a SQL predicate below, so every row the
- * query returns already satisfies it.
+ * `size` is the LIMIT, exactly — never inflated to leave room for a filter
+ * applied after the query. Every filter here is a SQL predicate, so every row
+ * the query returns already satisfies it.
  *
- * The service now asks for a window that covers every page up to the one it is
- * serving, plus one row of lookahead. That is still `size` meaning
- * `size` — it is a bigger number, not an inflated one — and it works only
- * because this query is *totally* ordered: the three-way bucket, then
- * `ts_rank`, then `courses.code ASC`. A LIMIT over a total order returns a
- * prefix, so a wider window returns a superset that begins with the narrower
- * one, and page 2 holds the same rows however deep the fetch went.
+ * The service asks for a window covering every page up to the one it is
+ * serving, plus one row of lookahead. That is a bigger number, not an inflated
+ * one, and it works only because this query is *totally* ordered: the three-way
+ * bucket, then `ts_rank`, then `courses.code ASC`. A LIMIT over a total order
+ * returns a prefix, so a wider window returns a superset that begins with the
+ * narrower one, and page 2 holds the same rows however deep the fetch went.
  */
 export async function searchByKeyword(
   query: string,

--- a/apps/web/server/search/router.spec.ts
+++ b/apps/web/server/search/router.spec.ts
@@ -40,7 +40,7 @@ describe("search.courses", () => {
    * if it were the size of the matching set. It is not replaced by a truthful
    * count: a de-duplicated union of a keyword ranking and a semantic one has no
    * count to take, and the semantic leg matches every course with an embedding
-   * at some distance. `hasMore` is what a prev/next pager actually asks (#148).
+   * at some distance. `hasMore` is what a prev/next pager actually asks.
    */
   it("reports whether there is another page, and no total at all", async () => {
     vi.mocked(searchCourses).mockResolvedValue({

--- a/apps/web/server/search/router.ts
+++ b/apps/web/server/search/router.ts
@@ -10,12 +10,10 @@ export const searchRouter = createTRPCRouter({
   /**
    * One page of the catalogue, and whether another one follows it.
    *
-   * `page` used to be accepted and dropped, and the reply carried
-   * `total: results.length` — the size of the page it had just built, offered
-   * as if it were the size of the matching set. Both are gone: `page` is
-   * honoured, and `total` is not replaced by a truthful count because there is
-   * no truthful count to compute over a de-duplicated union of a keyword
-   * ranking and a semantic one. `service.ts` sets out why at length.
+   * There is no `total`, and adding one would mean inventing it: a
+   * de-duplicated union of a keyword ranking and a semantic one has no
+   * truthful count short of running both across the whole catalogue.
+   * `service.ts` sets out why at length.
    *
    * What a prev/next pager actually asks is "is there another page", and
    * `hasMore` answers exactly that, from one extra row rather than a second

--- a/apps/web/server/search/router.ts
+++ b/apps/web/server/search/router.ts
@@ -12,7 +12,7 @@ export const searchRouter = createTRPCRouter({
    *
    * `page` used to be accepted and dropped, and the reply carried
    * `total: results.length` — the size of the page it had just built, offered
-   * as if it were the size of the matching set. Both are gone (#148): `page` is
+   * as if it were the size of the matching set. Both are gone: `page` is
    * honoured, and `total` is not replaced by a truthful count because there is
    * no truthful count to compute over a de-duplicated union of a keyword
    * ranking and a semantic one. `service.ts` sets out why at length.

--- a/apps/web/server/search/service.ts
+++ b/apps/web/server/search/service.ts
@@ -95,8 +95,8 @@ async function searchWithEmbedding(
 /**
  * How deep Explore can page, in pages.
  *
- * This is the one judgement call in #148 rather than something the data
- * dictates. The semantic leg has no relevance floor: its `WHERE` is effectively
+ * A judgement call rather than something the data dictates. The semantic leg
+ * has no relevance floor: its `WHERE` is effectively
  * "has an embedding", so every course in the catalogue is a hit at *some*
  * distance and the LIMIT is the only thing that makes the result a set rather
  * than the catalogue. Page 20 of that is not more results, it is courses sorted
@@ -148,23 +148,17 @@ function clampPage(page: number | undefined): number {
  *
  * ## `department` is the only filter, and it is deliberate
  *
- * There used to be a second one — a minimum-rating dropdown, "at least N
- * stars", thresholding the learning mean. It has been removed. It was in no
- * artboard: `docs/design_ref/2026-09-06/Course Community - Explore.dc.html`
- * draws no filter row at all, and the control was invented to satisfy #89.
- * With no design behind it there was nothing to be right about, so it went
- * rather than staying as a permanent, undesigned deviation.
+ * **A filter this domain cannot express in SQL does not belong here.** A
+ * minimum-rating filter is the tempting one, and it cannot be: the scores live
+ * in the reviews domain, so the threshold would have to be applied after the
+ * query came back, over an over-fetched window — and when more of that window
+ * misses the threshold than the window has slack for, the caller silently gets
+ * fewer results than it asked for with nothing on the wire saying more exist.
+ * `Course Community - Explore.dc.html` draws no filter row at all, so there is
+ * no design asking for one either.
  *
- * It also took a live bug with it. It could not be expressed in SQL — the
- * scores live in the reviews domain, so the threshold was applied here, in
- * application code, *after* the query had come back. To leave something to
- * filter, the query over-fetched `size * 5`. If more than four fifths of that
- * window missed the threshold the caller silently got fewer results than it
- * asked for, with nothing on the wire saying more existed. That failure mode
- * left with the feature, and the over-fetch went with it.
- *
- * `department` stays, and is still a deviation from the artboard — but a cheap
- * and honest one. It filters in SQL (`department ILIKE`, in the repository),
+ * `department` is a deviation from the artboard, but a cheap and honest one. It
+ * filters in SQL (`department ILIKE`, in the repository),
  * so the database does the narrowing, every returned row already satisfies it,
  * and it applies to the whole window rather than to one page. That is what
  * makes it survive paging: page 3 of a filtered search is page 3 of the
@@ -172,9 +166,7 @@ function clampPage(page: number | undefined): number {
  *
  * ## Paging with a lookahead, because there is no total to have
  *
- * `total` used to be returned here as `results.length` — the size of what had
- * just been returned, which is not a total of anything. It is gone rather than
- * corrected, because the honest version cannot be computed:
+ * There is no `total`, and there is no honest one to add:
  *
  * - the result set is the union of two independent rankings, de-duplicated in
  *   application code, so neither leg's count is the answer and the union's
@@ -194,10 +186,10 @@ function clampPage(page: number | undefined): number {
  * It does, for two reasons that have to hold together:
  *
  * - each leg is a LIMIT over a *totally* ordered query, so a wider LIMIT
- *   returns a superset beginning with the narrower one. The keyword leg has
- *   always ended `courses.code ASC`; the semantic leg does now, and #148 is
- *   where that was fixed — ordering on distance alone let equidistant rows
- *   swap between two fetches, which puts a course on two pages or on none.
+ *   returns a superset beginning with the narrower one. Both legs end
+ *   `courses.code ASC`, and the semantic one must: ordering on distance alone
+ *   lets equidistant rows swap between two fetches, which puts a course on two
+ *   pages or on none.
  * - the union of the two is itself prefix-stable. Where the keyword leg fills
  *   the window, the first `size` rows *are* keyword rows and the semantic leg
  *   cannot reach them; where it does not fill the window, it is exhausted and

--- a/apps/web/types/course-card.ts
+++ b/apps/web/types/course-card.ts
@@ -17,7 +17,7 @@
  * its buttons read "Add to comparison" / "Create new comparison". `CONTEXT.md`
  * bans "comparison" in identifiers and #68's settled decision 1 goes further:
  * there is no AI-comparison feature to name, so the word goes from the copy as
- * well. Identifier and label both say **Collection** (#90).
+ * well. Identifier and label both say **Collection**.
  */
 
 /**

--- a/apps/web/vitest.config.ts
+++ b/apps/web/vitest.config.ts
@@ -35,8 +35,7 @@ export default defineConfig({
           environment: "jsdom",
           // `components/**` is here because `components/ui/confirm-dialog.tsx`
           // is app UI with real behaviour to test, not a vendored shadcn
-          // primitive: it moved up from `features/collections/` when a third
-          // screen needed it, and its suite has to move with it.
+          // primitive.
           include: ["features/**/*.spec.tsx", "components/**/*.spec.tsx"],
           setupFiles: ["./vitest.setup.ts"],
         },


### PR DESCRIPTION
Closes part of #191 — the comment audit itself. 93 files, comments only.

**This is not a ratio result and the number is not the point.** Density across `apps/web` went 23.1% → 22.9%. Several of the heaviest files are *unchanged or barely changed* because they are heavy for good reasons, and one file got *longer*. What moved is the number of comments asserting a fact that nothing checks.

## Comments-only: how it was verified

Every changed file was run through the TypeScript compiler with `removeComments: true` (CSS through an exact block-comment scan), the output whitespace-collapsed, and the result compared between `dev` and this branch. **93 of 93 files produce byte-identical code.** The checker was itself sanity-checked by appending `export const __probe = 1;` to a file and confirming it reported `CODE CHANGED`.

## What was cut, by category

### 1. Stale facts — comments that were already wrong (8 files)

The expensive kind. Each was verified against the code or the current artboard before being touched.

| Comment | Reality |
| --- | --- |
| `globals.css`: "the artboards carry 22 inline `outline:none` declarations" | The 2026-09-06 export carries **25**. Same failure mode as the `globals.css` count named in the #191 thread. |
| `explore.tsx`: "`search.courses` … reports `total` as the length of that page" | There is no `total` on that reply at all. The comment described a shape the code had left behind. |
| `my-page.tsx`: "no longer redirected away by a proxy … the stale-cookie case that used to be the only way to reach this branch" | There is no `proxy.ts`. Nothing gates the route. (It also contained a literal `no no`.) |
| `course-card-item.tsx` + `features/courses/index.ts`: "Saved and Collections pin an end" of the card ramp | Neither does. `saved.tsx` computes `courseCardGeometry(resultsWidth)`; `collection-detail.tsx` takes a measured `geo`. `card-geometry.ts` already warned that naming screens is how these drift — and they had. |
| `reviewer-session.ts`: "the round-level refusals **below**" | They are above. |
| `saved.tsx`, `globals.css` ×2: cited the **2026-09-05** export | Re-read against 2026-09-06. All three claims still hold; re-cited by artboard name. |
| `collections.tsx:524`/`:553` cited from `globals.css` | Already nine lines out. |

### 2. Artboard and source line citations — 40 removed, 0 remain

`#191` names these specifically: they have gone stale at *every* export, and because artboards are revised rather than moved, a stale one is wrong about the design and not merely about the path. Every `.dc.html:NNN`, `(line NNN)` and bare `` `:NNN` `` is gone from `apps/web`. The artboard name stays, and so does the identifier inside it where that was doing the work — `toExplore()`, `pageLabel`, `savedLabel`, `pendingImport`, `searchBarMargin`, `runImport`.

Before: `` (`Course Community - Explore.dc.html:264`, whose `pageLabel` is built at :1289) ``
After: `` (its `pageLabel`) ``

### 3. Issue numbers used as explanation — 184 → 52

An issue number appended to a standing statement says which PR made the code this shape, not why the shape is right. 54 bare `(#NNN)` attributions were stripped mechanically; the rest were rewritten sentence by sentence.

**`#68` is kept everywhere — all 47 of them.** The binding frontend product calls live in that issue's comments, so `#68 §5` points at a live decision, not at history. `#87` is kept in `examination-palette.ts` for the same reason.

Where a reference stood in for a decision that has since been written down, it now points at the decision: `docs/adr/0005-personalization-tier-earning.md` replaces `#161` in `tier.ts`, `reviews/service.ts`, `ingest/transcript/service.ts` and `graph/repository.ts`.

The 52 that remain are almost all in `*.spec.*` files, where the number identifies the regression the test pins. Those are provenance for an assertion rather than explanation of a shape, and #191's rubric is about the latter.

### 4. History narration (≈30 passages)

Before: *"This file used to hold a byte-identical copy of `useTakenCourses`, and that was not a tidiness problem: …"*
After: *"…re-exported rather than re-declared: a second declaration is a second `useQuery` call site with its own cache entry, so My Page and the course card would fetch `taken.list` twice and could disagree about the answer."*

The consistent move is **from anecdote to rule**, because a rule survives the next change and an anecdote does not:

- `review-draft.ts`: "Both old copies started `{ ...EMPTY_REVIEW_DRAFT, ... }`…" → "Do not spread it, and here is what a spread costs."
- `dialog.tsx`: "There used to be an `sm:max-w-sm` beside it, and it was a trap" → "**Do not add a responsive clamp beside it**", with the tailwind-merge mechanics intact.
- `review.tsx`: "It used to be `max-w-4xl min-w-3xl`, and the floor was the bug" → "Do not add a `min-w-*` floor beside it", with the CSS precedence and the phone symptom intact.
- `reviewer-session.ts`, `guest-saves.ts`, `use-guest-saves.ts`, `guest-proposal.ts`, `open-courses.ts`, `use-explore.ts`, `saved.tsx`, `workspace-storage.ts`: same treatment.

### 5. Refactor predictions (#190 item 8)

`features/collections/index.ts` predicted that a third screen needing `ConfirmDialog` should move it to `components/ui/`. A third screen arrived and built a near-verbatim copy anyway. The move has since happened — and the prediction, *plus the story of it being missed*, had been restated in four files. All four now state the rule that still binds (the shell is one component; do not build a second) and none tells the story.

**Two forward-looking comments were removed rather than rewritten. They should become issues:**

1. `components/ui/confirm-dialog.tsx` — "`AlertDialogContent` still carries the `sm:max-w-sm` clamp; removing it is a change to a shared primitive that belongs in its own PR". The *trap* is kept and stated at both `confirm-dialog.tsx` and `alert-dialog.tsx`; only the promise of a future PR is gone.
2. `components/ui/alert-dialog.tsx` — "which vendored shadcn primitives should this repo still carry is one question about 37 files … see the follow-up issue". No such issue is findable from the comment. The file's real, checkable fact — it has no consumer — is kept.

### 6. The same explanation in several files

The `--cc-danger-tint`-not-`color-mix` argument appeared in full in `collection-chip.tsx`, `collection-tile.tsx`, `explore.tsx` and `feedback-form.tsx`. It now lives once, in the `globals.css` panel-tint block; the call sites state the rule in a line and point there. Same for the removed rating filter, whose lesson (a filter this domain cannot express in SQL breaks paging) is stated once in `server/search/service.ts`.

## What was deliberately kept

**The three files #191 defends.** Cuts in them are small and each is defensible:

- **`features/landing/lib/hero-keepout.ts`** — one paragraph, the retired synthetic-dot field. Everything else stays, including the closest-pair measurements (3.35px → 0.35px), the `(400, 235.999999)` collapse, the `PUSH_EPSILON` floating-point argument, and the "known residue, do not read the radial path as a guarantee" warning.
- **`features/landing/lib/neighbourhood-view.ts`** — the scale/anchor history compressed into the proof that survives it (`screen(p) − screen(q) = (p − q) · s`); a commit SHA dropped from the `ANCHOR_COMFORT` note while its 1920×600 / 360×480 measurements stay. The `VIEW_SCALE` density argument, the "no density policy" statement and the #68 supersession are untouched.
- **`server/graph/tier.ts`** — three edits, all citation swaps to ADR 0005. The ladder, the highest-rung-wins reasoning and the non-monotonicity paragraph are untouched. The ladder table is technically a second copy of ADR 0005, and it stays: it is the rule a reader of `deriveEarnedTier` needs at the call site, and ADR 0005 itself says the asymmetry is written at the rule, the writer and the repository on purpose.

**Traps, kept and strengthened.** `review-draft-panel.tsx`'s `peer-focus-visible` ring and `workspace-pane.tsx`'s `focus:bg-cc-pill` menu highlight both now open **"Do not remove this as a duplicate"** instead of citing a sweep's PR number — so the warning no longer depends on knowing what that PR was.

**External constraints, untouched.** The HNSW approximation caveat and the total-order prefix-stability argument in `server/search/`; the tailwind-merge group split; `schema.ts`'s `ALTER TYPE … ADD VALUE` note.

**Whole files left alone** because every line earns its place: `features/saved/api/mutations.ts` (the unsave→`collection_courses` cascade is invisible from the client and nothing but a comment can say so), `features/shell/components/search-morph.tsx` (spring constants derived from ζ and ω), `features/workspace/hooks/use-workspace-pane.ts` (why `hydrated` is state and `read` is a ref — opposite answers, and swapping them is the bug at both ends), `server/http/rate-limit.ts` and `app/api/user/transcript/route.ts`, `features/taken/lib/guest-proposal.ts`'s capability argument.

## Left alone pending an unanswered product question

**Which personalization axis each tier unlocks.** `server/graph/appearance.ts` says the pairing "was settled by the product owner on 2026-09-05: the rendered My Page artboard wins". ADR 0005 says the axis half of #161 is **still open** and that the code follows the rendered list *provisionally*. Both cannot be current. Every factual claim in that comment was re-verified against the 2026-09-06 export and all of them hold — the artboard draws `mk(1, "Dot color")`, `mk(2, "Dot style")`, `mk(3, "Signal on click")`, and `cc-store.js` still says `TIER_AXES = { 1: "color", 2: "signalStyle", 3: "style" }` — so the comment is accurate about the artboards and possibly wrong about the status. Resolving that is a product call, so **the comment is untouched**. ADR 0005 flags this as urgent now that members can actually reach tiers 1–3.

## Out of scope, reported not fixed

1. **`useRequireSession` has no non-test consumer.** `features/auth/hooks/session.ts` exports it, `features/auth/index.ts` re-exports it, and the only references left in `apps/web` are two spec files mocking it. It is the last of the client-side route gating. Dead code.
2. **ADR 0003 has gone out of date about "guest".** It states that *"the code already respects this line — 'guest' and 'member' appear only in copy, never as an identifier"*. That is no longer true: `useGuestSaves`, `toggleGuestSave`, `GuestImportState`, `GUEST_SAVE_PREFIX`, `guestReads`, `guestParses`, `guest-saves.ts` and `guest-proposal.ts` are all identifiers, and `CONTEXT.md` lists "guest" under **Visitor**'s `_Avoid_`. Either the glossary or the identifiers should move.
3. **`components/ui/chart.tsx` and `components/ui/alert-dialog.tsx` have no consumers.** Both are noted in comments; neither is imported anywhere in `apps/web`.
4. **Pre-existing `TODO`s in `apps/web/types/course.ts`** (`examTypes` "currently just a placeholder", "consider if we actually need both department and code") predate the reconciliation and are forward-looking in the way #190 item 8 warns about. Left alone under "when in doubt, keep" — they are honest markers of known gaps rather than predictions of a refactor, but they would be better as issues.

## Checks

```
$ bun run lint
Checked 427 files in 627ms. No fixes applied.
Found 8 warnings.        # exit 0
```

All 8 warnings are in `.agents/skills/neon-drizzle/` (`generate-schema.ts`, `run-migration.ts`, `db-http.ts`, `db-websocket.ts`, `drizzle-config.ts`, `schema-example.ts`) — files this branch does not touch. Pre-existing.

```
$ bun run test:web
Test Files  89 passed (89)
     Tests  1298 passed (1298)
  Duration  52.46s        # exit 0
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Qa1QZe2qHEVaYJqweThoEY
