### PR TITLE
docs(graph): settle the hero's travelling signals in the glossary and an ADR

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -159,6 +159,14 @@ draws **signals** travelling along it, which ADR 0006 settles as a deliberate
 dramatisation and not a claim about the data.
 _Avoid_: friendship, connection, follow, link, relationship
 
+**Graph window**:
+The bounded slice of the **community graph** a surface draws: a limited set of
+nodes and the **backbone edges** that run between them. A member's window is
+centred on their own node and is the one place "neighbourhood" means; a
+visitor's is centred on the community origin. It is derived per read and never
+stored, and an edge with one end outside it is not part of it.
+_Avoid_: viewport, camera, subgraph, cluster
+
 **Node profile**:
 A node's appearance, stored separately from graph topology.
 _Avoid_: avatar, skin, theme
@@ -178,9 +186,11 @@ the style; the edge carries the signal.
 _Avoid_: signal type, trail, effect
 
 **Burst**:
-The fan of signals a node sends along every one of its **backbone edges** at
-once, because somebody clicked it. Every node bursts; the tier decides only what
-its signals look like, never whether they go.
+The fan of signals a node sends at once, along every **backbone edge** it has
+within the drawn **graph window**, because somebody clicked it. A node near the
+window's rim is attached to nodes outside it; those edges are not part of the
+window and the burst does not reach them. Every node bursts; the tier decides
+only what its signals look like, never whether they go.
 _Avoid_: explosion, broadcast, emit, ripple
 
 **Personalization tier**:

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -154,7 +154,9 @@ _Avoid_: parent, host, neighbour
 **Backbone edge**:
 The stored attachment between a node and its anchor. Its direction records
 placement history — newer to older — and the UI may draw it undirected. It is
-not a friendship and carries no social meaning.
+not a friendship and carries no social meaning. The landing hero nonetheless
+draws **signals** travelling along it, which ADR 0006 settles as a deliberate
+dramatisation and not a claim about the data.
 _Avoid_: friendship, connection, follow, link, relationship
 
 **Node profile**:
@@ -162,18 +164,24 @@ A node's appearance, stored separately from graph topology.
 _Avoid_: avatar, skin, theme
 
 **Signal**:
-The moving trail rendered along a node. A visual state, never a stored event.
-A signal is ongoing: a node either carries one or it does not. A **one-shot
+A trail of light travelling along a **backbone edge**, from one node to the node
+at its other end. A visual state and never a stored event: nothing about a
+signal is written anywhere and none of it outlives the frame. A **one-shot
 reveal** — the ring **Find your dot** draws once on the viewer's own node — is a
-different thing, and *pulse* is its name. So `scene.pulse` is not a signal by
-another word, and the two are not interchangeable.
-_Today_: it does not move. `users_node_profiles.signal_style` stores the axis and
-`hero-network.tsx` draws each style standing still, because that canvas paints
-when an input changes rather than every frame and the pulse is the only frame
-loop it has. The ongoing/one-shot distinction still holds — a signal is painted
-whenever its node is, a pulse only while the label is up. Closed by whatever
-gives the hero a bounded loop a signal can ride on.
-_Avoid_: ping, animation, activity
+different thing, and *pulse* is its name. The two are not interchangeable.
+_Avoid_: ping, animation, activity, message
+
+**Signal style**:
+The shape of the wake a node's signals leave behind them. A **node profile**
+axis, the third and last one a **personalization tier** unlocks. The node owns
+the style; the edge carries the signal.
+_Avoid_: signal type, trail, effect
+
+**Burst**:
+The fan of signals a node sends along every one of its **backbone edges** at
+once, because somebody clicked it. Every node bursts; the tier decides only what
+its signals look like, never whether they go.
+_Avoid_: explosion, broadcast, emit, ripple
 
 **Personalization tier**:
 How far an app user has unlocked node personalisation, held as the highest value

--- a/docs/adr/0006-hero-signals-dramatise-the-community.md
+++ b/docs/adr/0006-hero-signals-dramatise-the-community.md
@@ -1,0 +1,89 @@
+# 6. The landing hero dramatises backbone edges as social exchange
+
+Date: 2026-09-06
+
+## Status
+
+Accepted. Reverses the reasoning written into `hero-network.tsx`'s header at
+#192, and supersedes the `_Today_` clause on **Signal** in `CONTEXT.md`, which
+this closes.
+
+## Context
+
+`docs/design_ref/2026-09-06/Course Community - Landing.dc.html` specifies a live
+hero: nodes drifting inside a small box around their own position, signals
+travelling along edges, and a click fanning one out along every edge a node has
+(`burst`, :1140, "A student passing their recommendation to everyone they are
+connected to"). `Course Community - My Page.dc.html:715` ties the third
+personalization tier to exactly that — "Refer friends to unlock a signal that
+goes out from your node."
+
+None of it was carried through. #68's reconciliation retired the artboard's
+synthetic Halton field in favour of the real stored graph, which was right, and
+the implementation then dropped the motion as a consequence of that, which was
+not asked for. `hero-network.tsx` argues the drop at length: once the dots are
+real people, a signal along a **backbone edge** would give it "a social meaning
+the data does not have", and a travelling signal means a frame loop that never
+stops.
+
+The result is a still landing page and a third personalization tier — the only
+axis a member reaches by reviewing their entire transcript — whose reward is a
+static ring nobody can tell from a slightly different dot. `CONTEXT.md` recorded
+this as an open gap rather than a settled position: "Closed by whatever gives the
+hero a bounded loop a signal can ride on."
+
+The product owner has settled it: the motion ships, in the artboard's own style.
+
+## Decision
+
+**The hero draws signals travelling along backbone edges, and this is a
+dramatisation we are choosing on purpose.** The edge is not a friendship, in the
+data or in `CONTEXT.md`, and nothing here writes a row, reads a relationship, or
+tells a visitor who knows whom. What the canvas asserts is only that this is a
+community and things move through it, which is true. The alternative — a still
+graph, honest to the point of being inert — was tried for a release and made the
+landing page's most expensive feature indistinguishable from a background image.
+
+Three consequences are load-bearing:
+
+**The frame loop is bounded by gates, not by having nothing to draw.** The old
+design's guarantee was "the scene is painted once"; the new one is a loop that
+runs only while the hero is visible, un-paused, un-hidden, and motion is allowed.
+That is a weaker guarantee and it is the price.
+
+**Every node signals; the tier only picks the style.** Exactly as with colour and
+shape, an unconfigured node draws the default. Gating the signal itself on tier 3
+would have made the feature invisible on a community where personalisation has
+close to no writers, which is the situation #68 recorded and accepted.
+
+**A friendship must never be drawn as an edge on this canvas, and must never emit
+a signal.** `docs/landing_docs/personal-community-viewport.md` defers a real
+friend feature whose mechanism is a "wormhole" that *moves the camera* to a
+friend's neighbourhood without touching either user's placement or backbone
+connections. That language — camera movement, not travelling light — stays
+available and distinct only if nobody later reaches for the obvious brighter
+edge. This decision spends the vocabulary of exchange on the backbone edge, and
+the friend feature must use the vocabulary of travel instead.
+
+## Considered and rejected
+
+**Click-burst only, no ambient traffic.** Preserves the paint-on-demand canvas
+and confines the dramatisation to a gesture the visitor chose. Rejected because a
+4px dot on a canvas that advertises nothing is not discoverable, so in practice
+the feature would ship to nobody and the landing page would stay inert.
+
+**Carrying the artboard's `INSIGHTS` payload.** The export gives each signal a
+course code and a line of advice (:620). Rejected: it is invented review text,
+which is the production mock data #134 forbids and #68 deleted the newsletter
+for. It is also vestigial in the export itself — `closeCard()` and
+`scheduleClose()` (:1400-1402) are empty stubs and nothing ever draws the note —
+so a signal that carries nothing is faithful to the artboard as shipped. Real
+review prose on an unauthenticated page is a privacy question, and a separate
+one.
+
+**Porting the export's `Math.random()` sampling.** The artboard seeds drift from
+a stable per-node hash but samples spawn, speed and the relay coin from
+`Math.random()`. We seed all of it from node and edge identity, so the engine is
+a pure function of the view and elapsed time. This is a deliberate improvement,
+not an accident of translation: it is what makes the traffic assertable in a
+test, reproducible across a reprojection, and quotable in a bug report.


### PR DESCRIPTION
Documentation only — no code. This is the settled half of #203, so that the implementation branch has something to cite instead of re-deciding.

## Why

The `2026-09-06` export specifies a living hero: nodes drifting in a small box around their own position (`Course Community - Landing.dc.html:1200-1227`), signals travelling along edges, and a click fanning one out along every edge a node has (`burst`, :1140). `Course Community - My Page.dc.html:715` ties the third personalization tier to exactly that — *"Refer friends to unlock a signal that goes out from your node."*

None of it was carried through. #68 retired the artboard's synthetic field in favour of the real stored graph, which was right, and the motion was dropped as a side effect of that, which was never asked for. The result is an inert landing page and a tier 3 — the axis a member reaches only by reviewing their **entire transcript** — whose reward is a static ring most people cannot tell from a slightly different dot.

`CONTEXT.md` recorded this as an open gap rather than a settled position: *"Closed by whatever gives the hero a bounded loop a signal can ride on."* The product owner has now settled it, and this is that closure.

## What changes

**`CONTEXT.md`**

- **Signal** rewritten as a trail travelling *along a backbone edge*, not "along a node". The `_Today_` clause is deleted outright — the gap it recorded is closed by the decision, not documented by it.
- **Signal style** added as its own entry, so *"the node owns the style; the edge carries the signal"* is stated rather than inferred. The export names this axis three different ways (`NODE_SIGNAL_STYLES`, `TIER_AXES`, `DOT_SIGNALS`) and the confusion is worth foreclosing.
- **Burst** added. It is user-facing copy on My Page, not just a function name in the artboard.
- **Backbone edge** gains one clause pointing at the ADR, so the glossary's own "not a friendship" line does not read as contradicting the hero.

**`docs/adr/0006-hero-signals-dramatise-the-community.md`** — new.

## The three things in the ADR worth reading before approving

**The frame-loop guarantee gets weaker, deliberately.** The old design's promise was "the scene is painted once". The new one is a loop gated on four conditions — hero visible, not paused, not hidden, motion allowed. That is the price of the feature and the ADR says so rather than glossing it.

**Every node signals; the tier picks only the style.** Gating the signal itself on tier 3 would have made the feature invisible on a community where #68 recorded personalisation as having close to zero writers.

**It reserves vocabulary for a feature that does not exist yet.** `docs/landing_docs/personal-community-viewport.md` defers a friend feature whose mechanism is a "wormhole" that *moves the camera* without touching anyone's placement or backbone connections. Since this PR spends the language of travelling light on the backbone edge, the ADR records the constraint that falls out: **a friendship must never be drawn as an edge on this canvas, and must never emit a signal.** Without writing that down now, the natural instinct later is a brighter edge, and the distinction dies quietly.

The ADR also records what was rejected and why — click-burst only, the artboard's `INSIGHTS` payload, and its `Math.random()` sampling — so none of the three gets re-proposed as an improvement in six months.

## Follow-up, not in this PR

#203 carries the implementation: `features/landing/lib/hero-signals.ts`, the drift, the three producers, the four trail geometries, pointer events on the canvas, the loop gates, and rewriting the three places that currently argue for the opposite decision (`hero-network.tsx:33-47`, `hero-network.spec.tsx:7-19`, `neighbourhood-view.ts:45-51`). Those rewrites belong with the code that makes them true, not here.

## Note for whoever merges

ADR **0007** (workspace tabs, #201) is being written concurrently on another branch and also touches `CONTEXT.md` — a **School** entry, in a different section. The numbering does not collide. Whichever of the two merges second needs a trivial rebase.

Closes nothing on its own. Refs #203.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015NfoMyi4cztYt5USkxSXhs
