### PR TITLE
fix(workspace): page-scoped tabs, and level tab strips across Explore and Saved

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -55,6 +55,19 @@ The full source prose stating who may take a course, kept verbatim in
 `courses.eligibility`. Authoritative where a prerequisite edge is only a hint.
 _Avoid_: prerequisites, requirements text
 
+**School**:
+The KTH school that owns a course, as KOPPS reports it — `department.name` on
+the course detail, ingested into `courses.department`. It is the reader's word
+for it: Explore's filter is `aria-label="School"` and offers "All schools".
+
+This is the one entry that runs the other way round, and deliberately. The
+identifier stays `department` — the column, the `department ILIKE` the search
+filter runs, and the field on the wire — because that is KOPPS's own name for it
+and renaming it would buy a word no reader ever sees. So School in copy,
+`department` in code, and this is a settled mapping rather than a _Today_: no
+migration closes it.
+_Avoid_: faculty, institution, division — in either.
+
 ### A user's courses
 
 Saving, taking and reviewing are three independent relationships. None implies

--- a/apps/web/app/globals.css
+++ b/apps/web/app/globals.css
@@ -447,6 +447,49 @@
   --cc-rail-btn-fg: #0a2449;
 }
 
+/* The height of Explore's search block, and the one number that keeps the two
+   workspace hosts' tab strips level.
+
+   Explore puts a search block between its `PageHeader` and the row the pane
+   sits in; Saved puts nothing there. The strip lives in that row on both pages,
+   so whatever the block measures is exactly how far Saved's strip sits above
+   Explore's — it was 118px. Making them agree means one side reserving what the
+   other spends, and a literal on each side is a pair that drifts the first time
+   either is edited. So Explore takes this as its block's **height** and Saved
+   takes the same token as its row's **padding-top**, and neither number can
+   move without the other.
+
+   74px is the Explore artboard's own search row: `padding:18px 24px 14px`
+   around a 42px bar. The block reached 118px here by carrying a second row —
+   the school filter, which the artboard does not draw at all — and that row
+   moves up beside the bar rather than the artboard's figure being adjusted.
+   Both sides are `@3xl` only, which is where the pane is a column and there are
+   two strips to level; the narrow layout keeps its stack and reserves nothing.
+
+   The width below is here for the same reason and buys the same thing across a
+   different seam. The landing's hero bar and Explore's are one element as far as
+   the reader is concerned — `search-morph.tsx` animates the second out of the
+   first — and it animates `translate3d` only, never width. Two literals that
+   disagreed would make the bar snap at the moment of arrival, which is precisely
+   the seam the hand-off exists to hide.
+
+   460 rather than the artboards' 560 buys clearance from the pane's divider, now
+   that the tab strip starts directly beneath the bar. It does not buy *all* of
+   it, and the shortfall is measured rather than assumed: with the row centred on
+   the viewport and the pane at its 504px default, the bar's right edge overhangs
+   the divider by a constant 48px at every width the content column is capped at
+   — 98px before this change. Closing it completely would take a 364px bar, which
+   is a smaller field than anyone has asked for. 460 is the authorised number and
+   the overhang is a known, bounded 48px.
+
+   Both are declared here rather than in the `:root` above because that block is
+   a verbatim mirror of `docs/design_ref/2026-09-06/cc-theme.css`, which names
+   colours only. These are layout constants with no line there to mirror. */
+:root {
+  --cc-search-block-h: 74px;
+  --cc-search-bar-w: 460px;
+}
+
 @layer base {
   * {
     @apply border-border outline-ring/50;

--- a/apps/web/features/landing/components/landing.tsx
+++ b/apps/web/features/landing/components/landing.tsx
@@ -433,7 +433,15 @@ export function Landing() {
                 height and the bar on the same 400px — only the copy above it
                 moves, which is the point: the artboard's 19 read too tight in
                 the built page. The 97 is still what the artboard says, and this
-                is knowingly 12 off it. */}
+                is knowingly 12 off it.
+
+                The cap is `--cc-search-bar-w`, the token Explore's own bar
+                takes its width from, and not the artboard's 560. The two have to
+                be the same number: `search-morph.tsx` animates the arriving bar
+                with `translate3d` alone and never interpolates its width, so a
+                hero bar wider than the one it turns into would snap narrower at
+                the moment of arrival — the one seam the hand-off exists to hide.
+                Only a cap is set here; the bar is still `w-full` below `@lg`. */}
             <form
               ref={barRef}
               data-hero-clear
@@ -441,7 +449,7 @@ export function Landing() {
                 event.preventDefault();
                 submitSearch(query);
               }}
-              className="mt-4 @lg:mt-[31px] flex h-[42px] w-full @lg:max-w-[560px] items-center gap-2.5 rounded-[10px] border border-cc-rule3 bg-cc-surface px-3.5"
+              className="mt-4 @lg:mt-[31px] flex h-[42px] w-full @lg:max-w-[var(--cc-search-bar-w)] items-center gap-2.5 rounded-[10px] border border-cc-rule3 bg-cc-surface px-3.5"
             >
               <Search
                 size={16}

--- a/apps/web/features/saved/components/saved.spec.tsx
+++ b/apps/web/features/saved/components/saved.spec.tsx
@@ -879,4 +879,63 @@ describe("Saved", { timeout: 20_000 }, () => {
       ).toBeVisible();
     });
   });
+
+  /**
+   * The space this page holds for a block it does not have.
+   *
+   * Explore spends `--cc-search-block-h` on its search block between the header
+   * and the row the workspace pane sits in; this page puts nothing there. The
+   * tab strip lives in that row on both, so without the reservation the two
+   * strips started 74px apart - 118px before Explore's block came down to one
+   * row. Both sides read the one token, so neither can be edited to a literal
+   * without the other noticing.
+   *
+   * jsdom lays nothing out, so this reads the declaration rather than the
+   * pixels, as `workspace-pane-host.spec.tsx` does for its own `@3xl` gate.
+   */
+  describe("the space above the row", () => {
+    function row() {
+      return screen.getByTestId("saved-results").parentElement;
+    }
+
+    it("reserves what Explore spends on its search block", () => {
+      saved("DD2380");
+      render(<Saved />);
+
+      expect(row()).toHaveClass("@3xl:pt-[var(--cc-search-block-h)]");
+    });
+
+    /**
+     * Permanent, not conditional on tabs being open: a page that jumped down
+     * 74px when the reader opened their first tab would be worse than 74px of
+     * quiet space, and it would move the collections strip under a reader
+     * mid-scroll.
+     */
+    it("holds the space whether or not anything is open", async () => {
+      saved("DD2380");
+      render(<Saved />);
+      expect(row()).toHaveClass("@3xl:pt-[var(--cc-search-block-h)]");
+
+      await userEvent.click(
+        within(cardFor("DD2380")).getByRole("button", {
+          name: /Artificial Intelligence/,
+        }),
+      );
+
+      expect(screen.getByTestId("workspace-pane-host")).toBeInTheDocument();
+      expect(row()).toHaveClass("@3xl:pt-[var(--cc-search-block-h)]");
+    });
+
+    /**
+     * `@3xl` is `WorkspacePaneHost`'s own condition. Below it the workspace is a
+     * sheet, there is no side-by-side column and no tab strip to line up with,
+     * and 74px of blank costs real height on a phone.
+     */
+    it("gives the space up where there is no tab strip to line up with", () => {
+      saved("DD2380");
+      render(<Saved />);
+
+      expect(row()).not.toHaveClass("pt-[var(--cc-search-block-h)]");
+    });
+  });
 });

--- a/apps/web/features/saved/components/saved.spec.tsx
+++ b/apps/web/features/saved/components/saved.spec.tsx
@@ -937,5 +937,19 @@ describe("Saved", { timeout: 20_000 }, () => {
 
       expect(row()).not.toHaveClass("pt-[var(--cc-search-block-h)]");
     });
+
+    /**
+     * The same query Explore spends its block on — unqualified, so it resolves
+     * against `PageColumn` rather than against the shell's named container. The
+     * rail's `@3xl/shell` is a whole rail width of viewport away from this one,
+     * and a reservation made on that threshold would part company with Explore
+     * between roughly 1004 and 1024px. See `explore.tsx` for the measurements.
+     */
+    it("reserves on the pane's threshold, not the rail's", () => {
+      saved("DD2380");
+      render(<Saved />);
+
+      expect(row()).not.toHaveClass("@3xl/shell:pt-[var(--cc-search-block-h)]");
+    });
   });
 });

--- a/apps/web/features/saved/components/saved.tsx
+++ b/apps/web/features/saved/components/saved.tsx
@@ -141,7 +141,7 @@ export function Saved({ openCollectionId = null, openCourse = null }: Props) {
   const containerRef = useRef<HTMLDivElement>(null);
   const rowRef = useRef<HTMLDivElement>(null);
   const presentation = useWorkspacePresentation(containerRef);
-  const workspace = useWorkspacePane();
+  const workspace = useWorkspacePane("saved");
   const [resultsRef, resultsWidth] = useResultsWidth();
   const geo = courseCardGeometry(resultsWidth);
 

--- a/apps/web/features/saved/components/saved.tsx
+++ b/apps/web/features/saved/components/saved.tsx
@@ -96,6 +96,13 @@ const SAVED_HEADING_ID = "saved-courses-heading";
  * owns the page's only scroll would clip a long collection instead.
  * `resultsMax` is computed by the artboard and never read by its
  * markup, so there is nothing to follow.
+ *
+ * The 236px it shortens by is the **rail's width**, which is what the same
+ * number means in the Explore artboard's `searchBarMargin` — but the two do
+ * different things with it. Explore's row is centred, so a right margin moves
+ * its bar; this block is left-aligned, so the margin only takes width off its
+ * right-hand end. Either way nothing is built from it here, because the strip is
+ * inside the column the pane already narrows.
  */
 type Props = {
   /**
@@ -272,10 +279,28 @@ export function Saved({ openCollectionId = null, openCourse = null }: Props) {
         subtitle="Keep track of courses you are interested in and organize them into collections."
       />
 
-      {/* The artboard's row: the results column, and the pane beside it. */}
+      {/*
+        The artboard's row: the results column, and the pane beside it.
+
+        The top padding is space this page does not use, held so that its tab
+        strip starts level with Explore's. Explore spends exactly
+        `--cc-search-block-h` on a search block between its header and this row;
+        this page has nothing to put there, and without the reservation the two
+        strips began 74px apart.
+
+        **Permanent, not conditional on tabs being open.** A page that jumped
+        down 74px when the reader opened their first tab would be a worse defect
+        than 74px of quiet space, and it would move the collections strip under
+        a reader mid-scroll.
+
+        Gated to `@3xl`, which is `WorkspacePaneHost`'s own condition. Below it
+        the workspace is a sheet, there is no side-by-side column and no tab
+        strip to line up with anything, and 74px of blank costs real height on a
+        phone.
+      */}
       <div
         ref={rowRef}
-        className="flex min-h-0 flex-1 gap-[18px] px-7 pb-5 @max-[440px]:px-[14px]"
+        className="flex min-h-0 flex-1 gap-[18px] px-7 pb-5 @3xl:pt-[var(--cc-search-block-h)] @max-[440px]:px-[14px]"
       >
         <div
           ref={resultsRef}

--- a/apps/web/features/search/components/explore.spec.tsx
+++ b/apps/web/features/search/components/explore.spec.tsx
@@ -1056,4 +1056,116 @@ describe("Explore", () => {
       expect(bar()?.style.transform).toBe("");
     });
   });
+
+  /**
+   * Where the search block leaves the tab strip.
+   *
+   * Explore and Saved both host the workspace pane, and the strip sits in the
+   * row each of them puts below its header. Explore spends a search block on
+   * the way there and Saved spends nothing, so the strips started 118px apart.
+   * The block is one row now, and both pages measure the same token — Explore
+   * as height, Saved as padding — so neither number can move without the other.
+   *
+   * jsdom lays nothing out, so these read the declarations rather than the
+   * pixels. That is the same bargain `workspace-pane-host.spec.tsx` makes for
+   * the `@3xl` gate, and it catches the thing that actually breaks: one side
+   * being edited to a literal.
+   */
+  describe("the search block", () => {
+    function block() {
+      return screen.getByLabelText("Search courses").closest("search");
+    }
+
+    function bar() {
+      return screen.getByLabelText("Search courses").closest("form");
+    }
+
+    it("is one row, at the height Saved reserves for it", () => {
+      render(<Explore />);
+
+      expect(block()).toHaveClass(
+        "@3xl:h-[var(--cc-search-block-h)]",
+        "@3xl:flex-row",
+      );
+    });
+
+    /**
+     * Only where there is a pane to line up with. Below `@3xl` the workspace is
+     * a sheet, Saved reserves nothing, and the block keeps the two-row stack it
+     * has always had — a phone measured with the row forced on it put the search
+     * field at 128px to keep a filter beside it.
+     */
+    it("keeps its own stack where there is no tab strip to line up with", () => {
+      render(<Explore />);
+
+      expect(block()).toHaveClass("flex-col");
+      expect(block()).not.toHaveClass("h-[var(--cc-search-block-h)]");
+    });
+
+    it("puts the school filter in the row rather than under it", () => {
+      render(<Explore />);
+
+      const row = block();
+      expect(row).not.toBeNull();
+      expect(row).toContainElement(bar());
+      expect(row).toContainElement(screen.getByLabelText("School"));
+      // Siblings in the row, not the bar's own children: a filter is its own
+      // committed choice and there is nothing here for a submit to gather.
+      expect(bar()).not.toContainElement(screen.getByLabelText("School"));
+    });
+
+    /**
+     * 236px is the rail's width, so a right margin of it on a centred row puts
+     * the bar on the viewport's centre line instead of the centre of the column
+     * beside the rail. Gated to `@3xl` because that is where the rail itself
+     * appears — below it there is nothing to compensate for.
+     */
+    it("shifts left by the rail's width, only where there is a rail", () => {
+      render(<Explore />);
+
+      expect(block()).toHaveClass("@3xl:mr-[236px]");
+      expect(block()).not.toHaveClass("mr-[236px]");
+    });
+
+    /**
+     * The bar is centred, not the bar and the filters together. "Clear filters"
+     * joins the row whenever a school is chosen, and a centred group would shove
+     * the field sideways each time it appeared — its resting position is what
+     * the landing hand-off aims at. A flexible track on each side is what holds
+     * it still, so the bar keeps its own place while the filters grow rightward.
+     */
+    it("keeps the bar's resting place when Clear filters joins the row", () => {
+      search = "q=graphs";
+      const plain = render(<Explore />);
+      expect(
+        screen.queryByRole("button", { name: "Clear filters" }),
+      ).not.toBeInTheDocument();
+      const spacer = bar()?.previousElementSibling;
+      expect(spacer).toBe(block()?.firstElementChild);
+      expect(spacer).toHaveClass("flex-1");
+      plain.unmount();
+
+      search = "q=graphs&department=EECS";
+      render(<Explore />);
+
+      expect(
+        screen.getByRole("button", { name: "Clear filters" }),
+      ).toBeVisible();
+      // The same balancing track, on the same side of the same bar: the button
+      // grows rightward off the field instead of pushing it.
+      expect(bar()?.previousElementSibling).toBe(block()?.firstElementChild);
+      expect(bar()?.previousElementSibling).toHaveClass("flex-1");
+    });
+
+    /**
+     * One bar across two pages. `search-morph.tsx` animates the arriving bar
+     * with `translate3d` alone and never interpolates width, so a hero bar of a
+     * different size would snap at the moment of arrival.
+     */
+    it("takes the width the landing's hero bar is capped at", () => {
+      render(<Explore />);
+
+      expect(bar()).toHaveClass("max-w-[var(--cc-search-bar-w)]");
+    });
+  });
 });

--- a/apps/web/features/search/components/explore.spec.tsx
+++ b/apps/web/features/search/components/explore.spec.tsx
@@ -12,6 +12,7 @@ import {
   SEARCH_MORPH_KEY,
   stashSearchBarHandoff,
 } from "@/features/shell/lib/search-morph";
+import { WORKSPACE_COLUMN_FROM } from "@/features/workspace";
 import type { CourseSummary } from "@/types";
 import { Explore } from "./explore";
 
@@ -1117,14 +1118,47 @@ describe("Explore", () => {
     /**
      * 236px is the rail's width, so a right margin of it on a centred row puts
      * the bar on the viewport's centre line instead of the centre of the column
-     * beside the rail. Gated to `@3xl` because that is where the rail itself
-     * appears — below it there is nothing to compensate for.
+     * beside the rail.
      */
-    it("shifts left by the rail's width, only where there is a rail", () => {
+    it("shifts left by the rail's width", () => {
       render(<Explore />);
 
       expect(block()).toHaveClass("@3xl:mr-[236px]");
       expect(block()).not.toHaveClass("mr-[236px]");
+    });
+
+    /**
+     * The gate is the **pane's** threshold, not the rail's, and the difference
+     * is a whole rail width of viewport.
+     *
+     * `AppShell` names its own container and draws the rail at `@3xl/shell`, so
+     * the rail arrives at a 768px viewport. Every `@3xl:` here is unqualified
+     * and resolves against `PageColumn`'s container, which the rail has already
+     * narrowed — so this block turns over at roughly a 1004px viewport instead.
+     * That is the right one: it is the same query `WorkspacePaneHost` gates its
+     * column on, the same box `useWorkspacePresentation` measures against
+     * `WORKSPACE_COLUMN_FROM`, and the same query Saved reserves its space on.
+     * Those four have to agree or the two tab strips part company, which is the
+     * defect this block exists to fix.
+     *
+     * Asserted as the *absence* of the shell-scoped variant as well as the
+     * presence of the plain one, because the two read almost identically and
+     * swapping them is a one-character edit. It is also not merely cosmetic:
+     * built against `@3xl/shell` and measured, the search field collapsed to
+     * 0px at an 800px viewport and 33px at 1003px, because the correction takes
+     * 236px out of a column the rail has already taken 236px out of.
+     */
+    it("turns over on the pane's threshold, not the rail's", () => {
+      render(<Explore />);
+
+      expect(WORKSPACE_COLUMN_FROM).toBe(768);
+      for (const shellScoped of [
+        "@3xl/shell:mr-[236px]",
+        "@3xl/shell:flex-row",
+        "@3xl/shell:h-[var(--cc-search-block-h)]",
+      ]) {
+        expect(block()).not.toHaveClass(shellScoped);
+      }
     });
 
     /**

--- a/apps/web/features/search/components/explore.tsx
+++ b/apps/web/features/search/components/explore.tsx
@@ -57,11 +57,25 @@ import { useExplore } from "../hooks/use-explore";
  *   SQL, so it is cheap, exact, and does not distort the result count. A filter
  *   that cannot be expressed in SQL does not belong beside it — see
  *   `server/search/service.ts`.
- * - The artboard narrows its **search bar** by 236px while tabs are open
- *   (`searchBarMargin`) so the field stays centred over the results
- *   rather than over the whole row. Not built: the bar is centred inside a
- *   `max-w-[560px]` box that is already narrower than the results column at
- *   every width the pane can open at, so the correction has nothing to correct.
+ * - The artboard shifts its **search bar** left by 236px while tabs are open
+ *   (`searchBarMargin`), and 236px is **the rail's width** —
+ *   `features/shell/components/app-shell.tsx` draws it `w-[236px]` and the
+ *   artboard's own rail is `width:236px`. The content column spans `236 → W`,
+ *   so its centre sits at `(W + 236) / 2`, which is 118px right of the
+ *   viewport's centre `W / 2`; a `margin-right` of 236px on a centred row
+ *   cancels exactly that. What the shift does is put the bar on the
+ *   **viewport's** centre line rather than on the centre of the column beside
+ *   the rail. Built, with two deliberate differences: it is applied
+ *   unconditionally rather than only while tabs are open, so the bar has one
+ *   resting position instead of sliding 118px sideways the moment a reader
+ *   opens their first tab — and the landing hand-off aims at that position. And
+ *   it is gated to `@3xl`, matching the rail's own `hidden @3xl/shell:block`,
+ *   because below that there is no rail to compensate for.
+ * - **The search block is one row, 74px tall, and the height is a token.**
+ *   `--cc-search-block-h` in `globals.css` is what Explore spends here and what
+ *   Saved reserves above its own row, so the two pages' tab strips start at the
+ *   same height. The school filter sits beside the bar rather than under it,
+ *   which is what gets the block from 118px down to the artboard's own 74.
  * - The artboard's **shared-element handoff from the landing hero** (its
  *   `pickUpSharedBar()`) *is* built, and is the one place in the app
  *   authorised to improve on the artboard rather than match it.
@@ -122,11 +136,42 @@ export function Explore() {
         />
       </div>
 
-      <search className="flex shrink-0 flex-col items-center gap-2.5 px-6 pt-[18px] pb-3.5">
+      {/*
+        The artboard's search row — `display:flex; align-items:center; gap:12px`
+        — at the height both pages measure their tab strips from. `mr-[236px]`
+        is the rail-width correction argued at the top of this file.
+
+        All of it is gated to `@3xl`, the same width the rail appears at, the
+        pane becomes a column and Saved reserves its matching space. Below it the
+        block keeps the two-row stack it has always had, and that is not a
+        compromise: there is no rail to correct for, no tab strip to line up
+        with, and a phone measured with the row forced on it put the search field
+        at 128px to keep a filter beside it. Nothing above @3xl reads the narrow
+        end, so the two layouts do not have to agree.
+      */}
+      <search className="flex shrink-0 flex-col items-center gap-2.5 px-6 pt-[18px] pb-3.5 @3xl:mr-[236px] @3xl:h-[var(--cc-search-block-h)] @3xl:flex-row @3xl:gap-3 @3xl:pt-0 @3xl:pb-0">
+        {/*
+          The bar's other half, and the whole reason it is centred rather than
+          the row's contents being centred together. It gives the left of the
+          row a flexible track equal to the one the filters occupy on the right,
+          so the field keeps one resting position whatever joins the row beside
+          it — "Clear filters" appears and disappears with the school, and a
+          centred group would shove the bar sideways each time. That resting
+          position is what the landing hand-off aims at, so it may not move.
+
+          It holds nothing and is announced as nothing.
+        */}
+        <div aria-hidden className="hidden min-w-0 flex-1 @3xl:block" />
+
+        {/*
+          `--cc-search-bar-w`, which the landing's hero bar is capped at too —
+          they are one bar to the reader and the hand-off between them does not
+          interpolate width. The token carries the argument.
+        */}
         <form
           ref={barRef}
           onSubmit={explore.onSubmit}
-          className="w-full max-w-[560px]"
+          className="w-full min-w-0 max-w-[var(--cc-search-bar-w)]"
         >
           <div className="flex h-[42px] items-center gap-2.5 rounded-[10px] border border-cc-rule3 bg-cc-surface px-3.5">
             <SearchIcon
@@ -513,8 +558,39 @@ function ResultsSkeleton() {
   );
 }
 
+/**
+ * The width rules are `@3xl:` only, and every number in them was measured in the
+ * running app rather than reasoned about. Below that width the control is
+ * exactly what it has always been: the narrow layout keeps its own row and is
+ * not touched here.
+ *
+ * A native `<select>` sizes itself to its widest **option**, and these options
+ * are whole department names — 100 of them, the longest "ECE/Skolan för
+ * teknikvetenskaplig kommunikation och lärande". Left alone the control comes
+ * out **398px** wide. That is harmless in a row of its own and is not once it
+ * shares a fixed-height row with the search bar: measured at a 1920px viewport
+ * it spilled 194px past its track and out of the row entirely.
+ *
+ * So on the row it is given a resting width and allowed to clip its own label,
+ * and nothing is lost by that — the open dropdown draws every option at full
+ * width, which is the one place the whole string has to be readable.
+ * `min-w-0` lets it give way first when "Clear filters" joins the row: measured
+ * at 1920 it settles to 112px beside the button and 176px without it, and in
+ * both cases the row ends exactly on its own content edge.
+ *
+ * What it may *not* do is vanish. `Filters` carries a `@3xl:min-w-[12.5rem]`
+ * floor for that: without one, the select is the control that collapses,
+ * because it sits in a flexible track while the bar has a real width to shrink
+ * from — at a 1010px viewport, where the rail correction has just taken 236px
+ * off a 498px row, it measured **22px**. With the floor the bar absorbs the
+ * loss instead and the pair settles at 226px and 108px, which is the right way
+ * round: a shorter search field is legible, a 22px filter is not. 12.5rem is
+ * also the largest floor the centring survives — the track is 204px at the
+ * content column's cap, and a floor above that would push the bar off the
+ * viewport's centre line at every width.
+ */
 const SELECT_CLASS =
-  "h-[34px] cursor-pointer rounded-[8px] border border-cc-rule3 bg-cc-surface px-2.5 font-medium text-[12.5px] text-cc-chip-ink hover:border-cc-hov focus-visible:outline-cc-brand";
+  "h-[34px] cursor-pointer rounded-[8px] border border-cc-rule3 bg-cc-surface px-2.5 font-medium text-[12.5px] text-cc-chip-ink @3xl:w-[11rem] @3xl:min-w-0 @3xl:max-w-full hover:border-cc-hov focus-visible:outline-cc-brand";
 
 /**
  * The school filter, and the only filter.
@@ -537,7 +613,7 @@ function Filters({ explore }: { explore: ReturnType<typeof useExplore> }) {
     // behind the arriving search bar rather than being there before it lands.
     <div
       data-cc-fade
-      className="flex flex-wrap items-center justify-center gap-2"
+      className="flex flex-wrap items-center justify-center gap-2 @3xl:min-w-[12.5rem] @3xl:flex-1 @3xl:flex-nowrap @3xl:justify-start"
     >
       <select
         aria-label="School"
@@ -557,7 +633,7 @@ function Filters({ explore }: { explore: ReturnType<typeof useExplore> }) {
         <button
           type="button"
           onClick={explore.onClearFilters}
-          className="h-[34px] cursor-pointer rounded-[8px] px-2.5 font-medium text-[12.5px] text-cc-brand hover:underline"
+          className="h-[34px] cursor-pointer rounded-[8px] px-2.5 font-medium text-[12.5px] text-cc-brand @3xl:shrink-0 hover:underline"
         >
           Clear filters
         </button>

--- a/apps/web/features/search/components/explore.tsx
+++ b/apps/web/features/search/components/explore.tsx
@@ -69,13 +69,47 @@ import { useExplore } from "../hooks/use-explore";
  *   unconditionally rather than only while tabs are open, so the bar has one
  *   resting position instead of sliding 118px sideways the moment a reader
  *   opens their first tab — and the landing hand-off aims at that position. And
- *   it is gated to `@3xl`, matching the rail's own `hidden @3xl/shell:block`,
- *   because below that there is no rail to compensate for.
+ *   it is gated on `@3xl`, which is **not** the width the rail appears at. See
+ *   the note below, because the two are easy to conflate and one of them is
+ *   unaffordable.
  * - **The search block is one row, 74px tall, and the height is a token.**
  *   `--cc-search-block-h` in `globals.css` is what Explore spends here and what
  *   Saved reserves above its own row, so the two pages' tab strips start at the
  *   same height. The school filter sits beside the bar rather than under it,
  *   which is what gets the block from 118px down to the artboard's own 74.
+ *
+ * ## `@3xl` here is the pane's threshold, not the rail's
+ *
+ * There are two container queries in play and they are **not** the same width.
+ * `AppShell` names its own container (`@container/shell`) and draws the rail at
+ * `@3xl/shell`, so the rail appears once the *viewport* reaches 768px. Every
+ * `@3xl:` on this page is unqualified, so it resolves against `PageColumn`'s
+ * own unnamed `@container` — which sits inside the shell, after the rail has
+ * taken its 236px. That threshold is therefore reached at roughly a 1004px
+ * viewport, and between 768 and 1003 the rail is up while this block is still
+ * stacked and the bar is still centred on the content column.
+ *
+ * That gap is deliberate, and the unqualified variant is the correct one.
+ *
+ * **It is the threshold that matters.** `WorkspacePaneHost` gates its column on
+ * the same unqualified `@3xl`, `useWorkspacePresentation` measures the same
+ * `PageColumn` box against `WORKSPACE_COLUMN_FROM`, and Saved reserves its
+ * matching space on the same query. Those are the conditions that decide
+ * whether there are two tab strips to level at all, which is the whole point.
+ * Moving this block onto `@3xl/shell` would desynchronise it from all three and
+ * from Saved, and the strips would part company again between 1004 and 1024.
+ *
+ * **And the rail's threshold is unaffordable.** Measured, by building the
+ * shell-scoped version and reading the boxes back: at an 800px viewport the row
+ * has 328px to work with once the 236px correction is taken out of a content
+ * column the rail has already narrowed, and the search field collapses to
+ * **0px** wide; at 1003px it is **33px**, with the school select overflowing the
+ * row. Applying the correction where the rail appears destroys the control it
+ * is meant to position.
+ *
+ * Nothing regresses in that band: the bar is centred on the content column
+ * there, which is exactly where it sat before this change, and there is no tab
+ * strip beneath it to be out of step with.
  * - The artboard's **shared-element handoff from the landing hero** (its
  *   `pickUpSharedBar()`) *is* built, and is the one place in the app
  *   authorised to improve on the artboard rather than match it.
@@ -141,13 +175,17 @@ export function Explore() {
         — at the height both pages measure their tab strips from. `mr-[236px]`
         is the rail-width correction argued at the top of this file.
 
-        All of it is gated to `@3xl`, the same width the rail appears at, the
-        pane becomes a column and Saved reserves its matching space. Below it the
-        block keeps the two-row stack it has always had, and that is not a
-        compromise: there is no rail to correct for, no tab strip to line up
-        with, and a phone measured with the row forced on it put the search field
-        at 128px to keep a filter beside it. Nothing above @3xl reads the narrow
-        end, so the two layouts do not have to agree.
+        All of it is gated on the unqualified `@3xl` — `PageColumn`'s container,
+        which is where the pane becomes a column and where Saved reserves its
+        matching space. That is deliberately *not* the width the rail appears at;
+        the header note on this component has the measurements for why the rail's
+        own threshold cannot be used here.
+
+        Below it the block keeps the two-row stack it has always had, and that is
+        not a compromise: there is no tab strip to line up with, and a phone
+        measured with the row forced on it put the search field at 128px to keep
+        a filter beside it. Nothing above `@3xl` reads the narrow end, so the two
+        layouts do not have to agree.
       */}
       <search className="flex shrink-0 flex-col items-center gap-2.5 px-6 pt-[18px] pb-3.5 @3xl:mr-[236px] @3xl:h-[var(--cc-search-block-h)] @3xl:flex-row @3xl:gap-3 @3xl:pt-0 @3xl:pb-0">
         {/*

--- a/apps/web/features/search/components/explore.tsx
+++ b/apps/web/features/search/components/explore.tsx
@@ -75,7 +75,7 @@ import { useExplore } from "../hooks/use-explore";
  *   the rail is the shell's and only the shell can hand it over.
  */
 export function Explore() {
-  const workspace = useWorkspacePane();
+  const workspace = useWorkspacePane("explore");
   const explore = useExplore({
     onOpenCourse: (request) => workspace.open(request.courseCode, request.kind),
   });

--- a/apps/web/features/shell/components/search-morph.tsx
+++ b/apps/web/features/shell/components/search-morph.tsx
@@ -36,13 +36,24 @@ import {
  * remaining travel are two views of it.
  *
  * That matters because the two motions are causally related rather than merely
- * simultaneous. The bar centres in the viewport on the landing and in the space
- * *beside* the rail on Explore, so its resting centre sits about half a rail
- * width further right: the horizontal half of the bar's travel is the rail's
- * arrival, measured. Driving them from one value is how that reads as a single
- * gesture instead of two things starting at once — and the horizontal component
- * is never assumed, because `dx` is the difference between two rects that were
- * actually measured.
+ * simultaneous. Driving them from one value is how they read as a single
+ * gesture instead of as two things starting at once.
+ *
+ * ## The travel is vertical now, and that is deliberate
+ *
+ * The bar used to come to rest about half a rail width further right on Explore
+ * than on the landing, because it centred in the viewport there and in the space
+ * *beside* the rail here — so the horizontal half of its travel was the rail's
+ * arrival, made visible. Explore now shifts its search row left by the rail's
+ * full width (`@3xl:mr-[236px]`, argued in `explore.tsx`), which puts the bar on
+ * the viewport's centre line on both pages and collapses `dx` to roughly zero.
+ *
+ * Nothing here needs changing for it and nothing is broken by it: `dx` is the
+ * difference between two rects that were actually measured, never a number this
+ * file assumes, and `dy` stays large enough that the bail-out below — which only
+ * refuses a bar that arrived where it already stood — is nowhere near. The rail
+ * still slides in on the same spring; it is only the bar that no longer travels
+ * sideways with it. Do not "restore" the offset as a bug.
  *
  * ## Why the offsets are written to the node
  *

--- a/apps/web/features/workspace/hooks/use-workspace-pane.spec.tsx
+++ b/apps/web/features/workspace/hooks/use-workspace-pane.spec.tsx
@@ -8,14 +8,14 @@ beforeEach(() => {
 
 describe("useWorkspacePane", () => {
   it("starts with nothing open, so the host hides the pane", () => {
-    const { result } = renderHook(() => useWorkspacePane());
+    const { result } = renderHook(() => useWorkspacePane("explore"));
 
     expect(result.current.openCourses).toEqual([]);
     expect(result.current.hasOpenCourses).toBe(false);
   });
 
   it("opens, activates and closes courses", () => {
-    const { result } = renderHook(() => useWorkspacePane());
+    const { result } = renderHook(() => useWorkspacePane("explore"));
 
     act(() => result.current.open("DD2380", "details"));
     act(() => result.current.open("SF1626", "details"));
@@ -30,12 +30,12 @@ describe("useWorkspacePane", () => {
   });
 
   it("brings the open courses back after the page reloads to sign in", () => {
-    const first = renderHook(() => useWorkspacePane());
+    const first = renderHook(() => useWorkspacePane("explore"));
     act(() => first.result.current.open("DD2380", "details"));
     act(() => first.result.current.open("DD2380", "review"));
     first.unmount();
 
-    const { result } = renderHook(() => useWorkspacePane());
+    const { result } = renderHook(() => useWorkspacePane("explore"));
 
     expect(result.current.openCourses.map((entry) => entry.id)).toEqual([
       "details:DD2380",
@@ -45,12 +45,12 @@ describe("useWorkspacePane", () => {
   });
 
   it("does not restore a workspace that was closed down to nothing", () => {
-    const first = renderHook(() => useWorkspacePane());
+    const first = renderHook(() => useWorkspacePane("explore"));
     act(() => first.result.current.open("DD2380", "details"));
     act(() => first.result.current.close("details:DD2380"));
     first.unmount();
 
-    const { result } = renderHook(() => useWorkspacePane());
+    const { result } = renderHook(() => useWorkspacePane("explore"));
 
     expect(result.current.hasOpenCourses).toBe(false);
   });
@@ -80,7 +80,7 @@ describe("useWorkspacePane", () => {
     let renders = 0;
     const { result } = renderHook(() => {
       renders += 1;
-      return useWorkspacePane();
+      return useWorkspacePane("explore");
     });
 
     act(() => result.current.open("DD2380", "details"));
@@ -114,31 +114,96 @@ describe("useWorkspacePane", () => {
    */
   it("does not blank the stored open list on the way to restoring it", () => {
     sessionStorage.setItem(
-      "cc.workspace.open",
+      "cc.workspace.open.explore",
       JSON.stringify({
         open: [{ id: "review:DD2380", courseCode: "DD2380", kind: "review" }],
         activeId: "review:DD2380",
       }),
     );
 
-    const { result } = renderHook(() => useWorkspacePane());
+    const { result } = renderHook(() => useWorkspacePane("explore"));
 
     expect(result.current.openCourses.map((entry) => entry.id)).toEqual([
       "review:DD2380",
     ]);
     expect(
-      JSON.parse(sessionStorage.getItem("cc.workspace.open") ?? "{}").open,
+      JSON.parse(sessionStorage.getItem("cc.workspace.open.explore") ?? "{}")
+        .open,
     ).toHaveLength(1);
   });
 
   it("ignores whatever else is in the tab's storage", () => {
     sessionStorage.setItem(
-      "cc.workspace.open",
+      "cc.workspace.open.explore",
       JSON.stringify({ open: [{ id: 1 }, "nope"], activeId: 7 }),
     );
 
-    const { result } = renderHook(() => useWorkspacePane());
+    const { result } = renderHook(() => useWorkspacePane("explore"));
 
     expect(result.current.openCourses).toEqual([]);
+  });
+
+  /*
+   * The defect this scope exists for. Both hosts used to read one key, so
+   * navigating Explore → Saved unmounted one and mounted the other onto the
+   * *same* stored list — and each page showed the tabs the other had opened.
+   *
+   * Unmounting and mounting is what a route change does to these two, so that
+   * is what the test does: a tab opened under one scope, then the other scope
+   * mounted in its place.
+   */
+  describe("the scope", () => {
+    it("keeps one page's tabs out of the other", () => {
+      const explore = renderHook(() => useWorkspacePane("explore"));
+      act(() => explore.result.current.open("DD2380", "details"));
+      explore.unmount();
+
+      const saved = renderHook(() => useWorkspacePane("saved"));
+
+      expect(saved.result.current.openCourses).toEqual([]);
+      expect(saved.result.current.hasOpenCourses).toBe(false);
+    });
+
+    it("brings a page's own tabs back when the reader returns to it", () => {
+      const explore = renderHook(() => useWorkspacePane("explore"));
+      act(() => explore.result.current.open("DD2380", "details"));
+      explore.unmount();
+
+      // Saved in between, writing its own empty list over its own key.
+      renderHook(() => useWorkspacePane("saved")).unmount();
+
+      const back = renderHook(() => useWorkspacePane("explore"));
+
+      expect(back.result.current.openCourses.map((entry) => entry.id)).toEqual([
+        "details:DD2380",
+      ]);
+    });
+
+    /*
+     * A reader mid-upgrade holds a shared list under the bare key. Adopting it
+     * into one page would recreate the leak the scope removes, so it is left
+     * to expire with the session — read by nothing and written by nothing.
+     */
+    it("ignores the shared list an older build left behind", () => {
+      sessionStorage.setItem(
+        "cc.workspace.open",
+        JSON.stringify({
+          open: [
+            { id: "details:DD2380", courseCode: "DD2380", kind: "details" },
+          ],
+          activeId: "details:DD2380",
+        }),
+      );
+
+      const { result } = renderHook(() => useWorkspacePane("explore"));
+      act(() => result.current.open("SF1626", "details"));
+
+      expect(result.current.openCourses.map((entry) => entry.id)).toEqual([
+        "details:SF1626",
+      ]);
+      expect(
+        JSON.parse(sessionStorage.getItem("cc.workspace.open") ?? "{}").open,
+      ).toHaveLength(1);
+    });
   });
 });

--- a/apps/web/features/workspace/hooks/use-workspace-pane.ts
+++ b/apps/web/features/workspace/hooks/use-workspace-pane.ts
@@ -8,6 +8,7 @@ import {
   type OpenCourseKind,
   openCourse,
   type Workspace,
+  type WorkspaceScope,
 } from "../lib/open-courses";
 import { readWorkspace, writeWorkspace } from "../lib/workspace-storage";
 
@@ -24,6 +25,20 @@ import { readWorkspace, writeWorkspace } from "../lib/workspace-storage";
  * OAuth redirect away and back — returns the student to the courses they had
  * open rather than to an empty pane. Restoring happens in an effect rather
  * than in the initial state so the server and the first client render agree.
+ *
+ * ## The scope, and why it is a parameter
+ *
+ * Each host passes its own {@link WorkspaceScope}, and that is what keeps
+ * Explore's tabs out of Saved: the two pages read and write separate keys, so
+ * navigating between them no longer rehydrates the other's list. Signing in
+ * still returns a reader to their tabs, because the redirect comes back to the
+ * *same* route and therefore to the same scope.
+ *
+ * It is passed in rather than read off `usePathname()` so the hook stays pure
+ * and testable and the host goes on owning its own state, which is the shape
+ * the rest of this comment describes. A host's scope is a literal and never
+ * changes for the life of the mount; the read guard below would not notice if
+ * it did.
  *
  * ## Why `hydrated` is state and not a ref
  *
@@ -60,7 +75,7 @@ import { readWorkspace, writeWorkspace } from "../lib/workspace-storage";
  * it has to arrive *with* the value it describes. Swapping them is the bug at
  * both ends.
  */
-export function useWorkspacePane() {
+export function useWorkspacePane(scope: WorkspaceScope) {
   const [workspace, setWorkspace] = useState<Workspace>(EMPTY_WORKSPACE);
   const [hydrated, setHydrated] = useState(false);
   const read = useRef(false);
@@ -68,13 +83,13 @@ export function useWorkspacePane() {
   useEffect(() => {
     if (read.current) return;
     read.current = true;
-    setWorkspace(readWorkspace());
+    setWorkspace(readWorkspace(scope));
     setHydrated(true);
-  }, []);
+  }, [scope]);
 
   useEffect(() => {
-    if (hydrated) writeWorkspace(workspace);
-  }, [hydrated, workspace]);
+    if (hydrated) writeWorkspace(scope, workspace);
+  }, [hydrated, scope, workspace]);
 
   const open = useCallback((courseCode: string, kind: OpenCourseKind) => {
     setWorkspace((current) => openCourse(current, courseCode, kind));

--- a/apps/web/features/workspace/index.ts
+++ b/apps/web/features/workspace/index.ts
@@ -41,5 +41,6 @@ export type {
   OpenCourse,
   OpenCourseKind,
   OpenCourseRequest,
+  WorkspaceScope,
 } from "./lib/open-courses";
 export { openCourseRequest } from "./lib/open-courses";

--- a/apps/web/features/workspace/lib/open-courses.ts
+++ b/apps/web/features/workspace/lib/open-courses.ts
@@ -8,9 +8,10 @@
  * both easy to get subtly wrong and cheap to test in isolation.
  *
  * Nothing here decides persistence: these are pure transitions over a value.
- * `use-workspace-pane.ts` is what keeps that value in `sessionStorage`, so that
- * signing in — an OAuth redirect away and back — returns to the courses that
- * were open.
+ * `use-workspace-pane.ts` is what keeps that value in `sessionStorage` — under
+ * the {@link WorkspaceScope} of the page that owns it — so that signing in, an
+ * OAuth redirect away and back to the same route, returns to the courses that
+ * were open there.
  */
 
 /**
@@ -27,6 +28,22 @@ export interface OpenCourse {
   courseCode: string;
   kind: OpenCourseKind;
 }
+
+/**
+ * Which page's open list this is.
+ *
+ * A tab belongs to the page it was opened on: Explore's tabs live in Explore,
+ * Saved's live in Saved, and neither page shows the other's. The artboards say
+ * the same thing by construction — `Course Community - Explore.dc.html` and
+ * `Course Community - Saved.dc.html` each declare their own `tabs: []` in local
+ * state, and `cc-store.js`, the store they genuinely share, carries no tab
+ * state at all.
+ *
+ * It is a domain word rather than a route string on purpose. The two hosts pass
+ * it as a literal, so nothing here reads `usePathname()` and the open list stays
+ * a value a test can hand around. See ADR 0007.
+ */
+export type WorkspaceScope = "explore" | "saved";
 
 /** Every course open in the pane, in tab order, and which one is in front. */
 export interface Workspace {

--- a/apps/web/features/workspace/lib/workspace-storage.spec.tsx
+++ b/apps/web/features/workspace/lib/workspace-storage.spec.tsx
@@ -1,4 +1,5 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
+import { EMPTY_WORKSPACE } from "./open-courses";
 import { EMPTY_REVIEW_DRAFT, type ReviewDraft } from "./review-draft";
 import {
   claimAwaitingSignIn,
@@ -382,14 +383,73 @@ describe("a stored draft that does not quite fit", () => {
  */
 describe("what stayed in the tab", () => {
   it("keeps the open list in sessionStorage", () => {
-    writeWorkspace({
+    writeWorkspace("explore", {
       open: [{ id: "review:DD2380", courseCode: "DD2380", kind: "review" }],
       activeId: "review:DD2380",
     });
 
-    expect(sessionStorage.getItem("cc.workspace.open")).not.toBeNull();
-    expect(localStorage.getItem("cc.workspace.open")).toBeNull();
-    expect(readWorkspace().open).toHaveLength(1);
+    expect(sessionStorage.getItem("cc.workspace.open.explore")).not.toBeNull();
+    expect(localStorage.getItem("cc.workspace.open.explore")).toBeNull();
+    expect(readWorkspace("explore").open).toHaveLength(1);
+  });
+
+  /*
+   * The open list is keyed per page, so Explore's tabs and Saved's are two
+   * lists that never see each other. Reading the *other* page's key back is
+   * what the old single key made impossible.
+   */
+  it("keeps each page's open list under its own key", () => {
+    writeWorkspace("explore", {
+      open: [{ id: "details:DD2380", courseCode: "DD2380", kind: "details" }],
+      activeId: "details:DD2380",
+    });
+    writeWorkspace("saved", {
+      open: [{ id: "details:SF1626", courseCode: "SF1626", kind: "details" }],
+      activeId: "details:SF1626",
+    });
+
+    expect(
+      readWorkspace("explore").open.map((entry) => entry.courseCode),
+    ).toEqual(["DD2380"]);
+    expect(
+      readWorkspace("saved").open.map((entry) => entry.courseCode),
+    ).toEqual(["SF1626"]);
+  });
+
+  it("leaves one page's list alone when the other is written", () => {
+    writeWorkspace("explore", {
+      open: [{ id: "details:DD2380", courseCode: "DD2380", kind: "details" }],
+      activeId: "details:DD2380",
+    });
+    writeWorkspace("saved", EMPTY_WORKSPACE);
+
+    expect(readWorkspace("explore").open).toHaveLength(1);
+    expect(readWorkspace("saved").open).toHaveLength(0);
+  });
+
+  /*
+   * The bare `cc.workspace.open` an older build wrote held *both* pages' tabs,
+   * which is the leak the scope removes. It is neither adopted nor cleaned up:
+   * adopting it into one page would put the leak straight back, and an open tab
+   * is one click to restore — the argument `adoptLegacyDrafts` makes for drafts
+   * does not carry here. It expires with the session.
+   */
+  it("never reads or writes the shared key an older build left behind", () => {
+    const legacy = JSON.stringify({
+      open: [{ id: "details:DD2380", courseCode: "DD2380", kind: "details" }],
+      activeId: "details:DD2380",
+    });
+    sessionStorage.setItem("cc.workspace.open", legacy);
+
+    expect(readWorkspace("explore")).toEqual(EMPTY_WORKSPACE);
+    expect(readWorkspace("saved")).toEqual(EMPTY_WORKSPACE);
+
+    writeWorkspace("explore", {
+      open: [{ id: "details:SF1626", courseCode: "SF1626", kind: "details" }],
+      activeId: "details:SF1626",
+    });
+
+    expect(sessionStorage.getItem("cc.workspace.open")).toBe(legacy);
   });
 
   it("keeps the published note in sessionStorage", () => {

--- a/apps/web/features/workspace/lib/workspace-storage.ts
+++ b/apps/web/features/workspace/lib/workspace-storage.ts
@@ -3,6 +3,7 @@ import {
   type OpenCourse,
   type OpenCourseKind,
   type Workspace,
+  type WorkspaceScope,
 } from "./open-courses";
 import {
   decodeReviewDraft,
@@ -80,7 +81,25 @@ import {
  * whole point of the stamp.
  */
 
-const WORKSPACE_KEY = "cc.workspace.open";
+/**
+ * The open list's key, per page.
+ *
+ * One bare `cc.workspace.open` used to hold both pages' tabs, so navigating
+ * Explore → Saved rehydrated the list the other page had written and each
+ * showed the other's tabs. A tab belongs to the page it was opened on — see
+ * {@link WorkspaceScope} and ADR 0007 — so the scope is in the key.
+ *
+ * **The bare key is legacy and is never read or written again.** A reader
+ * mid-upgrade holds one under it; it expires with their session. This is
+ * deliberately *not* what `adoptLegacyDrafts` does below: that migrates drafts,
+ * because losing unpublished writing is real damage, whereas an open tab is one
+ * click to restore. Adopting a shared list into one page would put the leak this
+ * key exists to remove straight back.
+ */
+function workspaceKey(scope: WorkspaceScope): string {
+  return `cc.workspace.open.${scope}`;
+}
+
 const DRAFTS_KEY = "cc.workspace.drafts";
 const PUBLISHED_KEY = "cc.workspace.published";
 const AWAITING_SIGN_IN_KEY = "cc.workspace.awaiting-sign-in";
@@ -155,8 +174,8 @@ function toOpenCourse(value: unknown): OpenCourse | null {
   return { id, courseCode, kind: kind as OpenCourseKind };
 }
 
-export function readWorkspace(): Workspace {
-  const value = read("session", WORKSPACE_KEY);
+export function readWorkspace(scope: WorkspaceScope): Workspace {
+  const value = read("session", workspaceKey(scope));
   if (!isRecord(value) || !Array.isArray(value.open)) return EMPTY_WORKSPACE;
 
   const open = value.open
@@ -172,8 +191,11 @@ export function readWorkspace(): Workspace {
   return { open, activeId };
 }
 
-export function writeWorkspace(workspace: Workspace): void {
-  write("session", WORKSPACE_KEY, workspace);
+export function writeWorkspace(
+  scope: WorkspaceScope,
+  workspace: Workspace,
+): void {
+  write("session", workspaceKey(scope), workspace);
 }
 
 /** One course's draft with the clock reading that decides when to forget it. */

--- a/docs/adr/0007-workspace-tabs-are-page-scoped.md
+++ b/docs/adr/0007-workspace-tabs-are-page-scoped.md
@@ -1,0 +1,106 @@
+# 7. Workspace tabs belong to the page they were opened on, and are still persisted
+
+Date: 2026-09-06
+
+## Status
+
+Accepted. Settles Part 1 of #201.
+
+## Context
+
+The workspace pane is the column Explore and Saved mount beside their results,
+and since #68 §5 retired `/course/<code>` it is the only surface a course opens
+in. Both pages host it, and both read their open list through
+`useWorkspacePane`.
+
+That list was kept under a single `sessionStorage` key, `cc.workspace.open`.
+Navigating Explore → Saved unmounts one host and mounts the other, which
+rehydrates the *same* list — so tabs opened while searching appeared in Saved,
+and tabs opened from a collection appeared in Explore. Neither page had asked
+for the other's work.
+
+A future reader will find a per-route storage key sitting beside artboards that
+persist nothing at all, and will reasonably wonder why we did not simply drop
+persistence and match the design. This records the three-way trade-off, because
+the answer is only inferable today from a long comment in
+`workspace-storage.ts`.
+
+### What the design says
+
+The artboards are unambiguous, and they say two things rather than one.
+
+**A tab belongs to one page.** `Course Community - Explore.dc.html:387` and
+`Course Community - Saved.dc.html:276` each declare their own `tabs: []` in
+local component state. `cc-store.js` — the store the two artboards genuinely
+share, and which does carry saved courses and collections across pages — has no
+tab state at all.
+
+**Nothing is persisted.** Those `tabs: []` are component state and start empty
+on every mount.
+
+A note for anyone reading the artboard source, because it is easy to misread:
+`closeAll()` in both files closes **popup menus** (`compareMenu`, `takenMenu`,
+`overflowOpen`), not tabs. The Explore artboard's
+`onOpen: () => { this.closeAll(); this.openTab(...) }` is "dismiss any open
+menu, then open the tab" — it is not tab replacement.
+
+### What persistence is for
+
+`AuthReasonDialog` tells a reader *"Your draft is held as it is — text, ratings
+and the course all stay put"*. Signing in is a redirect: the page navigates away
+and comes back, and everything in React state goes with it. The whole of
+`workspace-storage.ts` exists to keep that promise across it, and the open list
+is half of what the sentence names — a draft that survived into a pane with no
+tab to appear in would not be the promise being kept.
+
+## Decision
+
+**Scope the key, keep the persistence.** The two are independent, so we take
+both.
+
+- `WorkspaceScope` is `"explore" | "saved"`, a domain type in
+  `features/workspace/lib/open-courses.ts`.
+- The key becomes `cc.workspace.open.<scope>`.
+- Explore → Saved shows no tabs. Saved → Explore brings Explore's tabs back.
+- Sign-in still returns a reader to their tabs, because the redirect returns to
+  the **same route** and therefore to the same scope.
+
+"Living within Explore" is a statement about scope, not about forgetting. A
+reader who ducks into Saved and comes back to a lost review draft would be the
+worse surprise of the two, and it is the one we have a written promise about.
+
+**The scope is an explicit parameter, not `usePathname()`.** The hook stays
+pure and testable, the host goes on owning its own state — which is the existing
+shape, argued in the hook's own doc comment — and nothing in the workspace
+feature learns what a route is.
+
+**The legacy key is ignored: never read, never written again.** A reader
+mid-upgrade holds a shared list under the bare `cc.workspace.open`; it expires
+with their session.
+
+This deliberately does *not* follow the precedent of `adoptLegacyDrafts` in the
+same file. That function migrates **drafts**, because losing unpublished writing
+is real damage and no owner was recorded to restore them to. An open tab is one
+click to restore, and adopting a shared list into one page would recreate
+exactly the leak this change removes — the migration would be the bug.
+
+## Consequences
+
+- `useWorkspacePane` takes a required argument. There are exactly two callers,
+  `explore.tsx` and `saved.tsx`, and a third host would have to name its own
+  scope rather than inherit one by accident. That is the point.
+- The union has two members and adding a third is a real decision, not a
+  formality: a new host either owns its own tabs or deliberately shares another
+  page's, and the type is where that gets argued.
+- Two pages can now hold two open lists at once in one tab, so a reader may have
+  up to twice as many tabs stored. They are three fields each and expire with
+  the session; this is not a budget worth managing.
+- `?open=` is unaffected. `/course/<code>` redirects to `/search?open=…` and
+  opens in Explore; Collections navigates to `/saved?open=…` and opens in Saved.
+  Each lands on the route that owns that tab, which was already true and is now
+  true for a reason rather than by coincidence.
+- The Strict Mode guards in `use-workspace-pane.ts` — the `read` ref and the
+  `hydrated` state — are untouched. They solve effect replay, are documented at
+  length there, and scoping does not interact with either. A host's scope is a
+  literal that never changes for the life of the mount, which is what makes the
+  read guard's "once per mount, ever" still correct.


### PR DESCRIPTION
Closes #201.

Two independent defects, in the order the issue states them.

## Part 1 — tabs are page-scoped

Both hosts read and wrote one `cc.workspace.open`, so navigating Explore → Saved
unmounted one host and mounted the other onto the *same* stored list. The key
now takes a `WorkspaceScope` (`"explore" | "saved"`).

Persistence is kept, which the artboards do not have, because `AuthReasonDialog`
promises a draft survives sign-in and the redirect returns to the same route.
The scope is an explicit parameter, not `usePathname()`. The bare legacy key is
ignored — never read, never written — deliberately unlike `adoptLegacyDrafts`,
which migrates drafts because losing unpublished writing is real damage.

The two Strict Mode guards in `use-workspace-pane.ts` are untouched.

## Part 2 — the strips start level, and the bar sits on the viewport centre

`--cc-search-block-h: 74px` is spent by Explore as its block's height and
reserved by Saved as its row's padding-top, so the two cannot drift.
**Measured in the running app: both panes now start at y=229.**

`@3xl:mr-[236px]` on the search row, unconditionally. 236px is the rail's width,
so it puts the bar on the viewport's centre line. **Measured: bar centre 960 at
a 1920px viewport.** Applied always rather than only while tabs are open, so the
bar has one resting position for the landing hand-off to aim at.

Bar 560 → 460 on both pages via `--cc-search-bar-w`, since the hand-off animates
`translate3d` only.

Both comment corrections the issue asked for are in: the `searchBarMargin`
explanation in `explore.tsx` (it is the rail, and the correction did have
something to correct), and a note in `search-morph.tsx` that the horizontal
travel is now near zero by design.

## Parts 3 and 4

**School** added to `CONTEXT.md`, and `docs/adr/0007-workspace-tabs-are-page-scoped.md`.

## Things I measured rather than assumed, and what they changed

The issue asked for two verifications. Both produced findings.

**1. `search-morph.spec.tsx` needed no update.** Its `translate3d(-180px, 380px, 0)`
comes from mocked rects, not from the app's resting position — jsdom lays nothing
out — so it asserts the hook's arithmetic and is unaffected. Same for Explore's
own hand-off test.

**2. A 460px bar never clears the pane divider.** With the row centred on the
viewport and the pane at its 504px default the overhang is a **constant 48px** at
every width the content column is capped at, down from 98px. Clearing it entirely
needs a **364px** bar. 460 is the number the issue authorised, so 460 is what
shipped and the residual 48px is recorded at the token — flagging it rather than
changing an authorised number on my own.

**3. Two layout defects the issue did not anticipate, both fixed here.**

- The school select sizes itself to its widest **option**, and the options are
  whole department names — 100 of them. It measured **398px** and spilled 194px
  out of the row. It is now bounded on the row and yields to "Clear filters"
  before the bar does (112px beside the button, 176px without, ending exactly on
  the row's content edge).
- In the band just above `@3xl`, where the rail correction has taken 236px off a
  498px row, the select collapsed to **22px**. A `min-w` floor on the filter
  track makes the bar absorb the loss instead: 226px and 108px. 12.5rem is also
  the largest floor the centring survives, since the track is 204px at the cap.

**4. Everything in Part 2 is `@3xl` only.** A first pass applied the one-row
block at all widths and put a phone's search field at **128px** to keep a filter
beside it. Below `@3xl` there is no rail, no pane column and no tab strip, so the
narrow layout keeps the stack it has always had and is not touched by this PR.

## A finding worth its own issue

`courses.department` holds values like `ABE/Lantmäteri – fastighetsvetenskap och
geodesi` — a **school code and a department name**. The control is labelled
"School" and offers "All schools", but it lists ~100 departments, not KTH's
handful of schools. Part 3's decision (School in copy, `department` in code) is
right about the word; the `CONTEXT.md` entry describes what the column actually
holds rather than the issue's premise. Making the filter list real schools is a
data/behaviour change well outside this issue.

## Not in this PR

#174 is deliberately excluded — it is a pure refactor of these same two files and
belongs after this lands, with `useWorkspaceHost(scope)` as its signature.

## ADR numbering

Mine is **0007**. 0006 is already claimed by the in-flight
`0006-hero-signals-dramatise-the-community.md` and the `ADR 0006` citation
in `CONTEXT.md` that goes with it.

## Checks

`bun run lint` clean (8 pre-existing warnings, all in `.agents/skills/`).
`bun run test:web` — 90 files, **1319 passed**. `tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Evc51Y1qNjwPQKXLCLwgGN
