### PR TITLE
feat(landing): drift, travelling signals and burst-on-click in the hero

### DIFF
--- a/apps/web/features/landing/components/hero-network.spec.tsx
+++ b/apps/web/features/landing/components/hero-network.spec.tsx
@@ -1,21 +1,26 @@
-import { render } from "@testing-library/react";
+import { fireEvent, render } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { GraphWindow } from "../api/queries";
 import { NODE_RADIUS } from "../lib/neighbourhood-view";
 import { HeroNetwork } from "./hero-network";
 
 /**
- * What the hero canvas repaints for.
+ * What the hero canvas repaints for, and what it refuses to run a loop for.
  *
- * The scene is the real community graph, and a graph of stored world positions
- * does not move — so this canvas is painted on demand rather than 60 times a
- * second, and the pulse on a labelled node is the only thing that ever runs a
- * frame loop. That is the right shape, but it moves the burden: every input
- * `draw()` reads now needs an explicit trigger, and an input without one leaves
- * stale pixels on screen indefinitely rather than for 16ms.
+ * This file used to argue that "a graph of stored world positions does not
+ * move — so this canvas is painted on demand rather than 60 times a second".
+ * **ADR 0006 reverses that.** Nodes drift, signals travel, and the loop is
+ * real; what bounds it is now four gates rather than an empty scene, and those
+ * gates are what these tests hold. `hero-signals.spec.ts` holds the model the
+ * loop drives; this file holds the canvas around it.
  *
- * These tests are that checklist, executable. Each one names an input and
- * asserts that changing it repaints.
+ * The repaint checklist below survives the reversal and still earns its keep,
+ * because every gate closing lands the canvas back in exactly the old
+ * situation: a paused hero, a hidden tab, a hero scrolled off screen and — for
+ * as long as somebody's machine asks for it — reduced motion, where no frame is
+ * ever run at all. An input without an explicit repaint leaves stale pixels
+ * there indefinitely rather than for 16ms, which is what the reported theme bug
+ * was. Each test names an input and asserts that changing it repaints.
  */
 
 /**
@@ -147,6 +152,8 @@ const WINDOW: GraphWindow = {
 let recorder: ReturnType<typeof recordingContext>;
 /** The callback the scene hands to its ResizeObserver, so a test can fire it. */
 let onResize: (() => void) | null;
+/** The callback the scene hands to its IntersectionObserver, likewise. */
+let onIntersect: ((entries: { isIntersecting: boolean }[]) => void) | null;
 /** Resolves the stand-in `document.fonts.ready`, on the test's cue. */
 let loadFonts: () => void;
 let realGetContext: HTMLCanvasElement["getContext"];
@@ -155,6 +162,7 @@ let realMatchMedia: typeof window.matchMedia;
 beforeEach(() => {
   recorder = recordingContext();
   onResize = null;
+  onIntersect = null;
   realGetContext = HTMLCanvasElement.prototype.getContext;
   realMatchMedia = window.matchMedia;
   // jsdom has no ResizeObserver, and the scene prefers one over the window
@@ -164,6 +172,20 @@ beforeEach(() => {
     class {
       constructor(callback: () => void) {
         onResize = callback;
+      }
+      observe() {}
+      disconnect() {}
+    },
+  );
+  // The hero stops its loop when it scrolls out of view, and jsdom has no
+  // IntersectionObserver — so standing one up is what lets that gate be driven
+  // rather than assumed. Absent one, `onScreen` stays true; that is the
+  // fallback, and it is what every other test here runs under.
+  vi.stubGlobal(
+    "IntersectionObserver",
+    class {
+      constructor(callback: (entries: { isIntersecting: boolean }[]) => void) {
+        onIntersect = callback;
       }
       observe() {}
       disconnect() {}
@@ -194,6 +216,7 @@ beforeEach(() => {
 });
 
 afterEach(() => {
+  Reflect.deleteProperty(HTMLCanvasElement.prototype, "getBoundingClientRect");
   document.documentElement.className = "";
   document.documentElement.removeAttribute("data-cc-theme");
   document.documentElement.removeAttribute("style");
@@ -204,6 +227,78 @@ afterEach(() => {
 
 /** Let a MutationObserver callback, which runs as a microtask, land. */
 const settle = () => new Promise<void>((resolve) => setTimeout(resolve, 0));
+
+/**
+ * Ask for stillness — **before** the scene is built.
+ *
+ * `prefersReducedMotion()` is read once at mount and then only re-read when the
+ * media query fires a change, so a test that flips this after rendering is
+ * testing the change listener rather than the preference.
+ */
+function preferReducedMotion() {
+  window.matchMedia = vi.fn().mockReturnValue({
+    matches: true,
+    addEventListener: vi.fn(),
+    removeEventListener: vi.fn(),
+  }) as unknown as typeof window.matchMedia;
+}
+
+/**
+ * A hand-cranked `requestAnimationFrame`, so a test can run frames one at a
+ * time and know exactly how much time passed in each.
+ *
+ * The loop re-requests itself every frame, so `step` always drives the most
+ * recent callback. The clock is the test's, not the machine's: the scene clamps
+ * a frame to 50ms, so 20ms a step is an ordinary frame rather than a catch-up.
+ */
+function frameClock() {
+  const pending: FrameRequestCallback[] = [];
+  let now = 1000;
+  const request = vi
+    .spyOn(window, "requestAnimationFrame")
+    .mockImplementation((callback) => {
+      pending.push(callback);
+      return pending.length;
+    });
+  const cancel = vi
+    .spyOn(window, "cancelAnimationFrame")
+    .mockImplementation(() => {});
+  vi.spyOn(performance, "now").mockImplementation(() => now);
+  return {
+    request,
+    cancel,
+    get frames() {
+      return pending.length;
+    },
+    step(ms = 20) {
+      now += ms;
+      pending[pending.length - 1]?.(now);
+    },
+    restore() {
+      request.mockRestore();
+      cancel.mockRestore();
+      vi.mocked(performance.now).mockRestore();
+    },
+  };
+}
+
+/** The canvas has a real box, so a pointer event has somewhere to land. */
+function giveCanvasABox(width = 320, height = 220) {
+  HTMLCanvasElement.prototype.getBoundingClientRect = vi.fn(
+    () =>
+      ({
+        left: 0,
+        top: 0,
+        right: width,
+        bottom: height,
+        width,
+        height,
+        x: 0,
+        y: 0,
+        toJSON: () => ({}),
+      }) as DOMRect,
+  );
+}
 
 describe("HeroNetwork repaints when", () => {
   // The reported bug. Every colour is a `--cc-*` token resolved at draw time,
@@ -537,7 +632,18 @@ describe("HeroNetwork draws a node's appearance", () => {
     expect(paths).toHaveLength(1);
   });
 
+  /**
+   * The three still marks, which are now the **reduced-motion** form.
+   *
+   * A machine that has asked for stillness gets no drift, no travelling signal
+   * and no frame loop — but a member who spent a whole transcript on tier 3
+   * still has to be shown what they picked, so the style is drawn as a mark
+   * around the node. Everything under here therefore asks for reduced motion
+   * first; on an ordinary machine these same three styles are wakes behind a
+   * moving head instead, which is `hero-signals.spec.ts`'s subject.
+   */
   it("draws concentric rings, all wider than the node, for the fade signal", () => {
+    preferReducedMotion();
     const rings = paintOnce(windowOf({ signalStyle: "fade" })).filter(
       (path) => path.stroked && path.arcs.length === 1,
     );
@@ -550,6 +656,7 @@ describe("HeroNetwork draws a node's appearance", () => {
   });
 
   it("draws a broken ring for the dashed signal, and leaves no pattern behind", () => {
+    preferReducedMotion();
     const dashed = paintOnce(windowOf({ signalStyle: "dashed" })).filter(
       (path) => path.dash.length > 0,
     );
@@ -566,6 +673,7 @@ describe("HeroNetwork draws a node's appearance", () => {
    * across it. A node to the right of centre must trail off to the right.
    */
   it("trails a comet outward, away from the centre of the frame", () => {
+    preferReducedMotion();
     const segments = paintOnce({
       centre: { x: 0, y: 0 },
       nodes: [node({ id: "n", ...CLEAR_RIGHT, signalStyle: "comet" })],
@@ -591,15 +699,16 @@ describe("HeroNetwork draws a node's appearance", () => {
   });
 
   /**
-   * The whole canvas rests on painting when an input changes rather than 60
-   * times a second, and a signal is the obvious place to break that. Nothing
-   * added here animates: a scene with every signal style on it and no label
-   * must not arm a frame loop.
+   * The reversal, asserted.
+   *
+   * This test used to be "never starts a frame loop for a signal, however many
+   * are on screen", and it was the load-bearing statement of the old design.
+   * ADR 0006 reverses it: the field drifts and signals travel, so the loop runs
+   * with no label, no click and nobody having asked for anything. What replaces
+   * the old guarantee is the four gates below.
    */
-  it("never starts a frame loop for a signal, however many are on screen", () => {
-    const frame = vi
-      .spyOn(window, "requestAnimationFrame")
-      .mockReturnValue(1 as unknown as number);
+  it("runs a frame loop for the drifting graph window, label or no label", () => {
+    const clock = frameClock();
     try {
       render(
         <HeroNetwork
@@ -616,16 +725,58 @@ describe("HeroNetwork draws a node's appearance", () => {
         />,
       );
 
-      expect(frame).not.toHaveBeenCalled();
+      expect(clock.request).toHaveBeenCalled();
     } finally {
-      frame.mockRestore();
+      clock.restore();
+    }
+  });
+
+  /**
+   * The gate that has to hold hardest, because it is the one somebody asked
+   * for. Reduced motion is not a dimmer switch here: no drift, no travelling
+   * signal, no frame at all — the three still marks and nothing else.
+   */
+  it("runs no frame at all when the machine has asked for stillness", () => {
+    preferReducedMotion();
+    const clock = frameClock();
+    try {
+      render(<HeroNetwork window={WINDOW} labelled={true} />);
+
+      expect(clock.request).not.toHaveBeenCalled();
+    } finally {
+      clock.restore();
+    }
+  });
+
+  /**
+   * The gate the old paint-on-demand canvas never needed.
+   *
+   * The landing page is taller than its hero, so a reader down among the
+   * sections would otherwise pay sixty frames a second for a graph window
+   * nobody can see.
+   */
+  it("stops the loop once the hero has scrolled out of view, and resumes", () => {
+    const clock = frameClock();
+    try {
+      render(<HeroNetwork window={WINDOW} labelled={false} />);
+      expect(onIntersect).toBeTypeOf("function");
+
+      onIntersect?.([{ isIntersecting: false }]);
+      expect(clock.cancel).toHaveBeenCalled();
+
+      clock.request.mockClear();
+      onIntersect?.([{ isIntersecting: true }]);
+      expect(clock.request).toHaveBeenCalled();
+    } finally {
+      clock.restore();
     }
   });
 
   // The column is free text and the enums may grow. A name this build has never
-  // heard of draws as an ordinary node rather than dropping somebody out of a
-  // neighbourhood or throwing on their behalf.
+  // heard of draws as an ordinary node rather than dropping somebody out of the
+  // graph window or throwing on their behalf.
   it("draws an unknown style or signal as a plain unconfigured node", () => {
+    preferReducedMotion();
     const paths = paintOnce(
       windowOf({ style: "hexagon", signalStyle: "fireworks" }),
     );
@@ -634,5 +785,118 @@ describe("HeroNetwork draws a node's appearance", () => {
       paths.filter((path) => path.filled && path.arcs.length === 1),
     ).toHaveLength(1);
     expect(paths.filter((path) => path.stroked)).toHaveLength(0);
+  });
+});
+
+/**
+ * The canvas takes the pointer now.
+ *
+ * `landing.tsx` makes the copy layer transparent to the pointer everywhere the
+ * keep-out does not reserve, so a click in the gaps between the copy blocks
+ * reaches a node. Nothing here writes a row, changes any state or navigates —
+ * a **burst** is decoration a visitor asked for — which is also why the canvas
+ * stays `aria-hidden`.
+ */
+describe("HeroNetwork under the pointer", () => {
+  /**
+   * Where a node actually landed, read back off the recorder.
+   *
+   * The projection's anchor is a function of the frame and the measured copy,
+   * so hard-coding a screen position here would be asserting the anchor search
+   * rather than the hit test. An ordinary node is the one path with a single
+   * arc at exactly `NODE_RADIUS`, which is a thing the recorder already knows.
+   */
+  function drawnNodes() {
+    return recorder.paths
+      .filter(
+        (path) => path.arcs.length === 1 && path.arcs[0].r === NODE_RADIUS,
+      )
+      .map((path) => path.arcs[0]);
+  }
+
+  /** Two nodes clear of the copy, and the backbone edge between them. */
+  const WITH_EDGE: GraphWindow = {
+    centre: { x: 0, y: 0 },
+    nodes: [
+      node({ id: "a", ...CLEAR_LEFT }),
+      node({ id: "b", x: -260, y: 120 }),
+    ],
+    edges: [{ fromId: "a", toId: "b" }],
+  };
+
+  it("offers a pointer cursor over a node and takes it back off open space", () => {
+    giveCanvasABox();
+    const { getByTestId } = render(
+      <HeroNetwork window={WITH_EDGE} labelled={false} />,
+    );
+    const canvas = getByTestId("hero-network");
+    const dots = drawnNodes();
+    expect(dots.length).toBeGreaterThan(0);
+
+    fireEvent.pointerMove(canvas, { clientX: dots[0].x, clientY: dots[0].y });
+    expect(canvas.style.cursor).toBe("pointer");
+
+    // Well outside the hit radius of anything, and back to the default cursor.
+    fireEvent.pointerMove(canvas, {
+      clientX: dots[0].x + 120,
+      clientY: dots[0].y + 90,
+    });
+    expect(canvas.style.cursor).toBe("");
+  });
+
+  /**
+   * Nothing about the dots is advertised as clickable on a machine that asked
+   * for stillness, because on that machine they are not: the click path is off
+   * with the rest of the motion.
+   */
+  it("advertises nothing when the machine has asked for stillness", () => {
+    preferReducedMotion();
+    giveCanvasABox();
+    const { getByTestId } = render(
+      <HeroNetwork window={WITH_EDGE} labelled={false} />,
+    );
+    const canvas = getByTestId("hero-network");
+    const dots = drawnNodes();
+    expect(dots.length).toBeGreaterThan(0);
+
+    fireEvent.pointerMove(canvas, { clientX: dots[0].x, clientY: dots[0].y });
+
+    expect(canvas.style.cursor).toBe("");
+  });
+
+  /**
+   * The whole feature, end to end: a click on a dot puts light on the wire.
+   *
+   * A burst arm leaves at `p = 0` and the envelope is zero there, so this pumps
+   * frames rather than asserting on the click itself — a signal that appeared
+   * fully formed at its sender's own centre would be the bug this catches.
+   * `hero-signals.spec.ts` holds what the arms are; this holds that the click
+   * reaches them at all.
+   */
+  it("bursts light along the graph window's edges when a node is clicked", () => {
+    giveCanvasABox();
+    const clock = frameClock();
+    try {
+      const { getByTestId } = render(
+        <HeroNetwork window={WITH_EDGE} labelled={false} />,
+      );
+      const canvas = getByTestId("hero-network");
+      const dots = drawnNodes();
+      expect(dots.length).toBeGreaterThan(0);
+
+      fireEvent.pointerDown(canvas, { clientX: dots[0].x, clientY: dots[0].y });
+
+      recorder.paths.length = 0;
+      for (let i = 0; i < 40; i++) clock.step();
+
+      // A halo disc: filled, one arc, and wider than any node on the canvas.
+      const halo = recorder.paths.filter(
+        (path) =>
+          path.filled && path.arcs.length === 1 && path.arcs[0].r > NODE_RADIUS,
+      );
+      expect(halo.length).toBeGreaterThan(0);
+    } finally {
+      clock.restore();
+    }
   });
 });

--- a/apps/web/features/landing/components/hero-network.tsx
+++ b/apps/web/features/landing/components/hero-network.tsx
@@ -919,6 +919,10 @@ export function HeroNetwork({
       onPointerDown={(event) => {
         const scene = sceneRef.current;
         if (!scene || scene.reduced || scene.paused) return;
+        // The primary button only. A right-click is on its way to a context
+        // menu and a middle-click to a paste; neither is somebody asking the
+        // graph for anything. Touch and pen both report 0 here.
+        if (event.button !== 0) return;
         const hit = nodeUnder(scene, event);
         // Its own node bursts like any other, and that is the best discovery
         // moment this feature has: the page has just pointed at your dot.

--- a/apps/web/features/landing/components/hero-network.tsx
+++ b/apps/web/features/landing/components/hero-network.tsx
@@ -4,6 +4,16 @@ import { useEffect, useRef } from "react";
 import type { GraphWindow } from "../api/queries";
 import { fallbackRects, type Rect, SAFETY } from "../lib/hero-keepout";
 import {
+  advanceField,
+  burstAt,
+  createField,
+  type FieldNode,
+  hitTest,
+  type Signal,
+  signalPaint,
+  syncField,
+} from "../lib/hero-signals";
+import {
   FALLBACK_NODE_COLOR_VAR,
   type GraphWindowView,
   NO_SIGNAL,
@@ -11,6 +21,7 @@ import {
   NODE_RADIUS,
   projectGraphWindow,
   type ScreenNode,
+  VISIBLE,
 } from "../lib/neighbourhood-view";
 
 /**
@@ -22,35 +33,53 @@ import {
  * something a person should have to ask to see, so there is one thing on this
  * canvas now — a bounded window on the stored graph:
  *
- * - a member sees their own neighbourhood, centred on their own node;
- * - a visitor sees a window centred on the community origin, with no "You".
+ * - a member's **graph window** is their own neighbourhood, centred on their
+ *   own node;
+ * - a visitor's is centred on the community origin, with no "You".
  *
  * **Find your dot** no longer swaps anything. The graph is already on screen;
  * the flow only labels the viewer's own node, and the reveal is the pulse and
- * the label appearing. Nothing else changes, which is also what the artboard
- * does: "the graph never moves: the dot grows and pulses in place".
+ * the label appearing. The graph does not rearrange itself for it — the
+ * artboard's words at :814, *"the graph never moves: the dot grows and pulses
+ * in place"* — so the labelled node is also the one node that stops drifting
+ * while the label is up.
  *
- * The graph is still. Real world positions must not appear to wander, and no
- * signal travels along a line, because a **backbone edge records placement
- * history and is not a friendship** — animating a recommendation along one
- * would give it a social meaning the data does not have. The only motion on
- * this canvas is the pulse on the labelled node, so the frame loop runs only
- * while that pulse is on screen and the scene is otherwise drawn once.
+ * **The graph is alive, and that is a decision rather than a default.** Nodes
+ * drift inside a ±5px box around where the projection put them, signals travel
+ * along backbone edges, and a click fans one out along every backbone edge that
+ * node has inside the drawn graph window.
+ * The previous version of this file argued the opposite at length — that a
+ * signal along a **backbone edge** would give it "a social meaning the data
+ * does not have", and that a travelling signal would mean a frame loop that
+ * never stops — and **ADR 0006 reverses both**. The edge is still not a
+ * friendship, in the data or in `CONTEXT.md`; what the canvas asserts is only
+ * that this is a community and things move through it, which is true, and the
+ * still version of this hero made its most expensive feature indistinguishable
+ * from a background image. The frame loop is real, and it is bounded by gates
+ * rather than by having nothing to draw: it runs only while the hero is on
+ * screen, un-paused, un-hidden, and motion is allowed. That is a weaker
+ * guarantee than "painted once" and it is the price the ADR names.
  *
- * **Node appearance is drawn, and none of it animates.** A node draws its
- * `style` as a shape and its `signalStyle` as a mark around that shape. A signal
- * is *ongoing* — `CONTEXT.md` — so it is painted on every frame a node is
- * painted, unlike the **pulse**, which is a one-shot reveal on the viewer's own
- * node and the only thing here that moves. Drawing a signal in motion would mean
- * a frame loop that never stops, which is the one property of this canvas the
- * whole design rests on; the trail is therefore rendered rather than played, and
- * the geometry below says what each style looks like standing still.
+ * **Node appearance is drawn, and the third axis is the thing that moves.** A
+ * node draws its `style` as a shape and its `signalStyle` as the wake its
+ * signals leave — the third and last **personalization tier**, and the only
+ * axis a member reaches by reviewing their entire transcript. Every node
+ * signals; the tier picks the style and never whether it goes. The standing
+ * still marks below (`FADE_RINGS`, `COMET_SEGMENTS`, `DASHED_RING`) are kept as
+ * the **reduced-motion** form of the same three styles, so a member who chose
+ * one still sees what they chose on a machine that has asked for stillness.
+ *
+ * The model — drift, spawn, relay, burst, trail geometry — lives in
+ * `hero-signals.ts` as a pure function of the view and the elapsed time, seeded
+ * from node and edge identity with no `Math.random()` anywhere. This file
+ * measures, projects, paints, and owns the gates.
  *
  * Everything the projection derives — the scale, the anchor, the screen
- * coordinates, the keep-out push — is thrown away on the next resize. None of it
- * is ever sent back. The measuring below is what the derivation is a function
- * of: one padded rect per rendered content block, per line for a text block, so
- * a resize or a font swap re-derives rather than drifts.
+ * coordinates, the keep-out push — is thrown away on the next resize. None of
+ * it is ever sent back, and neither is a pixel of the drift. The measuring
+ * below is what the derivation is a function of: one padded rect per rendered
+ * content block, per line for a text block, so a resize or a font swap
+ * re-derives rather than drifts.
  */
 
 /** `PAL.dotA` and `PAL.lineA` from the Landing artboard's palette. */
@@ -68,21 +97,8 @@ const EDGE_ALPHA = 0.26;
  */
 const DIAMOND_REACH = Math.sqrt(Math.PI / 2);
 
-/** How much fainter than its node a signal is drawn. */
+/** How much fainter than its node a standing-still signal mark is drawn. */
 const SIGNAL_ALPHA = 0.5;
-
-/**
- * The clearance below which a thing is not painted at all.
- *
- * `pushClear` places nodes clear of the copy, so this is 1 for everything on an
- * ordinary frame and the threshold never fires. It fires where the push gave
- * up — a hero whose copy reaches past every edge has nowhere to put anybody —
- * and there it is the whole of the keep-out. **Everything painted on this
- * canvas has to pass it**, the reveal included: the reveal is a bigger mark
- * than the node it replaces, so a labelled viewer exempted from the check would
- * put more ink over the headline than the dot the check just removed.
- */
-const VISIBLE = 0.02;
 
 /**
  * `fade`: concentric rings, each fainter and wider than the last — a trail that
@@ -126,14 +142,22 @@ type Scene = {
   labelled: boolean;
   /** The page is handing itself over to Explore; nothing on this canvas moves. */
   paused: boolean;
+  /** The hero is on screen. Assumed true where there is no IntersectionObserver. */
+  onScreen: boolean;
   window: GraphWindow | null;
   view: GraphWindowView | null;
+  /** Drift and signals: the only mutable state on this canvas. */
+  field: ReturnType<typeof createField>;
+  /** The viewer's node id, so the loop can hold it still while it is labelled. */
+  viewerId: string | null;
+  /** The cursor last written to the canvas, so it is written only on a change. */
+  cursor: string;
   /**
-   * Start and stop the pulse loop. They close over the frame callback, so the
+   * Start and stop the frame loop. They close over the frame callback, so the
    * effect that builds it hands them back here for the props effects to use.
    */
-  startPulse?: () => void;
-  stopPulse?: () => void;
+  startLoop?: () => void;
+  stopLoop?: () => void;
 };
 
 /**
@@ -223,6 +247,12 @@ function nodeColour(palette: Palette, colorVar: string) {
  * Called on every relayout and whenever a read answers, so the projection is
  * always a function of the current frame — which is why it can be thrown away
  * and why none of it is ever persisted.
+ *
+ * The field is pointed at the result rather than rebuilt from it: **reproject,
+ * do not reset**. A resize keeps every node's wander and every signal's
+ * progress, because the people did not change; a refetch mints new ids and so
+ * clears, because different ids are different people-slots. `syncField` is
+ * where both of those fall out of one rule.
  */
 function refreshView(scene: Scene) {
   const measured = measureRects(scene.root, scene.canvas);
@@ -235,6 +265,9 @@ function refreshView(scene: Scene) {
         keepOut,
       })
     : null;
+  syncField(scene.field, scene.view, keepOut, scene.w);
+  scene.viewerId =
+    scene.field.nodes.find((node) => node.node.isViewer)?.node.id ?? null;
 }
 
 function resize(scene: Scene) {
@@ -251,8 +284,17 @@ function resize(scene: Scene) {
   scene.canvas.height = Math.round(h * dpr);
 }
 
+/**
+ * One frame.
+ *
+ * Everything is drawn from the **field** rather than from the view, including
+ * under reduced motion — there the field is simply never advanced, so every
+ * node sits exactly on the home the projection gave it and every edge keeps the
+ * clearance the projection sampled. One set of loops, one set of coordinates,
+ * and no second code path that only runs on somebody else's machine.
+ */
 function draw(scene: Scene) {
-  const { ctx, view } = scene;
+  const { ctx, view, field } = scene;
   ctx.setTransform(scene.dpr, 0, 0, scene.dpr, 0, 0);
   ctx.clearRect(0, 0, scene.w, scene.h);
   // Nobody has joined yet, or the read has not answered. An empty community
@@ -266,33 +308,40 @@ function draw(scene: Scene) {
   // a node, each multiplied by how clear of the copy it landed.
   ctx.strokeStyle = palette.line;
   ctx.lineWidth = 1;
-  for (const edge of view.edges) {
+  for (const edge of field.edges) {
     if (edge.clearance <= VISIBLE) continue;
     ctx.globalAlpha = EDGE_ALPHA * edge.clearance;
     ctx.beginPath();
-    ctx.moveTo(edge.from.screenX, edge.from.screenY);
-    ctx.lineTo(edge.to.screenX, edge.to.screenY);
+    ctx.moveTo(edge.from.x, edge.from.y);
+    ctx.lineTo(edge.to.x, edge.to.y);
     ctx.stroke();
   }
 
   // Signals go under the nodes, so a trail never sits on top of the dot it
   // belongs to. Two passes rather than one interleaved loop, because a node
   // drawn after its own signal would still be drawn before the *next* node's.
-  for (const node of view.nodes) {
-    if (node.clearance <= VISIBLE || node.signalStyle === NO_SIGNAL) continue;
-    drawSignal(scene, palette, node);
+  if (scene.reduced) {
+    for (const node of field.nodes) {
+      if (node.clearance <= VISIBLE || node.node.signalStyle === NO_SIGNAL)
+        continue;
+      drawSignalMark(scene, palette, node);
+    }
+  } else {
+    for (const signal of field.signals) {
+      drawSignal(scene, palette, signal);
+    }
   }
 
-  for (const node of view.nodes) {
+  for (const node of field.nodes) {
     if (node.clearance <= VISIBLE) continue;
     ctx.globalAlpha = NODE_ALPHA * node.clearance;
-    ctx.fillStyle = nodeColour(palette, node.colorVar);
+    ctx.fillStyle = nodeColour(palette, node.node.colorVar);
     ctx.strokeStyle = ctx.fillStyle;
-    drawNodeShape(ctx, node.screenX, node.screenY, NODE_RADIUS, node.style);
+    drawNodeShape(ctx, node.x, node.y, NODE_RADIUS, node.node.style);
   }
 
   if (scene.labelled) {
-    const you = view.nodes.find((node) => node.isViewer);
+    const you = field.nodes.find((node) => node.node.isViewer);
     // The same gate as every other mark. Their node is normally pushed clear
     // and this passes; when the copy left the push nowhere to go it does not,
     // and the reveal goes with the dot rather than being drawn over the
@@ -355,74 +404,111 @@ function drawNodeShape(
 }
 
 /**
- * The signal a node carries, drawn standing still.
+ * A signal in flight, in the wake its sender's `signalStyle` chose.
  *
- * **It does not move, and that is deliberate.** A signal is ongoing rather than
- * one-shot, so it is painted every time its node is painted — but this canvas
- * paints on demand, and a signal that animated would mean a frame loop running
- * for as long as anybody has the landing page open. `hero-network.spec.tsx` is
- * written as the checklist of what triggers a repaint precisely because there is
- * no such loop, and the pulse on the viewer's own node remains the only motion
- * here.
+ * `hero-signals.ts` has already decided everything: where the head is, how
+ * bright it is, how far the wake runs, and what shape it is. This traces the
+ * result. The one decision left here is the colour, and it is the **sending
+ * node's** — the signal is theirs, so it draws in the colour their dot draws
+ * in and no other.
  *
- * `comet` needs a direction, and the only one available is geometric: the trail
- * points away from the middle of the frame. That is stable across repaints, it
- * costs no per-node state, and it leans every trail outward — away from the hero
- * copy, which sits in the middle — rather than across it. A node exactly on the
- * centre has no outward direction and falls back to a fixed diagonal.
+ * `signalPaint` folds the edge's clearance into every alpha it returns, so this
+ * needs no clearance check of its own: a signal running under the copy arrives
+ * already faded to nothing, and one under a copy the push could not clear
+ * arrives at zero and is not returned at all.
+ */
+function drawSignal(scene: Scene, palette: Palette, signal: Signal) {
+  const { ctx } = scene;
+  const paint = signalPaint(scene.field, signal, { dim: scene.labelled });
+  if (!paint) return;
+  const colour = nodeColour(palette, paint.colorVar);
+
+  ctx.fillStyle = colour;
+  ctx.strokeStyle = colour;
+  for (const disc of paint.halo) {
+    ctx.globalAlpha = disc.alpha;
+    ctx.beginPath();
+    ctx.arc(disc.x, disc.y, disc.radius, 0, Math.PI * 2);
+    ctx.fill();
+  }
+
+  if (paint.dash) ctx.setLineDash?.(paint.dash);
+  ctx.lineCap = "round";
+  for (const stroke of paint.strokes) {
+    ctx.globalAlpha = stroke.alpha;
+    ctx.lineWidth = stroke.width;
+    ctx.beginPath();
+    ctx.moveTo(stroke.fromX, stroke.fromY);
+    ctx.lineTo(stroke.toX, stroke.toY);
+    ctx.stroke();
+  }
+  ctx.lineCap = "butt";
+  // Every later stroke on this frame — the next signal's, an edge, the pulse
+  // ring — is solid, so the pattern is cleared here rather than trusted to be
+  // reset by whoever comes next.
+  if (paint.dash) ctx.setLineDash?.([]);
+
+  ctx.lineWidth = 1;
+  for (const ring of paint.rings) {
+    ctx.globalAlpha = ring.alpha;
+    ctx.beginPath();
+    ctx.arc(ring.x, ring.y, ring.radius, 0, Math.PI * 2);
+    ctx.stroke();
+  }
+}
+
+/**
+ * The **reduced-motion** form of a node's signal style: the same wake, standing
+ * still.
  *
- * The middle of the **frame**, deliberately, and no longer `view.centre`. Those
- * were the same point while the projection was centred on the viewport; now that
+ * A machine that has asked for stillness gets no drift, no travelling signals
+ * and no frame loop — but a member who spent their whole transcript on tier 3
+ * still has to be able to see what they picked, so the style is drawn as a mark
+ * around the node instead. It is the better answer than the export's, which
+ * drops to two anonymous glows on two arbitrary nodes (:892-898) and shows
+ * nobody their own choice.
+ *
+ * `comet` needs a direction, and the only one available standing still is
+ * geometric: the trail points away from the middle of the frame. That is stable
+ * across repaints, it costs no per-node state, and it leans every trail
+ * outward — away from the hero copy, which sits in the middle — rather than
+ * across it. A node exactly on the centre has no outward direction and falls
+ * back to a fixed diagonal.
+ *
+ * The middle of the **frame**, deliberately, and not `view.centre`. Those were
+ * the same point while the projection was centred on the viewport; now that
  * `pickViewportCentre` anchors the graph clear of the copy they are not, and it
  * is the frame the copy sits in the middle of. Aiming at the anchor instead
  * would point the trail of every node below it straight back through the
- * headline. `pushClear` rotates a trail as it moves the node it belongs to,
- * which is right for the same reason: it points away from where the node ended
- * up rather than from where the projection first put it.
+ * headline.
  *
- * One knock-on from the push worth naming: `clearance` is 1 for every node the
- * push placed, so a signal beside the copy is drawn at full strength where it
- * used to be dimmed towards nothing. That is the fix working rather than a
- * regression — the copy is protected by 14px of distance now instead of by
- * dimness — and the margins hold: the longest mark here is `comet`, at
- * `5.4 * NODE_RADIUS` = 21.6px, so it reaches at most 7.6px into a padded rect
- * and stops about 17px short of the text `SAFETY` is padding.
+ * The margins hold: the longest mark here is `comet`, at `5.4 * NODE_RADIUS` =
+ * 21.6px, so it reaches at most 7.6px into a padded rect and stops about 17px
+ * short of the text `SAFETY` is padding.
  */
-function drawSignal(scene: Scene, palette: Palette, node: ScreenNode) {
+function drawSignalMark(scene: Scene, palette: Palette, node: FieldNode) {
   const { ctx } = scene;
-  const colour = nodeColour(palette, node.colorVar);
+  const colour = nodeColour(palette, node.node.colorVar);
   const base = NODE_ALPHA * node.clearance * SIGNAL_ALPHA;
   ctx.strokeStyle = colour;
 
-  if (node.signalStyle === "fade") {
+  if (node.node.signalStyle === "fade") {
     for (const ring of FADE_RINGS) {
       ctx.globalAlpha = base * ring.alpha;
       ctx.lineWidth = 1;
       ctx.beginPath();
-      ctx.arc(
-        node.screenX,
-        node.screenY,
-        NODE_RADIUS * ring.reach,
-        0,
-        Math.PI * 2,
-      );
+      ctx.arc(node.x, node.y, NODE_RADIUS * ring.reach, 0, Math.PI * 2);
       ctx.stroke();
     }
     return;
   }
 
-  if (node.signalStyle === "dashed") {
+  if (node.node.signalStyle === "dashed") {
     ctx.globalAlpha = base * DASHED_RING.alpha;
     ctx.lineWidth = DASHED_RING.width;
     ctx.setLineDash?.(DASHED_RING.dash);
     ctx.beginPath();
-    ctx.arc(
-      node.screenX,
-      node.screenY,
-      NODE_RADIUS * DASHED_RING.reach,
-      0,
-      Math.PI * 2,
-    );
+    ctx.arc(node.x, node.y, NODE_RADIUS * DASHED_RING.reach, 0, Math.PI * 2);
     ctx.stroke();
     // Every later stroke on this frame — the next node's, the pulse ring — is
     // solid, so the pattern is cleared here rather than trusted to be reset.
@@ -430,8 +516,8 @@ function drawSignal(scene: Scene, palette: Palette, node: ScreenNode) {
     return;
   }
 
-  const dx = node.screenX - scene.w / 2;
-  const dy = node.screenY - scene.h / 2;
+  const dx = node.x - scene.w / 2;
+  const dy = node.y - scene.h / 2;
   const length = Math.hypot(dx, dy);
   const ux = length > 0.5 ? dx / length : Math.SQRT1_2;
   const uy = length > 0.5 ? dy / length : -Math.SQRT1_2;
@@ -441,12 +527,12 @@ function drawSignal(scene: Scene, palette: Palette, node: ScreenNode) {
     ctx.lineWidth = segment.width;
     ctx.beginPath();
     ctx.moveTo(
-      node.screenX + ux * NODE_RADIUS * segment.from,
-      node.screenY + uy * NODE_RADIUS * segment.from,
+      node.x + ux * NODE_RADIUS * segment.from,
+      node.y + uy * NODE_RADIUS * segment.from,
     );
     ctx.lineTo(
-      node.screenX + ux * NODE_RADIUS * segment.to,
-      node.screenY + uy * NODE_RADIUS * segment.to,
+      node.x + ux * NODE_RADIUS * segment.to,
+      node.y + uy * NODE_RADIUS * segment.to,
     );
     ctx.stroke();
   }
@@ -456,13 +542,15 @@ function drawSignal(scene: Scene, palette: Palette, node: ScreenNode) {
 /**
  * The viewer's own node, once **Find your dot** has found it: a restrained
  * pulse and a small label, no fanfare — and drawn exactly where the node
- * already was. The reveal adds a label to the graph; it does not rearrange it.
+ * already was. The reveal adds a label to the graph; it does not rearrange it,
+ * and the loop holds this one node still for as long as the label is up so that
+ * the label is not attached to something that is wandering out from under it.
  */
-function drawYou(scene: Scene, palette: Palette, you: ScreenNode) {
+function drawYou(scene: Scene, palette: Palette, you: FieldNode) {
   const { ctx } = scene;
-  const x = you.screenX;
-  const y = you.screenY;
-  const colour = nodeColour(palette, you.colorVar);
+  const x = you.x;
+  const y = you.y;
+  const colour = nodeColour(palette, you.node.colorVar);
 
   if (!scene.reduced) {
     const phase = (scene.pulse % 1.9) / 1.9;
@@ -480,7 +568,7 @@ function drawYou(scene: Scene, palette: Palette, you: ScreenNode) {
   ctx.strokeStyle = colour;
   // The reveal enlarges the node the member already has; it does not swap it
   // for a generic dot. Somebody who chose a diamond is looking for a diamond.
-  drawNodeShape(ctx, x, y, 7.5, you.style);
+  drawNodeShape(ctx, x, y, 7.5, you.node.style);
   ctx.globalAlpha = 0.5;
   ctx.strokeStyle = colour;
   ctx.lineWidth = 1;
@@ -504,24 +592,47 @@ function drawYou(scene: Scene, palette: Palette, you: ScreenNode) {
   ctx.fillText(label, lx + 7, ly + 10);
 }
 
+/**
+ * Where a pointer event landed, in canvas pixels, or `null` if the canvas has
+ * no box to measure against.
+ *
+ * The canvas is laid out at CSS size and backed at `dpr`, so the ratio is
+ * between the rendered box and `scene.w`/`scene.h` — the same conversion the
+ * export does at :1428 — and not the device pixel ratio, which the transform
+ * has already accounted for.
+ */
+function pointerPoint(
+  scene: Scene,
+  event: { clientX: number; clientY: number },
+) {
+  const box = scene.canvas.getBoundingClientRect();
+  if (!box.width || !box.height) return null;
+  return {
+    x: ((event.clientX - box.left) * scene.w) / box.width,
+    y: ((event.clientY - box.top) * scene.h) / box.height,
+  };
+}
+
 type Props = {
   /**
-   * The bounded window to draw: the member's own neighbourhood, or the public
-   * one. `null` only while the first read is still in flight.
+   * The **graph window** to draw: the member's own neighbourhood, or the
+   * public one. `null` only while the first read is still in flight.
    */
   window: GraphWindow | null;
   /**
    * **Find your dot** has located the viewer's node. The graph is unaffected —
-   * this adds the pulse and the label and nothing else.
+   * this adds the pulse and the label, holds that one node still, and fades the
+   * rest of the traffic back so the label is what the eye goes to.
    */
   labelled: boolean;
   /**
    * The landing is leaving for Explore.
    *
    * Competing motion is the biggest tell in a shared-element transition, so for
-   * the length of it the only thing moving is the layout. The pulse is the only
-   * animation this canvas ever runs, and it stops here — the scene keeps its
-   * last painted frame and fades out with the rest of the hero.
+   * the length of it the only thing moving is the layout. The whole loop stops
+   * here — drift, signals and pulse alike — and the scene keeps its last
+   * painted frame and fades out with the rest of the hero. Clicks stop landing
+   * too: a burst fired into a page that is leaving is motion nobody asked for.
    */
   paused?: boolean;
 };
@@ -555,8 +666,12 @@ export function HeroNetwork({
       last: 0,
       labelled: false,
       paused: false,
+      onScreen: true,
       window: null,
       view: null,
+      field: createField(),
+      viewerId: null,
+      cursor: "",
     };
     sceneRef.current = scene;
     resize(scene);
@@ -564,16 +679,27 @@ export function HeroNetwork({
     draw(scene);
 
     /**
-     * The pulse, and only the pulse.
+     * The frame loop, and its four gates.
      *
-     * A graph of stored positions does not move, so there is nothing to animate
-     * until a node is labelled: the scene is painted once and left alone. This
-     * loop starts when the label appears and stops when it goes, rather than
-     * burning a frame every 16ms to redraw an identical picture.
+     * The scene is no longer painted on demand: nodes drift and signals travel,
+     * so this runs continuously — but only while **all** of the hero being on
+     * screen, the page not handing itself to Explore, the tab not hidden, and
+     * motion being allowed. ADR 0006 names that trade explicitly: a loop
+     * bounded by gates rather than by having nothing to draw is a weaker
+     * guarantee than "painted once", and it is the price of a hero that is not
+     * a background image.
+     *
+     * The pulse folds in rather than keeping its own bookkeeping. It advances
+     * only while a label is up, so its phase is still measured from the moment
+     * the label appeared and not from mount.
      */
     const tick = (ts: number) => {
-      scene.pulse += Math.max(0, Math.min(0.05, (ts - scene.last) / 1000));
+      const dt = Math.max(0, Math.min(0.05, (ts - scene.last) / 1000));
       scene.last = ts;
+      if (scene.labelled) scene.pulse += dt;
+      advanceField(scene.field, dt, {
+        holdId: scene.labelled ? scene.viewerId : null,
+      });
       draw(scene);
       scene.raf = requestAnimationFrame(tick);
     };
@@ -583,15 +709,19 @@ export function HeroNetwork({
       scene.raf = 0;
     };
     const start = () => {
-      if (scene.raf || !scene.labelled || scene.reduced || scene.paused) return;
-      // A hidden tab has nothing to animate for, and the label appearing while
-      // one is hidden must not arm a loop nothing will see.
+      if (scene.raf || scene.reduced || scene.paused || !scene.onScreen) return;
+      // A hidden tab has nothing to animate for, and a gate opening while one
+      // is hidden must not arm a loop nothing will see.
       if (document.hidden) return;
       scene.last = performance.now();
       scene.raf = requestAnimationFrame(tick);
     };
-    scene.startPulse = start;
-    scene.stopPulse = stop;
+    scene.startLoop = start;
+    scene.stopLoop = stop;
+    // Deliberately not started here. The `paused` and `labelled` effects below
+    // run immediately after this one on mount and each ends in a `startLoop()`
+    // that re-checks every gate, so arming it here as well would start a loop
+    // for a hero that mounted already paused and then cancel it a tick later.
 
     const relayout = () => {
       resize(scene);
@@ -608,6 +738,26 @@ export function HeroNetwork({
     const onWindowResize = () => relayout();
     if (!observer) window.addEventListener("resize", onWindowResize);
 
+    /**
+     * The hero scrolling out of view stops the loop.
+     *
+     * This is the gate the old paint-on-demand canvas did not need and the new
+     * one does: the landing page is taller than the hero, so a reader who has
+     * scrolled to the sections below would otherwise be paying 60 frames a
+     * second for a graph nobody can see. Where there is no `IntersectionObserver`
+     * — jsdom, and browsers old enough that the rest of this page has bigger
+     * problems — `onScreen` stays true and the other three gates still hold.
+     */
+    const watcher =
+      typeof IntersectionObserver === "function"
+        ? new IntersectionObserver((entries) => {
+            scene.onScreen = entries.some((entry) => entry.isIntersecting);
+            if (scene.onScreen) start();
+            else stop();
+          })
+        : null;
+    watcher?.observe(canvas);
+
     // A hidden tab has nothing to animate for. Browsers throttle rAF there, but
     // stopping outright means no work at all rather than less of it.
     const onVisibility = () => {
@@ -621,9 +771,11 @@ export function HeroNetwork({
      *
      * Every colour on this canvas is a `--cc-*` token resolved at draw time, so
      * the palette is an input to the frame exactly like the data and the size
-     * are. Pixels already rasterised do not re-resolve a custom property, and
-     * the scene is otherwise painted once and left alone, so without this the
-     * graph keeps its old colours until something else happens to redraw it.
+     * are. The loop covers this while it is running, but every one of its four
+     * gates is a state in which the scene is still on screen and still has to
+     * be right — a paused hero mid-transition, a hero the reader has scrolled
+     * back to, and above all a reduced-motion machine, which never runs a frame
+     * at all and would otherwise keep its old colours forever.
      *
      * The root element is watched rather than `next-themes`' `resolvedTheme`,
      * and the difference is not a preference. `ThemeProvider` applies the theme
@@ -642,8 +794,8 @@ export function HeroNetwork({
      * attribute and `next-themes` defaults to `data-theme` — so a filter here
      * would be a second place that has to be edited in step with
      * `app/layout.tsx`, and forgetting would leave stale pixels rather than a
-     * failing build. Root attributes change rarely enough that redrawing a
-     * still scene for one is cheaper than getting the filter wrong.
+     * failing build. Root attributes change rarely enough that redrawing for
+     * one is cheaper than getting the filter wrong.
      */
     const themeWatcher = new MutationObserver(() => draw(scene));
     themeWatcher.observe(document.documentElement, { attributes: true });
@@ -654,8 +806,8 @@ export function HeroNetwork({
      * The keep-out is measured off the rendered text — `getClientRects()` per
      * line — so it is measured against whatever font was in place at the time.
      * A fallback face swapping to Geist reflows those lines without necessarily
-     * resizing the section, so the `ResizeObserver` need not fire and the fade
-     * would go on protecting copy that has moved.
+     * resizing the section, so the `ResizeObserver` need not fire and the
+     * keep-out would go on protecting copy that has moved.
      *
      * `fonts.ready` cannot be cancelled, so the flag is the only teardown there
      * is: a hero unmounted during a slow font load would otherwise re-measure a
@@ -685,6 +837,7 @@ export function HeroNetwork({
       stop();
       themeWatcher.disconnect();
       observer?.disconnect();
+      watcher?.disconnect();
       document.removeEventListener("visibilitychange", onVisibility);
       window.removeEventListener("resize", onWindowResize);
       media?.removeEventListener?.("change", onMedia);
@@ -705,30 +858,72 @@ export function HeroNetwork({
     if (!scene) return;
     scene.paused = paused;
     // `start` re-checks every reason not to run, so this is a resume request
-    // rather than an assertion that the pulse should be on.
-    if (paused) scene.stopPulse?.();
-    else scene.startPulse?.();
+    // rather than an assertion that the loop should be on.
+    if (paused) scene.stopLoop?.();
+    else scene.startLoop?.();
   }, [paused]);
 
   useEffect(() => {
     const scene = sceneRef.current;
     if (!scene) return;
     scene.labelled = labelled;
-    if (labelled) {
-      scene.pulse = 0;
-      scene.startPulse?.();
-    } else {
-      scene.stopPulse?.();
-    }
+    // The phase is measured from the label appearing, not from mount.
+    if (labelled) scene.pulse = 0;
+    scene.startLoop?.();
     draw(scene);
   }, [labelled]);
+
+  /** The cursor is the only thing that advertises the dots as clickable. */
+  const setCursor = (scene: Scene, want: string) => {
+    if (scene.cursor === want) return;
+    scene.cursor = want;
+    scene.canvas.style.cursor = want;
+  };
+
+  const nodeUnder = (
+    scene: Scene,
+    event: { clientX: number; clientY: number },
+  ) => {
+    const at = pointerPoint(scene, event);
+    return at ? hitTest(scene.field, at.x, at.y) : null;
+  };
 
   return (
     <canvas
       ref={canvasRef}
+      /**
+       * **Deliberately hidden from assistive technology, and not an oversight.**
+       *
+       * A burst conveys no information, changes no state, writes no row and
+       * leads nowhere; there is no equivalent to offer because there is nothing
+       * to be equivalent to. Exposing it would mean up to 150 focusable dots in
+       * front of the search bar — the one control on this page that everybody
+       * needs — which makes the page materially worse for exactly the people
+       * the exposure would be for. The export reaches the same place by
+       * default: its `onVizKey` (:1452) is an empty stub. Everything this
+       * canvas draws is decoration for a graph whose meaning is elsewhere, so
+       * please do not "fix" this.
+       */
       aria-hidden
       className="block size-full"
       data-testid="hero-network"
+      onPointerMove={(event) => {
+        const scene = sceneRef.current;
+        if (!scene || scene.reduced || scene.paused) return;
+        setCursor(scene, nodeUnder(scene, event) ? "pointer" : "");
+      }}
+      onPointerLeave={() => {
+        const scene = sceneRef.current;
+        if (scene) setCursor(scene, "");
+      }}
+      onPointerDown={(event) => {
+        const scene = sceneRef.current;
+        if (!scene || scene.reduced || scene.paused) return;
+        const hit = nodeUnder(scene, event);
+        // Its own node bursts like any other, and that is the best discovery
+        // moment this feature has: the page has just pointed at your dot.
+        if (hit) burstAt(scene.field, hit);
+      }}
     />
   );
 }

--- a/apps/web/features/landing/components/landing.tsx
+++ b/apps/web/features/landing/components/landing.tsx
@@ -363,12 +363,22 @@ export function Landing() {
         className="relative min-h-[480px] lg:min-h-[400px] lg:flex-1 overflow-hidden"
       >
         {/* The graph clears with everything else. It is the backdrop the bar is
-            leaving, and a still canvas sitting behind a page that has faded out
-            would be the last thing on screen when the route swaps. */}
+            leaving, and a canvas sitting behind a page that has faded out would
+            be the last thing on screen when the route swaps.
+
+            It takes the pointer now: clicking a node bursts a signal out along
+            every backbone edge that node has inside the drawn graph window
+            (ADR 0006), so the canvas cannot be `pointer-events-none`. What
+            keeps the copy winning is the layer below rather than a listener
+            with a denylist — see the note there.
+
+            `aria-hidden` stays, and covers the canvas too. A burst conveys
+            nothing, changes nothing and leads nowhere; `hero-network.tsx` says
+            why at length. */}
         <motion.div
           variants={HERO_EXIT}
           aria-hidden
-          className="pointer-events-none absolute inset-0 z-0"
+          className="absolute inset-0 z-0"
         >
           {/*
             Find your dot only labels a node that is already on the canvas. The
@@ -382,8 +392,28 @@ export function Landing() {
           />
         </motion.div>
 
-        <div className="relative z-[1] flex min-h-[480px] lg:h-full lg:min-h-0 flex-col items-center justify-center px-4 @lg:px-7">
-          <div className="flex w-full max-w-[720px] flex-col items-center text-center">
+        {/*
+          The copy sits above the graph, and only the copy does.
+
+          Both wrappers are `pointer-events-none` and every `data-hero-clear`
+          block below is `pointer-events-auto`, which makes one rule out of two
+          things that were already true separately: **what the keep-out reserves
+          keeps the pointer, and everything else is canvas.** The search bar, the
+          chips, Find your dot and the header all win the hit they always won —
+          they are inside the blocks the graph is already forbidden to draw on —
+          and the gaps between them, which is where the nodes actually are, reach
+          the canvas.
+
+          Without this the layer is a full-bleed transparent div over the whole
+          hero and no click ever reaches a node. The alternative the artboard
+          reaches for — `onDocDown` (:1443), a capture-phase document listener
+          with a hand-maintained denylist of selectors — is deliberately not
+          ported: a list of things that must not be clicked has to be edited
+          every time this page grows a control, and forgetting is a dead button
+          rather than a failing build.
+        */}
+        <div className="pointer-events-none relative z-[1] flex min-h-[480px] lg:h-full lg:min-h-0 flex-col items-center justify-center px-4 @lg:px-7">
+          <div className="pointer-events-none flex w-full max-w-[720px] flex-col items-center text-center">
             {/* The artboard's 70px, and it is load-bearing: it grows the
                 centred column at the top, which is what sits the hero copy
                 where the artboard has it rather than 64px higher.
@@ -396,7 +426,7 @@ export function Landing() {
             <motion.p
               variants={HERO_EXIT}
               data-hero-clear
-              className="mt-[70px] @lg:mt-[58px] mb-0 font-semibold text-[11px] text-cc-dim uppercase tracking-[0.09em]"
+              className="pointer-events-auto mt-[70px] @lg:mt-[58px] mb-0 font-semibold text-[11px] text-cc-dim uppercase tracking-[0.09em]"
             >
               Run by students at KTH
             </motion.p>
@@ -404,7 +434,7 @@ export function Landing() {
               variants={HERO_EXIT}
               onAnimationComplete={onExitComplete}
               data-hero-clear
-              className="mt-3.5 text-balance font-semibold text-[30px] @lg:text-[44px] leading-[1.08] tracking-[-0.025em]"
+              className="pointer-events-auto mt-3.5 text-balance font-semibold text-[30px] @lg:text-[44px] leading-[1.08] tracking-[-0.025em]"
             >
               Find the Course You Will Be Happy You Took
             </motion.h1>
@@ -441,7 +471,7 @@ export function Landing() {
                 event.preventDefault();
                 submitSearch(query);
               }}
-              className="mt-4 @lg:mt-[31px] flex h-[42px] w-full @lg:max-w-[560px] items-center gap-2.5 rounded-[10px] border border-cc-rule3 bg-cc-surface px-3.5"
+              className="pointer-events-auto mt-4 @lg:mt-[31px] flex h-[42px] w-full @lg:max-w-[560px] items-center gap-2.5 rounded-[10px] border border-cc-rule3 bg-cc-surface px-3.5"
             >
               <Search
                 size={16}
@@ -462,7 +492,7 @@ export function Landing() {
             <motion.div
               variants={HERO_EXIT}
               data-hero-clear
-              className="mt-6 @lg:mt-[36px] flex flex-wrap items-center justify-center gap-[7px]"
+              className="pointer-events-auto mt-6 @lg:mt-[36px] flex flex-wrap items-center justify-center gap-[7px]"
             >
               <span className="text-[12px] text-cc-dim">Try</span>
               {TRY.map((term) => (
@@ -482,7 +512,7 @@ export function Landing() {
             <motion.p
               variants={HERO_EXIT}
               data-hero-clear
-              className="mt-5 flex items-center gap-1.5 text-[12.5px] text-cc-dim"
+              className="pointer-events-auto mt-5 flex items-center gap-1.5 text-[12.5px] text-cc-dim"
             >
               <span>Already a member?</span>
               <button

--- a/apps/web/features/landing/lib/hero-signals.spec.ts
+++ b/apps/web/features/landing/lib/hero-signals.spec.ts
@@ -1,0 +1,685 @@
+import { describe, expect, it } from "vitest";
+import type { Rect } from "./hero-keepout";
+import {
+  advanceField,
+  burstAt,
+  createField,
+  DRIFT_BOX,
+  edgeKey,
+  envelope,
+  type HeroField,
+  hitTest,
+  signalPaint,
+  syncField,
+  trailStyleOf,
+  unitHash,
+} from "./hero-signals";
+import {
+  type GraphWindowView,
+  NODE_RADIUS,
+  projectGraphWindow,
+  type ScreenNode,
+  VIEW_SCALE,
+  VISIBLE,
+} from "./neighbourhood-view";
+
+/**
+ * The engine behind the hero, with no canvas anywhere near it.
+ *
+ * `hero-signals.ts` is a pure function of the **graph window** and the elapsed
+ * time — everything it varies is derived from node and edge identity, and there
+ * is no `Math.random()` in it — so all of this runs against a plain object and
+ * a hand-cranked clock. That property is the point rather than a convenience:
+ * the artboard samples its spawn edge, speed, prominence and relay coin from
+ * `Math.random()`, so the same field replayed twice there is a different field
+ * and none of what follows could be asserted at all.
+ *
+ * `hero-network.spec.tsx` holds the canvas around this: what repaints, what
+ * gates the loop, and what the pointer does.
+ */
+
+/** A projected node, as `projectGraphWindow` would hand one over. */
+function screenNode(over: Partial<ScreenNode> = {}): ScreenNode {
+  return {
+    id: "n",
+    screenX: 100,
+    screenY: 100,
+    colorVar: "--cc-brand",
+    style: "solid",
+    signalStyle: "none",
+    isViewer: false,
+    clearance: 1,
+    ...over,
+  };
+}
+
+/**
+ * A view built by hand: `n` nodes on a horizontal line, chained end to end.
+ *
+ * A chain rather than a mesh because a chain is the shape a **backbone edge**
+ * actually makes — a joining node takes three to five anchors and nobody is
+ * re-placed — and because every node in it has a known, small degree, which is
+ * what makes a burst's arm count assertable.
+ */
+function chain(
+  count: number,
+  over: Partial<ScreenNode> = {},
+  spacing = 90,
+): GraphWindowView {
+  const nodes = Array.from({ length: count }, (_, i) =>
+    screenNode({
+      id: `n${i}`,
+      screenX: 100 + i * spacing,
+      screenY: 300,
+      ...over,
+    }),
+  );
+  const edges = nodes.slice(1).map((to, i) => ({
+    from: nodes[i],
+    to,
+    clearance: 1,
+  }));
+  return { scale: VIEW_SCALE, centre: { x: 0, y: 0 }, nodes, edges };
+}
+
+/** A field pointed at `view`, with no copy in the way unless one is given. */
+function fieldOf(view: GraphWindowView, rects: Rect[] = [], width = 1200) {
+  const field = createField();
+  syncField(field, view, rects, width);
+  return field;
+}
+
+/** Run `seconds` of animation at 60fps, which is how the loop drives it. */
+function run(
+  field: HeroField,
+  seconds: number,
+  options: { holdId?: string | null } = {},
+) {
+  const step = 1 / 60;
+  for (let i = 0; i < Math.round(seconds / step); i++) {
+    advanceField(field, step, options);
+  }
+}
+
+describe("unitHash", () => {
+  /**
+   * The whole engine rests on this: the same key is the same number, forever
+   * and on every machine. The artboard's own hash goes through `Math.sin`,
+   * whose precision ECMAScript leaves to the implementation; this is integer
+   * arithmetic end to end.
+   */
+  it("is stable for a key and spread across its salts", () => {
+    expect(unitHash("node-a", 1)).toBe(unitHash("node-a", 1));
+    expect(unitHash("node-a", 1)).not.toBe(unitHash("node-a", 2));
+    expect(unitHash("node-a", 1)).not.toBe(unitHash("node-b", 1));
+  });
+
+  it("stays inside the unit interval for a large sample", () => {
+    for (let i = 0; i < 500; i++) {
+      const value = unitHash(`node-${i}`, i % 13);
+      expect(value).toBeGreaterThanOrEqual(0);
+      expect(value).toBeLessThan(1);
+    }
+  });
+});
+
+describe("drift", () => {
+  /**
+   * The invariant the whole of drift exists to hold.
+   *
+   * A node wanders inside a ±5px box around the position the projection gave
+   * it and reflects off the walls. It is not a simulation with a settling time
+   * — there is no separation pass and no inset clamp to fight with — so the box
+   * holds on the first frame and on the ten-thousandth alike.
+   */
+  it("keeps every node inside its own box, however long it runs", () => {
+    const view = chain(6);
+    const field = fieldOf(view);
+    run(field, 120);
+
+    for (const node of field.nodes) {
+      expect(Math.abs(node.x - node.node.screenX)).toBeLessThanOrEqual(
+        DRIFT_BOX + 1e-9,
+      );
+      expect(Math.abs(node.y - node.node.screenY)).toBeLessThanOrEqual(
+        DRIFT_BOX + 1e-9,
+      );
+    }
+  });
+
+  /** The field breathes; it does not sit still. */
+  it("actually moves a node off its home", () => {
+    const field = fieldOf(chain(4));
+    run(field, 2);
+
+    const moved = field.nodes.filter(
+      (node) =>
+        Math.hypot(node.x - node.node.screenX, node.y - node.node.screenY) > 1,
+    );
+    expect(moved.length).toBe(field.nodes.length);
+  });
+
+  /** About five seconds to cross its own box: 1.8–2.2 px/s, and no faster. */
+  it("drifts at the artboard's pace, so it reads as the field breathing", () => {
+    const field = fieldOf(chain(12));
+
+    for (const node of field.nodes) {
+      const speed = Math.hypot(node.vx, node.vy);
+      expect(speed).toBeGreaterThanOrEqual(1.8);
+      expect(speed).toBeLessThanOrEqual(2.2);
+    }
+  });
+
+  /**
+   * Drift never carries anybody into the copy: it turns away at the margin.
+   *
+   * The rect below sits immediately to the right of a node whose home is well
+   * clear of it, so the only way in is by drifting — and the assertion is that
+   * `clearAt` never drops below 1 for it, which is the same statement as "the
+   * copy is never approached", not merely "never covered".
+   */
+  it("turns away from the copy rather than fading into it", () => {
+    const node = screenNode({ id: "solo", screenX: 100, screenY: 100 });
+    const view: GraphWindowView = {
+      scale: VIEW_SCALE,
+      centre: { x: 0, y: 0 },
+      nodes: [node],
+      edges: [],
+    };
+    // `FEATHER` is 10 and the node's radius is 4, so a rect whose left edge is
+    // 15px away is exactly one drifting pixel outside the turn-away margin.
+    const rects: Rect[] = [{ x: 115, y: 0, w: 400, h: 400 }];
+    const field = fieldOf(view, rects);
+
+    run(field, 60);
+
+    for (const drifted of field.nodes) {
+      expect(drifted.clearance).toBe(1);
+    }
+  });
+
+  /**
+   * **Find your dot** labels a node and that node stops.
+   *
+   * The artboard checks an `n.fixed` flag that nothing in it ever sets; its own
+   * prose says what it was for — "the graph never moves: the dot grows and
+   * pulses in place" — and this is the one place the words win over the code.
+   * The held node then resumes from where it stopped rather than snapping home.
+   */
+  it("holds the labelled node still, and resumes it where it stopped", () => {
+    const field = fieldOf(chain(3));
+    run(field, 1.5);
+    const held = field.nodes[1];
+    const parked = { x: held.x, y: held.y };
+
+    run(field, 3, { holdId: held.node.id });
+    expect(held.x).toBe(parked.x);
+    expect(held.y).toBe(parked.y);
+
+    run(field, 0.5);
+    expect(Math.hypot(held.x - parked.x, held.y - parked.y)).toBeGreaterThan(0);
+  });
+});
+
+describe("signal traffic", () => {
+  it("puts ambient signals on the wire on its own", () => {
+    const field = fieldOf(chain(10));
+    run(field, 6);
+
+    expect(field.signals.length).toBeGreaterThan(0);
+  });
+
+  /** Never two signals on one edge — a wire carries one thing at a time. */
+  it("never runs two signals along one backbone edge", () => {
+    const field = fieldOf(chain(10));
+    run(field, 60);
+
+    const keys = field.signals.map((signal) => signal.edgeKey);
+    expect(new Set(keys).size).toBe(keys.length);
+  });
+
+  /**
+   * Density is capped by edge count as well as by viewport width.
+   *
+   * The artboard's 3/5/8 ladder assumes a dense proximity mesh over a synthetic
+   * field. A real graph window is three to five anchors per node over a small
+   * community, and eight concurrent signals over twelve edges is strobing
+   * rather than life — so the cap is `min(width ladder, edges / 4)`.
+   */
+  it("caps ambient density by edge count, not only by viewport width", () => {
+    // Nine nodes, eight edges: two, well under the wide viewport's eight.
+    const field = fieldOf(chain(9), [], 1400);
+    expect(field.cap).toBe(2);
+
+    run(field, 90);
+    expect(field.signals.length).toBeLessThanOrEqual(field.cap + 3);
+  });
+
+  it("takes the viewport ladder when the graph window is dense enough", () => {
+    const dense = fieldOf(chain(60), [], 500);
+    expect(dense.cap).toBe(3);
+  });
+
+  /**
+   * `routeClear` (:1092) is defined in the export and called from nowhere, and
+   * `drawSignal` never multiplies by clearance either — so a signal there can
+   * run straight over the headline. The invariant this hero already states is
+   * that everything painted on the canvas passes the clearance check, and an
+   * ambient signal is not an exception to it.
+   */
+  it("never spawns ambient traffic onto an edge under the copy", () => {
+    const view = chain(10);
+    // A band across the middle of the chain, so the inner edges are buried.
+    const rects: Rect[] = [{ x: 250, y: 200, w: 400, h: 200 }];
+    const field = fieldOf(view, rects);
+    run(field, 90);
+
+    const buried = field.edges.filter((edge) => edge.clearance <= VISIBLE);
+    expect(buried.length).toBeGreaterThan(0);
+    for (const signal of field.signals) {
+      const edge = field.edgeByKey.get(signal.edgeKey);
+      expect(edge?.clearance).toBeGreaterThan(VISIBLE);
+    }
+  });
+
+  /** The engine is a pure function of the graph window and the elapsed time. */
+  it("replays identically from the same graph window and the same clock", () => {
+    const first = fieldOf(chain(8));
+    const second = fieldOf(chain(8));
+    run(first, 30);
+    run(second, 30);
+
+    expect(second.signals.map((s) => [s.edgeKey, s.fromId, s.p])).toEqual(
+      first.signals.map((s) => [s.edgeKey, s.fromId, s.p]),
+    );
+    expect(second.nodes.map((n) => [n.x, n.y])).toEqual(
+      first.nodes.map((n) => [n.x, n.y]),
+    );
+  });
+});
+
+describe("burst", () => {
+  /**
+   * A click fans a signal out along **every free backbone edge the node has
+   * inside the drawn graph window** — never along an edge the payload does not
+   * carry, because there is no such edge here to reach for.
+   */
+  it("fires one arm per edge of the node that was clicked", () => {
+    const field = fieldOf(chain(5));
+    // The middle of a chain: two edges, so an arm count of two is a fact about
+    // the node rather than about the fixture's size.
+    const middle = field.nodes[2];
+    burstAt(field, middle);
+
+    expect(field.signals).toHaveLength(2);
+    for (const signal of field.signals) {
+      expect(signal.fromId).toBe(middle.node.id);
+      // A burst does not relay: it is one gesture, not a chain reaction.
+      expect(signal.relay).toBe(0);
+    }
+  });
+
+  /** Staggered, so the arms leave in order rather than as a ring. */
+  it("staggers the arms rather than firing them as one ring", () => {
+    const field = fieldOf(chain(5));
+    burstAt(field, field.nodes[2]);
+
+    // Each arm waits its own turn, and the first does not wait at all: `p` is
+    // the head's progress, so a negative one is an arm still on the launch pad.
+    const departures = field.signals.map((signal) => signal.p);
+    expect(new Set(departures).size).toBe(departures.length);
+    expect(Math.max(...departures)).toBeCloseTo(0, 10);
+    expect(Math.min(...departures)).toBeLessThan(0);
+  });
+
+  /**
+   * An arm under the copy still fires and simply draws faint to invisible. An
+   * arm that was not there would read as broken; one that dims reads as depth.
+   * The cap is for ambient traffic, and a click is not ambient traffic.
+   */
+  it("fires every arm even where the copy has buried the edge", () => {
+    const view = chain(5);
+    const rects: Rect[] = [{ x: 0, y: 200, w: 1000, h: 200 }];
+    const field = fieldOf(view, rects);
+    // One frame, so the rolling refresh has measured at least one edge.
+    run(field, 1);
+    field.signals.length = 0;
+
+    burstAt(field, field.nodes[2]);
+    expect(field.signals).toHaveLength(2);
+  });
+
+  it("leaves an edge that is already carrying a signal alone", () => {
+    const field = fieldOf(chain(5));
+    burstAt(field, field.nodes[2]);
+    const before = field.signals.length;
+    burstAt(field, field.nodes[2]);
+
+    expect(field.signals).toHaveLength(before);
+  });
+});
+
+describe("hit testing", () => {
+  it("finds the nearest node inside the hit radius and nothing outside it", () => {
+    const field = fieldOf(chain(3));
+    const target = field.nodes[1];
+
+    expect(hitTest(field, target.x + 5, target.y + 5)?.node.id).toBe(
+      target.node.id,
+    );
+    expect(hitTest(field, target.x, target.y - 200)).toBeNull();
+  });
+
+  /** An invisible node is not a clickable node. */
+  it("skips a node the copy has faded out", () => {
+    const node = screenNode({ id: "buried", screenX: 300, screenY: 300 });
+    const view: GraphWindowView = {
+      scale: VIEW_SCALE,
+      centre: { x: 0, y: 0 },
+      nodes: [node],
+      edges: [],
+    };
+    const field = fieldOf(view, [{ x: 200, y: 200, w: 200, h: 200 }]);
+
+    expect(field.nodes[0].clearance).toBeLessThanOrEqual(VISIBLE);
+    expect(hitTest(field, 300, 300)).toBeNull();
+  });
+});
+
+describe("reprojection and refetch", () => {
+  /**
+   * **Reproject, do not reset.** A resize re-derives every screen coordinate,
+   * but the people did not change: node ids are stable for the life of a
+   * response, so a signal keeps its progress and simply finds its edge in a new
+   * place. Blanking the field because somebody dragged a window edge reads as a
+   * glitch.
+   */
+  it("keeps a signal's progress across a reprojection", () => {
+    const field = fieldOf(chain(6));
+    run(field, 8);
+    expect(field.signals.length).toBeGreaterThan(0);
+    const before = field.signals.map((signal) => [signal.edgeKey, signal.p]);
+
+    // The same graph window, projected somewhere else entirely.
+    const moved = chain(6);
+    for (const node of moved.nodes) {
+      node.screenX += 240;
+      node.screenY -= 80;
+    }
+    syncField(field, moved, [], 1200);
+
+    expect(field.signals.map((signal) => [signal.edgeKey, signal.p])).toEqual(
+      before,
+    );
+  });
+
+  it("keeps a node's wander across a reprojection rather than snapping home", () => {
+    const field = fieldOf(chain(4));
+    run(field, 3);
+    const offsets = field.nodes.map((n) => [
+      n.x - n.node.screenX,
+      n.y - n.node.screenY,
+    ]);
+
+    const moved = chain(4);
+    for (const node of moved.nodes) node.screenX += 500;
+    syncField(field, moved, [], 1200);
+
+    // Compared to a tolerance rather than exactly: re-homing is one add and one
+    // subtract in floating point, so the offset comes back the same wander to
+    // within a fraction of a millipixel and not to the last bit.
+    field.nodes.forEach((n, i) => {
+      expect(n.x - n.node.screenX).toBeCloseTo(offsets[i][0], 9);
+      expect(n.y - n.node.screenY).toBeCloseTo(offsets[i][1], 9);
+    });
+  });
+
+  /**
+   * A refetch is the other case, and it needs no branch of its own.
+   * `graph.neighbourhood` mints `crypto.randomUUID()` per response, so a new
+   * read means ids nothing recognises — and resuming across them would be
+   * resuming onto strangers.
+   */
+  it("clears every signal when the read comes back with new ids", () => {
+    const field = fieldOf(chain(6));
+    run(field, 8);
+    expect(field.signals.length).toBeGreaterThan(0);
+
+    const refetched = chain(6);
+    refetched.nodes.forEach((node, i) => {
+      node.id = `fresh-${i}`;
+    });
+    syncField(field, refetched, [], 1200);
+
+    expect(field.signals).toHaveLength(0);
+    expect(field.nodes).toHaveLength(6);
+  });
+
+  it("empties out when the graph window goes away", () => {
+    const field = fieldOf(chain(4));
+    run(field, 5);
+    syncField(field, null, [], 1200);
+
+    expect(field.nodes).toHaveLength(0);
+    expect(field.edges).toHaveLength(0);
+    expect(field.signals).toHaveLength(0);
+    expect(field.cap).toBe(0);
+  });
+
+  it("names an edge by its endpoints, so identity survives a reprojection", () => {
+    const field = fieldOf(chain(3));
+    expect(field.edges.map((edge) => edge.key)).toEqual([
+      edgeKey("n0", "n1"),
+      edgeKey("n1", "n2"),
+    ]);
+  });
+});
+
+describe("trail geometry", () => {
+  /** The envelope: faint on departure, defined mid-flight, gone on arrival. */
+  it("rises from nothing and returns to nothing", () => {
+    expect(envelope(0)).toBe(0);
+    expect(envelope(1)).toBe(0);
+    expect(envelope(0.5)).toBeGreaterThan(0.5);
+  });
+
+  /** Every node signals; the tier picks the style and never whether it goes. */
+  it("sends the default wake for an unconfigured node", () => {
+    expect(trailStyleOf(screenNode({ signalStyle: "none" }))).toBe("default");
+    expect(trailStyleOf(screenNode({ signalStyle: "comet" }))).toBe("comet");
+  });
+
+  /**
+   * **The style is the wake and never the pace.**
+   *
+   * Head, speed and envelope are identical across all four, because nobody's
+   * node may read as faster or more important than anybody else's. Given the
+   * same edge, the same sender and the same progress, the four styles must
+   * agree on where the head is and how bright it is, and differ only behind it.
+   */
+  it("puts the head in the same place, at the same brightness, for all four", () => {
+    const heads = (["default", "comet", "fade", "dashed"] as const).map(
+      (style) => {
+        const field = fieldOf(chain(2, { signalStyle: "none" }));
+        burstAt(field, field.nodes[0]);
+        field.signals[0].style = style;
+        field.signals[0].p = 0.5;
+        const paint = signalPaint(field, field.signals[0]);
+        if (!paint) throw new Error("expected a visible signal");
+        return paint;
+      },
+    );
+
+    for (const paint of heads.slice(1)) {
+      expect(paint.headX).toBeCloseTo(heads[0].headX, 10);
+      expect(paint.headY).toBeCloseTo(heads[0].headY, 10);
+      expect(paint.halo).toEqual(heads[0].halo);
+    }
+  });
+
+  it("gives each style the wake its name promises", () => {
+    // A long edge on purpose. A wake is clamped to what the signal has actually
+    // travelled — it may never run back past the node that sent it — so on a
+    // short edge every style saturates at the same length and only the shape of
+    // the wake tells them apart. The length difference needs room to show.
+    const paintWith = (style: "default" | "comet" | "fade" | "dashed") => {
+      const field = fieldOf(chain(2, {}, 600));
+      burstAt(field, field.nodes[0]);
+      field.signals[0].style = style;
+      field.signals[0].p = 0.6;
+      const paint = signalPaint(field, field.signals[0]);
+      if (!paint) throw new Error("expected a visible signal");
+      return paint;
+    };
+
+    // `fade` is rings dropped behind the head, and nothing stroked.
+    const fade = paintWith("fade");
+    expect(fade.strokes).toHaveLength(0);
+    expect(fade.rings.length).toBeGreaterThan(1);
+    const radii = fade.rings.map((ring) => ring.radius);
+    expect(radii).toEqual([...radii].sort((a, b) => a - b));
+    expect(Math.min(...radii)).toBeGreaterThan(NODE_RADIUS);
+
+    // `dashed` is the same trail, stroked through a pattern.
+    const dashed = paintWith("dashed");
+    expect(dashed.dash).not.toBeNull();
+    expect(dashed.rings).toHaveLength(0);
+    expect(paintWith("default").dash).toBeNull();
+
+    // `comet` is the same stroke, run further back.
+    const comet = paintWith("comet");
+    const plain = paintWith("default");
+    expect(reach(comet)).toBeGreaterThan(reach(plain));
+  });
+
+  /** How far behind the head the furthest piece of a wake sits. */
+  function reach(paint: {
+    headX: number;
+    headY: number;
+    strokes: { fromX: number; fromY: number }[];
+  }) {
+    return Math.max(
+      ...paint.strokes.map((stroke) =>
+        Math.hypot(stroke.fromX - paint.headX, stroke.fromY - paint.headY),
+      ),
+    );
+  }
+
+  /**
+   * A signal is faded by the clearance of the edge it is on, all the way to
+   * not being drawn. This is the rule `routeClear` was written for in the
+   * export and then never wired up.
+   */
+  it("does not draw a signal on an edge the copy has buried", () => {
+    const view = chain(2);
+    const field = fieldOf(view, [{ x: 0, y: 200, w: 1000, h: 200 }]);
+    run(field, 1);
+    burstAt(field, field.nodes[0]);
+    field.signals[0].p = 0.5;
+
+    expect(field.edges[0].clearance).toBeLessThanOrEqual(VISIBLE);
+    expect(signalPaint(field, field.signals[0])).toBeNull();
+  });
+
+  /**
+   * While a label is up the traffic fades back to about a quarter rather than
+   * halting — but the viewer's own signals do not, because a burst from the dot
+   * the page has just pointed at is the discovery moment, and dimming it would
+   * be pointing and then looking away.
+   */
+  it("dims the field for a label, and exempts the viewer's own signals", () => {
+    const build = (isViewer: boolean) => {
+      const view = chain(2);
+      view.nodes[0].isViewer = isViewer;
+      const field = fieldOf(view);
+      burstAt(field, field.nodes[0]);
+      field.signals[0].p = 0.5;
+      return field;
+    };
+
+    const stranger = build(false);
+    const undimmed = signalPaint(stranger, stranger.signals[0]);
+    const dimmed = signalPaint(stranger, stranger.signals[0], { dim: true });
+    expect(dimmed?.halo[0].alpha).toBeLessThan(undimmed?.halo[0].alpha ?? 0);
+
+    const viewer = build(true);
+    expect(signalPaint(viewer, viewer.signals[0], { dim: true })).toEqual(
+      signalPaint(viewer, viewer.signals[0]),
+    );
+  });
+
+  /** A wake never runs off the end of the edge it is travelling along. */
+  it("keeps the whole wake on its own edge", () => {
+    const field = fieldOf(chain(2));
+    burstAt(field, field.nodes[0]);
+    const [from, to] = [field.edges[0].from, field.edges[0].to];
+    const length = Math.hypot(to.x - from.x, to.y - from.y);
+
+    for (let p = 0.05; p < 1; p += 0.05) {
+      field.signals[0].p = p;
+      const paint = signalPaint(field, field.signals[0]);
+      if (!paint) continue;
+      for (const stroke of paint.strokes) {
+        const along = Math.hypot(stroke.fromX - from.x, stroke.fromY - from.y);
+        expect(along).toBeGreaterThanOrEqual(-1e-9);
+        expect(along).toBeLessThanOrEqual(length + 1e-9);
+      }
+    }
+  });
+
+  /** A burst arm still waiting its turn is not on the canvas yet. */
+  it("draws nothing for an arm that has not left", () => {
+    const field = fieldOf(chain(4));
+    burstAt(field, field.nodes[1]);
+    const waiting = field.signals.find((signal) => signal.p < 0);
+    expect(waiting).toBeDefined();
+    if (waiting) expect(signalPaint(field, waiting)).toBeNull();
+  });
+});
+
+describe("against a real projection", () => {
+  /**
+   * The fixtures above build a view by hand, which is right for asserting the
+   * engine. This one goes through `projectGraphWindow` instead, so the two
+   * halves are held together: a node the push placed is a node the field homes
+   * on, and the drift is an overlay on the projection rather than a second
+   * opinion about where anybody is.
+   */
+  it("homes every node on where the projection put it", () => {
+    const view = projectGraphWindow({
+      window: {
+        centre: { x: 0, y: 0 },
+        nodes: [
+          {
+            id: "a",
+            x: 0,
+            y: 0,
+            color: "default",
+            style: "default",
+            signalStyle: "default",
+            isViewer: true,
+          },
+          {
+            id: "b",
+            x: 220,
+            y: 60,
+            color: "default",
+            style: "default",
+            signalStyle: "comet",
+            isViewer: false,
+          },
+        ],
+        edges: [{ fromId: "a", toId: "b" }],
+      },
+      width: 1200,
+      height: 600,
+      keepOut: [{ x: 300, y: 100, w: 600, h: 200 }],
+    });
+    const field = fieldOf(view, [{ x: 300, y: 100, w: 600, h: 200 }]);
+
+    expect(field.nodes.map((node) => [node.x, node.y])).toEqual(
+      view.nodes.map((node) => [node.screenX, node.screenY]),
+    );
+    expect(field.edges).toHaveLength(1);
+  });
+});

--- a/apps/web/features/landing/lib/hero-signals.spec.ts
+++ b/apps/web/features/landing/lib/hero-signals.spec.ts
@@ -627,6 +627,41 @@ describe("trail geometry", () => {
     }
   });
 
+  /**
+   * A signal leaves the node that sent it, whichever end of the edge that is.
+   *
+   * A **backbone edge** is stored newer-to-older and drawn undirected, but a
+   * signal has a sender: `spawnSignal` tosses for the end it leaves from and a
+   * **burst** leaves from whichever node was clicked, which is as often the
+   * edge's `to` as its `from`. Measuring progress from the view model's `from`
+   * regardless draws half the traffic running backwards, out of a node that did
+   * not send it — which is exactly the bug this pins.
+   */
+  it("travels away from its sender, not away from the edge's first endpoint", () => {
+    const walk = (senderIndex: 0 | 1) => {
+      const field = fieldOf(chain(2, {}, 600));
+      burstAt(field, field.nodes[senderIndex]);
+      const signal = field.signals[0];
+      const sender = field.nodes[senderIndex];
+      signal.p = 0.25;
+      const near = signalPaint(field, signal);
+      signal.p = 0.75;
+      const far = signalPaint(field, signal);
+      if (!near || !far) throw new Error("expected a visible signal");
+      return {
+        near: Math.hypot(near.headX - sender.x, near.headY - sender.y),
+        far: Math.hypot(far.headX - sender.x, far.headY - sender.y),
+      };
+    };
+
+    // Sent from the edge's `from`, and sent from its `to`: in both cases the
+    // head is further from its own sender at 0.75 than it was at 0.25.
+    for (const index of [0, 1] as const) {
+      const { near, far } = walk(index);
+      expect(far).toBeGreaterThan(near);
+    }
+  });
+
   /** A burst arm still waiting its turn is not on the canvas yet. */
   it("draws nothing for an arm that has not left", () => {
     const field = fieldOf(chain(4));

--- a/apps/web/features/landing/lib/hero-signals.spec.ts
+++ b/apps/web/features/landing/lib/hero-signals.spec.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import type { Rect } from "./hero-keepout";
+import { lineClearance, type Rect } from "./hero-keepout";
 import {
   advanceField,
   burstAt,
@@ -65,6 +65,7 @@ function chain(
   count: number,
   over: Partial<ScreenNode> = {},
   spacing = 90,
+  keepOut: Rect[] = [],
 ): GraphWindowView {
   const nodes = Array.from({ length: count }, (_, i) =>
     screenNode({
@@ -74,10 +75,16 @@ function chain(
       ...over,
     }),
   );
+  // Sampled the way `projectGraphWindow` samples it, so a fixture built with a
+  // keep-out is the same shape of thing the real projection hands over.
   const edges = nodes.slice(1).map((to, i) => ({
     from: nodes[i],
     to,
-    clearance: 1,
+    clearance: lineClearance(
+      { x: nodes[i].screenX, y: nodes[i].screenY },
+      { x: to.screenX, y: to.screenY },
+      keepOut,
+    ),
   }));
   return { scale: VIEW_SCALE, centre: { x: 0, y: 0 }, nodes, edges };
 }
@@ -453,6 +460,29 @@ describe("reprojection and refetch", () => {
 
     expect(field.signals).toHaveLength(0);
     expect(field.nodes).toHaveLength(6);
+  });
+
+  /**
+   * A relayout is the one event that moves the copy, so it is the one event
+   * after which a cached clearance cannot be trusted.
+   *
+   * Clearance is otherwise cached on the edge and refreshed on a rolling slice,
+   * which is right while only the drift is moving — but carrying that cache
+   * across a reprojection keeps a clear reading for an edge the headline has
+   * just been reflowed on top of. **Under reduced motion nothing ever advances
+   * the field**, so the rolling refresh never arrives to correct it and the
+   * edge draws across protected copy for as long as the page is open. This runs
+   * no frames at all, deliberately: it is the reduced-motion path.
+   */
+  it("takes the new clearance when a relayout moves the copy onto an edge", () => {
+    const field = fieldOf(chain(3));
+    expect(field.edges.every((edge) => edge.clearance > VISIBLE)).toBe(true);
+
+    // The same graph window, re-projected with the copy now over the chain.
+    const rects: Rect[] = [{ x: 0, y: 200, w: 1000, h: 200 }];
+    syncField(field, chain(3, {}, 90, rects), rects, 1200);
+
+    expect(field.edges.every((edge) => edge.clearance <= VISIBLE)).toBe(true);
   });
 
   it("empties out when the graph window goes away", () => {

--- a/apps/web/features/landing/lib/hero-signals.ts
+++ b/apps/web/features/landing/lib/hero-signals.ts
@@ -1,0 +1,1026 @@
+/**
+ * The living half of the hero: **drift** and **signals**.
+ *
+ * `neighbourhood-view.ts` says where the **graph window** lands on the glass,
+ * once, as a pure projection. This says what happens on it afterwards — nodes
+ * breathing inside a small box around where they were projected, and signals
+ * travelling along backbone edges between them. `hero-network.tsx` measures,
+ * projects, paints and owns the frame loop; it calls in here for geometry
+ * exactly as it already does with `hero-keepout.ts`.
+ *
+ * **Everything here is bounded by the drawn graph window and cannot see past
+ * it.** A window carries a limited set of nodes and the backbone edges that run
+ * between them; `anonymise` keeps an edge only when both endpoint tokens
+ * resolve, and `projectGraphWindow` drops it again if either endpoint is
+ * missing. So a node near the rim has attachments this file has never been told
+ * about, and a **burst** reaches every edge that node has *inside the window*
+ * and no further. That is a property of the payload rather than a rule enforced
+ * here: there is no edge to reach for.
+ *
+ * **A signal is a dramatisation, chosen on purpose.** A backbone edge records
+ * placement history and is not a friendship; ADR 0006 settles that drawing
+ * light travelling along one asserts only "this is a community and things move
+ * through it", which is true, and that the friend feature must reach for the
+ * vocabulary of *travel* — a camera moving — rather than a brighter edge.
+ * Nothing here reads a relationship, and nothing here writes a row: the field
+ * below is derived from the projection every frame and thrown away with it.
+ *
+ * **Everything is seeded from stable identity, and there is no `Math.random()`
+ * in this file.** The artboard is inconsistent about this — drift comes from a
+ * per-node hash (`Landing.dc.html:717`) but the spawn edge, the speed, the
+ * prominence and the relay coin all come from `Math.random()` — so the same
+ * field replayed twice there is a different field. Deriving all of it from node
+ * and edge id plus a sequence counter makes the engine a pure function of the
+ * view and the elapsed time, which is what lets a test assert the traffic, lets
+ * a reprojection resume rather than restart, and lets a bug report quote a
+ * frame. It is a deliberate improvement on the export, not an accident of
+ * translation.
+ *
+ * The two passes of the artboard's own drift loop that are **not** ported, both
+ * on the product owner's instruction (#203):
+ *
+ * - the **frame inset clamp** (:1211-1214), which keeps every node 20px inside
+ *   the frame. The artboard constructs its nodes inside the frame; ours are
+ *   projected from stored world coordinates and legitimately sit off-canvas,
+ *   which is how "the network continues past the frame" already works here.
+ * - the **min-gap separation pass** (:1233-1247), whose own comment names its
+ *   reason — "drift must not undo the even Halton spread" — and there is no
+ *   Halton spread here. It moves real nodes relative to each other, which
+ *   changes the shape of a neighbourhood and breaks the recognition promise
+ *   `neighbourhood-view.ts` exists to hold.
+ */
+
+import { clearAt, lineClearance, type Rect } from "./hero-keepout";
+import {
+  type GraphWindowView,
+  NO_SIGNAL,
+  NODE_RADIUS,
+  type ScreenNode,
+  VISIBLE,
+} from "./neighbourhood-view";
+
+/* ------------------------------------------------------------------ drift */
+
+/**
+ * Half the width of the box a node wanders inside, in px. The artboard's `R`
+ * (:1205): "each student wanders inside a 10px box around where it started".
+ */
+export const DRIFT_BOX = 5;
+
+/**
+ * Drift speed, in px/s: `1.8 + hash * 0.4`, straight from `makeNode` (:716).
+ *
+ * About five seconds to cross its own box, which is the point of the number.
+ * It has to read as the field breathing rather than as an individual dot
+ * going somewhere.
+ */
+const DRIFT_SPEED_MIN = 1.8;
+const DRIFT_SPEED_SPAN = 0.4;
+
+/**
+ * The extra pixel the turn-away tests with, as `clearAt(n.x, n.y, n.r + 1)`
+ * does at :1224. A node turns back one pixel before its own edge would touch
+ * the feathered margin, so the copy is never approached at all rather than
+ * approached and then dimmed.
+ *
+ * A **pushed** node gets only half a box out of this, and that is accepted.
+ * `pushClear` lands it at `FEATHER + NODE_RADIUS + ε`, which is exactly where
+ * `clearAt` first returns 1, so a step towards the copy trips the turn-away on
+ * the very next frame. It is self-limiting rather than broken: a node parked at
+ * the copy's edge looking crowded is the honest picture, and widening
+ * `pushClear`'s margin to buy it a full box would move every node in the hero.
+ */
+const TURN_MARGIN = 1;
+
+/**
+ * The longest step the integrator will take, in seconds — the artboard's own
+ * clamp (:1177).
+ *
+ * A backgrounded tab that comes back hands `requestAnimationFrame` a gap of
+ * whole seconds. Integrated straight, that is a node teleporting across its box
+ * and a signal arriving instantly; clamped, it is one ordinary frame and the
+ * scene picks up where it was.
+ */
+const MAX_STEP = 0.05;
+
+/* ---------------------------------------------------------------- signals */
+
+/** px/s along the edge: `26 + hash * 22` (:1108). Constant pace, any length. */
+const SIGNAL_SPEED_MIN = 26;
+const SIGNAL_SPEED_SPAN = 22;
+
+/** The floor on a crossing, in seconds (:1112). A short edge is not a blink. */
+const MIN_DURATION = 2.6;
+
+/** How bright one signal is allowed to be: `0.72 + hash * 0.28` (:1114). */
+const PROM_MIN = 0.72;
+const PROM_SPAN = 0.28;
+
+/** Seconds between ambient spawns: `260 + hash * 900` ms (:1300). */
+const SPAWN_GAP_MIN = 0.26;
+const SPAWN_GAP_SPAN = 0.9;
+
+/** How many edges an ambient spawn will try before giving up (:1120). */
+const SPAWN_ATTEMPTS = 14;
+
+/** The relay coin and its second flip (:1117): 42%, then 35% for a third hop. */
+const RELAY_CHANCE = 0.42;
+const RELAY_SECOND_CHANCE = 0.35;
+
+/** How far over the cap a relay may take the field (:1305). */
+const RELAY_HEADROOM = 3;
+
+/** Seconds between the arms of a burst (:1149). */
+const BURST_STAGGER = 0.06;
+
+/**
+ * How many concurrent signals the frame will carry, **capped by edge count as
+ * well as by width**.
+ *
+ * The width ladder is the artboard's (:886). The `edges / 4` term is not, and
+ * it is the more important half here: the export's numbers assume a dense
+ * proximity mesh over a synthetic field, while a real neighbourhood is three to
+ * five backbone anchors per node over a community #68 recorded as small. Eight
+ * concurrent signals over twelve edges is strobing, not life.
+ */
+const EDGES_PER_SIGNAL = 4;
+const NARROW_WIDTH = 620;
+const WIDE_WIDTH = 1000;
+const NARROW_CAP = 3;
+const MEDIUM_CAP = 5;
+const WIDE_CAP = 8;
+
+/**
+ * How much a signal fades back while **Find your dot** holds a label up:
+ * `1 - 0.74 * dim` (:1368).
+ *
+ * They fade to about a quarter rather than halting, because a field that
+ * stopped dead the moment somebody found their dot would read as the page
+ * breaking rather than as the page pointing.
+ */
+const DIM_FACTOR = 0.74;
+
+/** The pointer is this close to a node's centre before it counts (:1433). */
+const HIT_RADIUS = 20;
+
+/** How many frames a full sweep of edge clearances is spread over (:1253). */
+const CLEAR_SLICES = 30;
+
+/* -------------------------------------------------------------- the trail */
+
+/**
+ * The length of the wake behind the head, in px: `16 + 74 * k` (:1371). It
+ * grows with the envelope, so a signal both brightens and lengthens as it
+ * leaves and shortens as it lands.
+ */
+const TRAIL_BASE = 16;
+const TRAIL_GAIN = 74;
+
+/** The head's halo radius, in px: `5 + 9 * k` (:1375). */
+const HALO_BASE = 5;
+const HALO_GAIN = 9;
+
+/** How many discs the halo is drawn as, and how bright its core is at `k = 1`.
+ * `PAL.haloA` in the export's palette. See `haloDiscs`. */
+const HALO_STEPS = 3;
+const HALO_ALPHA = 0.85;
+
+/** The stroke width along the whole trail: `1.1 + 1.9 * k` (:1387). */
+const WIDTH_BASE = 1.1;
+const WIDTH_GAIN = 1.9;
+
+/**
+ * The artboard's gradient (:1382-1386), as stops rather than as a gradient.
+ *
+ * `createLinearGradient` needs a colour it can vary the alpha of, and every
+ * colour on this canvas is a `--cc-*` token read as an opaque string — so
+ * matching the export's four stops would mean parsing CSS colour syntax at draw
+ * time, or interpolating from `transparent`, which canvas does in
+ * non-premultiplied sRGB and which greys the tail. Sampling the same stop curve
+ * into a handful of sub-strokes under `globalAlpha` produces the same taper
+ * with neither, and it is the technique `COMET_SEGMENTS` already uses in this
+ * hero. `at` is the fraction from tail to head; `alpha` multiplies `k`.
+ */
+const TRAIL_STOPS: { at: number; alpha: number }[] = [
+  { at: 0, alpha: 0 },
+  { at: 0.55, alpha: 0.5 },
+  { at: 0.9, alpha: 0.9 },
+  { at: 1, alpha: 1.1 },
+];
+
+/** How many sub-strokes the stop curve above is sampled into. */
+const TRAIL_STEPS = 8;
+
+/**
+ * `fade`: the ring radii and alphas of the standing-still mark, reused moving.
+ *
+ * The same numbers as `FADE_RINGS` in `hero-network.tsx`, and deliberately so —
+ * the moving and the still form of a style have to read as the same family, or
+ * a member who picked one in the picker will not recognise what they picked on
+ * the landing page. Radii are multiples of `NODE_RADIUS`.
+ */
+const FADE_TRAIL_RINGS = [
+  { reach: 1.9, alpha: 0.34 },
+  { reach: 2.9, alpha: 0.19 },
+  { reach: 3.9, alpha: 0.1 },
+] as const;
+
+/**
+ * `comet`: the width and alpha steps of the standing-still mark, reused moving.
+ *
+ * Mirrors `COMET_SEGMENTS` in `hero-network.tsx`. `from`/`to` are positions
+ * along the wake, and only their *proportions* are used: the band they span is
+ * stretched over whatever trail the envelope has produced, so the head segment
+ * always lands on the head.
+ */
+const COMET_TRAIL_SEGMENTS = [
+  { from: 1.1, to: 2.5, width: 1.7, alpha: 0.62 },
+  { from: 2.5, to: 3.9, width: 1.2, alpha: 0.36 },
+  { from: 3.9, to: 5.4, width: 0.8, alpha: 0.16 },
+] as const;
+
+/** `dashed`: the dash pattern of the standing-still ring, reused moving. */
+const DASHED_TRAIL_DASH = [2.2, 2.6];
+
+/**
+ * How much longer the `comet` wake runs than the other three.
+ *
+ * Standing still, `comet` reaches `5.4 * NODE_RADIUS` behind its node and
+ * `fade` reaches `3.9` — the comet is the longest of the three marks, by that
+ * margin. Moving, it keeps exactly the same margin over the same rival rather
+ * than taking a factor chosen by eye. **This is the only thing the style
+ * changes.** Head, speed and envelope are identical across all four, because
+ * the style is the wake and never the pace: nobody's node may read as faster or
+ * more important than anybody else's.
+ */
+const COMET_LENGTHEN =
+  COMET_TRAIL_SEGMENTS[COMET_TRAIL_SEGMENTS.length - 1].to /
+  FADE_TRAIL_RINGS[FADE_TRAIL_RINGS.length - 1].reach;
+
+/** The far end of the comet band, in the units `COMET_TRAIL_SEGMENTS` uses. */
+const COMET_REACH = COMET_TRAIL_SEGMENTS[COMET_TRAIL_SEGMENTS.length - 1].to;
+
+/* ------------------------------------------------------------ determinism */
+
+/** FNV-1a over a key, as an unsigned 32-bit integer. */
+function hashKey(key: string): number {
+  let h = 2166136261;
+  for (let i = 0; i < key.length; i++) {
+    h ^= key.charCodeAt(i);
+    h = Math.imul(h, 16777619);
+  }
+  return h >>> 0;
+}
+
+/**
+ * A number in `[0, 1)` from a string key and a salt. **The only source of
+ * variety in this file.**
+ *
+ * The artboard's own `hash` (:709) is `frac(sin(i * 12.9898 + salt * 78.233) *
+ * 43758.5453)`, which is the standard shader trick and which relies on
+ * `Math.sin` — whose precision ECMAScript leaves to the implementation, so two
+ * engines may disagree on the last bits and a test written against it would
+ * assert one engine's rounding. This is the same idea done in integers
+ * (`murmur3`'s finaliser), so the field is byte-identical everywhere.
+ */
+export function unitHash(key: string, salt: number): number {
+  let h = hashKey(key) ^ Math.imul(salt + 1, 0x9e3779b1);
+  h ^= h >>> 16;
+  h = Math.imul(h, 0x21f0aaad);
+  h ^= h >>> 15;
+  h = Math.imul(h, 0x735a2d97);
+  h ^= h >>> 15;
+  return (h >>> 0) / 4294967296;
+}
+
+/** Salts, named so two uses of `unitHash` can never silently collide. */
+const SALT = {
+  driftDirection: 1,
+  driftSpeed: 2,
+  spawnEdge: 5,
+  spawnDirection: 6,
+  relayCoin: 7,
+  relaySecondCoin: 12,
+  prominence: 8,
+  speed: 9,
+  spawnGap: 10,
+  relayEdge: 11,
+} as const;
+
+/* --------------------------------------------------------------- the model */
+
+/** The four wakes a signal can leave. `default` is what an unconfigured node
+ * sends, which today is nearly everybody. */
+export type TrailStyle = "default" | "fade" | "comet" | "dashed";
+
+/**
+ * One node, drifting around where the projection put it.
+ *
+ * `node` is the projected `ScreenNode`, untouched — it is the **home**, and
+ * `x`/`y` are where this node has wandered to. Keeping them apart is what makes
+ * the drift an overlay on a pure projection rather than a mutation of it, and
+ * it is what lets a reprojection re-home a node without losing where it was.
+ */
+export type FieldNode = {
+  node: ScreenNode;
+  x: number;
+  y: number;
+  vx: number;
+  vy: number;
+  /** `clearAt` at the live position, not at the projected one. */
+  clearance: number;
+};
+
+/** One backbone edge, with the clearance of the line as it is drifting now. */
+export type FieldEdge = {
+  /** Identity across a reprojection: the two node ids, in stored order. */
+  key: string;
+  from: FieldNode;
+  to: FieldNode;
+  clearance: number;
+};
+
+/**
+ * One signal in flight.
+ *
+ * It stores no endpoints. They are read from the live node positions every
+ * frame (:1310), because a burst whose arms stayed where the node was when it
+ * was clicked detaches from the dot that sent it within a second.
+ *
+ * It carries **no payload**, and that is settled. The artboard gives each
+ * signal a line from `INSIGHTS` (:620) — invented review text, which is the
+ * production mock data #134 forbids — and the note card that would have shown
+ * it is never drawn: `closeCard()` and `scheduleClose()` are empty stubs. A
+ * signal that carries nothing is faithful to the artboard as shipped.
+ */
+export type Signal = {
+  id: number;
+  edgeKey: string;
+  /** The node that sent it, and whose `signalStyle` picked the wake. */
+  fromId: string;
+  /** The node it is arriving at, and which may relay it onward. */
+  toId: string;
+  /** Progress along the edge. Negative while a burst arm waits its turn. */
+  p: number;
+  speed: number;
+  prom: number;
+  /** Hops left after this one. */
+  relay: number;
+  style: TrailStyle;
+};
+
+/**
+ * Everything the loop mutates, and the only mutable state this hero has.
+ *
+ * Rebuilt from the view by `syncField` on every reprojection; nothing in it is
+ * ever written back to the server, and nothing in it outlives the component.
+ */
+export type HeroField = {
+  nodes: FieldNode[];
+  nodeById: Map<string, FieldNode>;
+  edges: FieldEdge[];
+  edgeByKey: Map<string, FieldEdge>;
+  edgesByNode: Map<string, FieldEdge[]>;
+  signals: Signal[];
+  rects: Rect[];
+  /** Seconds of animation, which is the clock everything else is keyed on. */
+  elapsed: number;
+  /** Signals created so far. The sequence half of every seed. */
+  seq: number;
+  /** Ambient spawn attempts so far, so a failed attempt does not repeat. */
+  attempt: number;
+  /** `elapsed` at which the next ambient spawn is due. */
+  nextSpawn: number;
+  /** Where the rolling edge-clearance refresh has got to. */
+  clearCursor: number;
+  /** Concurrent ambient signals allowed on this frame. */
+  cap: number;
+};
+
+export function createField(): HeroField {
+  return {
+    nodes: [],
+    nodeById: new Map(),
+    edges: [],
+    edgeByKey: new Map(),
+    edgesByNode: new Map(),
+    signals: [],
+    rects: [],
+    elapsed: 0,
+    seq: 0,
+    attempt: 0,
+    nextSpawn: 0,
+    clearCursor: 0,
+    cap: 0,
+  };
+}
+
+/** The identity of an edge across a reprojection: its two endpoints' ids. */
+export function edgeKey(fromId: string, toId: string): string {
+  return `${fromId}|${toId}`;
+}
+
+function viewportCap(width: number): number {
+  if (width < NARROW_WIDTH) return NARROW_CAP;
+  if (width < WIDE_WIDTH) return MEDIUM_CAP;
+  return WIDE_CAP;
+}
+
+/**
+ * Point the field at a freshly projected view. **Reproject, do not reset.**
+ *
+ * A resize re-derives every screen coordinate, but the people did not change:
+ * `WindowNode.id` is stable for the life of a response, so a node keeps its
+ * offset from home and its heading, and a signal keeps its progress `p` and
+ * simply finds its edge in a new place. Blanking the field because somebody
+ * dragged a window edge reads as a glitch.
+ *
+ * A **refetch** is the other case and needs no separate branch. `service.ts`
+ * mints `crypto.randomUUID()` per response, so a new read means new ids, no
+ * node or edge is recognised, and the field is rebuilt from nothing — which is
+ * exactly "clear and restart". Different ids are genuinely different
+ * people-slots, so resuming across them would be resuming onto strangers.
+ */
+export function syncField(
+  field: HeroField,
+  view: GraphWindowView | null,
+  rects: Rect[],
+  width: number,
+): void {
+  field.rects = rects;
+
+  const previous = field.nodeById;
+  const nodes: FieldNode[] = [];
+  const nodeById = new Map<string, FieldNode>();
+  for (const node of view?.nodes ?? []) {
+    const was = previous.get(node.id);
+    const placed = was ? rehome(was, node) : seedNode(node);
+    placed.clearance = clearAt(placed.x, placed.y, rects, NODE_RADIUS);
+    nodes.push(placed);
+    nodeById.set(node.id, placed);
+  }
+
+  const wasEdge = field.edgeByKey;
+  const edges: FieldEdge[] = [];
+  const edgeByKey = new Map<string, FieldEdge>();
+  const edgesByNode = new Map<string, FieldEdge[]>();
+  for (const edge of view?.edges ?? []) {
+    const from = nodeById.get(edge.from.id);
+    const to = nodeById.get(edge.to.id);
+    if (!from || !to) continue;
+    const key = edgeKey(edge.from.id, edge.to.id);
+    const placed: FieldEdge = {
+      key,
+      from,
+      to,
+      // The projection already sampled this line; take its answer rather than
+      // paying for eleven more samples per edge on a frame that is already
+      // rebuilding everything.
+      clearance: wasEdge.get(key)?.clearance ?? edge.clearance,
+    };
+    edges.push(placed);
+    edgeByKey.set(key, placed);
+    for (const id of [edge.from.id, edge.to.id]) {
+      const list = edgesByNode.get(id);
+      if (list) list.push(placed);
+      else edgesByNode.set(id, [placed]);
+    }
+  }
+
+  field.nodes = nodes;
+  field.nodeById = nodeById;
+  field.edges = edges;
+  field.edgeByKey = edgeByKey;
+  field.edgesByNode = edgesByNode;
+  field.cap = Math.min(
+    viewportCap(width),
+    Math.ceil(edges.length / EDGES_PER_SIGNAL),
+  );
+  field.clearCursor = 0;
+  // A signal whose edge or sender did not survive has nowhere to be.
+  field.signals = field.signals.filter(
+    (signal) =>
+      edgeByKey.has(signal.edgeKey) &&
+      nodeById.has(signal.fromId) &&
+      nodeById.has(signal.toId),
+  );
+}
+
+/** A node the field has not seen before: at home, heading somewhere stable. */
+function seedNode(node: ScreenNode): FieldNode {
+  const direction = unitHash(node.id, SALT.driftDirection) * Math.PI * 2;
+  const speed =
+    DRIFT_SPEED_MIN + unitHash(node.id, SALT.driftSpeed) * DRIFT_SPEED_SPAN;
+  return {
+    node,
+    x: node.screenX,
+    y: node.screenY,
+    vx: Math.cos(direction) * speed,
+    vy: Math.sin(direction) * speed,
+    clearance: node.clearance,
+  };
+}
+
+/** The same node, projected somewhere else: keep the wander, move the home. */
+function rehome(was: FieldNode, node: ScreenNode): FieldNode {
+  const offsetX = clampBox(was.x - was.node.screenX);
+  const offsetY = clampBox(was.y - was.node.screenY);
+  return {
+    node,
+    x: node.screenX + offsetX,
+    y: node.screenY + offsetY,
+    vx: was.vx,
+    vy: was.vy,
+    clearance: node.clearance,
+  };
+}
+
+function clampBox(offset: number): number {
+  return Math.max(-DRIFT_BOX, Math.min(DRIFT_BOX, offset));
+}
+
+/**
+ * One frame of the model: drift, refresh, spawn, advance.
+ *
+ * `holdId` is the node that must not move — the viewer's own, while **Find your
+ * dot** holds a label on it. The artboard checks an `n.fixed` flag at :1202
+ * that nothing anywhere sets, a dead branch somebody meant to use; its own
+ * prose says what it was for at :814, *"the graph never moves: the dot grows
+ * and pulses in place"*. This is the one place we follow the artboard's words
+ * over its code. The held node resumes from where it stopped, not from home.
+ */
+export function advanceField(
+  field: HeroField,
+  dt: number,
+  options: { holdId?: string | null } = {},
+): void {
+  const step = Math.max(0, Math.min(MAX_STEP, dt));
+  field.elapsed += step;
+  drift(field, step, options.holdId ?? null);
+  refreshEdgeClearance(field);
+  spawnAmbient(field);
+  advanceSignals(field, step);
+}
+
+/** Port of :1200-1227, less the frame inset clamp and the separation pass. */
+function drift(field: HeroField, step: number, holdId: string | null): void {
+  for (const node of field.nodes) {
+    if (node.node.id !== holdId) {
+      const homeX = node.node.screenX;
+      const homeY = node.node.screenY;
+      node.x += node.vx * step;
+      node.y += node.vy * step;
+
+      if (node.x < homeX - DRIFT_BOX) {
+        node.x = homeX - DRIFT_BOX;
+        node.vx = Math.abs(node.vx);
+      }
+      if (node.x > homeX + DRIFT_BOX) {
+        node.x = homeX + DRIFT_BOX;
+        node.vx = -Math.abs(node.vx);
+      }
+      if (node.y < homeY - DRIFT_BOX) {
+        node.y = homeY - DRIFT_BOX;
+        node.vy = Math.abs(node.vy);
+      }
+      if (node.y > homeY + DRIFT_BOX) {
+        node.y = homeY + DRIFT_BOX;
+        node.vy = -Math.abs(node.vy);
+      }
+
+      // Drift never carries anybody into the copy: it turns away at the margin.
+      if (clearAt(node.x, node.y, field.rects, NODE_RADIUS + TURN_MARGIN) < 1) {
+        node.x -= node.vx * step * 2;
+        node.y -= node.vy * step * 2;
+        node.vx = -node.vx;
+        node.vy = -node.vy;
+        // The step back is twice the step forward, so it can leave the box by
+        // up to one frame's travel. The artboard lets that stand; here the box
+        // is the invariant the tests hold, so it is closed rather than nearly
+        // held.
+        node.x = homeX + clampBox(node.x - homeX);
+        node.y = homeY + clampBox(node.y - homeY);
+      }
+    }
+
+    node.clearance = clearAt(node.x, node.y, field.rects, NODE_RADIUS);
+  }
+}
+
+/**
+ * A rolling slice of the edge clearances, never the whole set (:1251-1260).
+ *
+ * `lineClearance` samples eleven points per edge against every measured rect,
+ * so re-deriving all of them every frame is the one thing in this loop that
+ * would actually cost something. Drift is clamped to `DRIFT_BOX`, so an edge's
+ * clearance moves by a few pixels' worth at most between refreshes — spreading
+ * a full sweep over `CLEAR_SLICES` frames is well inside what the eye can tell.
+ */
+function refreshEdgeClearance(field: HeroField): void {
+  const edges = field.edges;
+  if (!edges.length) {
+    field.clearCursor = 0;
+    return;
+  }
+  const slice = Math.max(1, Math.ceil(edges.length / CLEAR_SLICES));
+  const from = field.clearCursor;
+  for (let i = 0; i < slice; i++) {
+    const edge = edges[(from + i) % edges.length];
+    edge.clearance = lineClearance(
+      { x: edge.from.x, y: edge.from.y },
+      { x: edge.to.x, y: edge.to.y },
+      field.rects,
+    );
+  }
+  field.clearCursor = (from + slice) % edges.length;
+}
+
+/**
+ * The ambient producer: `spawnSignal` (:1116), with two rules of our own.
+ *
+ * Never two signals on one edge, which is the export's. And **never an edge
+ * below `VISIBLE`**, which is not: `routeClear` (:1092) is defined in the
+ * export and never called from anywhere, and `drawSignal` never multiplies by
+ * clearance either, so a signal there can run straight over the headline. The
+ * invariant `hero-network.tsx` states — everything painted on this canvas
+ * passes the clearance check — holds here too.
+ */
+function spawnAmbient(field: HeroField): void {
+  if (field.elapsed < field.nextSpawn) return;
+  if (field.signals.length >= field.cap) return;
+  const edges = field.edges;
+  if (!edges.length) return;
+
+  const attempt = field.attempt++;
+  for (let i = 0; i < SPAWN_ATTEMPTS; i++) {
+    const roll = unitHash(`spawn:${attempt}:${i}`, SALT.spawnEdge);
+    const edge =
+      edges[Math.min(edges.length - 1, Math.floor(roll * edges.length))];
+    if (edge.clearance <= VISIBLE) continue;
+    if (field.signals.some((signal) => signal.edgeKey === edge.key)) continue;
+    const forward =
+      unitHash(`dir:${edge.key}:${attempt}`, SALT.spawnDirection) < 0.5;
+    field.signals.push(makeSignal(field, edge, forward ? edge.from : edge.to));
+    break;
+  }
+
+  // Rescheduled whether or not an edge was free, exactly as the export does:
+  // a frame with nowhere to put a signal waits for the next slot rather than
+  // retrying fourteen times per frame forever.
+  field.nextSpawn =
+    field.elapsed +
+    SPAWN_GAP_MIN +
+    unitHash(`gap:${attempt}`, SALT.spawnGap) * SPAWN_GAP_SPAN;
+}
+
+/**
+ * The wake a node sends. **Every node signals**; the tier picks only the style.
+ *
+ * An unconfigured node — which today is very nearly all of them — sends the
+ * `default` wake, exactly as it draws the default shape and the default
+ * colour. Gating the signal itself on tier 3 would have made the feature
+ * invisible on the community #68 recorded and accepted.
+ */
+export function trailStyleOf(node: ScreenNode): TrailStyle {
+  return node.signalStyle === NO_SIGNAL ? "default" : node.signalStyle;
+}
+
+function makeSignal(
+  field: HeroField,
+  edge: FieldEdge,
+  from: FieldNode,
+  overrides: { relay?: number; p?: number } = {},
+): Signal {
+  const id = ++field.seq;
+  const seed = `signal:${edge.key}:${id}`;
+  const to = from === edge.from ? edge.to : edge.from;
+  const relayed =
+    unitHash(seed, SALT.relayCoin) < RELAY_CHANCE
+      ? 1 + (unitHash(seed, SALT.relaySecondCoin) < RELAY_SECOND_CHANCE ? 1 : 0)
+      : 0;
+  return {
+    id,
+    edgeKey: edge.key,
+    fromId: from.node.id,
+    toId: to.node.id,
+    p: overrides.p ?? 0,
+    speed: SIGNAL_SPEED_MIN + unitHash(seed, SALT.speed) * SIGNAL_SPEED_SPAN,
+    prom: PROM_MIN + unitHash(seed, SALT.prominence) * PROM_SPAN,
+    relay: overrides.relay ?? relayed,
+    style: trailStyleOf(from.node),
+  };
+}
+
+/** `relaySignal` (:1128): the signal carries on from the node that received it. */
+function relaySignal(field: HeroField, arrived: Signal): void {
+  const from = field.nodeById.get(arrived.toId);
+  if (!from) return;
+  const open = (field.edgesByNode.get(arrived.toId) ?? []).filter(
+    (edge) =>
+      edge.key !== arrived.edgeKey &&
+      edge.clearance > VISIBLE &&
+      !field.signals.some((signal) => signal.edgeKey === edge.key),
+  );
+  if (!open.length) return;
+  const roll = unitHash(`relay:${arrived.id}`, SALT.relayEdge);
+  const edge = open[Math.min(open.length - 1, Math.floor(roll * open.length))];
+  field.signals.push(
+    makeSignal(field, edge, from, { relay: arrived.relay - 1 }),
+  );
+}
+
+/**
+ * `burst` (:1140): one click fans a signal out along every free backbone edge
+ * the node has **within the drawn graph window**, staggered so they leave in
+ * order rather than as a ring. It does not reach a node the window does not
+ * hold, because no such edge is on the wire to begin with.
+ *
+ * Unlike the ambient producer this does not skip a dim edge, and does not stop
+ * at the cap. A burst is a gesture somebody made: an arm that simply was not
+ * there would read as broken, whereas an arm that draws faint-to-invisible
+ * under the copy reads as depth. The cap exists to keep ambient traffic from
+ * strobing, and a click is not ambient traffic.
+ */
+export function burstAt(field: HeroField, node: FieldNode): void {
+  let delay = 0;
+  for (const edge of field.edgesByNode.get(node.node.id) ?? []) {
+    if (field.signals.some((signal) => signal.edgeKey === edge.key)) continue;
+    field.signals.push(makeSignal(field, edge, node, { relay: 0, p: -delay }));
+    delay += BURST_STAGGER;
+  }
+}
+
+function edgeLength(edge: FieldEdge): number {
+  return Math.max(
+    1,
+    Math.hypot(edge.to.x - edge.from.x, edge.to.y - edge.from.y),
+  );
+}
+
+function advanceSignals(field: HeroField, step: number): void {
+  for (let i = field.signals.length - 1; i >= 0; i--) {
+    const signal = field.signals[i];
+    const edge = field.edgeByKey.get(signal.edgeKey);
+    if (!edge) {
+      field.signals.splice(i, 1);
+      continue;
+    }
+    // The pace is constant in px/s regardless of how long the edge is, with a
+    // floor so a short edge is a crossing rather than a blink.
+    const duration = Math.max(MIN_DURATION, edgeLength(edge) / signal.speed);
+    signal.p += step / duration;
+    if (signal.p < 1) continue;
+    field.signals.splice(i, 1);
+    if (signal.relay > 0 && field.signals.length < field.cap + RELAY_HEADROOM) {
+      relaySignal(field, signal);
+    }
+  }
+}
+
+/**
+ * The node under the pointer, if any: `hitAt` (:1424).
+ *
+ * Nearest within `HIT_RADIUS`, and **an invisible node is not clickable** —
+ * anything the clearance check would not paint is skipped here for the same
+ * reason it is skipped there. The export tests its own mask at 0.35; ours tests
+ * `VISIBLE`, because `pushClear` means our nodes are either placed clear or not
+ * placed at all.
+ */
+export function hitTest(
+  field: HeroField,
+  x: number,
+  y: number,
+): FieldNode | null {
+  let best: FieldNode | null = null;
+  let bestDistance = HIT_RADIUS * HIT_RADIUS;
+  for (const node of field.nodes) {
+    if (node.clearance <= VISIBLE) continue;
+    const dx = node.x - x;
+    const dy = node.y - y;
+    const distance = dx * dx + dy * dy;
+    if (distance < bestDistance) {
+      bestDistance = distance;
+      best = node;
+    }
+  }
+  return best;
+}
+
+/* --------------------------------------------------------------- painting */
+
+/** One stroked piece of a wake. */
+export type TrailStroke = {
+  fromX: number;
+  fromY: number;
+  toX: number;
+  toY: number;
+  width: number;
+  alpha: number;
+};
+
+/** One ring dropped behind the head, for the `fade` wake. */
+export type TrailRing = {
+  x: number;
+  y: number;
+  radius: number;
+  alpha: number;
+};
+
+/** One filled disc of the head's halo. */
+export type TrailDisc = { x: number; y: number; radius: number; alpha: number };
+
+/**
+ * Everything one signal asks the canvas for, as data.
+ *
+ * The painter sets a colour and traces this; it makes no decisions. That is
+ * what lets the geometry be asserted with a plain object and a fake clock
+ * rather than through `getContext("2d")`.
+ */
+export type SignalPaint = {
+  /** The custom property the sending node draws in. A signal is *theirs*. */
+  colorVar: string;
+  headX: number;
+  headY: number;
+  /** The head, identical across all four styles. */
+  halo: TrailDisc[];
+  /** The wake as strokes. Empty for `fade`. */
+  strokes: TrailStroke[];
+  /** The wake as rings. Empty for everything but `fade`. */
+  rings: TrailRing[];
+  /** The dash pattern the strokes are traced through, or `null`. */
+  dash: number[] | null;
+};
+
+/** `env` (:1157): faint on departure, defined mid-flight, gone on arrival. */
+export function envelope(p: number): number {
+  const rise = smoothStep(0.03, 0.42, p) ** 1.5;
+  const fall = 1 - smoothStep(0.86, 1, p);
+  return Math.min(rise, fall);
+}
+
+function smoothStep(a: number, b: number, x: number): number {
+  const t = Math.max(0, Math.min(1, (x - a) / (b - a)));
+  return t * t * (3 - 2 * t);
+}
+
+/** The `at(s, p)` of :1091, which — its control point being the midpoint of its
+ * own endpoints — reduces exactly to a straight interpolation. Written as one. */
+function pointAt(edge: FieldEdge, p: number) {
+  return {
+    x: edge.from.x + (edge.to.x - edge.from.x) * p,
+    y: edge.from.y + (edge.to.y - edge.from.y) * p,
+  };
+}
+
+/**
+ * Below this the signal is not drawn at all — the export's own guard (:1369).
+ */
+const PAINT_FLOOR = 0.002;
+
+/**
+ * What to draw for one signal on this frame, or `null` if it is not visible.
+ *
+ * `dim` is **Find your dot** holding a label up. The field fades back to about
+ * a quarter for as long as it does — but a signal the viewer's own node sent is
+ * exempt, as their node is at :1281, because a burst from the dot the page has
+ * just pointed at is the best discovery moment this feature has and dimming it
+ * would be pointing and then looking away.
+ */
+export function signalPaint(
+  field: HeroField,
+  signal: Signal,
+  options: { dim?: boolean } = {},
+): SignalPaint | null {
+  const edge = field.edgeByKey.get(signal.edgeKey);
+  const sender = field.nodeById.get(signal.fromId);
+  if (!edge || !sender) return null;
+  if (signal.p <= 0 || signal.p >= 1) return null;
+
+  const dimmed = options.dim && !sender.node.isViewer ? 1 - DIM_FACTOR : 1;
+  const k = Math.min(
+    1,
+    envelope(signal.p) * signal.prom * edge.clearance * dimmed,
+  );
+  if (k <= PAINT_FLOOR) return null;
+
+  const length = edgeLength(edge);
+  const wanted =
+    (TRAIL_BASE + TRAIL_GAIN * k) *
+    (signal.style === "comet" ? COMET_LENGTHEN : 1);
+  // Never behind the node it left: a wake that ran off the end of its own edge
+  // would be a line to somebody the signal is not travelling to.
+  const back = Math.min(signal.p, wanted / length);
+  const head = pointAt(edge, signal.p);
+  const tail = pointAt(edge, signal.p - back);
+  const available = back * length;
+  const width = WIDTH_BASE + WIDTH_GAIN * k;
+
+  const paint: SignalPaint = {
+    colorVar: sender.node.colorVar,
+    headX: head.x,
+    headY: head.y,
+    halo: haloDiscs(head.x, head.y, k),
+    strokes: [],
+    rings: [],
+    dash: signal.style === "dashed" ? DASHED_TRAIL_DASH : null,
+  };
+
+  if (signal.style === "fade") {
+    const steps = FADE_TRAIL_RINGS.length;
+    const lead = FADE_TRAIL_RINGS[0].alpha;
+    FADE_TRAIL_RINGS.forEach((ring, index) => {
+      // Each ring is dropped further back than the last, and is wider and
+      // fainter for having been left there longer.
+      const at = signal.p - back * ((index + 1) / steps);
+      const spot = pointAt(edge, at);
+      paint.rings.push({
+        x: spot.x,
+        y: spot.y,
+        radius: NODE_RADIUS * ring.reach,
+        alpha: k * (ring.alpha / lead),
+      });
+    });
+    return paint;
+  }
+
+  if (signal.style === "comet") {
+    const lead = COMET_TRAIL_SEGMENTS[0];
+    for (const segment of COMET_TRAIL_SEGMENTS) {
+      const near = available * (segment.from / COMET_REACH);
+      const far = available * (segment.to / COMET_REACH);
+      paint.strokes.push({
+        fromX: head.x - unitX(edge) * far,
+        fromY: head.y - unitY(edge) * far,
+        toX: head.x - unitX(edge) * near,
+        toY: head.y - unitY(edge) * near,
+        width: width * (segment.width / lead.width),
+        alpha: k * (segment.alpha / lead.alpha),
+      });
+    }
+    return paint;
+  }
+
+  // `default` and `dashed`: the artboard's single tapering stroke, sampled off
+  // `TRAIL_STOPS` into sub-strokes so the taper needs no colour arithmetic.
+  for (let i = 0; i < TRAIL_STEPS; i++) {
+    const a = i / TRAIL_STEPS;
+    const b = (i + 1) / TRAIL_STEPS;
+    paint.strokes.push({
+      fromX: tail.x + (head.x - tail.x) * a,
+      fromY: tail.y + (head.y - tail.y) * a,
+      toX: tail.x + (head.x - tail.x) * b,
+      toY: tail.y + (head.y - tail.y) * b,
+      width,
+      alpha: Math.min(1, k * stopAlpha((a + b) / 2)),
+    });
+  }
+  return paint;
+}
+
+function unitX(edge: FieldEdge): number {
+  return (edge.to.x - edge.from.x) / edgeLength(edge);
+}
+
+function unitY(edge: FieldEdge): number {
+  return (edge.to.y - edge.from.y) / edgeLength(edge);
+}
+
+/** `TRAIL_STOPS`, interpolated. `at` runs 0 at the tail to 1 at the head. */
+function stopAlpha(at: number): number {
+  let previous = TRAIL_STOPS[0];
+  for (const stop of TRAIL_STOPS) {
+    if (at <= stop.at) {
+      const span = stop.at - previous.at;
+      const t = span > 0 ? (at - previous.at) / span : 1;
+      return previous.alpha + (stop.alpha - previous.alpha) * t;
+    }
+    previous = stop;
+  }
+  return previous.alpha;
+}
+
+/**
+ * The head's halo, as discs rather than as a radial gradient.
+ *
+ * Same reason as `TRAIL_STOPS`: the colour is a token, not something whose
+ * alpha this file can vary inside a gradient stop. Three concentric discs of
+ * falling alpha read as the export's `createRadialGradient` halo does at the
+ * five-to-fourteen pixel radii it actually uses, and cost three arcs.
+ */
+function haloDiscs(x: number, y: number, k: number): TrailDisc[] {
+  const reach = HALO_BASE + HALO_GAIN * k;
+  const discs: TrailDisc[] = [];
+  // Widest first, so the core is painted over its own glow rather than under
+  // it. Alpha falls as the square of the radius, which is the shape of the
+  // export's gradient between `haloA` at the centre and zero at the rim.
+  for (let i = HALO_STEPS; i >= 1; i--) {
+    const t = i / HALO_STEPS;
+    discs.push({
+      x,
+      y,
+      radius: reach * t,
+      alpha: k * HALO_ALPHA * (1 - t + 1 / HALO_STEPS) ** 2,
+    });
+  }
+  return discs;
+}

--- a/apps/web/features/landing/lib/hero-signals.ts
+++ b/apps/web/features/landing/lib/hero-signals.ts
@@ -711,7 +711,15 @@ function makeSignal(
   };
 }
 
-/** `relaySignal` (:1128): the signal carries on from the node that received it. */
+/**
+ * `relaySignal` (:1128): the signal carries on from the node that received it.
+ *
+ * A relay is ambient traffic continuing rather than a gesture anybody made, so
+ * it takes the ambient producer's rules: not back down the edge it arrived on,
+ * not onto an edge already carrying something, and **not onto an edge the copy
+ * has buried**. A burst is the one producer exempt from that last rule, because
+ * a burst arm is somebody's click and a missing arm would read as broken.
+ */
 function relaySignal(field: HeroField, arrived: Signal): void {
   const from = field.nodeById.get(arrived.toId);
   if (!from) return;
@@ -740,6 +748,11 @@ function relaySignal(field: HeroField, arrived: Signal): void {
  * there would read as broken, whereas an arm that draws faint-to-invisible
  * under the copy reads as depth. The cap exists to keep ambient traffic from
  * strobing, and a click is not ambient traffic.
+ *
+ * Skipping the cap costs nothing unbounded, which is the reason it is safe to
+ * do: one edge carries one signal, so however fast somebody clicks, the field
+ * cannot hold more signals than the graph window has edges — and a window is a
+ * *bounded* slice of the community by construction.
  */
 export function burstAt(field: HeroField, node: FieldNode): void {
   let delay = 0;

--- a/apps/web/features/landing/lib/hero-signals.ts
+++ b/apps/web/features/landing/lib/hero-signals.ts
@@ -863,12 +863,45 @@ function smoothStep(a: number, b: number, x: number): number {
   return t * t * (3 - 2 * t);
 }
 
-/** The `at(s, p)` of :1091, which — its control point being the midpoint of its
- * own endpoints — reduces exactly to a straight interpolation. Written as one. */
-function pointAt(edge: FieldEdge, p: number) {
+/**
+ * Which way along the edge this signal is actually going.
+ *
+ * A **backbone edge** is stored newer-to-older and drawn undirected, but a
+ * signal has a sender and a receiver — `spawnSignal` tosses for the end it
+ * leaves from and a **burst** leaves from whichever node was clicked, which is
+ * as often the edge's `to` as its `from`. So `p` is progress *from the sender*,
+ * and everything geometric below has to be measured from the sender rather than
+ * from whichever endpoint the view model happened to list first. Getting this
+ * wrong draws the signal running backwards, out of a node that did not send it.
+ */
+function travel(edge: FieldEdge, signal: Signal) {
+  const forward = signal.fromId === edge.from.node.id;
+  const a = forward ? edge.from : edge.to;
+  const b = forward ? edge.to : edge.from;
+  const length = Math.max(1, Math.hypot(b.x - a.x, b.y - a.y));
   return {
-    x: edge.from.x + (edge.to.x - edge.from.x) * p,
-    y: edge.from.y + (edge.to.y - edge.from.y) * p,
+    /** The sender's end. */
+    ax: a.x,
+    ay: a.y,
+    /** The receiver's end. */
+    bx: b.x,
+    by: b.y,
+    length,
+    /** A unit vector pointing the way the signal is travelling. */
+    ux: (b.x - a.x) / length,
+    uy: (b.y - a.y) / length,
+  };
+}
+
+/**
+ * The `at(s, p)` of :1091, which — its control point being the midpoint of its
+ * own endpoints — reduces exactly to a straight interpolation. Written as one,
+ * and measured from the sender.
+ */
+function pointAt(along: ReturnType<typeof travel>, p: number) {
+  return {
+    x: along.ax + (along.bx - along.ax) * p,
+    y: along.ay + (along.by - along.ay) * p,
   };
 }
 
@@ -903,16 +936,16 @@ export function signalPaint(
   );
   if (k <= PAINT_FLOOR) return null;
 
-  const length = edgeLength(edge);
+  const along = travel(edge, signal);
   const wanted =
     (TRAIL_BASE + TRAIL_GAIN * k) *
     (signal.style === "comet" ? COMET_LENGTHEN : 1);
   // Never behind the node it left: a wake that ran off the end of its own edge
   // would be a line to somebody the signal is not travelling to.
-  const back = Math.min(signal.p, wanted / length);
-  const head = pointAt(edge, signal.p);
-  const tail = pointAt(edge, signal.p - back);
-  const available = back * length;
+  const back = Math.min(signal.p, wanted / along.length);
+  const head = pointAt(along, signal.p);
+  const tail = pointAt(along, signal.p - back);
+  const available = back * along.length;
   const width = WIDTH_BASE + WIDTH_GAIN * k;
 
   const paint: SignalPaint = {
@@ -932,7 +965,7 @@ export function signalPaint(
       // Each ring is dropped further back than the last, and is wider and
       // fainter for having been left there longer.
       const at = signal.p - back * ((index + 1) / steps);
-      const spot = pointAt(edge, at);
+      const spot = pointAt(along, at);
       paint.rings.push({
         x: spot.x,
         y: spot.y,
@@ -949,10 +982,10 @@ export function signalPaint(
       const near = available * (segment.from / COMET_REACH);
       const far = available * (segment.to / COMET_REACH);
       paint.strokes.push({
-        fromX: head.x - unitX(edge) * far,
-        fromY: head.y - unitY(edge) * far,
-        toX: head.x - unitX(edge) * near,
-        toY: head.y - unitY(edge) * near,
+        fromX: head.x - along.ux * far,
+        fromY: head.y - along.uy * far,
+        toX: head.x - along.ux * near,
+        toY: head.y - along.uy * near,
         width: width * (segment.width / lead.width),
         alpha: k * (segment.alpha / lead.alpha),
       });
@@ -975,14 +1008,6 @@ export function signalPaint(
     });
   }
   return paint;
-}
-
-function unitX(edge: FieldEdge): number {
-  return (edge.to.x - edge.from.x) / edgeLength(edge);
-}
-
-function unitY(edge: FieldEdge): number {
-  return (edge.to.y - edge.from.y) / edgeLength(edge);
 }
 
 /** `TRAIL_STOPS`, interpolated. `at` runs 0 at the tail to 1 at the head. */

--- a/apps/web/features/landing/lib/hero-signals.ts
+++ b/apps/web/features/landing/lib/hero-signals.ts
@@ -460,7 +460,6 @@ export function syncField(
     nodeById.set(node.id, placed);
   }
 
-  const wasEdge = field.edgeByKey;
   const edges: FieldEdge[] = [];
   const edgeByKey = new Map<string, FieldEdge>();
   const edgesByNode = new Map<string, FieldEdge[]>();
@@ -473,10 +472,18 @@ export function syncField(
       key,
       from,
       to,
-      // The projection already sampled this line; take its answer rather than
-      // paying for eleven more samples per edge on a frame that is already
-      // rebuilding everything.
-      clearance: wasEdge.get(key)?.clearance ?? edge.clearance,
+      // **The fresh projection's answer, never the cache's.** A relayout is
+      // exactly the event that moves the copy, so the cached clearance is the
+      // one measurement that cannot be trusted across one: an edge the
+      // headline has just been reflowed on top of would keep the clear reading
+      // it had before. Under reduced motion nothing ever advances the field,
+      // so the rolling refresh would never come along to correct it and the
+      // edge would draw across protected copy for as long as the page is open.
+      //
+      // It costs nothing to take, either — `projectGraphWindow` has already
+      // sampled this line against the new keep-out on the way here, so this is
+      // reading a number that has been computed rather than computing one.
+      clearance: edge.clearance,
     };
     edges.push(placed);
     edgeByKey.set(key, placed);

--- a/apps/web/features/landing/lib/neighbourhood-view.ts
+++ b/apps/web/features/landing/lib/neighbourhood-view.ts
@@ -45,6 +45,19 @@
  * port rather than a liberty. Issue #68 settled the opposite — "the centre is
  * the viewport centre", "keep-out may only fade nodes" — and both of those are
  * superseded here on the product owner's instruction.
+ *
+ * **What is projected here no longer has to be where a node is drawn.** ADR
+ * 0006 brings back the artboard's drift: every node wanders inside a ±5px box
+ * around the position derived below, and `hero-signals.ts` owns that wander as
+ * an overlay keyed on node id. This file's output is the **home** it wanders
+ * around, and stays a pure projection — the drift never writes back into a
+ * `ScreenNode`, so a reprojection re-homes a node without having to unpick
+ * where it had got to. The one thing drift may not do is change a node's
+ * position *relative to its neighbours*, which is why the artboard's min-gap
+ * separation pass is deliberately not ported: the promise the two paragraphs
+ * above make is that a returning member recognises the shape of their own
+ * neighbourhood, and a pass that eases close pairs apart is a pass that
+ * reshapes it.
  */
 
 import {
@@ -254,6 +267,23 @@ export const VIEW_SCALE = 0.72;
 
 /** Drawn radius of an ordinary node, in px. A dot is cleared by its edge. */
 export const NODE_RADIUS = 4;
+
+/**
+ * The clearance below which a thing is not painted at all.
+ *
+ * `pushClear` places nodes clear of the copy, so this is 1 for everything on an
+ * ordinary frame and the threshold never fires. It fires where the push gave
+ * up — a hero whose copy reaches past every edge has nowhere to put anybody —
+ * and there it is the whole of the keep-out. **Everything painted on this
+ * canvas has to pass it**: the reveal, which is a bigger mark than the node it
+ * replaces; a **signal**, which is why `hero-signals.ts` multiplies one by its
+ * edge's clearance and will not spawn ambient traffic below this; and the hit
+ * test, because a node nobody can see is not a node anybody can click.
+ *
+ * It lives here rather than in the canvas because it is a statement about the
+ * projection's `clearance`, and there are now three consumers of it.
+ */
+export const VISIBLE = 0.02;
 
 /** How coarse the anchor search is, per axis. */
 const ANCHOR_STEPS = 12;


### PR DESCRIPTION
Implements #203. The landing hero was specified as a living **graph window** and shipped as a still picture; ADR 0006 settles that the motion ships, and in doing so makes the third **personalization tier** — the only axis a member reaches by reviewing their entire transcript — pay out something you can actually see.

**No server changes.** Nothing under `apps/web/server/` is touched; the data was already on the wire.

## What changed

**New pure module `apps/web/features/landing/lib/hero-signals.ts`** holds the model: anchored drift, the three signal producers, trail geometry as data, and the hit test. It is a pure function of the graph window and the elapsed time — every seed comes from node or edge identity plus a sequence counter, and there is no `Math.random()` in it. That is what makes the traffic assertable in a test, reproducible across a reprojection, and quotable in a bug report. `hero-network.tsx` keeps measuring, projecting, painting and the rAF gates, and calls in for geometry exactly as it already does with `hero-keepout.ts`.

- **Anchored drift.** A ±5px box around the projected home, 1.8–2.2 px/s from a stable per-node hash, reflecting off the walls and turning away from the copy at the margin. The artboard's **frame inset clamp** and **min-gap separation pass** are deliberately not ported, for the reasons #203 gives; the module records both.
- **Three producers** — ambient (never two signals on one edge), relay (42%, carrying on from the receiving node), and burst-on-click (one arm per free backbone edge that node has *within the drawn graph window*, staggered 0.06s).
- **Four wakes** — `default`, `comet`, `fade`, `dashed` — with an **identical head, speed and envelope**. The style is the wake and never the pace.
- **Clearance is enforced on signals.** Alpha is multiplied by the edge's clearance and ambient traffic will not spawn below `VISIBLE`. The export defines `routeClear` (:1092) and never calls it, so a signal there can run over the headline; this upholds the invariant the canvas already states. A burst still fires on every arm and draws faint-to-invisible under the copy.
- **Density is capped by edge count as well as viewport**: `min(viewportCap, ceil(edges / 4))`, keeping the artboard's 3/5/8 ladder as the ceiling.
- **One bounded rAF loop** replaces the pulse-only loop, gated on the hero being on screen (`IntersectionObserver`), un-paused, un-hidden, and motion being allowed. The pulse folds in and its separate bookkeeping is gone.
- **Reduced motion** falls back to today's still marks — `FADE_RINGS`, `COMET_SEGMENTS`, `DASHED_RING` become the reduced-motion form — with no drift, no travelling signal and **no frame at all**.
- **The labelled node holds still** while Find your dot has a label on it, and resumes from where it stopped. Signals keep the export's `1 - 0.74 * dim` factor; the viewer's own are exempt.
- **Resize reprojects rather than resets** (signals keep `p`, nodes keep their wander); a **refetch clears**, which falls out of the same identity rule because `WindowNode.id` is minted per response.
- **The canvas takes the pointer**: hover offers `cursor: pointer`, a click bursts. It stays `aria-hidden` deliberately, with a comment saying why so a reviewer does not "fix" it.

**The three stale rationales are rewritten in this same commit** — `hero-network.tsx`'s header, `hero-network.spec.tsx`'s header, and a second supersession line in `neighbourhood-view.ts`. All three argued confidently for the opposite decision and would have read as current guidance.

## Base branch

This was developed on top of `docs/hero-signals-203` (PR #204), which carried the rewritten `CONTEXT.md` glossary entries and ADR 0006 that this work depends on. #204 has since merged to `dev`, so this branch was rebased with `git rebase --onto origin/dev origin/docs/hero-signals-203` and **the diff is now code-only**, as intended.

## Things I had to decide that #203 did not cover

Three, all flagged rather than quietly taken:

1. **`pointer-events-none` alone was not enough, and #203's stated reason for it is factually wrong.** The issue says to drop `pointer-events-none` from the canvas wrapper because "the copy layer is already `relative z-[1]` above a `z-0` canvas, so the search bar, chips, header and dialogs win the hit naturally". The copy layer is in fact a **full-bleed transparent div covering the whole hero**, so dropping the class alone leaves every pointer event on that div and no click ever reaches a node — the feature would ship dead. Rather than porting `onDocDown`'s document-level capture listener with a hand-maintained denylist, which #203 explicitly rejects and I agree with, I made the copy layer pointer-transparent and gave `pointer-events-auto` back to every `data-hero-clear` block. That turns the issue's intent into one rule: **what the keep-out reserves keeps the pointer; everything else is canvas.** It is also exactly aligned with the geometry, since those blocks are what the graph is already forbidden to draw on. Interactive elements and text selection are unaffected.

2. **No canvas gradients.** The export's `default` trail is a four-stop `createLinearGradient` and its head is a `createRadialGradient`. Every colour here is a `--cc-*` token read as an opaque string, so varying alpha inside a gradient stop would mean parsing CSS colour syntax at draw time, or interpolating from `transparent`, which canvas does in non-premultiplied sRGB and which greys the tail. Both are sampled into sub-strokes and concentric discs under `globalAlpha` instead — the same curve, the same read, and the technique `COMET_SEGMENTS` already used in this file.

3. **`VISIBLE` moved** from `hero-network.tsx` into `neighbourhood-view.ts`. It is a statement about the projection's `clearance` and there are now three consumers of it (the painter, the signal engine, the hit test).

One thing worth knowing rather than deciding: a wake is clamped to the distance the signal has actually travelled, so it may never run back past the node that sent it. On a short edge every style therefore saturates at the same length and only the *shape* of the wake tells them apart; `comet` is visibly longer only where there is room. The artboard has the same clamp.

## Tests

- `hero-signals.spec.ts` (new, 33 cases) against the pure module with a hand-cranked clock: the drift box holds over two minutes of frames, drift never approaches the copy, the labelled node holds and resumes, ambient traffic never doubles up on an edge or spawns under the copy, the cap is edge-count-bounded, a burst fires one arm per edge and staggers them, a reprojection preserves `p` and the wander, a refetch clears, all four styles agree on the head, and the field replays identically from the same graph window and clock.
- `hero-network.spec.tsx` extends the existing recording 2d-context harness rather than replacing it: the still marks now run under reduced motion, the loop-gate tests replace the old "never starts a frame loop" test that ADR 0006 reverses, and there is new coverage for the IntersectionObserver gate, the cursor affordance and a click producing light on the wire.

Gates: `bun run lint`, `bun run typecheck`, `bun run test:web` — all green (1342 tests, 91 files).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015NfoMyi4cztYt5USkxSXhs
