### PR TITLE
fix(auth,search): one sign-in card everywhere, and a search bar that neither rings its text nor zooms a phone

### DIFF
--- a/apps/web/app/globals.css
+++ b/apps/web/app/globals.css
@@ -94,6 +94,11 @@
   --color-cc-checked-tint: var(--cc-checked-tint);
   --color-cc-checked-hover-tint: var(--cc-checked-hover-tint);
   --color-cc-applied: var(--cc-applied);
+  /* `--focus` in `cc-theme.css`, registered as a colour utility because one
+     control paints with it rather than only being ringed by it: the search bar
+     lights its own border on keyboard focus. See the composite-control rule
+     further down. */
+  --color-cc-focus: var(--cc-focus);
 }
 
 :root {
@@ -547,7 +552,10 @@
    `focus:bg-cc-pill` (a menu highlight, not a ring), and
    `search/components/explore.tsx`'s `focus-visible:outline-cc-brand`, which
    this rule already overrides and which is therefore dead. Anything else added
-   in `features/**` is a duplicate of this rule. */
+   in `features/**` is a duplicate of this rule — with one exception, which is
+   the `data-cc-field` rule below and is not a duplicate but a *move*: the two
+   search bars draw this treatment on the box the reader sees instead of on the
+   input inside it. */
 :focus-visible:not([tabindex="-1"]) {
   /* biome-ignore lint/complexity/noImportantStyles: it has to beat the 22 inline `outline:none` declarations the artboards carry, and the shadcn primitives' own ring. Without it a focus style exists everywhere except where it is needed. */
   outline: 2px solid var(--cc-focus) !important;
@@ -562,6 +570,73 @@
   outline-color: var(--cc-rail-focus) !important;
   /* biome-ignore lint/complexity/noImportantStyles: as above — it replaces an `!important` halo, not a plain one. */
   box-shadow: 0 0 0 4px var(--cc-rail-focus-ring) !important;
+}
+
+/* The one exception to the two rules above: a field whose *wrapper* is the
+   control.
+
+   The rule lands on whatever element actually takes focus, which is normally
+   the thing the reader sees. It is not, for a text field inside a box that is
+   drawn as the control — Explore's search bar and the landing's hero bar are a
+   bordered 42px box around a transparent input, so the ring came up around the
+   *text*: a rounded rectangle floating inside another rounded rectangle, two
+   pixels of surface showing between them.
+
+   `data-cc-field` marks such an input. It suppresses that input's own ring and
+   nothing else; the wrapper takes the treatment instead, through
+   `has-[input:focus-visible]:border-cc-focus`, which keeps it keyboard-only in
+   exactly the way the rule above is. `:has()` rather than `:focus-within`
+   deliberately — `focus-within` has no `-visible` counterpart, so it would ring
+   the bar on a mouse click, which is the behaviour this file's first paragraph
+   exists to avoid.
+
+   **An input carrying this attribute and nothing lighting up around it has no
+   focus indicator at all.** That is why it is a deliberate mark on two known
+   bars rather than a class to reach for: pair it with a wrapper treatment or do
+   not use it.
+
+   Specificity is 0,3,0 against the rule above's 0,2,0, so it wins on its own
+   terms rather than on where it happens to sit in this file.
+
+   One thing to know before debugging this: the border does not change
+   instantly. `cc-theme` transitions `border-color` over 0.34s on every element
+   inside it, and the focus border inherits that — so `getComputedStyle` read in
+   the same tick as `.focus()` returns the *unfocused* colour, and the treatment
+   looks broken when it is only mid-transition. Measured at rest: `#f4eee252`
+   (`--cc-rule3`) unfocused, `rgb(139, 179, 239)` (`--cc-focus`, dark) 600ms
+   after focus. */
+[data-cc-field]:focus-visible:not([tabindex="-1"]) {
+  /* biome-ignore lint/complexity/noImportantStyles: it overrides an `!important` rule, which a plain declaration cannot do however specific it is. */
+  outline: none !important;
+  /* biome-ignore lint/complexity/noImportantStyles: as above — the halo it replaces is `!important` too, and half a treatment is worse than either. */
+  box-shadow: none !important;
+}
+
+/* No field under 16px on a touch device, ever.
+
+   iOS Safari zooms the page in when a field smaller than 16px takes focus, and
+   hands none of that zoom back when the field is blurred — so a reader who taps
+   the search bar gets the page magnified onto it, and then keeps the
+   magnification, off-centre, for the rest of the session. Nothing in the app
+   can undo it: there is no API to reset the scale, and the alternative fix
+   (`maximum-scale=1` in the viewport meta) buys it by taking pinch-zoom away
+   from everybody, which is a WCAG 1.4.4 failure.
+
+   16px is the whole of the threshold. Fields keep their designed size on every
+   pointer that is not a finger, which is where the artboards' 12.5–14px sizes
+   were drawn to be read.
+
+   `!important` because every field in this app is sized by a utility class —
+   `text-[14px]`, or shadcn's `md:text-sm` — and a bare element selector loses to
+   all of them. Checkboxes and radios are excluded: they carry no text, and a
+   font size on them moves layout in browsers that size them from it. */
+@media (pointer: coarse) {
+  input:not([type="checkbox"]):not([type="radio"]),
+  select,
+  textarea {
+    /* biome-ignore lint/complexity/noImportantStyles: it exists to beat the per-field utility classes; without it the rule matches everywhere and applies nowhere. */
+    font-size: 16px !important;
+  }
 }
 
 /* The default for every scroll container in the app: thin and muted, so a pane

--- a/apps/web/app/layout.tsx
+++ b/apps/web/app/layout.tsx
@@ -1,5 +1,5 @@
 // Other imports
-import type { Metadata } from "next";
+import type { Metadata, Viewport } from "next";
 import { Geist, Geist_Mono } from "next/font/google";
 import { ThemeProvider } from "@/components/theme-provider";
 // For authentication
@@ -23,6 +23,28 @@ export const metadata: Metadata = {
   icons: {
     icon: "/compass.png",
   },
+};
+
+/**
+ * The first two lines are Next's own defaults, written out because the third
+ * cannot be added without them.
+ *
+ * `interactiveWidget: "resizes-content"` is the on-screen keyboard's effect on
+ * the layout viewport. Every screen in the app is `h-dvh` with `overflow-hidden`
+ * — `AppShell` — so with the default (`resizes-visual`) the keyboard slides over
+ * a page that still believes it is full height, and the browser scrolls the
+ * whole thing up to reveal the focused field. `resizes-content` shortens the
+ * viewport instead, so `dvh` accounts for the keyboard and the layout stays put.
+ *
+ * There is deliberately no `maximumScale` or `userScalable: false` here. That
+ * would also stop iOS zooming into a small field, and it would do it by taking
+ * pinch-zoom away from everyone who needs it — WCAG 1.4.4. The size of the
+ * fields is the fix instead; `globals.css` holds it.
+ */
+export const viewport: Viewport = {
+  width: "device-width",
+  initialScale: 1,
+  interactiveWidget: "resizes-content",
 };
 
 export default function RootLayout({

--- a/apps/web/features/auth/components/sign-in-prompt.spec.tsx
+++ b/apps/web/features/auth/components/sign-in-prompt.spec.tsx
@@ -1,0 +1,92 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it, vi } from "vitest";
+import { SignInPrompt } from "./sign-in-prompt";
+
+describe("SignInPrompt", () => {
+  describe("the link form, for a page that is entirely signed out", () => {
+    it("offers both ways in, and sends both to the same place", () => {
+      render(
+        <SignInPrompt
+          title="Sign in to see your page"
+          action={{ kind: "link", href: "/auth?next=%2Fprofile" }}
+        />,
+      );
+
+      // Two controls rather than one: the pair is what tells a first-time
+      // reader they are welcome. `/auth` signs up and logs in from one field,
+      // so they lead to the same href — that is the surface, not a slip.
+      for (const name of ["Sign up", "Log in"]) {
+        expect(screen.getByRole("link", { name })).toHaveAttribute(
+          "href",
+          "/auth?next=%2Fprofile",
+        );
+      }
+    });
+  });
+
+  describe("the ask form, for a prompt over a page the reader is working in", () => {
+    it("raises the sign-in dialog instead of navigating", async () => {
+      const onSignUp = vi.fn();
+      const onLogIn = vi.fn();
+      render(
+        <SignInPrompt
+          title="Organize your saved courses into collections"
+          action={{ kind: "ask", onSignUp, onLogIn }}
+        />,
+      );
+
+      expect(screen.queryByRole("link")).toBeNull();
+
+      await userEvent.click(screen.getByRole("button", { name: "Sign up" }));
+      expect(onSignUp).toHaveBeenCalledTimes(1);
+      expect(onLogIn).not.toHaveBeenCalled();
+
+      await userEvent.click(screen.getByRole("button", { name: "Log in" }));
+      expect(onLogIn).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  /**
+   * The height is a contract, not a style. Saved draws this card inside a band
+   * that is exactly `--cc-search-block-h` tall, and that band is what puts
+   * Saved's workspace tab strip on the same line as Explore's. A taller card
+   * here moves a tab strip two pages away.
+   */
+  it("is the slim card the band can hold", () => {
+    render(
+      <SignInPrompt title="Sign in" action={{ kind: "link", href: "/auth" }} />,
+    );
+
+    const card = screen.getByTestId("sign-in-prompt");
+    expect(card).toHaveClass("h-[42px]");
+    // The card chrome My Page had and the band did not — this is the half of
+    // the reconciliation that came *back*.
+    expect(card).toHaveClass("border", "border-cc-rule2", "bg-cc-surface");
+    // And the half that did not: it takes the width it is given.
+    expect(card).not.toHaveClass("max-w-[520px]");
+  });
+
+  it("carries no promise it has no room for", () => {
+    render(
+      <SignInPrompt title="Sign in" action={{ kind: "link", href: "/auth" }} />,
+    );
+
+    expect(screen.queryByText(/sync across devices/)).toBeNull();
+  });
+
+  it("keeps the host's spacing outside its own border", () => {
+    render(
+      <SignInPrompt
+        title="Sign in"
+        action={{ kind: "link", href: "/auth" }}
+        className="min-w-0 flex-1"
+      />,
+    );
+
+    expect(screen.getByTestId("sign-in-prompt")).toHaveClass(
+      "min-w-0",
+      "flex-1",
+    );
+  });
+});

--- a/apps/web/features/auth/components/sign-in-prompt.tsx
+++ b/apps/web/features/auth/components/sign-in-prompt.tsx
@@ -1,0 +1,124 @@
+"use client";
+
+import { Lock } from "lucide-react";
+import Link from "next/link";
+
+/**
+ * What the two controls do, which is the one thing that differs between the
+ * places this prompt stands.
+ *
+ * `link` sends the reader to `/auth` and back. `ask` raises
+ * {@link AuthReasonDialog} over the page they are already on. The choice is the
+ * host page's: a page that is *entirely* signed out has nothing to come back to
+ * mid-task, and a band above a working list does.
+ */
+export type SignInPromptAction =
+  | {
+      kind: "link";
+      /**
+       * Where both controls lead. One href, not two: `/auth` is a single
+       * surface that signs up and logs in from the same field, so the two
+       * labels are two ways of naming the same destination — which is what
+       * My Page's panel has always done.
+       */
+      href: string;
+    }
+  | { kind: "ask"; onSignUp: () => void; onLogIn: () => void };
+
+type Props = {
+  /** The one line of copy. There is no second line — see the note below. */
+  title: string;
+  action: SignInPromptAction;
+  /** Spacing from the host. The card owns everything inside its border. */
+  className?: string;
+};
+
+/**
+ * The app's invitation to sign in, wherever a signed-out reader meets a surface
+ * that needs an account.
+ *
+ * ## One shape, everywhere
+ *
+ * There used to be three of these, in two shapes. My Page and `/collections`
+ * each drew a `max-w-[520px]` card of three rows — lock and title, a line of
+ * body copy, then the buttons — and Saved drew a bare 42px row with no card
+ * around it at all, because #208 had to fit it inside a band that levels two
+ * pages' tab strips and a 120px card does not fit in 74px.
+ *
+ * This is the reconciliation, and it goes the *slim* way: the card chrome comes
+ * back and the height does not. Full width of whatever column it stands in, one
+ * line, buttons pinned right. The card that fits in Saved's band is the card
+ * every page gets, so the three surfaces are one component rather than three
+ * that drift.
+ *
+ * ## The body copy is gone, knowingly
+ *
+ * "Your course list, reviews and average stay private to you and sync across
+ * devices" and "Sign up or log in to create collections and sync across
+ * devices" are not here. One line has no room for them, and this is the second
+ * time that promise has been dropped for the same reason — `CollectionsStrip`
+ * dropped it first, in #208, on the argument that signing up is one click away
+ * and the promise is better kept by `/auth` than by a banner. The same argument
+ * covers the other two now.
+ *
+ * ## Height
+ *
+ * `h-[42px]` is Explore's search bar and the collection chip, and it is what
+ * lets this stand in Saved's `--cc-search-block-h` band without moving the
+ * workspace tab strips off Explore's line. The buttons are `h-8` inside it
+ * rather than filling it, because they are the row's controls and not the row.
+ *
+ * Below `@560px` it takes its natural height and the controls wrap, which is
+ * the narrow behaviour `GuestRow` already had. Nothing below that width is
+ * levelling anything.
+ */
+export function SignInPrompt({ title, action, className }: Readonly<Props>) {
+  return (
+    <div
+      data-testid="sign-in-prompt"
+      className={`flex h-[42px] items-center gap-2 rounded-[10px] border border-cc-rule2 bg-cc-surface px-3.5 @max-[560px]:h-auto @max-[560px]:flex-wrap @max-[560px]:py-2.5 ${className ?? ""}`}
+    >
+      <Lock size={15} className="flex-none text-cc-dim" aria-hidden />
+      <span className="min-w-0 truncate font-semibold text-[13.5px]">
+        {title}
+      </span>
+      <div className="ml-auto flex flex-none gap-[7px] @max-[560px]:ml-0">
+        {action.kind === "link" ? (
+          <>
+            <Link href={action.href} className={SIGN_UP_CLASS}>
+              Sign up
+            </Link>
+            <Link href={action.href} className={LOG_IN_CLASS}>
+              Log in
+            </Link>
+          </>
+        ) : (
+          <>
+            <button
+              type="button"
+              onClick={action.onSignUp}
+              className={`cursor-pointer ${SIGN_UP_CLASS}`}
+            >
+              Sign up
+            </button>
+            <button
+              type="button"
+              onClick={action.onLogIn}
+              className={`cursor-pointer ${LOG_IN_CLASS}`}
+            >
+              Log in
+            </button>
+          </>
+        )}
+      </div>
+    </div>
+  );
+}
+
+/** The filled control, on `--btn`. Shared by both renderings so they cannot drift. */
+const SIGN_UP_CLASS =
+  "flex h-8 items-center whitespace-nowrap rounded-[8px] bg-cc-btn px-3.5 font-semibold text-[12.5px] text-cc-btn-fg no-underline hover:opacity-[0.88]";
+
+/** The outlined one beside it. */
+const LOG_IN_CLASS =
+  "flex h-8 items-center whitespace-nowrap rounded-[8px] border border-cc-rule3 bg-cc-surface px-3.5 font-medium text-[12.5px] text-cc-brand no-underline hover:border-cc-hov";

--- a/apps/web/features/auth/index.ts
+++ b/apps/web/features/auth/index.ts
@@ -3,6 +3,10 @@ export {
   type AuthReason,
   AuthReasonDialog,
 } from "./components/auth-reason-dialog";
+export {
+  SignInPrompt,
+  type SignInPromptAction,
+} from "./components/sign-in-prompt";
 export { useRequireSession, useSessionData } from "./hooks/session";
 export { useLogout } from "./hooks/use-logout";
 export { useMe } from "./hooks/use-me";

--- a/apps/web/features/collections/components/collections-body.tsx
+++ b/apps/web/features/collections/components/collections-body.tsx
@@ -1,9 +1,9 @@
 "use client";
 
-import { Check, Lock, Plus } from "lucide-react";
+import { Check, Plus } from "lucide-react";
 import { useRouter } from "next/navigation";
 import { ConfirmDialog } from "@/components/ui/confirm-dialog";
-import { AuthReasonDialog } from "@/features/auth";
+import { AuthReasonDialog, SignInPrompt } from "@/features/auth";
 import type { OpenCourseKind } from "@/features/workspace";
 import type { CollectionsState } from "../hooks/use-collections-state";
 import { CollectionDetail } from "./collection-detail";
@@ -158,38 +158,24 @@ export function CollectionsBody({
         ) : null}
 
         {/*
-          The invitation to sign in, at page scale. Embedded it is the band's
-          one-line row instead — see `CollectionsStrip`'s `GuestRow`, and #208
-          for why a 120px card cannot sit in a band that levels two pages.
+          The invitation to sign in on `/collections`. Embedded there is none
+          here at all: Saved puts it in the band instead — see
+          `CollectionsStrip`'s `GuestRow`, and #208 for why a 120px card cannot
+          sit in a band that levels two pages.
+
+          It is the same `SignInPrompt` the band draws. The two used to be
+          different shapes for that reason, and the slim one won: a card that
+          fits the band fits a page as well, and the reverse was never true.
         */}
         {!state.isLoading && !state.signedIn && !embedded ? (
-          <div className="max-w-[520px] rounded-[11px] border border-cc-rule2 bg-cc-surface p-[16px_17px]">
-            <div className="flex items-center gap-2">
-              <Lock size={15} className="text-cc-dim" aria-hidden />
-              <div className="font-semibold text-[13.5px]">
-                Organize your saved courses
-              </div>
-            </div>
-            <div className="mt-1.5 text-[12.5px] text-cc-muted leading-[1.5]">
-              Sign up or log in to create collections and sync across devices.
-            </div>
-            <div className="mt-[11px] flex gap-[7px]">
-              <button
-                type="button"
-                onClick={() => state.setAuthReason("sign-up")}
-                className="flex h-8 cursor-pointer items-center rounded-[8px] bg-cc-btn px-3.5 font-semibold text-[12.5px] text-cc-btn-fg hover:opacity-[0.88]"
-              >
-                Sign up
-              </button>
-              <button
-                type="button"
-                onClick={() => state.setAuthReason("log-in")}
-                className="flex h-8 cursor-pointer items-center rounded-[8px] border border-cc-rule3 bg-cc-surface px-3.5 font-medium text-[12.5px] text-cc-brand hover:border-cc-hov"
-              >
-                Log in
-              </button>
-            </div>
-          </div>
+          <SignInPrompt
+            title="Organize your saved courses into collections"
+            action={{
+              kind: "ask",
+              onSignUp: () => state.setAuthReason("sign-up"),
+              onLogIn: () => state.setAuthReason("log-in"),
+            }}
+          />
         ) : null}
 
         {!state.isLoading &&

--- a/apps/web/features/collections/components/collections-strip.tsx
+++ b/apps/web/features/collections/components/collections-strip.tsx
@@ -1,6 +1,7 @@
 "use client";
 
-import { Lock, Plus } from "lucide-react";
+import { Plus } from "lucide-react";
+import { SignInPrompt } from "@/features/auth";
 import type { CollectionsState } from "../hooks/use-collections-state";
 import { CollectionChip } from "./collection-chip";
 
@@ -108,33 +109,29 @@ function StripSkeleton() {
  * has no room for it and signing up is one click away. Both buttons stay, and
  * they are `h-8` inside a 42px row rather than filling it, because they are the
  * row's controls and not the row.
+ *
+ * The row itself is {@link SignInPrompt} now, shared with My Page and
+ * `/collections`. This was the only one of the three drawn without a card
+ * around it, and the shared component is this row grown a border rather than
+ * the other two shrunk into a band — so the height, and everything the height
+ * levels, is unchanged.
+ *
+ * It is drawn at {@link CONTROL_H} by the shared component itself rather than
+ * by anything passed from here, which is why this is the one control in the
+ * band that does not carry that class: repeating it would be two files
+ * declaring one height, and the one that lost would do so silently.
  */
 function GuestRow({ state }: { state: CollectionsState }) {
   return (
-    <div
-      className={`flex min-w-0 flex-1 items-center gap-2 ${CONTROL_H} @max-[560px]:h-auto @max-[560px]:flex-wrap`}
-    >
-      <Lock size={15} className="flex-none text-cc-dim" aria-hidden />
-      <span className="min-w-0 truncate text-[13px] text-cc-muted">
-        Organize your saved courses into collections.
-      </span>
-      <div className="ml-auto flex flex-none gap-[7px] @max-[560px]:ml-0">
-        <button
-          type="button"
-          onClick={() => state.setAuthReason("sign-up")}
-          className="flex h-8 cursor-pointer items-center rounded-[8px] bg-cc-btn px-3.5 font-semibold text-[12.5px] text-cc-btn-fg hover:opacity-[0.88]"
-        >
-          Sign up
-        </button>
-        <button
-          type="button"
-          onClick={() => state.setAuthReason("log-in")}
-          className="flex h-8 cursor-pointer items-center rounded-[8px] border border-cc-rule3 bg-cc-surface px-3.5 font-medium text-[12.5px] text-cc-brand hover:border-cc-hov"
-        >
-          Log in
-        </button>
-      </div>
-    </div>
+    <SignInPrompt
+      title="Organize your saved courses into collections"
+      action={{
+        kind: "ask",
+        onSignUp: () => state.setAuthReason("sign-up"),
+        onLogIn: () => state.setAuthReason("log-in"),
+      }}
+      className="min-w-0 flex-1"
+    />
   );
 }
 

--- a/apps/web/features/collections/components/collections.spec.tsx
+++ b/apps/web/features/collections/components/collections.spec.tsx
@@ -37,9 +37,14 @@ vi.mock("next/navigation", () => ({
   useRouter: () => ({ replace, push }),
   usePathname: () => "/collections",
 }));
-vi.mock("@/features/auth", () => ({
+// The real `SignInPrompt`, not a stub — the visitor's panel is that component,
+// so a stub would take the thing under test out of the test. Imported inside
+// the factory because `vi.mock` is hoisted above this file's imports.
+vi.mock("@/features/auth", async () => ({
   useMe: () => useMe(),
   AuthReasonDialog: () => null,
+  SignInPrompt: (await import("@/features/auth/components/sign-in-prompt"))
+    .SignInPrompt,
 }));
 vi.mock("@/features/saved", () => ({
   useSetCourseSaved: () => ({ setSaved: vi.fn().mockResolvedValue(undefined) }),
@@ -597,10 +602,16 @@ describe("a visitor", () => {
     setup({ signedIn: false });
     render(<Collections />);
 
-    expect(screen.getByText("Organize your saved courses")).toBeVisible();
+    expect(
+      screen.getByText("Organize your saved courses into collections"),
+    ).toBeVisible();
     expect(screen.getByRole("button", { name: "Sign up" })).toBeVisible();
+    expect(screen.getByRole("button", { name: "Log in" })).toBeVisible();
     // There is no comparison feature to promise (#68).
     expect(screen.queryByText(/AI/)).not.toBeInTheDocument();
+    // The sync promise went with the slim card, on this page as in the band:
+    // one line has no room for it. See `SignInPrompt`.
+    expect(screen.queryByText(/sync across devices/)).toBeNull();
   });
 });
 

--- a/apps/web/features/landing/components/landing.tsx
+++ b/apps/web/features/landing/components/landing.tsx
@@ -16,6 +16,7 @@ import {
   stashSearchBarHandoff,
   ThemeToggle,
 } from "@/features/shell";
+import { dismissKeyboard } from "@/lib/dismiss-keyboard";
 import { isUnplaced, useNeighbourhood, usePublicWindow } from "../api/queries";
 import { FindYourDot, type FindYourDotStatus } from "./find-your-dot";
 import { HeroNetwork } from "./hero-network";
@@ -477,9 +478,13 @@ export function Landing() {
               data-hero-clear
               onSubmit={(event) => {
                 event.preventDefault();
+                // Before `submitSearch`, which measures this bar for the
+                // hand-off: on a phone the keyboard has the page shifted up,
+                // and a rect measured there is a rect Explore animates from.
+                dismissKeyboard(event.currentTarget);
                 submitSearch(query);
               }}
-              className="pointer-events-auto mt-4 @lg:mt-[31px] flex h-[42px] w-full @lg:max-w-[var(--cc-search-bar-w)] items-center gap-2.5 rounded-[10px] border border-cc-rule3 bg-cc-surface px-3.5"
+              className="pointer-events-auto mt-4 @lg:mt-[31px] flex h-[42px] w-full @lg:max-w-[var(--cc-search-bar-w)] items-center gap-2.5 rounded-[10px] border border-cc-rule3 bg-cc-surface px-3.5 has-[input:focus-visible]:border-cc-focus"
             >
               <Search
                 size={16}
@@ -487,7 +492,13 @@ export function Landing() {
                 aria-hidden
                 className="shrink-0 text-cc-muted"
               />
+              {/* `data-cc-field`, and the border above: the bar is the control,
+                  so the focus ring goes on its edge rather than around the text
+                  inside it. Explore's bar carries the same pair — they are one
+                  bar to the reader and the hand-off does not interpolate a
+                  focus style. `globals.css` argues both halves. */}
               <input
+                data-cc-field
                 value={query}
                 onChange={(event) => setQuery(event.target.value)}
                 onFocus={warmExplore}

--- a/apps/web/features/my-page/components/my-page.spec.tsx
+++ b/apps/web/features/my-page/components/my-page.spec.tsx
@@ -32,10 +32,15 @@ vi.mock("@/trpc/client", () => ({
   }),
 }));
 
-vi.mock("@/features/auth", () => ({
+// The real `SignInPrompt`: the signed-out panel is that component, and the
+// specs below assert on the links it draws. Imported inside the factory because
+// `vi.mock` is hoisted above this file's imports.
+vi.mock("@/features/auth", async () => ({
   useMe: () => me(),
   useLogout: () => logout,
   authHref: (to: string) => `/auth?next=${encodeURIComponent(to)}`,
+  SignInPrompt: (await import("@/features/auth/components/sign-in-prompt"))
+    .SignInPrompt,
 }));
 
 vi.mock("@/lib/user", () => ({ uploadProfilePicture: vi.fn() }));

--- a/apps/web/features/my-page/components/my-page.tsx
+++ b/apps/web/features/my-page/components/my-page.tsx
@@ -1,10 +1,10 @@
 "use client";
 
-import { Lock, RotateCw, TriangleAlert } from "lucide-react";
+import { RotateCw, TriangleAlert } from "lucide-react";
 import Link from "next/link";
 import { useRouter } from "next/navigation";
 import { useMemo, useRef, useState } from "react";
-import { authHref, useMe } from "@/features/auth";
+import { authHref, SignInPrompt, useMe } from "@/features/auth";
 import {
   type EditableReview,
   Review,
@@ -461,40 +461,22 @@ export function MyPage() {
  *
  * `authHref` rather than a bare `/auth`, so signing in comes back to this page
  * instead of to `/search`.
+ *
+ * ## It is the band's card now, not a 520px one
+ *
+ * The panel was a three-row `max-w-[520px]` card of its own, and Saved's
+ * signed-out row was a bare line with no card at all. They are one
+ * {@link SignInPrompt} now, in the slim shape — full width, one line — because
+ * that is the only shape that also fits Saved's 74px band. The artboard's body
+ * copy goes with it; the shared component says why.
  */
 function SignedOutPanel() {
   return (
     <div className="px-7 pt-[18px] @max-[440px]:px-[14px]">
-      <div className="max-w-[520px] rounded-[11px] border border-cc-rule2 bg-cc-surface px-[17px] py-4">
-        <div className="flex items-center gap-2">
-          <Lock
-            aria-hidden
-            className="size-[15px] text-cc-dim"
-            strokeWidth={1.8}
-          />
-          <div className="font-semibold text-[13.5px]">
-            Sign in to see your page
-          </div>
-        </div>
-        <p className="m-0 mt-1.5 text-[12.5px] text-cc-muted leading-[1.5]">
-          Your course list, reviews and average stay private to you and sync
-          across devices.
-        </p>
-        <div className="mt-[11px] flex gap-[7px]">
-          <Link
-            href={authHref("/profile")}
-            className="inline-flex h-8 items-center whitespace-nowrap rounded-lg bg-cc-btn px-3.5 font-semibold text-[12.5px] text-cc-btn-fg no-underline hover:opacity-[.88]"
-          >
-            Sign up
-          </Link>
-          <Link
-            href={authHref("/profile")}
-            className="inline-flex h-8 items-center whitespace-nowrap rounded-lg border border-cc-rule3 bg-cc-surface px-3.5 font-medium text-[12.5px] text-cc-brand no-underline hover:border-cc-hov"
-          >
-            Log in
-          </Link>
-        </div>
-      </div>
+      <SignInPrompt
+        title="Sign in to see your page"
+        action={{ kind: "link", href: authHref("/profile") }}
+      />
     </div>
   );
 }

--- a/apps/web/features/saved/components/saved.spec.tsx
+++ b/apps/web/features/saved/components/saved.spec.tsx
@@ -30,10 +30,17 @@ vi.mock("next/navigation", () => ({
   useRouter: () => ({ push, replace }),
   usePathname: () => "/saved",
 }));
-vi.mock("@/features/auth", () => ({
+// `SignInPrompt` is the real component rather than a stub: the band's guest
+// state *is* that component now, so stubbing it would leave these specs
+// asserting against markup no reader ever sees. It is imported from its module
+// rather than from the barrel this factory is replacing, and inside the factory
+// because `vi.mock` is hoisted above the imports at the top of this file.
+vi.mock("@/features/auth", async () => ({
   useMe: () => useMe(),
   AuthReasonDialog: () => null,
   authHref: (to: string) => `/auth?next=${encodeURIComponent(to)}`,
+  SignInPrompt: (await import("@/features/auth/components/sign-in-prompt"))
+    .SignInPrompt,
 }));
 vi.mock("@/features/courses/api/queries", () => ({
   useCourseDetails: () => ({ data: undefined }),
@@ -1130,7 +1137,7 @@ describe("Saved", { timeout: 20_000 }, () => {
 
       const band = screen.getByTestId("collections-band");
       expect(
-        within(band).getByText("Organize your saved courses into collections."),
+        within(band).getByText("Organize your saved courses into collections"),
       ).toBeVisible();
       expect(
         within(band).getByRole("button", { name: "Sign up" }),

--- a/apps/web/features/search/components/explore.spec.tsx
+++ b/apps/web/features/search/components/explore.spec.tsx
@@ -1201,5 +1201,71 @@ describe("Explore", () => {
 
       expect(bar()).toHaveClass("max-w-[var(--cc-search-bar-w)]");
     });
+
+    /**
+     * The bar is the control the reader sees; the input inside it is
+     * transparent and unbordered. So the app's one focus ring — `globals.css` —
+     * has to land on the box and not on the field, or it draws a rounded
+     * rectangle around the *text*, inside the bar's own border.
+     *
+     * The two halves are asserted together because neither works alone: without
+     * `data-cc-field` there are two rings, and without the border variant there
+     * is none at all.
+     */
+    it("takes focus on the bar's edge rather than around the text", () => {
+      render(<Explore />);
+
+      const field = screen.getByLabelText("Search courses");
+      expect(field).toHaveAttribute("data-cc-field");
+      expect(field.parentElement).toHaveClass(
+        "has-[input:focus-visible]:border-cc-focus",
+      );
+    });
+  });
+
+  /**
+   * iOS Safari leaves the keyboard up after a submit, over the results the
+   * reader just asked for, on a shell that is `h-dvh overflow-hidden` and has
+   * no scroll to spare. `dismissKeyboard` is the fix and the pointer is its
+   * gate — see `lib/dismiss-keyboard.ts`.
+   */
+  describe("submitting on a touch device", () => {
+    function setPointer(kind: "coarse" | "fine") {
+      vi.spyOn(window, "matchMedia").mockImplementation(
+        (query: string) =>
+          ({
+            matches: query.includes(kind),
+            media: query,
+            onchange: null,
+            addListener: () => {},
+            removeListener: () => {},
+            addEventListener: () => {},
+            removeEventListener: () => {},
+            dispatchEvent: () => false,
+          }) as MediaQueryList,
+      );
+    }
+
+    it("closes the keyboard by taking focus off the field", async () => {
+      setPointer("coarse");
+      render(<Explore />);
+
+      const field = screen.getByLabelText("Search courses");
+      await userEvent.type(field, "graphs{Enter}");
+
+      expect(field).not.toHaveFocus();
+    });
+
+    it("leaves focus alone where there is no keyboard to close", async () => {
+      setPointer("fine");
+      render(<Explore />);
+
+      const field = screen.getByLabelText("Search courses");
+      await userEvent.type(field, "graphs{Enter}");
+
+      // A desktop reader is still typing in the field they just searched from.
+      // Blurring here is the regression the pointer query exists to prevent.
+      expect(field).toHaveFocus();
+    });
   });
 });

--- a/apps/web/features/search/components/explore.tsx
+++ b/apps/web/features/search/components/explore.tsx
@@ -7,6 +7,7 @@ import { AuthReasonDialog } from "@/features/auth";
 import { CourseCardItem } from "@/features/courses";
 import { PageColumn, PageHeader, useSearchBarArrival } from "@/features/shell";
 import { useWorkspaceHost, WorkspaceHost } from "@/features/workspace";
+import { dismissKeyboard } from "@/lib/dismiss-keyboard";
 import { useExplore } from "../hooks/use-explore";
 
 /**
@@ -199,10 +200,23 @@ export function Explore() {
         */}
         <form
           ref={barRef}
-          onSubmit={explore.onSubmit}
+          onSubmit={(event) => {
+            explore.onSubmit(event);
+            dismissKeyboard(event.currentTarget);
+          }}
           className="w-full min-w-0 max-w-[var(--cc-search-bar-w)]"
         >
-          <div className="flex h-[42px] items-center gap-2.5 rounded-[10px] border border-cc-rule3 bg-cc-surface px-3.5">
+          {/*
+            The focus treatment is on this box and not on the field inside it.
+            The bar *is* the control to the reader — the input is transparent and
+            unbordered — so the app's ring came up around the text, inside the
+            bar's own border, with a couple of pixels of surface showing between
+            the two rounded rectangles. The border lights up instead, and
+            `data-cc-field` on the input is what stops the ring being drawn twice.
+            Both halves are argued in `globals.css`; neither works without the
+            other.
+          */}
+          <div className="flex h-[42px] items-center gap-2.5 rounded-[10px] border border-cc-rule3 bg-cc-surface px-3.5 has-[input:focus-visible]:border-cc-focus">
             <SearchIcon
               size={16}
               strokeWidth={2}
@@ -211,6 +225,7 @@ export function Explore() {
             />
             <input
               type="search"
+              data-cc-field
               value={explore.field}
               onChange={(event) => explore.onQueryChange(event.target.value)}
               placeholder="Search a course, code or subject"

--- a/apps/web/lib/dismiss-keyboard.ts
+++ b/apps/web/lib/dismiss-keyboard.ts
@@ -1,0 +1,30 @@
+/**
+ * Take focus off a submitted form's field, on touch devices only, so the
+ * on-screen keyboard closes with the submit that asked for it.
+ *
+ * ## Why it is needed at all
+ *
+ * Submitting a form does not blur anything. The field keeps focus, so on a
+ * phone the keyboard stays up over the results the reader just asked for — on a
+ * shell that is `h-dvh overflow-hidden` and has no scroll to spare, which is
+ * half of why the page looks displaced afterwards. The landing's bar has a
+ * second reason: it measures its own rect at submit time and hands it to
+ * Explore for the arrival animation, and a rect measured while the browser has
+ * the page shifted up for a keyboard is a rect Explore then animates *from*.
+ *
+ * ## Why only on a coarse pointer
+ *
+ * There is no keyboard to dismiss on a desktop, and blurring there would take
+ * focus off the field a keyboard user is still typing in every time they press
+ * Enter. The media query is the difference between fixing a phone and breaking
+ * a desktop, so it is not an optimisation.
+ *
+ * @param form the form that was submitted. Only a field inside it is blurred —
+ *   never whatever else on the page happens to hold focus.
+ */
+export function dismissKeyboard(form: HTMLFormElement): void {
+  if (!window.matchMedia("(pointer: coarse)").matches) return;
+
+  const active = document.activeElement;
+  if (active instanceof HTMLElement && form.contains(active)) active.blur();
+}


### PR DESCRIPTION
Three defects reported together. All three are a control drawn in the wrong place.

## 1. One sign-in prompt, one shape

There were **three** of these, in two shapes:

| where | shape | controls |
| --- | --- | --- |
| `my-page.tsx` signed-out panel | `max-w-[520px]` card, three rows | `Link` to `authHref("/profile")` |
| `collections-body.tsx` (`/collections`) | the same 520px card | `AuthReasonDialog` |
| `collections-strip.tsx` `GuestRow` (Saved) | **no card at all** — a bare 42px row | `AuthReasonDialog` |

Saved's row lost its card in #208 for a reason that still holds: its band is `--cc-search-block-h` (74px), and that height is what puts Saved's workspace tab strip on the same line as Explore's. A 120px card does not fit in 74px.

They are one `SignInPrompt` now (`features/auth`), and the reconciliation goes the **slim** way: the card chrome comes back, the height does not. Full width of whatever column it stands in, one line, buttons pinned right, wrapping to two rows below `@560px` exactly as `GuestRow` already did.

The body copy ("…and sync across devices") does not survive. One line has no room for it, and this is the second time it has been dropped for that reason — #208 dropped it from the band first, on the argument that signing up is one click away. The same argument now covers the other two.

Each host keeps the behaviour it had: My Page navigates to `/auth` and comes back, the two collections surfaces raise the dialog over the page the reader is standing in. That is the `action` prop, and it is the only thing that differs between the three call sites.

**Measured**, signed out, 1536px viewport:

| | before | after |
| --- | --- | --- |
| My Page card | 520px wide, 3 rows | **1120 × 42**, card chrome kept |
| Saved band card | no border, 42px | **1120 × 42**, card chrome gained |
| Saved band height | 74px | **74px** |
| Saved row top | y=229.39 | **y=229.39** |
| Explore row top | y=229.39 | **y=229.39** |

At a 400px container the card wraps to two rows (81.85px) with no overflow, which is the narrow behaviour the band already had.

## 2. Focus on the bar's edge, not around the text

`globals.css` paints one app-wide `:focus-visible` outline plus halo, and it lands on whatever element actually takes focus. For a search bar that is the **transparent input inside the box the reader sees** — so the ring came up around the *text*, a rounded rectangle floating inside another rounded rectangle with two pixels of surface showing between them. The artboards' own `cc-theme.css` does the same thing, so this was inherited rather than a slip.

`data-cc-field` marks such an input and suppresses its ring; the wrapper takes the treatment through `has-[input:focus-visible]:border-cc-focus`. `:has()` rather than `:focus-within`, because `focus-within` has no `-visible` counterpart and would ring the bar on a mouse click — the thing that gets a focus style deleted again a week later. Both halves are argued in `globals.css`; neither works alone.

Applied to Explore's bar and the landing's hero bar, which are one bar to the reader.

**Measured** (dark, `/search`): field `outline: none`, `box-shadow: none` while `:focus-visible` matches; bar border `#f4eee252` (`--cc-rule3`) at rest → `rgb(139, 179, 239)` (`--cc-focus`) focused. Note the border inherits `cc-theme`'s 0.34s `border-color` transition, so a `getComputedStyle` read in the same tick as `.focus()` shows the *old* colour and the treatment looks broken when it is only mid-transition. That is now written down where the next person will look.

## 3. No zoom, no drift, on a phone

Two bugs stacked, and only the first is the one that gets reported:

1. Both search inputs are `text-[14px]`. **iOS Safari zooms into any focused field under 16px, and hands none of the zoom back on blur.** That is the "page zooms onto the search bar" half.
2. `AppShell` is `h-dvh overflow-hidden` and the app exported no `viewport` at all, so the keyboard slid over a page that still believed it was full height and the browser scrolled the whole thing up to reveal the field. That is the "everything skewed and slightly out of place after Enter" half.

- **16px on `(pointer: coarse)`**, app-wide rather than on these two bars: the same defect is in the collection-name field, the taken-course dialog, the review form and the feedback form. Fields keep their designed 12.5–14px on every pointer that is not a finger. Deliberately **not** `maximum-scale=1`, which fixes the zoom by taking pinch-zoom away from everybody (WCAG 1.4.4).
- **`interactiveWidget: "resizes-content"`** in a new `viewport` export, so the keyboard shortens the viewport `dvh` measures instead of sliding over it.
- **`dismissKeyboard`** closes the keyboard on submit — on a coarse pointer only, so a desktop reader keeps focus in the field they just searched from. On the landing it runs *before* `submitSearch`, which measures the bar's rect for the arrival animation: a rect measured while the browser has the page shifted up for a keyboard is a rect Explore then animates from.

**Verified in the served output**: `input:not([type="checkbox"]):not([type="radio"]), select, textarea { font-size: 16px !important }` inside `@media (pointer: coarse)`, the `[data-cc-field]` rule, and `content="width=device-width, initial-scale=1, interactive-widget=resizes-content"`. The coarse-pointer branch itself cannot be exercised from a desktop browser; `dismissKeyboard`'s two branches are covered by tests instead.

## Tests

`93 files, 1387 tests` green; lint and typecheck clean.

- New `sign-in-prompt.spec.tsx`: both action forms, and the 42px/full-width contract as a regression guard on the band levelling.
- `explore.spec.tsx`: the focus pair (`data-cc-field` + the wrapper variant), and submit blurring on a coarse pointer while leaving desktop focus alone.
- The three suites that mock `@/features/auth` now expose the real `SignInPrompt` rather than a stub, so they still assert against markup a reader actually sees.

## Note for review

The blanket `:focus-visible` treatment and the three-row card both come from `docs/design_ref/2026-09-06/`. This PR departs from both, on the product owner's call. The departures are argued at their call sites rather than left implicit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018QdCdwBRSMCGD7Sc7kKdKi
