### PR TITLE
fix(workspace): key the Offerings list on the round's id, not on what it displays

### DIFF
--- a/apps/web/features/workspace/components/course-details-panel.tsx
+++ b/apps/web/features/workspace/components/course-details-panel.tsx
@@ -276,10 +276,31 @@ export function CourseDetailsPanel({
             {course.rounds.length === 0 ? (
               <div className="text-cc-dim2">No offering on file.</div>
             ) : (
-              course.rounds.map((round, index) => (
-                <div
-                  key={`${round.startTerm}-${round.formattedPeriodsAndCredits ?? index}`}
-                >
+              /*
+                Keyed on the round's own id, because nothing it *displays*
+                identifies it. This used to be
+                `${startTerm}-${formattedPeriodsAndCredits ?? index}`, and the
+                `?? index` only ever helped when the label was null: two rounds
+                of one course in one term with the same periods and credits —
+                "20252-P2 (6,0 hp)" twice — got the same key and React said so.
+
+                That is the data rather than a defect in it. On the exact key
+                this list was building, 126 groups of rounds collide and 152
+                rows are in excess of one per key — DD2380 among them. And a
+                *maximal* label-derived key does no better: ADR 0004 counted 77
+                groups that still collide once language, tutoring form,
+                tutoring time and the programme flags are added, which is every
+                field this list draws. Only `ladokUID` ever separated those, and
+                KOPPS is closed. So there is nothing to fall back to, and the id
+                is carried through `findRoundDetails` → `getDetails` →
+                `CourseRoundSummary` for this.
+
+                Those same 77 groups are why some courses draw two identical
+                lines here. That is a display question, not a key one, and it is
+                deliberately not answered by this.
+              */
+              course.rounds.map((round) => (
+                <div key={round.id}>
                   <span className="font-semibold text-cc-ink">
                     {round.formattedPeriodsAndCredits ?? "—"}
                   </span>{" "}

--- a/apps/web/features/workspace/components/workspace-pane.spec.tsx
+++ b/apps/web/features/workspace/components/workspace-pane.spec.tsx
@@ -102,6 +102,7 @@ const DETAILS: CourseDetails = {
   eligibility: null,
   rounds: [
     {
+      id: 1,
       startTerm: 20252,
       formattedPeriodsAndCredits: "P2 (6,0 hp)",
       studyPace: 50,
@@ -318,6 +319,54 @@ describe("the details tab", () => {
     expect(
       screen.getByRole("link", { name: /Open on KTH.se/ }),
     ).toHaveAttribute("href", "https://www.kth.se/student/kurser/kurs/DD2380");
+  });
+
+  /**
+   * Two rounds of one course, in one term, identical in every field this list
+   * draws. ADR 0004 counted 77 such groups over the catalogue's 2320 rows —
+   * only KOPPS' `ladokUID` ever separated them, and that API is closed — so
+   * this is the data rather than a defect in it.
+   *
+   * The old key was `${startTerm}-${formattedPeriodsAndCredits ?? index}`,
+   * whose `index` fallback only fired on a null label. These two therefore both
+   * keyed on "20252-P2 (6,0 hp)", and React warned that it "may cause children
+   * to be duplicated and/or omitted".
+   *
+   * Both halves are asserted, because the warning and the loss are different
+   * failures: React logs the first even when it happens to render both rows,
+   * and a future key that is merely *quieter* without being unique would pass a
+   * test that only counted the lines.
+   */
+  it("draws both of two rounds that differ only by id, and keys them apart", () => {
+    const identical = DETAILS.rounds[0];
+    if (!identical) throw new Error("fixture has no round to duplicate");
+    useCourseDetails.mockReturnValue({
+      data: {
+        ...DETAILS,
+        rounds: [identical, { ...identical, id: identical.id + 1 }],
+      },
+      isLoading: false,
+      error: null,
+    });
+    const consoleError = vi
+      .spyOn(console, "error")
+      .mockImplementation(() => {});
+
+    renderPane([openCourse("details")]);
+
+    expect(screen.getAllByText(/P2 \(6,0 hp\)/)).toHaveLength(2);
+    // Read off every argument of every call rather than matched positionally:
+    // React formats this one as `("…same key, `%s`…", key, …)` and the arity
+    // has moved between versions, so a positional matcher would go quietly
+    // green against a warning that did fire.
+    const warnedAboutKeys = consoleError.mock.calls.some((call) =>
+      call.some(
+        (argument) =>
+          typeof argument === "string" && argument.includes("same key"),
+      ),
+    );
+    consoleError.mockRestore();
+    expect(warnedAboutKeys).toBe(false);
   });
 
   it("renders the review means raw on the 1-10 scale", () => {

--- a/apps/web/server/course/repository.ts
+++ b/apps/web/server/course/repository.ts
@@ -56,6 +56,9 @@ export async function findExamCodesByCodes(codes: string[]) {
 export async function findRoundDetails(courseCode: string) {
   return db
     .select({
+      // The row's identity, and the only column that distinguishes two rounds
+      // of one course in one term — see `CourseRoundSummary.id` and ADR 0004.
+      id: courseRounds.id,
       startTerm: courseRounds.startTerm,
       formattedPeriodsAndCredits: courseRounds.formattedPeriodsAndCredits,
       studyPace: courseRounds.studyPace,

--- a/apps/web/server/course/service.ts
+++ b/apps/web/server/course/service.ts
@@ -274,6 +274,7 @@ export async function getDetails(
   if (!course) return null;
 
   const mappedRounds: CourseRoundSummary[] = rounds.map((r) => ({
+    id: r.id,
     startTerm: r.startTerm,
     formattedPeriodsAndCredits: r.formattedPeriodsAndCredits,
     studyPace: r.studyPace,

--- a/apps/web/types/course.ts
+++ b/apps/web/types/course.ts
@@ -93,6 +93,17 @@ export interface CourseDetails {
 
 /** One offering of a course in a given term (e.g. DD2421 P2 vs P3). */
 export interface CourseRoundSummary {
+  /**
+   * `course_rounds.id`, and the only thing that tells two rounds apart.
+   *
+   * Nothing else here does. `docs/adr/0004-course-round-identity.md` measured
+   * it over all 2320 rows: `(course_code, start_term)` collides in 184 groups,
+   * and adding language, tutoring form, tutoring time and the two programme
+   * flags still leaves 77. Only KOPPS' `round.ladokUID` ever separated those,
+   * and that API is closed, so no key derived from the fields below can be made
+   * unique — a UI that needs one per round has to use this.
+   */
+  id: number;
   startTerm: number; // e.g. 20252
   formattedPeriodsAndCredits: string | null; // e.g. "P1 (7,5 hp)"
   studyPace: number | null; // percentage, e.g. 50

--- a/docs/adr/0004-course-round-identity.md
+++ b/docs/adr/0004-course-round-identity.md
@@ -67,6 +67,14 @@ decision forecloses nothing.
 
 - Rounds cannot be addressed by a stable external identifier. Acceptable: they
   are only ever listed under a course.
+- **Application code selects `id` after all, from 2026-09-07.** The Context
+  above records that none did when this was decided, and that is no longer
+  true: `findRoundDetails` selects it, `getDetails` maps it, and it reaches the
+  browser as `CourseRoundSummary.id`. The reason is this decision's own
+  finding — the 77 groups that collide on every descriptive column mean the
+  course details pane cannot key its Offerings list on anything it displays,
+  and React requires a unique key per sibling. Nothing about the decision
+  changes; the id is read, never written or addressed from outside.
 - Duplicate rounds are not prevented by the schema. Four rows are already
   identical to another row on every column but `id`. Whether those are
   ingestion artefacts or genuinely parallel rounds cannot be determined from


### PR DESCRIPTION
Fixes the React warning reported from the course details pane:

> Encountered two children with the same key, `20252-P2 (6,0 hp)`.

## Where it came from

`course-details-panel.tsx` keyed its Offerings list on

```tsx
key={`${round.startTerm}-${round.formattedPeriodsAndCredits ?? index}`}
```

The `?? index` fallback only fires when the label is **null**. It does nothing when two rounds share the same non-null label — which is exactly the reported case: two rounds of one course, in one term, both "P2 (6,0 hp)".

## It is the data, not a defect in it

Measured against the catalogue, on the exact key this list was building (`course_code, start_term, formatted_periods_and_credits`):

| | |
| --- | ---: |
| colliding groups | **126** |
| rows in excess of one per key | **152** |

DD2380 "Artificial Intelligence" is one of them, along with 10 other courses carrying the reported `20252` / `P2 (6,0 hp)` pair exactly.

And a *maximal* label-derived key does no better. `docs/adr/0004-course-round-identity.md` already counted this when it decided the table's key:

| Candidate key | Colliding groups | Excess rows |
| --- | ---: | ---: |
| `(course_code, start_term)` | 184 | 215 |
| + language, tutoring_form, tutoring_time, is_pu, is_vu | 77 | 104 |
| every column except `id` | 4 | 4 |

That second row is **every field this list draws**. Only KOPPS' `round.ladokUID` ever separated those 77 groups, and that API is closed — so no key built from what the pane displays can be made unique, and no amount of adding fields to the template would have fixed this.

## The fix

`course_rounds.id` — which ADR 0004 made the permanent key, on the reasoning that with no re-ingestion there is nothing to destabilise it. It simply never reached the browser: `findRoundDetails` didn't select it → `getDetails` couldn't map it → `CourseRoundSummary` didn't carry it → the component was left to invent a key from display fields. It is selected, mapped and typed now, and read only — never written, never addressed from outside.

Four one-line changes and a doc:

- `server/course/repository.ts` — select `id`
- `server/course/service.ts` — map it
- `types/course.ts` — `CourseRoundSummary.id`, documented with why nothing else identifies a round
- `course-details-panel.tsx` — `key={round.id}`
- `docs/adr/0004-course-round-identity.md` — its Context says "no application code selects `id`", which was true on 2026-09-04 and is not now. A dated Consequences entry records the change and that it is this decision's own finding that forced it.

Note there is no repository→service test asserting the id survives the mapping, because the compiler already does: drop `id` from the select and `r.id` in the service stops compiling.

## Verified

**On the real course, both builds.** `dev` on one port, this branch on another, same page, same click:

| | Offerings rendered | Console |
| --- | --- | --- |
| `dev` | 2 lines | `Encountered two children with the same key, 20252-P2 (6,0 hp)` |
| this branch | 2 lines | *(nothing)* |

**In tests.** A new case in `workspace-pane.spec.tsx` renders two rounds differing only by `id` and asserts both that both lines draw and that React logged no key warning. Both halves matter: React logs the warning even when it happens to render both rows, so a length-only test would go green against a key that is merely quieter without being unique. Confirmed red against the old key (`expected true to be false`) and green against the new one.

`93 files, 1388 tests` green; lint and typecheck clean.

## Left open, deliberately

Those 77 groups are identical in every field this list renders, so on those courses the pane draws **two identical lines** — as DD2380 does. A unique key stops React complaining; it does not make the duplicate rows less confusing to read. Whether to de-duplicate the display, or surface something that distinguishes them (`studyPace`, `isProgrammeCourse`), is a product call and is not made here. ADR 0004 also notes 4 rows that are identical on every column but `id`, where "whether those are ingestion artefacts or genuinely parallel rounds cannot be determined from the retained data".

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018QdCdwBRSMCGD7Sc7kKdKi
