### PR TITLE
feat(graph): one origin-centred window for everyone, and a placement backfill

### DIFF
--- a/apps/web/features/landing/api/queries.ts
+++ b/apps/web/features/landing/api/queries.ts
@@ -15,7 +15,10 @@ import { type RouterOutputs, useTRPC } from "@/trpc/client";
  */
 export type GraphWindow = RouterOutputs["graph"]["publicWindow"];
 
-/** The member read: the same window, centred on their own node. */
+/**
+ * The member read: the same window a visitor gets, centred on the same
+ * community origin, with one node in it flagged as theirs.
+ */
 export type Neighbourhood = RouterOutputs["graph"]["neighbourhood"];
 
 /**

--- a/apps/web/features/landing/lib/hero-keepout.spec.ts
+++ b/apps/web/features/landing/lib/hero-keepout.spec.ts
@@ -258,7 +258,9 @@ describe("pushClear", () => {
     /**
      * A point *on* the anchor has no bearing to preserve, so there is nothing
      * radial to do and the nearest wall is as good an answer as any. Asserted
-     * because the viewer's own node lands exactly here.
+     * because a node at the community origin lands exactly here — which, since
+     * every window is origin-centred, is whoever joined first rather than
+     * whoever is reading.
      */
     it("falls back to the axis walls for a point on the origin itself", () => {
       const out = pushClear(ORIGIN.x, ORIGIN.y, BLOCK, RADIUS, ORIGIN);

--- a/apps/web/features/landing/lib/neighbourhood-view.spec.ts
+++ b/apps/web/features/landing/lib/neighbourhood-view.spec.ts
@@ -7,6 +7,7 @@ import { clearAt, fallbackRects, MAX_PUSH, type Rect } from "./hero-keepout";
 import {
   DEFAULT_NODE_COLOR_VAR,
   FALLBACK_NODE_COLOR_VAR,
+  fitViewerInFrame,
   type GraphWindowInput,
   NODE_COLOR_VARS,
   NODE_RADIUS,
@@ -14,6 +15,7 @@ import {
   pickViewportCentre,
   projectGraphWindow,
   VIEW_SCALE,
+  VIEWER_MARGIN,
 } from "./neighbourhood-view";
 
 const WIDTH = 1000;
@@ -199,6 +201,144 @@ describe("pickViewportCentre", () => {
         y: HEIGHT / 2,
       });
     }
+  });
+});
+
+/**
+ * The camera nudge that replaced centring the window on the viewer.
+ *
+ * Every window is centred on the community origin now, so nobody is drawn at
+ * the middle of their own community — two members comparing screens would both
+ * be the centre, and the graph would read as generated per viewer rather than
+ * as one place they are both in. This is what still lets somebody find
+ * themselves, and the smallness of it is the whole design.
+ */
+describe("fitViewerInFrame", () => {
+  const ANCHOR = { x: 500, y: 300 };
+
+  function fit(viewer: { x: number; y: number } | null, anchor = ANCHOR) {
+    return fitViewerInFrame({ anchor, viewer, width: WIDTH, height: HEIGHT });
+  }
+
+  it("leaves the camera alone for a window with no You in it", () => {
+    expect(fit(null)).toEqual(ANCHOR);
+  });
+
+  it("leaves the camera alone when the viewer is already on the canvas", () => {
+    expect(fit({ x: 120, y: -80 })).toEqual(ANCHOR);
+  });
+
+  it("brings a viewer off any edge back onto the canvas", () => {
+    for (const viewer of [
+      { x: -900, y: 0 },
+      { x: 900, y: 0 },
+      { x: 0, y: -700 },
+      { x: 0, y: 700 },
+      { x: -900, y: 700 },
+    ]) {
+      const centre = fit(viewer);
+      expect(centre.x + viewer.x).toBeGreaterThanOrEqual(VIEWER_MARGIN);
+      expect(centre.x + viewer.x).toBeLessThanOrEqual(WIDTH - VIEWER_MARGIN);
+      expect(centre.y + viewer.y).toBeGreaterThanOrEqual(VIEWER_MARGIN);
+      expect(centre.y + viewer.y).toBeLessThanOrEqual(HEIGHT - VIEWER_MARGIN);
+    }
+  });
+
+  /**
+   * Just enough, never more. Panning further than it takes to get the dot in
+   * frame is how a shared picture turns back into a personal one.
+   */
+  it("moves the camera no further than it has to", () => {
+    const viewer = { x: -900, y: 0 };
+    const centre = fit(viewer);
+
+    // Exactly on the margin, not comfortably inside it and not centred.
+    expect(centre.x + viewer.x).toBeCloseTo(VIEWER_MARGIN);
+    expect(centre.y).toBe(ANCHOR.y);
+    expect(centre.x).not.toBeCloseTo(WIDTH / 2);
+  });
+
+  it("does not shuffle the dot on a frame narrower than its own margins", () => {
+    expect(
+      fitViewerInFrame({
+        anchor: ANCHOR,
+        viewer: { x: -900, y: 0 },
+        width: VIEWER_MARGIN,
+        height: HEIGHT,
+      }).x,
+    ).toBe(ANCHOR.x);
+  });
+});
+
+/**
+ * The property the whole change exists for, stated as two people comparing
+ * screens: same graph, same arrangement, two different dots lit up.
+ */
+describe("two members looking at the same community", () => {
+  /** One window on the origin-centred graph, as the server now returns it. */
+  function windowFor(viewerId: string | null) {
+    return graphWindow({ x: 0, y: 0 }, [
+      { id: "p", x: 0, y: 0, isViewer: viewerId === "p" },
+      { id: "q", x: 300, y: -120, isViewer: viewerId === "q" },
+      { id: "r", x: -160, y: 240, isViewer: viewerId === "r" },
+    ]);
+  }
+
+  it("shows both of them the same nodes in the same arrangement", () => {
+    const mine = project(windowFor("p"), COPY);
+    const theirs = project(windowFor("q"), COPY);
+
+    const separations = (view: ReturnType<typeof project>) =>
+      view.nodes.map((node) => ({
+        id: node.id,
+        dx: node.screenX - (view.nodes[0]?.screenX ?? 0),
+        dy: node.screenY - (view.nodes[0]?.screenY ?? 0),
+      }));
+
+    expect(separations(theirs)).toEqual(separations(mine));
+  });
+
+  it("lights up a different dot for each of them", () => {
+    expect(
+      project(windowFor("p"), COPY).nodes.find((n) => n.isViewer)?.id,
+    ).toBe("p");
+    expect(
+      project(windowFor("q"), COPY).nodes.find((n) => n.isViewer)?.id,
+    ).toBe("q");
+  });
+
+  /**
+   * Nobody is the middle. That is the claim two friends would otherwise catch
+   * out, and it is why the window centre stopped being the reader's own node.
+   */
+  it("puts neither of them at the centre of their own screen", () => {
+    for (const viewerId of ["q", "r"]) {
+      const view = project(windowFor(viewerId), COPY);
+      const me = view.nodes.find((node) => node.isViewer);
+      expect(
+        Math.hypot(
+          (me?.screenX ?? 0) - view.centre.x,
+          (me?.screenY ?? 0) - view.centre.y,
+        ),
+      ).toBeGreaterThan(NODE_RADIUS);
+    }
+  });
+
+  /** But each of them can still find themselves. */
+  it("keeps a member far from the origin on their own canvas", () => {
+    const view = project(
+      graphWindow({ x: 0, y: 0 }, [
+        { id: "origin", x: 0, y: 0 },
+        { id: "rim", x: 9000, y: -7000, isViewer: true },
+      ]),
+      COPY,
+    );
+    const me = view.nodes.find((node) => node.isViewer);
+
+    expect(me?.screenX).toBeGreaterThanOrEqual(0);
+    expect(me?.screenX).toBeLessThanOrEqual(WIDTH);
+    expect(me?.screenY).toBeGreaterThanOrEqual(0);
+    expect(me?.screenY).toBeLessThanOrEqual(HEIGHT);
   });
 });
 

--- a/apps/web/features/landing/lib/neighbourhood-view.ts
+++ b/apps/web/features/landing/lib/neighbourhood-view.ts
@@ -6,7 +6,7 @@
  * `graph.publicWindow` hand back the persisted world positions untouched;
  * everything in this file is derived at read time and thrown away on the next
  * resize. Nothing here is ever written back, exactly as
- * `docs/landing_docs/personal-community-viewport.md` requires.
+ * `docs/landing_docs/shared-community-viewport.md` requires.
  *
  * The projection is that document's, taken literally:
  *
@@ -32,12 +32,23 @@
  * keep-out adjustment" the viewport document lists as derived and never written
  * back. `pickViewportCentre` below is that function.
  *
- * What it buys, beyond the copy staying readable, is that the viewer's own node
- * lands *on* the anchor by identity: `input.centre` **is** their persisted
- * world position, so their offset from it is zero. No search for their dot, no
- * special case, nothing stored. It holds across sessions for as long as the
- * frame and the copy layout hold — a resize or a reworded headline moves the
- * anchor, and that is a responsive adjustment rather than a broken promise.
+ * **Nobody is drawn at the middle of their own community.** `input.centre` is
+ * `COMMUNITY_ORIGIN` for a member and a visitor alike, so a member's dot sits
+ * wherever their world position puts it — somewhere specific, and not special.
+ * The window used to be centred on the reader, which drew every one of them at
+ * the centre; put two members' screens side by side and both are the middle,
+ * and the graph stops reading as one community and starts reading as something
+ * generated per viewer. The arrangement two friends compare is now the same
+ * arrangement, with two different dots lit up in it.
+ *
+ * Finding yourself is `fitViewerInFrame`'s job: the camera is nudged by the
+ * fewest pixels that put your dot on the canvas, and by nothing more. A pan
+ * translates every node equally, so it changes which part of the graph is on
+ * screen and never what the graph looks like. For most members it moves nothing
+ * at all and their page is the visitor's page exactly. It holds across sessions
+ * for as long as the frame and the copy layout hold — a resize or a reworded
+ * headline moves the anchor, and that is a responsive adjustment rather than a
+ * broken promise.
  *
  * Keep-out is no longer only a fade. `pushClear` walks a node out from under
  * the copy first, and the fade is what is left for the case it refuses; see
@@ -236,7 +247,7 @@ export type GraphWindowView = {
 /**
  * Pixels per world unit. A **constant**, and that is the whole point.
  *
- * `personal-community-viewport.md` calls the visible-node maximum "a
+ * `shared-community-viewport.md` calls the visible-node maximum "a
  * frontend/query policy", so the number is ours to choose — but it may not be a
  * function of who is looking or of what their neighbourhood happens to contain,
  * or two people in one region of the graph see it at two different zooms.
@@ -372,6 +383,86 @@ export function pickViewportCentre(
 }
 
 /**
+ * How much room a panned-in dot keeps between itself and the frame edge, in px.
+ *
+ * Sized for the largest mark the canvas draws on a node rather than for a node:
+ * **Find your dot** replaces the viewer's dot with a radius-7.5 shape inside a
+ * 12.5px ring, so a dot 14px in can still wear its reveal whole.
+ */
+export const VIEWER_MARGIN = 14;
+
+/**
+ * The viewer's projected offset from the window centre, or `null` if this
+ * window has no "You" in it — every visitor's window, and a member's until the
+ * server flags their node.
+ */
+function viewerOffset(
+  input: GraphWindowInput,
+): { x: number; y: number } | null {
+  const me = input.nodes.find((node) => node.isViewer);
+  if (!me) return null;
+  return {
+    x: (me.x - input.centre.x) * VIEW_SCALE,
+    y: (me.y - input.centre.y) * VIEW_SCALE,
+  };
+}
+
+/**
+ * Nudge the camera just far enough that the viewer's own dot is on the canvas.
+ *
+ * **The smallest possible nudge, and the smallness is the design.** Every
+ * window is centred on `COMMUNITY_ORIGIN` now — nobody is drawn at the middle of
+ * their own community, because two members comparing screens would both be the
+ * centre and the graph would read as generated per viewer rather than as one
+ * place they are both in. This is what keeps that true while still letting
+ * somebody find themselves: it moves the camera by the fewest pixels that put
+ * their dot in frame, so their neighbours come with them, in the arrangement
+ * everybody else sees them in. Pan further and the page starts being about the
+ * viewer again.
+ *
+ * A pan translates every node equally, so it cannot change what the graph looks
+ * like — only which part of it is on screen. Nodes pushed off the far edge by
+ * the nudge are **not** a failure: a member out at the rim seeing the community
+ * from the rim is the honest picture, and the rest of it is still there, just
+ * not in this viewport.
+ *
+ * On-canvas is the whole test. It deliberately does not try to keep the dot
+ * clear of the copy — `pushClear` already walks any node out from under the
+ * headline, and a camera that also chased legibility would move further than
+ * "just enough" and start composing a personal view.
+ *
+ * A window with no viewer in it returns the anchor untouched, which is every
+ * visitor's page.
+ */
+export function fitViewerInFrame(args: {
+  anchor: { x: number; y: number };
+  viewer: { x: number; y: number } | null;
+  width: number;
+  height: number;
+}): { x: number; y: number } {
+  const { anchor, viewer, width, height } = args;
+  if (!viewer) return anchor;
+  return {
+    x: anchor.x + nudge(anchor.x + viewer.x, width),
+    y: anchor.y + nudge(anchor.y + viewer.y, height),
+  };
+}
+
+/**
+ * How far one axis has to move to bring `at` inside the frame, and 0 when it is
+ * already there.
+ *
+ * A frame narrower than its own two margins has no inside to reach; the dot is
+ * left where it is rather than being shuffled between two impossible bounds.
+ */
+function nudge(at: number, extent: number): number {
+  if (extent < VIEWER_MARGIN * 2) return 0;
+  if (at < VIEWER_MARGIN) return VIEWER_MARGIN - at;
+  if (at > extent - VIEWER_MARGIN) return extent - VIEWER_MARGIN - at;
+  return 0;
+}
+
+/**
  * Project a bounded window onto a canvas of `width` by `height`.
  *
  * The result is pure derivation: `input` is not mutated, and nothing computed
@@ -384,7 +475,15 @@ export function projectGraphWindow(args: {
   keepOut: Rect[];
 }): GraphWindowView {
   const { window: input, width, height, keepOut } = args;
-  const centre = pickViewportCentre(width, height, keepOut);
+  // Where the camera would sit for a visitor, then the smallest nudge that
+  // brings the viewer's own dot onto the canvas. For most people the second
+  // step changes nothing and their page is the visitor's page exactly.
+  const centre = fitViewerInFrame({
+    anchor: pickViewportCentre(width, height, keepOut),
+    viewer: viewerOffset(input),
+    width,
+    height,
+  });
 
   const byId = new Map<string, ScreenNode>();
   const nodes = input.nodes.map((node) => {

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -12,6 +12,7 @@
     "format": "biome format --write",
     "ingest": "bun --env-file=.env.local scripts/ingest.ts",
     "backfill:tiers": "bun --env-file=.env.local scripts/backfill-personalization-tiers.ts",
+    "backfill:placements": "bun --env-file=.env.local scripts/backfill-graph-placements.ts",
     "db:generate": "drizzle-kit generate --config server/db/drizzle.config.ts",
     "db:push": "drizzle-kit push --config server/db/drizzle.config.ts",
     "db:migrate": "drizzle-kit migrate --config server/db/drizzle.config.ts",

--- a/apps/web/scripts/backfill-graph-placements.ts
+++ b/apps/web/scripts/backfill-graph-placements.ts
@@ -1,0 +1,27 @@
+import { backfillCommunityGraphPlacements } from "../server/graph/service";
+
+/**
+ * Place the app users the two live placement paths never reached.
+ *
+ * Sign-up places an account and a member's own first read repairs one, so the
+ * people left over are those who joined before the community graph existed and
+ * those whose sign-up hook swallowed a failure — real accounts with no dot on
+ * the hero, and no way to get one until they next sign in.
+ *
+ * A one-off, but safe to re-run: joining is idempotent, so a second run finds
+ * nobody unplaced and writes nothing. Run it after deploying the graph, and
+ * again any time the hero looks shorter than the membership.
+ */
+async function main() {
+  const { placed } = await backfillCommunityGraphPlacements();
+  console.log(
+    placed === 0
+      ? "Every app user already has a node; nothing to place."
+      : `Placed ${placed} app users in the community graph.`,
+  );
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/apps/web/server/graph/repository.ts
+++ b/apps/web/server/graph/repository.ts
@@ -2,8 +2,10 @@ import {
   and,
   count,
   eq,
+  gt,
   inArray,
   isNotNull,
+  isNull,
   lt,
   max,
   ne,
@@ -103,6 +105,49 @@ export async function countNodes(): Promise<number> {
     .select({ value: count() })
     .from(schema.usersGraphNodes);
   return row?.value ?? 0;
+}
+
+/**
+ * A page of the app users who have no node in the community graph at all.
+ *
+ * This set is exactly the people neither placement path reached: accounts
+ * created before the graph existed and so never seen by the sign-up hook, and
+ * accounts whose hook swallowed a failure — it is written to swallow, so a
+ * placement can be lost without anything else noticing. A member's own first
+ * read repairs their row, which is why the set is usually small and is only
+ * ever people who have not signed in since.
+ *
+ * Paged on the user id with a cursor rather than an offset, for a reason the
+ * tier backfill does not have: placing somebody **removes them from this set**,
+ * so every page shifts the rows underneath an offset and it would step over
+ * whoever slid into the gap. The cursor is also what makes the walk terminate
+ * if a placement ever silently does not take, instead of re-reading the same
+ * app user for ever.
+ *
+ * An anti-join rather than a `not exists`: both sides are keyed on the user id,
+ * so it is an index scan either way, and this is the shape the rest of this
+ * file reads in.
+ */
+export async function findUnplacedUserIds(
+  after: string | null,
+  limit: number,
+): Promise<string[]> {
+  const rows = await db
+    .select({ userId: schema.users.id })
+    .from(schema.users)
+    .leftJoin(
+      schema.usersGraphNodes,
+      eq(schema.usersGraphNodes.userId, schema.users.id),
+    )
+    .where(
+      and(
+        isNull(schema.usersGraphNodes.userId),
+        after === null ? undefined : gt(schema.users.id, after),
+      ),
+    )
+    .orderBy(schema.users.id)
+    .limit(limit);
+  return rows.map((row) => row.userId);
 }
 
 /**

--- a/apps/web/server/graph/service.spec.ts
+++ b/apps/web/server/graph/service.spec.ts
@@ -929,6 +929,27 @@ describe("backfillCommunityGraphPlacements", () => {
       "neon is having a day",
     );
   });
+
+  /**
+   * The count is rows this run wrote, not app users it walked past.
+   *
+   * Somebody selected as unplaced can be placed by their own sign-up or first
+   * read in the moment before the backfill's insert, and the placement then
+   * returns the winner's node rather than failing. Counting that would have the
+   * command report a repair it did not perform — which defeats the only reason
+   * the number is printed.
+   */
+  it("does not count an app user a concurrent placement got to first", async () => {
+    unplaced(["u1"], 100);
+    // Selected as unplaced, but their own first read commits while this run is
+    // computing a position: the insert finds a row and returns nothing.
+    vi.mocked(graphRepo.persistPlacement).mockResolvedValue(undefined);
+    vi.mocked(graphRepo.findNode)
+      .mockResolvedValueOnce(undefined)
+      .mockResolvedValue({ userId: "u1", x: 7, y: -3 });
+
+    expect(await backfillCommunityGraphPlacements()).toEqual({ placed: 0 });
+  });
 });
 
 describe("a window's node appearance", () => {

--- a/apps/web/server/graph/service.spec.ts
+++ b/apps/web/server/graph/service.spec.ts
@@ -10,6 +10,7 @@ import {
 import type { BackboneEdge, NeighbourNode, PlacementWrite } from "./repository";
 import * as graphRepo from "./repository";
 import {
+  backfillCommunityGraphPlacements,
   backfillEarnedPersonalizationTiers,
   COMMUNITY_ORIGIN,
   getNeighbourhood,
@@ -18,8 +19,7 @@ import {
   getPublicWindow,
   joinCommunityGraph,
   joinCommunityGraphOnSignUp,
-  MAX_NEIGHBOURHOOD_NODES,
-  MAX_PUBLIC_WINDOW_NODES,
+  MAX_WINDOW_NODES,
   recordEarnedPersonalizationTier,
   recordEarnedPersonalizationTierOnContribution,
   setNodeAppearance,
@@ -320,26 +320,78 @@ describe("getNeighbourhood", () => {
     });
   }
 
-  it("bounds the node set to the neighbourhood maximum", async () => {
+  it("bounds the node set to the window maximum", async () => {
     placedViewer();
     vi.mocked(graphRepo.findNearestNodes).mockResolvedValue([viewer]);
 
     await getNeighbourhood("viewer");
 
     expect(graphRepo.findNearestNodes).toHaveBeenCalledWith(
-      { x: 100, y: 100 },
-      MAX_NEIGHBOURHOOD_NODES,
+      COMMUNITY_ORIGIN,
+      MAX_WINDOW_NODES,
     );
   });
 
-  it("centres the window on the viewer's own world position", async () => {
+  /**
+   * The requirement, as a test. A window centred on whoever is reading it draws
+   * every member at the middle of their own community, and two members
+   * comparing screens would both be the centre — which makes the graph read as
+   * something generated per viewer. Everyone gets the origin; finding yourself
+   * is the camera's job, on the client.
+   */
+  it("centres the window on the community origin, not on the viewer", async () => {
     placedViewer();
     vi.mocked(graphRepo.findNearestNodes).mockResolvedValue([viewer]);
 
-    expect((await getNeighbourhood("viewer")).centre).toEqual({
-      x: 100,
-      y: 100,
-    });
+    expect((await getNeighbourhood("viewer")).centre).toEqual(COMMUNITY_ORIGIN);
+  });
+
+  it("serves a member and a visitor the same window, differing only in the flag", async () => {
+    placedViewer();
+    vi.mocked(graphRepo.findNearestNodes).mockResolvedValue([
+      viewer,
+      neighbour("them", 300, -80),
+    ]);
+
+    const mine = await getNeighbourhood("viewer");
+    const theirs = await getPublicWindow();
+
+    expect(mine.centre).toEqual(theirs.centre);
+    expect(mine.nodes.map((node) => [node.x, node.y])).toEqual(
+      theirs.nodes.map((node) => [node.x, node.y]),
+    );
+    expect(mine.nodes.filter((node) => node.isViewer)).toHaveLength(1);
+    expect(theirs.nodes.filter((node) => node.isViewer)).toHaveLength(0);
+  });
+
+  /**
+   * The window is the nodes nearest the *origin*, a set the caller has no claim
+   * on — so a member out past `MAX_WINDOW_NODES` would not be in it at all, and
+   * no camera pan can show a dot that is not in the payload. Before, when the
+   * window was centred on them, they were in it by construction.
+   */
+  it("appends the viewer's own node when the bounded read did not reach them", async () => {
+    placedViewer();
+    vi.mocked(graphRepo.findNearestNodes).mockResolvedValue([
+      neighbour("near-the-origin", 0, 0),
+    ]);
+    vi.mocked(graphRepo.findNodeProfile).mockResolvedValue(undefined);
+
+    const { nodes } = await getNeighbourhood("viewer");
+
+    const me = nodes.find((node) => node.isViewer);
+    expect(me).toMatchObject({ x: 100, y: 100 });
+    // Unconfigured, which is what the column defaults would have said anyway.
+    expect(me).toMatchObject({ color: "default", style: "default" });
+  });
+
+  it("spends no extra query on a viewer the bounded read already returned", async () => {
+    placedViewer();
+    vi.mocked(graphRepo.findNearestNodes).mockResolvedValue([viewer]);
+
+    await getNeighbourhood("viewer");
+
+    expect(graphRepo.findNodeProfile).not.toHaveBeenCalled();
   });
 
   it("includes the viewer's own node, flagged, so they can find their dot", async () => {
@@ -455,7 +507,7 @@ describe("getPublicWindow", () => {
 
     expect(graphRepo.findNearestNodes).toHaveBeenCalledWith(
       COMMUNITY_ORIGIN,
-      MAX_PUBLIC_WINDOW_NODES,
+      MAX_WINDOW_NODES,
     );
     expect(window.centre).toEqual({ x: 0, y: 0 });
   });
@@ -790,6 +842,90 @@ describe("backfillEarnedPersonalizationTiers", () => {
     );
 
     await expect(backfillEarnedPersonalizationTiers()).rejects.toThrow(
+      "neon is having a day",
+    );
+  });
+});
+
+/**
+ * Sign-up placement swallows its failures and accounts older than the graph
+ * never saw it, so a real account can exist with no dot on the hero. These
+ * cover what makes one pass over those people safe: it visits each of them
+ * once, it pages until the pages run out, a second run is a no-op — and,
+ * the property with teeth, it places them one at a time so no two are
+ * computed against the same node count.
+ */
+describe("backfillCommunityGraphPlacements", () => {
+  /** Unplaced app users served a page at a time, as the repository serves them. */
+  function unplaced(userIds: string[], pageSize: number) {
+    vi.mocked(graphRepo.findUnplacedUserIds).mockImplementation(
+      async (after, limit) => {
+        const start = after === null ? 0 : userIds.indexOf(after) + 1;
+        return userIds.slice(start, start + Math.min(limit, pageSize));
+      },
+    );
+  }
+
+  it("places every unplaced app user, following the cursor across pages", async () => {
+    unplaced(["u1", "u2", "u3", "u4", "u5"], 2);
+
+    expect(await backfillCommunityGraphPlacements(2)).toEqual({ placed: 5 });
+
+    const placed = vi
+      .mocked(graphRepo.persistPlacement)
+      .mock.calls.map((call) => call[0].node.userId);
+    expect(placed).toEqual(["u1", "u2", "u3", "u4", "u5"]);
+  });
+
+  it("does nothing when every app user already has a node", async () => {
+    unplaced([], 100);
+
+    expect(await backfillCommunityGraphPlacements()).toEqual({ placed: 0 });
+    expect(graphRepo.persistPlacement).not.toHaveBeenCalled();
+  });
+
+  /**
+   * The one that matters. `computeWorldPosition` reads the node count before
+   * the write, so anything that placed a page concurrently would compute the
+   * same radius for all of it — and at index 0 the identical point, because a
+   * jittered angle times a zero radius is still the origin. Two people would
+   * then share a dot, which is the exact failure this backfill exists to undo.
+   */
+  it("places one at a time, so no two land on the same radius", async () => {
+    inMemoryCommunity();
+    unplaced(["u1", "u2", "u3", "u4"], 100);
+
+    await backfillCommunityGraphPlacements();
+
+    const radii = vi
+      .mocked(graphRepo.persistPlacement)
+      .mock.calls.map((call) => Math.hypot(call[0].node.x, call[0].node.y));
+    expect(radii).toHaveLength(4);
+    for (let i = 1; i < radii.length; i++) {
+      expect(radii[i]).toBeGreaterThan(radii[i - 1] as number);
+    }
+  });
+
+  it("is a no-op on a second run, because joining is idempotent", async () => {
+    inMemoryCommunity();
+    unplaced(["u1", "u2"], 100);
+    await backfillCommunityGraphPlacements();
+    vi.mocked(graphRepo.persistPlacement).mockClear();
+
+    // Everybody has a node now, so the repository reports nobody unplaced.
+    unplaced([], 100);
+
+    expect(await backfillCommunityGraphPlacements()).toEqual({ placed: 0 });
+    expect(graphRepo.persistPlacement).not.toHaveBeenCalled();
+  });
+
+  it("stops rather than reporting a half-finished run", async () => {
+    unplaced(["u1", "u2"], 100);
+    vi.mocked(graphRepo.countNodes).mockRejectedValue(
+      new Error("neon is having a day"),
+    );
+
+    await expect(backfillCommunityGraphPlacements()).rejects.toThrow(
       "neon is having a day",
     );
   });

--- a/apps/web/server/graph/service.ts
+++ b/apps/web/server/graph/service.ts
@@ -118,10 +118,34 @@ export type GraphWindow = {
  * node is placed at the outer edge of the community and attached to three to
  * five established anchors — nobody already placed is asked to move, and no
  * global layout pass ever runs.
+ *
+ * Where the node came from is `placeInCommunityGraph`'s to report; almost every
+ * caller only wants somewhere to draw a dot, and gets it.
  */
 export async function joinCommunityGraph(userId: string): Promise<GraphNode> {
+  return (await placeInCommunityGraph(userId)).node;
+}
+
+/**
+ * The same placement, and **whether this call is the one that wrote it**.
+ *
+ * `created` is false in the two idempotent cases — the app user already had a
+ * node, or a concurrent sign-up or first read committed theirs while this call
+ * was computing a position — and true only when this call's own insert landed.
+ * The node comes back either way; the flag says nothing about whether the
+ * caller has somewhere to draw them, only about who put it there.
+ *
+ * It exists because a backfill that counts what it did not do is a backfill
+ * whose output cannot be trusted: "placed 4 app users" has to mean four rows
+ * that were not there before, or an operator reading it learns nothing. Nobody
+ * else needs the distinction, which is why `joinCommunityGraph` above still
+ * hands back a bare node.
+ */
+export async function placeInCommunityGraph(
+  userId: string,
+): Promise<{ node: GraphNode; created: boolean }> {
   const existing = await graphRepo.findNode(userId);
-  if (existing) return existing;
+  if (existing) return { node: existing, created: false };
 
   const position = computeWorldPosition(userId, await graphRepo.countNodes());
   const node: GraphNode = { userId, ...position };
@@ -144,18 +168,19 @@ export async function joinCommunityGraph(userId: string): Promise<GraphNode> {
       anchorUserId: anchor.userId,
     })),
   });
-  if (placed) return placed;
+  if (placed) return { node: placed, created: true };
 
   // A concurrent join for the same app user committed first. Their placement
   // stands and ours was abandoned whole, so report where this app user really
-  // is rather than coordinates that were never stored.
+  // is rather than coordinates that were never stored — and say plainly that we
+  // are not the ones who put them there.
   const winner = await graphRepo.findNode(userId);
   if (!winner) {
     throw new Error(
       `Placement for app user ${userId} conflicted but no node was found`,
     );
   }
-  return winner;
+  return { node: winner, created: false };
 }
 
 /**
@@ -477,6 +502,14 @@ const PLACEMENT_BACKFILL_PAGE = 100;
  * Like the tier backfill and for the same reason, it does **not** swallow: a
  * run that half-finished and reported success is worse than one that stops and
  * says where it stopped.
+ *
+ * `placed` counts **rows this run wrote**, which is not the same as app users
+ * it visited. Somebody selected as unplaced can be placed by their own sign-up
+ * or first read in the moment between the two, and `placeInCommunityGraph` then
+ * hands back the winner's node with `created: false`. Counting that would have
+ * the command claim work it did not do — and the number exists precisely so an
+ * operator can tell a run that repaired something from a run that found nothing
+ * to repair.
  */
 export async function backfillCommunityGraphPlacements(
   pageSize: number = PLACEMENT_BACKFILL_PAGE,
@@ -493,8 +526,8 @@ export async function backfillCommunityGraphPlacements(
 
     for (const userId of userIds) {
       // One at a time. See the note on concurrency above.
-      await joinCommunityGraph(userId);
-      placed += 1;
+      const { created } = await placeInCommunityGraph(userId);
+      if (created) placed += 1;
     }
 
     if (userIds.length < pageSize) return { placed };

--- a/apps/web/server/graph/service.ts
+++ b/apps/web/server/graph/service.ts
@@ -25,30 +25,31 @@ import * as graphRepo from "./repository";
 import { deriveEarnedTier, deriveEffectiveTier } from "./tier";
 
 /**
- * How many nodes one bounded neighbourhood read may return.
+ * How many nodes a window may return.
  *
- * This is a query policy, not a database column: the landing page never loads
- * the whole community, and the bound belongs to the domain that answers the
- * question.
+ * A query policy, not a database column: the landing page never loads the whole
+ * community, and the bound belongs to the domain that answers the question.
+ *
+ * There is **one** number rather than one per caller, because there is now one
+ * window. A member and a visitor are served the same slice of the same graph
+ * and differ only in whether one node in it is flagged as theirs; a second
+ * bound would be a second picture waiting to happen.
  */
-export const MAX_NEIGHBOURHOOD_NODES = 150;
+export const MAX_WINDOW_NODES = 150;
 
 /**
- * How many nodes the public window may return.
- *
- * Deliberately its own number rather than a reuse of the one above. The
- * neighbourhood is a read a member makes about themselves; this one is served
- * to anybody who loads `/`, so it must be possible to tighten it — for cost, or
- * because the community has grown enough that a stranger seeing 150 nodes at
- * once starts to say something — without changing what a member sees.
- */
-export const MAX_PUBLIC_WINDOW_NODES = 150;
-
-/**
- * Where the community's world coordinate system begins, and what the public
+ * Where the community's world coordinate system begins, and what **every**
  * window is centred on. `computeWorldPosition` puts the very first node exactly
  * here and grows the radius from it, so the origin is the densest part of the
- * graph and the honest place to point a camera that has no viewer to follow.
+ * graph.
+ *
+ * It is the centre for members too, not only for visitors, and that is the
+ * point rather than a simplification. A window centred on whoever is reading it
+ * draws every member at the middle of their own community — and the moment two
+ * of them compare screens, the graph reads as a diorama built per viewer rather
+ * than one place they both live in. Centring on the origin makes a member's
+ * position a fact about them: somewhere specific, not special, and the same
+ * somewhere on their friend's screen.
  */
 export const COMMUNITY_ORIGIN: WorldPosition = { x: 0, y: 0 };
 
@@ -97,8 +98,13 @@ export type WindowEdge = { fromId: string; toId: string };
 /** A bounded slice of the community graph, ready to project. */
 export type GraphWindow = {
   /**
-   * The world position the client's projection subtracts: the viewer's own node
-   * for a member, the community origin for a visitor. World units, untouched.
+   * The world position the client's projection subtracts: `COMMUNITY_ORIGIN`,
+   * for a member and a visitor alike. World units, untouched.
+   *
+   * It no longer varies by caller. Getting the viewer onto the canvas is the
+   * **camera's** job on the client, and it is a pan of a few pixels rather than
+   * a different world centre — so the graph two people compare is the same
+   * graph, laid out the same way, with their two dots in two different places.
    */
   centre: WorldPosition;
   nodes: WindowNode[];
@@ -174,13 +180,25 @@ export async function joinCommunityGraphOnSignUp(
 }
 
 /**
- * The bounded neighbourhood around an app user's own node: the nearby nodes and
- * the backbone edges spanning exactly that set.
+ * The community window, with the caller's own node flagged as theirs.
  *
- * `nodes` deliberately contains the viewer's own node, flagged `isViewer` — it
- * is the one they came to find, and it needs the same appearance every other
- * node has. `centre` repeats its world position because the client's projection
- * is expressed relative to it, so nothing has to search the set for itself.
+ * **It is the public window plus a flag, and that is the whole difference.**
+ * The read used to be centred on the caller and to return the nodes nearest
+ * *them*, which drew every member at the middle of their own community. That is
+ * a claim the data does not support: put two members' screens side by side and
+ * both are the centre, so the graph reads as something generated per viewer
+ * rather than one community they are both in. Centring everybody on
+ * `COMMUNITY_ORIGIN` makes it checkable — the same nodes in the same
+ * arrangement on both screens, with two different dots lit up.
+ *
+ * Getting the caller onto the canvas is the **client's** job and is a camera
+ * pan of a few pixels, not a different world centre — see `fitViewerInFrame`.
+ *
+ * `nodes` therefore contains the caller's own node, flagged `isViewer`, even
+ * when the bounded read would not have reached them: `withViewer` appends it.
+ * Without that the flag would silently go missing for anybody outside the
+ * nearest `MAX_WINDOW_NODES`, and no amount of panning can show a dot that is
+ * not in the payload.
  *
  * World units come back untouched. Projecting them into screen pixels, and any
  * responsive keep-out adjustment, happens on the client and never returns here.
@@ -199,18 +217,16 @@ export async function getNeighbourhood(userId: string): Promise<GraphWindow> {
   // graph existed never saw it. Joining here repairs both, and because joining
   // is idempotent an app user who already has a node just gets it back.
   const node = await joinCommunityGraph(userId);
-  const centre: WorldPosition = { x: node.x, y: node.y };
 
-  return readWindow(centre, MAX_NEIGHBOURHOOD_NODES, userId);
+  return readWindow(COMMUNITY_ORIGIN, MAX_WINDOW_NODES, node);
 }
 
 /**
- * A bounded window on the real community graph for someone with no node of
- * their own — a visitor, or a member whose own read did not answer.
+ * The same window, for someone with no node of their own — a visitor, or a
+ * member whose own read did not answer.
  *
- * Centred on the community origin rather than on anybody, so it is the same
- * graph for everyone who asks and nothing about the caller shapes it. There is
- * no "You" in it: `isViewer` is false throughout.
+ * The only thing that distinguishes it from `getNeighbourhood` is that there is
+ * no "You" in it: `isViewer` is false throughout, and nothing is appended.
  *
  * The community is small, so this window is sparse, and it is empty until
  * somebody joins. That is the honest answer and the landing draws it as such —
@@ -218,7 +234,7 @@ export async function getNeighbourhood(userId: string): Promise<GraphWindow> {
  * community rather than the community.
  */
 export async function getPublicWindow(): Promise<GraphWindow> {
-  return readWindow(COMMUNITY_ORIGIN, MAX_PUBLIC_WINDOW_NODES);
+  return readWindow(COMMUNITY_ORIGIN, MAX_WINDOW_NODES);
 }
 
 /** Both tier numbers for one app user, and the appearance they have stored. */
@@ -429,6 +445,64 @@ export async function backfillEarnedPersonalizationTiers(
 }
 
 /**
+ * How many app users one placement backfill page looks at.
+ *
+ * Smaller than the tier page because each app user here costs a count, an
+ * anchor search and a write transaction rather than two reads, and because the
+ * set it walks is normally tiny — the only people in it are the ones neither
+ * placement path reached.
+ */
+const PLACEMENT_BACKFILL_PAGE = 100;
+
+/**
+ * Give a node to every app user who has none.
+ *
+ * The two live paths are the sign-up hook and a member's own first read, and
+ * neither covers everybody: accounts created before the graph existed never saw
+ * the hook, and the hook is deliberately written to swallow its failures so it
+ * cannot cost somebody their sign-up. Both leave an account that is real but
+ * absent from the hero. This is the one-off that closes that, and it is safe to
+ * run whenever the graph looks short: `joinCommunityGraph` is idempotent, so a
+ * second run finds nobody and writes nothing.
+ *
+ * **Strictly one app user at a time, and that is not incidental.**
+ * `computeWorldPosition` takes the current node count as the placement index,
+ * and the count is read before the write rather than inside it — so two
+ * placements computed against the same count land at the same radius, separated
+ * only by `ANGLE_JITTER`. At index 0 they land on exactly the same point,
+ * because a jittered angle times a zero radius is still the origin. A
+ * `Promise.all` over a page would therefore stack the very people this function
+ * exists to make visible. The sequential `await` is the fix and must stay one.
+ *
+ * Like the tier backfill and for the same reason, it does **not** swallow: a
+ * run that half-finished and reported success is worse than one that stops and
+ * says where it stopped.
+ */
+export async function backfillCommunityGraphPlacements(
+  pageSize: number = PLACEMENT_BACKFILL_PAGE,
+): Promise<{ placed: number }> {
+  let after: string | null = null;
+  let placed = 0;
+
+  for (;;) {
+    const userIds: string[] = await graphRepo.findUnplacedUserIds(
+      after,
+      pageSize,
+    );
+    if (userIds.length === 0) return { placed };
+
+    for (const userId of userIds) {
+      // One at a time. See the note on concurrency above.
+      await joinCommunityGraph(userId);
+      placed += 1;
+    }
+
+    if (userIds.length < pageSize) return { placed };
+    after = userIds[userIds.length - 1] ?? null;
+  }
+}
+
+/**
  * Recompute the earned tier after a contribution that could have raised it.
  *
  * **When this runs.** The two moments the inputs change are publishing a review
@@ -473,19 +547,23 @@ export async function recordEarnedPersonalizationTierOnContribution(
 
 /**
  * The bounded read both windows are: the nearest `limit` nodes to `centre`, the
- * backbone edges spanning exactly that set, and nothing else.
+ * caller's own node if it was not among them, the backbone edges spanning
+ * exactly that set, and nothing else.
  *
- * This is `personal-community-viewport.md`'s "Bounded rendering" in one place —
+ * This is `shared-community-viewport.md`'s "Bounded rendering" in one place —
  * read a position, select a bounded set with a product-defined maximum, load
  * only the edges that set needs — so neither caller can quietly widen it.
  */
 async function readWindow(
   centre: WorldPosition,
   limit: number,
-  viewerUserId?: string,
+  viewer?: GraphNode,
   now: Date = new Date(),
 ): Promise<GraphWindow> {
-  const nodes = await graphRepo.findNearestNodes(centre, limit);
+  const nodes = await withViewer(
+    await graphRepo.findNearestNodes(centre, limit),
+    viewer,
+  );
   const userIds = nodes.map((node) => node.userId);
   // Two independent reads over the same bounded set. The tier bases are what
   // masks a dormant axis back to unconfigured, and they are fetched for the
@@ -494,7 +572,48 @@ async function readWindow(
     graphRepo.findBackboneEdgesWithin(userIds),
     graphRepo.findNodeTierBases(userIds),
   ]);
-  return anonymise({ centre, nodes, edges, viewerUserId, tierBases, now });
+  return anonymise({
+    centre,
+    nodes,
+    edges,
+    viewerUserId: viewer?.userId,
+    tierBases,
+    now,
+  });
+}
+
+/**
+ * The bounded set, guaranteed to contain the caller's own node.
+ *
+ * The window is the nodes nearest the **origin**, which is a set the caller has
+ * no special claim on: a member placed out at the edge of a community larger
+ * than `MAX_WINDOW_NODES` is simply not in it. Before, when the window was
+ * centred on them, they were in it by construction; now they have to be put
+ * back, or "you can always see your own dot" quietly stops being true at
+ * exactly the size where it starts to matter.
+ *
+ * Appending rather than displacing the farthest node: the bound is a cost
+ * policy, and one node past it costs nothing worth the extra rule. It is also
+ * the rare path — every member inside the window returns here untouched, having
+ * spent no query at all.
+ *
+ * The appearance is read separately because `findNearestNodes` is what normally
+ * carries it and this node did not come from there. No profile row is a normal
+ * state, not an error, so it reads as unconfigured — the same answer the column
+ * defaults give.
+ */
+async function withViewer(
+  nearest: NeighbourNode[],
+  viewer?: GraphNode,
+): Promise<NeighbourNode[]> {
+  if (!viewer) return nearest;
+  if (nearest.some((node) => node.userId === viewer.userId)) return nearest;
+
+  const appearance = await graphRepo.findNodeProfile(viewer.userId);
+  return [
+    ...nearest,
+    { ...viewer, ...(appearance ?? UNCONFIGURED_APPEARANCE) },
+  ];
 }
 
 /**

--- a/docs/adr/0003-context-vocabulary.md
+++ b/docs/adr/0003-context-vocabulary.md
@@ -85,7 +85,7 @@ Three rules keep those lines honest:
 None of `users_graph_nodes`, `users_graph_backbone_edges`,
 `users_node_profiles` or `users.personalization_tier_earned` exists. Their words
 are settled anyway, by the design and by
-[`personal-community-viewport.md`](../landing_docs/personal-community-viewport.md), and
+[`shared-community-viewport.md`](../landing_docs/shared-community-viewport.md), and
 every one of those entries carries a `_Today_` line saying the table is absent
 and the landing hero renders a synthetic field.
 

--- a/docs/adr/0006-hero-signals-dramatise-the-community.md
+++ b/docs/adr/0006-hero-signals-dramatise-the-community.md
@@ -57,7 +57,7 @@ would have made the feature invisible on a community where personalisation has
 close to no writers, which is the situation #68 recorded and accepted.
 
 **A friendship must never be drawn as an edge on this canvas, and must never emit
-a signal.** `docs/landing_docs/personal-community-viewport.md` defers a real
+a signal.** `docs/landing_docs/shared-community-viewport.md` defers a real
 friend feature whose mechanism is a "wormhole" that *moves the camera* to a
 friend's neighbourhood without touching either user's placement or backbone
 connections. That language — camera movement, not travelling light — stays

--- a/docs/landing_docs/shared-community-viewport.md
+++ b/docs/landing_docs/shared-community-viewport.md
@@ -1,20 +1,39 @@
-# Personal community viewport strategy
+# Shared community viewport strategy
 
-Updated: 2026-08-29  
+Updated: 2026-09-07  
 Status: approved graph direction reflected in the current Lucidchart target.
+
+Supersedes the personal-viewport rule this document carried until 2026-09-07, under which each member's window was centred on their own node. See "One graph, one centre" below for why that was reversed.
 
 ## Product behavior
 
-The community is a persistent global graph with a virtual coordinate system. A returning user keeps the same world-space position and a familiar local neighborhood. The landing page renders a bounded viewport around that position rather than rebuilding the entire graph or generating new positions and edges on every visit.
+The community is a persistent global graph with a virtual coordinate system. A returning user keeps the same world-space position and the same neighbors around it. The landing page renders a bounded viewport on that graph rather than rebuilding it or generating new positions and edges on every visit.
 
 World coordinates are not browser pixels. The frontend projects them into the current device and may apply responsive content-avoidance adjustments without changing the persisted position:
 
 ```text
-screenX = (node.x - currentUser.x) * scale + viewportCenterX
-screenY = (node.y - currentUser.y) * scale + viewportCenterY
+screenX = (node.x - communityOrigin.x) * scale + cameraX
+screenY = (node.y - communityOrigin.y) * scale + cameraY
 ```
 
 Do not persist viewport width, height, or browser-specific screen coordinates. A separate camera-preference record is unnecessary until free pan/zoom and resume-last-view become explicit features.
+
+## One graph, one centre
+
+Every window is centred on the community origin, for members and visitors alike. A member is **not** drawn at the middle of their own screen.
+
+The rule this replaces centred each member's window on their own node. That is a claim the data does not support: if every reader is the centre, then two members comparing screens are both the centre, and the graph reads as a diorama generated per viewer rather than as one community they are both in. Centring everyone on the origin makes a member's position checkable — the same nodes in the same arrangement on both screens, with two different dots lit up.
+
+Finding yourself is the camera's job, on the client, and it is deliberately the smallest possible intervention:
+
+1. Choose the camera from the frame and the copy alone, exactly as a visitor's page does.
+2. If the reader's own node would fall outside the canvas, translate the camera by the fewest pixels that bring it inside, and by no more.
+
+A pan translates every node equally, so it changes which part of the graph is on screen and never what the graph looks like. For a member near the origin it moves nothing at all, and their page is byte-identical to the visitor's. Panning further than step 2 requires is how a shared picture turns back into a personal one, so it is not done.
+
+Nodes pushed off the far edge by that pan are not a failure. A member out at the rim seeing the community from the rim is the honest picture; the rest of the graph is still there, simply not in this viewport.
+
+The reader's own node must always be **in the payload**, even when the bounded set would not have reached it. Once the community is larger than the visible-node maximum, a member out past that bound is not among the nodes nearest the origin, and no amount of panning can show a dot the response does not contain.
 
 ## Lucidchart target
 
@@ -61,13 +80,13 @@ Do not globally reposition established users whenever the community grows. Add n
 
 The landing page never loads the whole community:
 
-1. Read the current user's persistent `x`/`y`.
-2. Select a bounded nearby/relevant node set with a product-defined maximum.
-3. Load the backbone edges needed for that set.
+1. Select a bounded node set around the community origin, with a product-defined maximum.
+2. For a signed-in reader, add their own node to that set if it is not already in it, and flag it as theirs.
+3. Load the backbone edges needed for the resulting set.
 4. Project world coordinates into the current viewport.
-5. Render only that local neighborhood.
+5. Render that set.
 
-The maximum visible-node count is a frontend/query policy, not a column in the database target.
+The maximum visible-node count is a frontend/query policy, not a column in the database target. It is one number, not one per caller: a member and a visitor are served the same slice of the same graph, and a second bound would be a second picture waiting to happen.
 
 ## Persistence boundary
 

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "docker:web:build": "bun run --filter kth-course-community-web build",
     "ingest": "bun run --filter kth-course-community-web ingest",
     "backfill:tiers": "bun run --filter kth-course-community-web backfill:tiers",
+    "backfill:placements": "bun run --filter kth-course-community-web backfill:placements",
     "db:push": "bun run --filter kth-course-community-web db:push",
     "db:generate": "bun run --filter kth-course-community-web db:generate",
     "db:migrate": "bun run --filter kth-course-community-web db:migrate",


### PR DESCRIPTION
Five accounts were drawing two dots on the landing hero. Two separate causes, both fixed here.

## Every account gets a node

One of the five had no `users_graph_nodes` row at all. Placement has two paths and neither is a guarantee: the sign-up hook swallows its own failures by design (a graph outage must not cost somebody their account), and accounts older than the graph never saw it.

`bun run backfill:placements` walks the app users with no node and places them through the same idempotent `joinCommunityGraph`. Safe to re-run — a second pass finds nobody and writes nothing.

It places **strictly one at a time**, and that is not incidental: `computeWorldPosition` takes the current node count as the placement index and reads it before the write, so a `Promise.all` over a page would land the whole page on one radius — and at index 0 on exactly one point, because a jittered angle times a zero radius is still the origin. That is the test with teeth.

Like `backfill:tiers`, it does not swallow: a run that half-finished and reported success is worse than one that stops and says where.

## Nobody is the centre of their own community

The member read was centred on the caller and returned the nodes nearest *them*, so every member was drawn at the middle of their own screen. Put two members' screens side by side and both are the centre — the graph stops reading as one community and starts reading as something generated per viewer.

Every window is now centred on `COMMUNITY_ORIGIN`. A member gets the visitor's window with one node flagged as theirs, and the client nudges the camera by the fewest pixels that bring that node onto the canvas. A pan translates every node equally, so it changes which part of the graph is on screen and never what the graph looks like: two friends compare the same nodes in the same arrangement, with two different dots lit up. For a member near the origin it moves nothing at all and their page is the visitor's page exactly.

Nodes pushed off the far edge by the pan stay off it. A member out at the rim seeing the community from the rim is the honest picture, and the rest of the graph is still there — just not in this viewport.

The window also has to *contain* the caller. Once the community outgrows `MAX_WINDOW_NODES`, a member out past the bound is not among the nodes nearest the origin, and no amount of panning shows a dot the payload does not carry — so `withViewer` appends it, at the cost of one extra profile read and only on that rare path.

`MAX_NEIGHBOURHOOD_NODES` and `MAX_PUBLIC_WINDOW_NODES` collapse into one `MAX_WINDOW_NODES`: there is one window now, and a second bound would be a second picture waiting to happen.

## Docs

`personal-community-viewport.md` encoded the old rule in its projection formula (`node.x - currentUser.x`) and in step 1 of Bounded rendering. It is rewritten and renamed to `shared-community-viewport.md`, and its five citations are swept to the new path in the same commit.

## Checks

- 1414 tests pass (93 files), typecheck and lint clean.
- Backfill run against the dev database: placed 1, and reported nothing to do on a second run.
- Landing hero verified in Chrome against the real data.

## Note for the reviewer

This reverses two documented decisions on the product owner's instruction: the personal viewport in `personal-community-viewport.md`, and — as a consequence — the invariant that the projection's centre is `pickViewportCentre`'s answer whatever the window holds. The test pinning the latter is rewritten rather than deleted, and now asserts what survives: the camera reads the window's shape, never its position in world space.

`pushClear` is deliberately left alone. It moves individual nodes out from under the copy, so two members at different window sizes still see slightly different arrangements of the same neighbours — the remaining leak in the "we could both check and it holds up" property. It has its own history and bundling it here would reverse a third decision in one commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DxpL1ED7zRZLf8JvaC1jdS
