### PR TITLE
docs: the placement backfill in the quick reference, and a shared graph window

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,6 +13,7 @@ Bun workspace monorepo (`workspaces: ["apps/*"]`). The only app is `apps/web`: N
 - DB: `bun run db:push` / `bun run db:generate`
 - Ingest: `bun run ingest` (optional `--test`)
 - Backfill earned personalization tiers: `bun run backfill:tiers` (idempotent; only ever raises)
+- Backfill missing graph nodes: `bun run backfill:placements` (idempotent; places app users who have none)
 
 Run scripts from the repo root. Env lives in `apps/web/.env.local` (see `apps/web/.env.example`). Path alias `@/*` → `apps/web/*`.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -13,6 +13,7 @@ Bun workspace monorepo (`workspaces: ["apps/*"]`). The only app is `apps/web`: N
 - DB: `bun run db:push` / `bun run db:generate`
 - Ingest: `bun run ingest` (optional `--test`)
 - Backfill earned personalization tiers: `bun run backfill:tiers` (idempotent; only ever raises)
+- Backfill missing graph nodes: `bun run backfill:placements` (idempotent; places app users who have none)
 
 Run scripts from the repo root. Env lives in `apps/web/.env.local` (see `apps/web/.env.example`). Path alias `@/*` → `apps/web/*`.
 

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -145,8 +145,9 @@ bulk review, quick rating
 
 **Community graph**:
 One persistent global graph of app users in a shared world coordinate space. It
-is not rebuilt per visit: a returning user keeps their place and their
-neighbourhood.
+is not rebuilt per visit and not rebuilt per reader: a returning user keeps
+their place, and the people around them are the same people on anybody else's
+screen.
 _Avoid_: network, social graph, map, constellation
 
 **Node**:
@@ -174,11 +175,25 @@ _Avoid_: friendship, connection, follow, link, relationship
 
 **Graph window**:
 The bounded slice of the **community graph** a surface draws: a limited set of
-nodes and the **backbone edges** that run between them. A member's window is
-centred on their own node and is the one place "neighbourhood" means; a
-visitor's is centred on the community origin. It is derived per read and never
-stored, and an edge with one end outside it is not part of it.
-_Avoid_: viewport, camera, subgraph, cluster
+nodes and the **backbone edges** that run between them. It is centred on the
+community origin for everybody — a member's window is a visitor's window with
+one node flagged as theirs. Nobody is drawn at the middle of their own
+community: if every reader were the centre, two members comparing screens would
+both be it. It is derived per read and never stored, and an edge with one end
+outside it is not part of it.
+_Avoid_: viewport, subgraph, cluster, neighbourhood (a window is not centred on
+anybody, so it is nobody's neighbourhood). Not **camera** either: the window is
+which nodes a surface draws, the camera is where it puts them.
+
+**Camera**:
+Where a **graph window** lands on the canvas. Chosen from the frame and the copy
+alone, then nudged by the fewest pixels that bring the reader's own node onto
+the canvas — and by no more, because panning further starts composing a personal
+view of a shared graph. A pan translates every node equally, so it changes which
+part of the graph is on screen and never what the graph looks like. Nodes it
+leaves off the edge are still in the community; they are simply not in this
+viewport.
+_Avoid_: centre (that is the window's, in world units), zoom, focus
 
 **Node profile**:
 A node's appearance, stored separately from graph topology.


### PR DESCRIPTION
Follow-up to #222, which shipped `bun run backfill:placements` and made every graph window centred on the community origin — but left three documents describing the world before it.

## Quick reference

`CLAUDE.md` and `AGENTS.md` list one backfill. There are two now, and they are independent: one gives accounts a graph node, the other gives contributors the personalization tier they already earned. An agent that cannot see the second one will reach for SQL.

## Domain language

`CONTEXT.md` is where the words are settled, so a stale entry there is worse than a stale comment — it is the thing other documents are checked against.

**Graph window** said *"a member's window is centred on their own node and is the one place 'neighbourhood' means; a visitor's is centred on the community origin."* Both halves are now false. Every window is origin-centred, and a member's window is a visitor's window with one node flagged as theirs. "Neighbourhood" no longer names anything, because no window is centred on anybody — it moves to _Avoid_.

**Camera** is added as its own term, because the change split one idea into two. The window is *which nodes* a surface draws; the camera is *where it puts them*, and only the camera knows who is reading. Keeping them one word is what would let "just centre it on the viewer" back in.

**Community graph** gains one clause: not rebuilt per visit *and not rebuilt per reader*. That is the property the whole change exists to protect — two friends comparing screens see the same people in the same arrangement.

Docs only; no code, no tests affected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DxpL1ED7zRZLf8JvaC1jdS
