### PR TITLE
refactor(search): remove dead focus utility (#214)

### DIFF
--- a/apps/web/app/globals.css
+++ b/apps/web/app/globals.css
@@ -545,17 +545,15 @@
 
    ## The hand-rolled treatments that remain
 
-   This rule is meant to be the only focus treatment in the app. Three call
-   sites in `features/**` still carry their own, and each says why at the call
+   This rule is meant to be the only focus treatment in the app. Two call sites
+   in `features/**` still carry their own, and each says why at the call
    site: `review-draft-panel.tsx`'s checkbox ring (painted on a sibling of an
    `sr-only` peer, which this rule cannot reach), `workspace-pane.tsx`'s
-   `focus:bg-cc-pill` (a menu highlight, not a ring), and
-   `search/components/explore.tsx`'s `focus-visible:outline-cc-brand`, which
-   this rule already overrides and which is therefore dead. Anything else added
-   in `features/**` is a duplicate of this rule — with one exception, which is
-   the `data-cc-field` rule below and is not a duplicate but a *move*: the two
-   search bars draw this treatment on the box the reader sees instead of on the
-   input inside it. */
+   `focus:bg-cc-pill` (a menu highlight, not a ring). Anything else added in
+   `features/**` is a duplicate of this rule — with one exception, which is the
+   `data-cc-field` rule below and is not a duplicate but a *move*: the two search
+   bars draw this treatment on the box the reader sees instead of on the input
+   inside it. */
 :focus-visible:not([tabindex="-1"]) {
   /* biome-ignore lint/complexity/noImportantStyles: it has to beat the 22 inline `outline:none` declarations the artboards carry, and the shadcn primitives' own ring. Without it a focus style exists everywhere except where it is needed. */
   outline: 2px solid var(--cc-focus) !important;

--- a/apps/web/features/search/components/explore.tsx
+++ b/apps/web/features/search/components/explore.tsx
@@ -641,7 +641,7 @@ function ResultsSkeleton() {
  *
  */
 const SELECT_CLASS =
-  "h-[34px] min-w-0 max-w-full cursor-pointer rounded-[8px] border border-cc-rule3 bg-cc-surface px-2.5 font-medium text-[12.5px] text-cc-chip-ink @3xl:w-[11rem] hover:border-cc-hov focus-visible:outline-cc-brand";
+  "h-[34px] min-w-0 max-w-full cursor-pointer rounded-[8px] border border-cc-rule3 bg-cc-surface px-2.5 font-medium text-[12.5px] text-cc-chip-ink @3xl:w-[11rem] hover:border-cc-hov";
 
 /**
  * The school filter, and the only filter.


### PR DESCRIPTION
Closes #214.

## Summary

- remove the redundant `focus-visible:outline-cc-brand` utility from the school filter
- update the global focus-treatment inventory to document the two intentional feature-local exceptions
- preserve the existing global `!important` focus outline behavior

## Checks

- targeted Biome check passed
- `explore.spec.tsx` and `theme-tokens.spec.tsx`: 76 tests passed
- `git diff --check` passed

Manual QA should use `/search`; the issue body still refers to the retired `/explore` route.