### PR TITLE
fix(taken): one search bar, and a focus ring that lands on it

### DIFF
--- a/apps/web/app/globals.css
+++ b/apps/web/app/globals.css
@@ -551,7 +551,7 @@
    `sr-only` peer, which this rule cannot reach), `workspace-pane.tsx`'s
    `focus:bg-cc-pill` (a menu highlight, not a ring). Anything else added in
    `features/**` is a duplicate of this rule — with one exception, which is the
-   `data-cc-field` rule below and is not a duplicate but a *move*: the two search
+   `data-cc-field` rule below and is not a duplicate but a *move*: the search
    bars draw this treatment on the box the reader sees instead of on the input
    inside it. */
 :focus-visible:not([tabindex="-1"]) {
@@ -575,10 +575,11 @@
 
    The rule lands on whatever element actually takes focus, which is normally
    the thing the reader sees. It is not, for a text field inside a box that is
-   drawn as the control — Explore's search bar and the landing's hero bar are a
-   bordered 42px box around a transparent input, so the ring came up around the
-   *text*: a rounded rectangle floating inside another rounded rectangle, two
-   pixels of surface showing between them.
+   drawn as the control — `CourseSearchField` (Explore's bar, and the catalogue
+   search in "Add a course by hand") and the landing's hero bar are a bordered
+   42px box around a transparent input, so the ring came up around the *text*: a
+   rounded rectangle floating inside another rounded rectangle, two pixels of
+   surface showing between them.
 
    `data-cc-field` marks such an input. It suppresses that input's own ring and
    nothing else; the wrapper takes the treatment instead, through
@@ -589,9 +590,14 @@
    exists to avoid.
 
    **An input carrying this attribute and nothing lighting up around it has no
-   focus indicator at all.** That is why it is a deliberate mark on two known
-   bars rather than a class to reach for: pair it with a wrapper treatment or do
-   not use it.
+   focus indicator at all.** That is why it is a deliberate mark on the two
+   components that draw such a box rather than a class to reach for: pair it
+   with a wrapper treatment or do not use it.
+
+   The inverse is what "Add a course by hand" shipped — a bar built to look like
+   Explore's, carrying neither half — and the ring came up around its text.
+   Keeping the pair inside `features/search/components/course-search-field.tsx`
+   is what stops another one being drawn the same way.
 
    Specificity is 0,3,0 against the rule above's 0,2,0, so it wins on its own
    terms rather than on where it happens to sit in this file.

--- a/apps/web/features/search/components/course-search-field.tsx
+++ b/apps/web/features/search/components/course-search-field.tsx
@@ -1,0 +1,84 @@
+"use client";
+
+import { Search as SearchIcon } from "lucide-react";
+import { cn } from "@/lib/utils";
+
+type Props = {
+  value: string;
+  onChange: (value: string) => void;
+  placeholder: string;
+  /** The field's accessible name. There is no visible label inside the bar. */
+  label: string;
+  /**
+   * Layout only — the width cap, the margins, the place in a row. The bar's own
+   * shape (its height, border, radius and focus treatment) is not a prop,
+   * because a caller that changes it stops being this bar.
+   */
+  className?: string;
+};
+
+/**
+ * The bar a course is searched from — Explore's, and the catalogue search
+ * inside "Add a course by hand".
+ *
+ * From `docs/design_ref/2026-09-06/Course Community - Explore.dc.html`. The
+ * modal in `Course Community - Taken Courses.dc.html` draws its own bar a
+ * hair tighter (9px radius, 13px padding, 13.5px text); this renders Explore's
+ * measurements in both places. They are one control to the reader — the same
+ * icon, the same box, searching the same catalogue — and the half-pixel
+ * differences between the two artboards buy nothing that being one component
+ * does not buy more of.
+ *
+ * ## The focus treatment is the reason this is a component
+ *
+ * The bar *is* the control here: the input inside it is transparent and
+ * unbordered, so the app's one focus ring came up around the *text*, inside
+ * the bar's own border, with a couple of pixels of surface showing between the
+ * two rounded rectangles. `data-cc-field` suppresses the input's own ring and
+ * `has-[input:focus-visible]:border-cc-focus` lights the box's border instead.
+ * Both halves are argued in `globals.css`, and **neither works without the
+ * other** — an input carrying `data-cc-field` with nothing lighting up around
+ * it has no focus indicator at all. Keeping the pair in one place is what
+ * stops a third bar being built with only one half of it, which is how the
+ * modal's bar came to ring its text.
+ *
+ * The landing's hero bar is deliberately not this component. It is the element
+ * `search-morph.tsx` measures and animates, and it carries `data-hero-clear`
+ * for the graph's keep-out — it is a bar with a second job, and it renders the
+ * same pair by hand with a comment saying so.
+ */
+export function CourseSearchField({
+  value,
+  onChange,
+  placeholder,
+  label,
+  className,
+}: Props) {
+  return (
+    <div
+      className={cn(
+        "flex h-[42px] items-center gap-2.5 rounded-[10px] border border-cc-rule3 bg-cc-surface px-3.5 has-[input:focus-visible]:border-cc-focus",
+        className,
+      )}
+    >
+      <SearchIcon
+        size={16}
+        strokeWidth={2}
+        aria-hidden
+        className="shrink-0 text-cc-muted"
+      />
+      {/* `type="search"` for the Escape-clears and the semantics; the native
+          clear button is hidden because the artboard draws none, and the two
+          surfaces that use this bar both offer their own way back to nothing. */}
+      <input
+        type="search"
+        data-cc-field
+        value={value}
+        onChange={(event) => onChange(event.target.value)}
+        placeholder={placeholder}
+        aria-label={label}
+        className="min-w-0 flex-1 border-none bg-transparent text-[14px] text-cc-ink outline-none placeholder:text-cc-dim2 [&::-webkit-search-cancel-button]:hidden"
+      />
+    </div>
+  );
+}

--- a/apps/web/features/search/components/explore.tsx
+++ b/apps/web/features/search/components/explore.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { RotateCcw, Search as SearchIcon, TriangleAlert } from "lucide-react";
+import { RotateCcw, TriangleAlert } from "lucide-react";
 import type { ReactNode } from "react";
 import { useEffect, useRef } from "react";
 import { AuthReasonDialog } from "@/features/auth";
@@ -9,6 +9,7 @@ import { PageColumn, PageHeader, useSearchBarArrival } from "@/features/shell";
 import { useWorkspaceHost, WorkspaceHost } from "@/features/workspace";
 import { dismissKeyboard } from "@/lib/dismiss-keyboard";
 import { useExplore } from "../hooks/use-explore";
+import { CourseSearchField } from "./course-search-field";
 
 /**
  * Explore: the search-and-browse workspace, and the app's front door to the
@@ -207,32 +208,17 @@ export function Explore() {
           className="w-full min-w-0 max-w-[var(--cc-search-bar-w)]"
         >
           {/*
-            The focus treatment is on this box and not on the field inside it.
-            The bar *is* the control to the reader — the input is transparent and
-            unbordered — so the app's ring came up around the text, inside the
-            bar's own border, with a couple of pixels of surface showing between
-            the two rounded rectangles. The border lights up instead, and
-            `data-cc-field` on the input is what stops the ring being drawn twice.
-            Both halves are argued in `globals.css`; neither works without the
-            other.
+            The bar itself, shared with the catalogue search in Taken courses'
+            "Add a course by hand" — including the focus treatment, which is on
+            the box and not on the field inside it. `course-search-field.tsx`
+            argues both.
           */}
-          <div className="flex h-[42px] items-center gap-2.5 rounded-[10px] border border-cc-rule3 bg-cc-surface px-3.5 has-[input:focus-visible]:border-cc-focus">
-            <SearchIcon
-              size={16}
-              strokeWidth={2}
-              className="shrink-0 text-cc-muted"
-              aria-hidden
-            />
-            <input
-              type="search"
-              data-cc-field
-              value={explore.field}
-              onChange={(event) => explore.onQueryChange(event.target.value)}
-              placeholder="Search a course, code or subject"
-              aria-label="Search courses"
-              className="min-w-0 flex-1 border-none bg-transparent text-[14px] text-cc-ink outline-none placeholder:text-cc-dim2 [&::-webkit-search-cancel-button]:hidden"
-            />
-          </div>
+          <CourseSearchField
+            value={explore.field}
+            onChange={explore.onQueryChange}
+            placeholder="Search a course, code or subject"
+            label="Search courses"
+          />
         </form>
 
         {/* Outside the form: each filter is its own committed choice, so there

--- a/apps/web/features/search/index.ts
+++ b/apps/web/features/search/index.ts
@@ -1,14 +1,16 @@
 /**
  * The cross-feature API of the search feature.
  *
- * `Explore` is the workspace. `useSearchCourses` and `useDebouncedQuery` cross
- * the boundary because a second surface looks courses up in the catalogue:
- * Taken courses has to find the course a reader is adding by hand, and
- * `search.courses` is the only procedure that finds one by code or name. It
- * reuses this hook rather than wrapping the procedure again, so both surfaces
- * share one query key and one debounce.
+ * `Explore` is the workspace. `useSearchCourses`, `useDebouncedQuery` and
+ * `CourseSearchField` cross the boundary because a second surface looks courses
+ * up in the catalogue: Taken courses has to find the course a reader is adding
+ * by hand, and `search.courses` is the only procedure that finds one by code or
+ * name. It reuses the hooks rather than wrapping the procedure again, so both
+ * surfaces share one query key and one debounce — and it reuses the bar, so
+ * both surfaces search from one control rather than two that drift.
  */
 
 export { useSearchCourses } from "./api/queries";
+export { CourseSearchField } from "./components/course-search-field";
 export { Explore } from "./components/explore";
 export { useDebouncedQuery } from "./hooks/use-debounced-query";

--- a/apps/web/features/taken/components/add-taken-course-dialog.tsx
+++ b/apps/web/features/taken/components/add-taken-course-dialog.tsx
@@ -1,6 +1,5 @@
 "use client";
 
-import { Search } from "lucide-react";
 import { useState } from "react";
 import {
   Dialog,
@@ -8,7 +7,11 @@ import {
   DialogDescription,
   DialogTitle,
 } from "@/components/ui/dialog";
-import { useDebouncedQuery, useSearchCourses } from "@/features/search";
+import {
+  CourseSearchField,
+  useDebouncedQuery,
+  useSearchCourses,
+} from "@/features/search";
 import { creditsLabel, type TakenEdits } from "../lib/taken-rows";
 
 /** The credits a KTH course usually carries, as the artboard's own chips. */
@@ -151,24 +154,21 @@ export function AddTakenCourseDialog({
           <span className="font-medium text-[11.5px] text-cc-dim">
             Search the KTH catalogue
           </span>
-          <div className="mt-1.5 flex h-[42px] items-center gap-2.5 rounded-[9px] border border-cc-rule3 bg-cc-surface px-[13px]">
-            <Search
-              size={16}
-              strokeWidth={2}
-              aria-hidden
-              className="flex-none text-cc-dim"
-            />
-            <input
-              value={query}
-              onChange={(event) => {
-                setQuery(event.target.value);
-                setPicked(null);
-              }}
-              placeholder="Course code or name, e.g. DD2421"
-              aria-label="Search the KTH catalogue"
-              className="min-w-0 flex-1 border-none bg-transparent text-[13.5px] text-cc-ink outline-none"
-            />
-          </div>
+          {/* Explore's bar, not a second one drawn to look like it. The
+              hand-rolled copy that stood here carried the box but not the
+              `data-cc-field` half of its focus treatment, so the app's ring came
+              up around the *text* inside the bar instead of on the bar's own
+              edge. */}
+          <CourseSearchField
+            className="mt-1.5"
+            value={query}
+            onChange={(next) => {
+              setQuery(next);
+              setPicked(null);
+            }}
+            placeholder="Course code or name, e.g. DD2421"
+            label="Search the KTH catalogue"
+          />
         </div>
 
         {picked === null && debounced.trim() !== "" ? (

--- a/apps/web/features/taken/components/taken-courses.spec.tsx
+++ b/apps/web/features/taken/components/taken-courses.spec.tsx
@@ -121,7 +121,16 @@ vi.mock("@/features/reviews/components/reviewer", () => ({
     );
   },
 }));
-vi.mock("@/features/search", () => ({
+// The barrel is stubbed rather than loaded because it also exports `Explore`,
+// which drags in the tRPC client. `CourseSearchField` is handed back real: the
+// add-by-hand dialog searches from Explore's own bar, and a stub of it would
+// hide the focus treatment that is the reason the bar is shared at all.
+vi.mock("@/features/search", async () => ({
+  CourseSearchField: (
+    await vi.importActual<
+      typeof import("@/features/search/components/course-search-field")
+    >("@/features/search/components/course-search-field")
+  ).CourseSearchField,
   useDebouncedQuery: (value: string) => [value, vi.fn()] as const,
   useSearchCourses: ({ q }: { q: string }) => ({
     data: q.trim() ? { results: searchResults() } : undefined,
@@ -417,6 +426,30 @@ describe("editing in place", () => {
 });
 
 describe("adding by hand", () => {
+  /**
+   * The bar is Explore's, and the reason it is Explore's rather than a second
+   * one drawn to match: the box is what the reader sees as the control, so the
+   * app's one focus ring has to land on its border and not around the text
+   * inside it. The copy that stood here carried neither half of that treatment.
+   *
+   * Both halves are asserted together because neither works alone: without
+   * `data-cc-field` there are two rings, and without the border variant there
+   * is none at all. `globals.css` argues the pair.
+   */
+  it("searches from the same bar Explore does", async () => {
+    render(<TakenCourses />);
+
+    await userEvent.click(
+      screen.getByRole("button", { name: "Add a course by hand" }),
+    );
+
+    const field = screen.getByLabelText("Search the KTH catalogue");
+    expect(field).toHaveAttribute("data-cc-field");
+    expect(field.parentElement).toHaveClass(
+      "has-[input:focus-visible]:border-cc-focus",
+    );
+  });
+
   it("records a course the reader picked out of the catalogue", async () => {
     render(<TakenCourses />);
 


### PR DESCRIPTION
## What

The catalogue search in **Add a course by hand** drew its own bar to look like Explore's, and carried neither half of Explore's focus treatment — so the app's one focus ring came up around the *text* inside the bar instead of on the bar's own edge.

Explore's bar is now `features/search/components/course-search-field.tsx`, and both surfaces render it.

## Why a component and not two more classes

The treatment is a pair — `data-cc-field` on the input to suppress its own ring, and `has-[input:focus-visible]:border-cc-focus` on the box to light the border instead — and **neither half does anything alone**: an input carrying only the attribute has no focus indicator at all. `globals.css` has said so for a while; a second bar built by hand is exactly how one half goes missing. Keeping the pair inside one component is what stops that happening again.

## Notes

- The modal artboard (`docs/design_ref/2026-09-06/Course Community - Taken Courses.dc.html`) draws its bar a hair tighter than Explore's — 9px radius, 13px padding, 13.5px text against 10/14/14. The shared component renders Explore's measurements in both places: they are one control to the reader, searching one catalogue, and the half-pixels buy less than being one component does.
- The dialog's field is now `type="search"`, as Explore's is. The native clear button stays hidden, as it is on Explore.
- **The landing's hero bar is deliberately left hand-rolled.** It is the element `search-morph.tsx` measures and animates between the hero and Explore, and it carries `data-hero-clear` for the graph's keep-out — a bar with a second job. It renders the same pair by hand with a comment saying so.
- `globals.css`'s argument for `data-cc-field` is updated to name the component, and to record what shipped without it.

## Testing

- `bun run lint`, `bun run typecheck` clean.
- `bun run test:web` — 1416 passed (93 files), including a new `adding by hand > searches from the same bar Explore does`, which asserts both halves of the treatment on the dialog's field.
- Checked in Chrome on `/search`: the bar renders 460×42 at 10px radius with a 14px field, and on keyboard focus the box's border lights up with no ring drawn around the text. The dialog itself is behind sign-in for a guest, so it was verified by the unit test rather than by hand.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RHqbg5vtuZATmLqo2ywSe2
