### PR TITLE
fix(transcript): persist fill-only imports

### DIFF
--- a/apps/web/features/taken/components/taken-courses.spec.tsx
+++ b/apps/web/features/taken/components/taken-courses.spec.tsx
@@ -737,6 +737,7 @@ describe("reading a transcript", () => {
   });
 
   it("fills only an empty field, and keeps the periods while doing it", async () => {
+    confirmImport.mockResolvedValue({ inserted: 0, updated: 1 });
     takenList.mockReturnValue([
       takenCourse({ grade: null, earnedCredits: 9, attendancePeriods: "P3" }),
     ]);
@@ -767,6 +768,50 @@ describe("reading a transcript", () => {
       }),
     );
     expect(updateTaken).not.toHaveBeenCalled();
+    expect(
+      screen.getByText(
+        "Transcript saved — 1 course had a missing field filled in",
+      ),
+    ).toBeInTheDocument();
+    expect(screen.queryByText(/new course/)).not.toBeInTheDocument();
+  });
+
+  it("reports server-confirmed creates and fills as separate counts", async () => {
+    confirmImport.mockResolvedValue({ inserted: 1, updated: 1 });
+    takenList.mockReturnValue([takenCourse({ grade: null })]);
+    uploadTranscript.mockResolvedValue(
+      proposal({
+        candidates: [
+          ...proposal().candidates,
+          {
+            courseCode: "DD2380",
+            transcriptName: "Artificiell intelligens",
+            catalogueName: "Artificial Intelligence",
+            grade: "A",
+            earnedCredits: 6,
+            attendanceYear: 2026,
+          },
+        ],
+      }),
+    );
+    render(<TakenCourses />);
+    await userEvent.click(
+      screen.getByRole("button", { name: "Update transcript" }),
+    );
+    await userEvent.click(
+      screen.getByRole("switch", { name: /Read grades from transcript/ }),
+    );
+    await uploadPdf();
+    await userEvent.click(
+      await screen.findByRole("button", { name: "Looks right" }),
+    );
+
+    expect(
+      await screen.findByText(
+        "Transcript saved — 1 new course, 1 course had a missing field filled in",
+      ),
+    ).toBeInTheDocument();
+    expect(screen.queryByText(/2 new courses/)).not.toBeInTheDocument();
   });
 
   it("keeps the transcript's grades once the reader asks for them", async () => {

--- a/apps/web/features/taken/components/taken-courses.tsx
+++ b/apps/web/features/taken/components/taken-courses.tsx
@@ -535,10 +535,10 @@ export function TakenCourses() {
   /**
    * Makes the writes the confirmed proposal describes, and only those.
    *
-   * New courses go through `transcript.confirm`, which stamps them imported.
-   * Courses the reader already has are only touched to fill an empty field,
-   * and then through `taken.update`, which cannot overwrite what they
-   * corrected by hand — see `planTranscriptImport`.
+   * New courses and fills both go through `transcript.confirm`. New rows are
+   * stamped imported; existing courses are touched only where a field remains
+   * empty, so the endpoint cannot overwrite what the reader corrected by hand
+   * — see `planTranscriptImport`.
    *
    * **The plan is built against a freshly read list, not the render's copy.**
    * It lets the page fill fields that are already empty, and it makes retries
@@ -598,9 +598,7 @@ export function TakenCourses() {
       setIsResumed(false);
       clearGuestProposal();
       pendingHandoff.current = null;
-      setBanner(
-        importedSummary(written.inserted + written.updated, plan.fill.length),
-      );
+      setBanner(importedSummary(written.inserted, written.updated));
     } catch (error) {
       setConfirmError(
         error instanceof Error && error.message

--- a/apps/web/features/taken/lib/taken-rows.ts
+++ b/apps/web/features/taken/lib/taken-rows.ts
@@ -98,17 +98,17 @@ export type ConfirmedCourse = {
  * keep the edits you made — only new rows and missing fields are filled in."*
  * Two things in the write path make that a split rather than one call.
  *
- * So a course the reader does not have yet goes through `transcript.confirm`,
- * which atomically inserts only absent rows and stamps `transcript_imported_at`.
- * A course they already have is
- * only touched when the transcript can fill a field that is still empty, and
- * then through `taken.update`, which writes the whole row — stored values
- * included, periods carried — and leaves provenance alone.
+ * So a course the reader does not have yet goes through `transcript.confirm`
+ * as a create, which atomically inserts only absent rows and stamps
+ * `transcript_imported_at`. A course they already have goes through the same
+ * endpoint as a fill only when the transcript can supply a field that is still
+ * empty. The fill keeps every non-empty stored value and leaves provenance
+ * alone.
  */
 export type TranscriptImportPlan = {
   /** Courses with no row yet. Written by `transcript.confirm`, stamped imported. */
   create: ConfirmedCourse[];
-  /** Rows that exist and have an empty field the transcript can fill. */
+  /** Existing rows whose empty fields `transcript.confirm` can fill. */
   fill: TakenUpdateInput[];
   /** Rows the reader already has with nothing missing. Nothing writes to these. */
   unchanged: number;

--- a/apps/web/server/ingest/transcript/service.spec.ts
+++ b/apps/web/server/ingest/transcript/service.spec.ts
@@ -95,7 +95,7 @@ describe("buildTranscriptProposal", () => {
 
     await buildTranscriptProposal(fixture("ladok-english.txt"));
 
-    expect(takenService.recordTranscriptCoursesIfAbsent).not.toHaveBeenCalled();
+    expect(takenService.recordTranscriptConfirmation).not.toHaveBeenCalled();
   });
 });
 
@@ -121,7 +121,7 @@ describe("confirmTranscriptImport", () => {
     vi.mocked(courseService.getSummariesByCodes).mockResolvedValue(
       catalogue("SF1625", "DD1337"),
     );
-    vi.mocked(takenService.recordTranscriptCoursesIfAbsent).mockResolvedValue({
+    vi.mocked(takenService.recordTranscriptConfirmation).mockResolvedValue({
       inserted: 2,
       updated: 0,
     });
@@ -132,10 +132,8 @@ describe("confirmTranscriptImport", () => {
       importedAt,
     );
 
-    expect(takenService.recordTranscriptCoursesIfAbsent).toHaveBeenCalledTimes(
-      1,
-    );
-    expect(takenService.recordTranscriptCoursesIfAbsent).toHaveBeenCalledWith(
+    expect(takenService.recordTranscriptConfirmation).toHaveBeenCalledTimes(1);
+    expect(takenService.recordTranscriptConfirmation).toHaveBeenCalledWith(
       "user-1",
       [
         {
@@ -151,6 +149,7 @@ describe("confirmTranscriptImport", () => {
           attendanceYear: 2023,
         },
       ],
+      [],
       importedAt,
     );
     expect(result).toEqual({ inserted: 2, updated: 0 });
@@ -168,14 +167,14 @@ describe("confirmTranscriptImport", () => {
         importedAt,
       ),
     ).rejects.toBeInstanceOf(NotFoundError);
-    expect(takenService.recordTranscriptCoursesIfAbsent).not.toHaveBeenCalled();
+    expect(takenService.recordTranscriptConfirmation).not.toHaveBeenCalled();
   });
 
-  it("delegates repeated transcript confirmations to the insert-only write", async () => {
+  it("delegates repeated transcript confirmations to the atomic write", async () => {
     vi.mocked(courseService.getSummariesByCodes).mockResolvedValue(
       catalogue("SF1625", "DD1337"),
     );
-    vi.mocked(takenService.recordTranscriptCoursesIfAbsent).mockResolvedValue({
+    vi.mocked(takenService.recordTranscriptConfirmation).mockResolvedValue({
       inserted: 0,
       updated: 0,
     });
@@ -183,12 +182,9 @@ describe("confirmTranscriptImport", () => {
     await confirmTranscriptImport("user-1", confirmed, importedAt);
     await confirmTranscriptImport("user-1", confirmed, importedAt);
 
-    expect(takenService.recordTranscriptCoursesIfAbsent).toHaveBeenCalledTimes(
-      2,
-    );
-    for (const [, rows] of vi.mocked(
-      takenService.recordTranscriptCoursesIfAbsent,
-    ).mock.calls) {
+    expect(takenService.recordTranscriptConfirmation).toHaveBeenCalledTimes(2);
+    for (const [, rows] of vi.mocked(takenService.recordTranscriptConfirmation)
+      .mock.calls) {
       expect(rows.map((row) => row.courseCode)).toEqual(["SF1625", "DD1337"]);
     }
   });
@@ -197,7 +193,7 @@ describe("confirmTranscriptImport", () => {
     vi.mocked(courseService.getSummariesByCodes).mockResolvedValue(
       catalogue("SF1625"),
     );
-    vi.mocked(takenService.recordTranscriptCoursesIfAbsent).mockResolvedValue({
+    vi.mocked(takenService.recordTranscriptConfirmation).mockResolvedValue({
       inserted: 1,
       updated: 0,
     });
@@ -208,8 +204,8 @@ describe("confirmTranscriptImport", () => {
       importedAt,
     );
 
-    const [, rows] = vi.mocked(takenService.recordTranscriptCoursesIfAbsent)
-      .mock.calls[0];
+    const [, rows] = vi.mocked(takenService.recordTranscriptConfirmation).mock
+      .calls[0];
     expect(rows).toEqual([
       {
         courseCode: "SF1625",
@@ -224,8 +220,7 @@ describe("confirmTranscriptImport", () => {
     const result = await confirmTranscriptImport("user-1", [], importedAt);
 
     expect(result).toEqual({ inserted: 0, updated: 0 });
-    expect(takenService.recordTranscriptCoursesIfAbsent).not.toHaveBeenCalled();
-    expect(takenService.fillTranscriptCourseFields).not.toHaveBeenCalled();
+    expect(takenService.recordTranscriptConfirmation).not.toHaveBeenCalled();
     expect(courseService.getSummariesByCodes).not.toHaveBeenCalled();
     // Nothing was imported, so nothing about the ladder can have changed.
     expect(
@@ -237,7 +232,10 @@ describe("confirmTranscriptImport", () => {
     vi.mocked(courseService.getSummariesByCodes).mockResolvedValue(
       catalogue("SF1625"),
     );
-    vi.mocked(takenService.fillTranscriptCourseFields).mockResolvedValue(1);
+    vi.mocked(takenService.recordTranscriptConfirmation).mockResolvedValue({
+      inserted: 0,
+      updated: 1,
+    });
 
     const result = await confirmTranscriptImport("user-1", [], importedAt, [
       {
@@ -249,9 +247,9 @@ describe("confirmTranscriptImport", () => {
     ]);
 
     expect(courseService.getSummariesByCodes).toHaveBeenCalledWith(["SF1625"]);
-    expect(takenService.recordTranscriptCoursesIfAbsent).not.toHaveBeenCalled();
-    expect(takenService.fillTranscriptCourseFields).toHaveBeenCalledWith(
+    expect(takenService.recordTranscriptConfirmation).toHaveBeenCalledWith(
       "user-1",
+      [],
       [
         {
           courseCode: "SF1625",
@@ -260,6 +258,7 @@ describe("confirmTranscriptImport", () => {
           attendanceYear: 2023,
         },
       ],
+      importedAt,
     );
     expect(
       graphService.recordEarnedPersonalizationTierOnContribution,
@@ -268,10 +267,54 @@ describe("confirmTranscriptImport", () => {
       vi.mocked(graphService.recordEarnedPersonalizationTierOnContribution).mock
         .invocationCallOrder[0],
     ).toBeGreaterThan(
-      vi.mocked(takenService.fillTranscriptCourseFields).mock
+      vi.mocked(takenService.recordTranscriptConfirmation).mock
         .invocationCallOrder[0] ?? 0,
     );
     expect(result).toEqual({ inserted: 0, updated: 1 });
+  });
+
+  it("writes creates and fills through one atomic taken operation", async () => {
+    vi.mocked(courseService.getSummariesByCodes).mockResolvedValue(
+      catalogue("SF1625", "DD1337"),
+    );
+    vi.mocked(takenService.recordTranscriptConfirmation).mockResolvedValue({
+      inserted: 1,
+      updated: 1,
+    });
+
+    const result = await confirmTranscriptImport(
+      "user-1",
+      [confirmed[0]],
+      importedAt,
+      [confirmed[1]],
+    );
+
+    expect(takenService.recordTranscriptConfirmation).toHaveBeenCalledWith(
+      "user-1",
+      [confirmed[0]],
+      [confirmed[1]],
+      importedAt,
+    );
+    expect(result).toEqual({ inserted: 1, updated: 1 });
+  });
+
+  it("does not recompute the tier when the atomic write fails", async () => {
+    vi.mocked(courseService.getSummariesByCodes).mockResolvedValue(
+      catalogue("SF1625", "DD1337"),
+    );
+    vi.mocked(takenService.recordTranscriptConfirmation).mockRejectedValue(
+      new Error("fill failed"),
+    );
+
+    await expect(
+      confirmTranscriptImport("user-1", [confirmed[0]], importedAt, [
+        confirmed[1],
+      ]),
+    ).rejects.toThrow("fill failed");
+
+    expect(
+      graphService.recordEarnedPersonalizationTierOnContribution,
+    ).not.toHaveBeenCalled();
   });
 
   it("validates fill-only course codes before writing anything", async () => {
@@ -283,8 +326,7 @@ describe("confirmTranscriptImport", () => {
       ]),
     ).rejects.toBeInstanceOf(NotFoundError);
 
-    expect(takenService.recordTranscriptCoursesIfAbsent).not.toHaveBeenCalled();
-    expect(takenService.fillTranscriptCourseFields).not.toHaveBeenCalled();
+    expect(takenService.recordTranscriptConfirmation).not.toHaveBeenCalled();
     expect(
       graphService.recordEarnedPersonalizationTierOnContribution,
     ).not.toHaveBeenCalled();
@@ -300,7 +342,7 @@ describe("confirmTranscriptImport", () => {
     vi.mocked(courseService.getSummariesByCodes).mockResolvedValue(
       catalogue("SF1625", "DD1337"),
     );
-    vi.mocked(takenService.recordTranscriptCoursesIfAbsent).mockResolvedValue({
+    vi.mocked(takenService.recordTranscriptConfirmation).mockResolvedValue({
       inserted: 2,
       updated: 0,
     });
@@ -314,7 +356,7 @@ describe("confirmTranscriptImport", () => {
       vi.mocked(graphService.recordEarnedPersonalizationTierOnContribution).mock
         .invocationCallOrder[0],
     ).toBeGreaterThan(
-      vi.mocked(takenService.recordTranscriptCoursesIfAbsent).mock
+      vi.mocked(takenService.recordTranscriptConfirmation).mock
         .invocationCallOrder[0] ?? 0,
     );
   });
@@ -326,7 +368,7 @@ describe("confirmTranscriptImport", () => {
     vi.mocked(courseService.getSummariesByCodes).mockResolvedValue(
       catalogue("SF1625", "DD1337"),
     );
-    vi.mocked(takenService.recordTranscriptCoursesIfAbsent).mockResolvedValue({
+    vi.mocked(takenService.recordTranscriptConfirmation).mockResolvedValue({
       inserted: 0,
       updated: 0,
     });

--- a/apps/web/server/ingest/transcript/service.spec.ts
+++ b/apps/web/server/ingest/transcript/service.spec.ts
@@ -225,8 +225,66 @@ describe("confirmTranscriptImport", () => {
 
     expect(result).toEqual({ inserted: 0, updated: 0 });
     expect(takenService.recordTranscriptCoursesIfAbsent).not.toHaveBeenCalled();
+    expect(takenService.fillTranscriptCourseFields).not.toHaveBeenCalled();
     expect(courseService.getSummariesByCodes).not.toHaveBeenCalled();
     // Nothing was imported, so nothing about the ladder can have changed.
+    expect(
+      graphService.recordEarnedPersonalizationTierOnContribution,
+    ).not.toHaveBeenCalled();
+  });
+
+  it("persists a fill-only confirmation and recomputes the tier", async () => {
+    vi.mocked(courseService.getSummariesByCodes).mockResolvedValue(
+      catalogue("SF1625"),
+    );
+    vi.mocked(takenService.fillTranscriptCourseFields).mockResolvedValue(1);
+
+    const result = await confirmTranscriptImport("user-1", [], importedAt, [
+      {
+        courseCode: " sf1625 ",
+        grade: "A",
+        earnedCredits: 7.5,
+        attendanceYear: 2023,
+      },
+    ]);
+
+    expect(courseService.getSummariesByCodes).toHaveBeenCalledWith(["SF1625"]);
+    expect(takenService.recordTranscriptCoursesIfAbsent).not.toHaveBeenCalled();
+    expect(takenService.fillTranscriptCourseFields).toHaveBeenCalledWith(
+      "user-1",
+      [
+        {
+          courseCode: "SF1625",
+          grade: "A",
+          earnedCredits: 7.5,
+          attendanceYear: 2023,
+        },
+      ],
+    );
+    expect(
+      graphService.recordEarnedPersonalizationTierOnContribution,
+    ).toHaveBeenCalledWith("user-1");
+    expect(
+      vi.mocked(graphService.recordEarnedPersonalizationTierOnContribution).mock
+        .invocationCallOrder[0],
+    ).toBeGreaterThan(
+      vi.mocked(takenService.fillTranscriptCourseFields).mock
+        .invocationCallOrder[0] ?? 0,
+    );
+    expect(result).toEqual({ inserted: 0, updated: 1 });
+  });
+
+  it("validates fill-only course codes before writing anything", async () => {
+    vi.mocked(courseService.getSummariesByCodes).mockResolvedValue([]);
+
+    await expect(
+      confirmTranscriptImport("user-1", [], importedAt, [
+        { courseCode: "ZZ9999", grade: "A" },
+      ]),
+    ).rejects.toBeInstanceOf(NotFoundError);
+
+    expect(takenService.recordTranscriptCoursesIfAbsent).not.toHaveBeenCalled();
+    expect(takenService.fillTranscriptCourseFields).not.toHaveBeenCalled();
     expect(
       graphService.recordEarnedPersonalizationTierOnContribution,
     ).not.toHaveBeenCalled();

--- a/apps/web/server/ingest/transcript/service.ts
+++ b/apps/web/server/ingest/transcript/service.ts
@@ -2,8 +2,7 @@ import { getSummariesByCodes } from "../../course/service";
 import { NotFoundError } from "../../errors";
 import { recordEarnedPersonalizationTierOnContribution } from "../../graph/service";
 import {
-  fillTranscriptCourseFields,
-  recordTranscriptCoursesIfAbsent,
+  recordTranscriptConfirmation,
   type TakenCourseInput,
 } from "../../taken/service";
 import { matchCandidates, type UnmatchedCandidate } from "./match";
@@ -133,14 +132,12 @@ export async function confirmTranscriptImport(
     );
   }
 
-  const created =
-    inputs.length > 0
-      ? await recordTranscriptCoursesIfAbsent(userId, inputs, importedAt)
-      : { inserted: 0, updated: 0 };
-  const updated =
-    fillInputs.length > 0
-      ? await fillTranscriptCourseFields(userId, fillInputs)
-      : 0;
+  const written = await recordTranscriptConfirmation(
+    userId,
+    inputs,
+    fillInputs,
+    importedAt,
+  );
 
   // The other moment the personalization ladder can move: an import earns 2, and it
   // earns tier 3 outright for somebody who had already reviewed everything on
@@ -150,5 +147,5 @@ export async function confirmTranscriptImport(
   // second import that leaves courses unreviewed cannot take tier 3 away.
   await recordEarnedPersonalizationTierOnContribution(userId);
 
-  return { inserted: created.inserted, updated };
+  return written;
 }

--- a/apps/web/server/ingest/transcript/service.ts
+++ b/apps/web/server/ingest/transcript/service.ts
@@ -105,9 +105,10 @@ function toTakenCourseInput(row: ConfirmedTranscriptRow): TakenCourseInput {
  * client from confirming a code that was never proposed. Only catalogue courses
  * become taken courses.
  *
- * The write itself belongs to `server/taken`. It inserts only when the user
- * does not already have a row for the course, so a manual entry that races this
- * confirmation is never overwritten by transcript values.
+ * The writes themselves belong to `server/taken`. New rows are inserted only
+ * when the user does not already have the course; fills update only fields
+ * that are still empty. A manual entry or correction that races this
+ * confirmation is therefore never overwritten by transcript values.
  */
 export async function confirmTranscriptImport(
   userId: string,
@@ -116,9 +117,11 @@ export async function confirmTranscriptImport(
   fills: ConfirmedTranscriptRow[] = [],
 ): Promise<{ inserted: number; updated: number }> {
   const inputs = rows.map(toTakenCourseInput);
-  if (inputs.length === 0) return { inserted: 0, updated: 0 };
-
   const fillInputs = fills.map(toTakenCourseInput);
+  if (inputs.length === 0 && fillInputs.length === 0) {
+    return { inserted: 0, updated: 0 };
+  }
+
   const codes = [...inputs, ...fillInputs].map((input) => input.courseCode);
   const known = new Set(
     (await getSummariesByCodes(codes)).map((summary) => summary.courseCode),
@@ -130,11 +133,10 @@ export async function confirmTranscriptImport(
     );
   }
 
-  const created = await recordTranscriptCoursesIfAbsent(
-    userId,
-    inputs,
-    importedAt,
-  );
+  const created =
+    inputs.length > 0
+      ? await recordTranscriptCoursesIfAbsent(userId, inputs, importedAt)
+      : { inserted: 0, updated: 0 };
   const updated =
     fillInputs.length > 0
       ? await fillTranscriptCourseFields(userId, fillInputs)

--- a/apps/web/server/taken/repository.spec.ts
+++ b/apps/web/server/taken/repository.spec.ts
@@ -1,0 +1,159 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { db } from "../db";
+import { applyTranscriptConfirmation } from "./repository";
+
+vi.mock("../db", () => ({
+  db: {
+    transaction: vi.fn(),
+  },
+}));
+
+describe("applyTranscriptConfirmation", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("commits mixed creates and fills in one transaction", async () => {
+    const insertQuery = {
+      values() {
+        return this;
+      },
+      onConflictDoNothing() {
+        return this;
+      },
+      returning() {
+        return Promise.resolve([{ courseCode: "SF1625" }]);
+      },
+    };
+    const updateQuery = {
+      set() {
+        return this;
+      },
+      where() {
+        return this;
+      },
+      returning() {
+        return Promise.resolve([{ courseCode: "DD1337" }]);
+      },
+    };
+    const tx = {
+      insert: vi.fn(() => insertQuery),
+      update: vi.fn(() => updateQuery),
+    };
+    vi.mocked(db.transaction).mockImplementation((callback) =>
+      callback(tx as never),
+    );
+
+    await expect(
+      applyTranscriptConfirmation(
+        "user-1",
+        [
+          {
+            courseCode: "SF1625",
+            grade: "A",
+            earnedCredits: 7.5,
+            attendancePeriods: null,
+            attendanceYear: 2023,
+          },
+        ],
+        [
+          {
+            courseCode: "DD1337",
+            grade: "B",
+            earnedCredits: 6,
+            attendancePeriods: null,
+            attendanceYear: 2022,
+          },
+        ],
+        new Date("2026-09-04T10:00:00.000Z"),
+      ),
+    ).resolves.toEqual({ inserted: 1, updated: 1 });
+
+    expect(db.transaction).toHaveBeenCalledTimes(1);
+    expect(tx.insert).toHaveBeenCalledTimes(1);
+    expect(tx.update).toHaveBeenCalledTimes(1);
+  });
+
+  it("rolls back inserts and earlier fills when a later fill fails", async () => {
+    let persisted = ["existing:empty"];
+    let stagedEarlierFill = false;
+
+    vi.mocked(db.transaction).mockImplementation(async (callback) => {
+      const pending = [...persisted];
+      let updateNumber = 0;
+      const insertQuery = {
+        values() {
+          return this;
+        },
+        onConflictDoNothing() {
+          pending.push("created");
+          return this;
+        },
+        returning() {
+          return Promise.resolve([{ courseCode: "SF1625" }]);
+        },
+      };
+      const updateQuery = {
+        set() {
+          return this;
+        },
+        where() {
+          return this;
+        },
+        returning() {
+          updateNumber += 1;
+          if (updateNumber === 1) {
+            pending[0] = "existing:filled";
+            stagedEarlierFill = true;
+            return Promise.resolve([{ courseCode: "DD1337" }]);
+          }
+          return Promise.reject(new Error("second fill failed"));
+        },
+      };
+      const tx = {
+        insert: vi.fn(() => insertQuery),
+        update: vi.fn(() => updateQuery),
+      };
+
+      const result = await callback(tx as never);
+      persisted = pending;
+      return result;
+    });
+
+    await expect(
+      applyTranscriptConfirmation(
+        "user-1",
+        [
+          {
+            courseCode: "SF1625",
+            grade: "A",
+            earnedCredits: 7.5,
+            attendancePeriods: null,
+            attendanceYear: 2023,
+          },
+        ],
+        [
+          {
+            courseCode: "DD1337",
+            grade: "B",
+            earnedCredits: 6,
+            attendancePeriods: null,
+            attendanceYear: 2022,
+          },
+          {
+            courseCode: "DD1396",
+            grade: "C",
+            earnedCredits: 7.5,
+            attendancePeriods: null,
+            attendanceYear: 2024,
+          },
+        ],
+        new Date("2026-09-04T10:00:00.000Z"),
+      ),
+    ).rejects.toThrow("second fill failed");
+
+    expect(persisted).toEqual(["existing:empty"]);
+    expect(stagedEarlierFill).toBe(true);
+    expect(db.transaction).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/web/server/taken/repository.ts
+++ b/apps/web/server/taken/repository.ts
@@ -88,60 +88,61 @@ export async function upsertTakenCourses(
 }
 
 /**
- * Inserts transcript rows without replacing a row that another client already
- * recorded. The primary-key conflict decision happens in PostgreSQL with the
- * insert, so a manual write that lands between a browser's list refresh and
- * transcript confirmation is preserved.
+ * Applies one transcript confirmation in a transaction.
  *
- * Returns the codes that this statement actually inserted. `ON CONFLICT DO
- * NOTHING` also handles a course duplicated within one transcript batch.
+ * New rows never replace a concurrent manual write, and fills preserve fields
+ * that a concurrent manual edit has already supplied. If any write fails, the
+ * inserts and preceding fills are rolled back together.
  */
-export async function insertTakenCoursesIfAbsent(
+export async function applyTranscriptConfirmation(
   userId: string,
   rows: TakenCourseWrite[],
+  fills: TakenCourseWrite[],
   importedAt: Date,
-): Promise<string[]> {
-  if (rows.length === 0) return [];
-  const inserted = await db
-    .insert(schema.userTakenCourses)
-    .values(
-      rows.map((row) => ({
-        userId,
-        ...row,
-        transcriptImportedAt: importedAt,
-      })),
-    )
-    .onConflictDoNothing({
-      target: [
-        schema.userTakenCourses.userId,
-        schema.userTakenCourses.courseCode,
-      ],
-    })
-    .returning({ courseCode: schema.userTakenCourses.courseCode });
-  return inserted.map((row) => row.courseCode);
-}
+): Promise<{ inserted: number; updated: number }> {
+  return db.transaction(async (tx) => {
+    const inserted =
+      rows.length > 0
+        ? await tx
+            .insert(schema.userTakenCourses)
+            .values(
+              rows.map((row) => ({
+                userId,
+                ...row,
+                transcriptImportedAt: importedAt,
+              })),
+            )
+            .onConflictDoNothing({
+              target: [
+                schema.userTakenCourses.userId,
+                schema.userTakenCourses.courseCode,
+              ],
+            })
+            .returning({ courseCode: schema.userTakenCourses.courseCode })
+        : [];
 
-/** Fills only fields that are still null, preserving concurrent edits. */
-export async function fillTakenCourseFieldsIfEmpty(
-  userId: string,
-  row: TakenCourseWrite,
-): Promise<boolean> {
-  const updated = await db
-    .update(schema.userTakenCourses)
-    .set({
-      grade: sql`coalesce(${schema.userTakenCourses.grade}, ${row.grade})`,
-      earnedCredits: sql`coalesce(${schema.userTakenCourses.earnedCredits}, ${row.earnedCredits})`,
-      attendanceYear: sql`coalesce(${schema.userTakenCourses.attendanceYear}, ${row.attendanceYear})`,
-      updatedAt: new Date(),
-    })
-    .where(
-      and(
-        eq(schema.userTakenCourses.userId, userId),
-        eq(schema.userTakenCourses.courseCode, row.courseCode),
-      ),
-    )
-    .returning({ courseCode: schema.userTakenCourses.courseCode });
-  return updated.length > 0;
+    let updated = 0;
+    for (const row of fills) {
+      const filled = await tx
+        .update(schema.userTakenCourses)
+        .set({
+          grade: sql`coalesce(${schema.userTakenCourses.grade}, ${row.grade})`,
+          earnedCredits: sql`coalesce(${schema.userTakenCourses.earnedCredits}, ${row.earnedCredits})`,
+          attendanceYear: sql`coalesce(${schema.userTakenCourses.attendanceYear}, ${row.attendanceYear})`,
+          updatedAt: new Date(),
+        })
+        .where(
+          and(
+            eq(schema.userTakenCourses.userId, userId),
+            eq(schema.userTakenCourses.courseCode, row.courseCode),
+          ),
+        )
+        .returning({ courseCode: schema.userTakenCourses.courseCode });
+      if (filled.length > 0) updated += 1;
+    }
+
+    return { inserted: inserted.length, updated };
+  });
 }
 
 /**

--- a/apps/web/server/taken/service.spec.ts
+++ b/apps/web/server/taken/service.spec.ts
@@ -5,7 +5,7 @@ import {
   addTakenCourse,
   listTakenCourses,
   recordTakenCourses,
-  recordTranscriptCoursesIfAbsent,
+  recordTranscriptConfirmation,
   removeTakenCourse,
   updateTakenCourse,
 } from "./service";
@@ -145,25 +145,38 @@ describe("recordTakenCourses", () => {
   });
 });
 
-describe("recordTranscriptCoursesIfAbsent", () => {
-  it("uses an atomic insert-only write so an existing row is preserved", async () => {
-    vi.mocked(takenRepo.insertTakenCoursesIfAbsent).mockResolvedValue([]);
+describe("recordTranscriptConfirmation", () => {
+  it("normalizes creates and fills before one atomic repository write", async () => {
+    vi.mocked(takenRepo.applyTranscriptConfirmation).mockResolvedValue({
+      inserted: 0,
+      updated: 1,
+    });
 
     await expect(
-      recordTranscriptCoursesIfAbsent(
+      recordTranscriptConfirmation(
         "u1",
         [{ courseCode: "SF1625", grade: "A" }],
+        [{ courseCode: "DD1337", earnedCredits: 7.5 }],
         importedAt,
       ),
-    ).resolves.toEqual({ inserted: 0, updated: 0 });
+    ).resolves.toEqual({ inserted: 0, updated: 1 });
 
-    expect(takenRepo.insertTakenCoursesIfAbsent).toHaveBeenCalledWith(
+    expect(takenRepo.applyTranscriptConfirmation).toHaveBeenCalledWith(
       "u1",
       [
         {
           courseCode: "SF1625",
           grade: "A",
           earnedCredits: null,
+          attendancePeriods: null,
+          attendanceYear: null,
+        },
+      ],
+      [
+        {
+          courseCode: "DD1337",
+          grade: null,
+          earnedCredits: 7.5,
           attendancePeriods: null,
           attendanceYear: null,
         },

--- a/apps/web/server/taken/service.ts
+++ b/apps/web/server/taken/service.ts
@@ -108,38 +108,19 @@ export async function recordTakenCourses(
   return { inserted: deduped.length - updated, updated };
 }
 
-/**
- * Records transcript rows only when no taken-course row exists yet.
- *
- * Unlike the manual upsert path, transcript confirmation must never overwrite
- * a course the reader added or corrected in another session. The repository
- * makes that decision atomically with `ON CONFLICT DO NOTHING`.
- */
-export async function recordTranscriptCoursesIfAbsent(
+/** Applies all creates and fills from one transcript confirmation atomically. */
+export async function recordTranscriptConfirmation(
   userId: string,
   rows: TakenCourseInput[],
+  fills: TakenCourseInput[],
   importedAt: Date,
 ): Promise<{ inserted: number; updated: number }> {
-  const inserted = await takenRepo.insertTakenCoursesIfAbsent(
+  return takenRepo.applyTranscriptConfirmation(
     userId,
     dedupeByCourseCode(rows).map(toWrite),
+    dedupeByCourseCode(fills).map(toWrite),
     importedAt,
   );
-  return { inserted: inserted.length, updated: 0 };
-}
-
-/** Atomically fills transcript facts only where the stored row is still empty. */
-export async function fillTranscriptCourseFields(
-  userId: string,
-  rows: TakenCourseInput[],
-): Promise<number> {
-  let updated = 0;
-  for (const row of dedupeByCourseCode(rows)) {
-    if (await takenRepo.fillTakenCourseFieldsIfEmpty(userId, toWrite(row))) {
-      updated += 1;
-    }
-  }
-  return updated;
 }
 
 /** Records one course the user says they took. Idempotent. */


### PR DESCRIPTION
## Summary

- allow transcript confirmations that only fill missing fields to reach the write path
- validate both new-course and fill course codes while preserving the true empty no-op
- report server-confirmed insert/fill counts in the success banner and correct the stale import-plan documentation

## Validation

- [x] targeted transcript service and Taken UI tests — 81 passed
- [x] `bun run typecheck`
- [x] `bun run lint`
- [x] independent code review — no findings
- [ ] `bun run test:web` — 1,458 passed; three unrelated PDF extraction tests could not resolve `unpdf` in the isolated local dependency install

No database migration or schema change. No rows are deleted.

Closes #229
