### PR TITLE
fix(transcript): accept degree-project course codes

### DIFF
--- a/apps/web/server/ingest/transcript/parse.spec.ts
+++ b/apps/web/server/ingest/transcript/parse.spec.ts
@@ -246,6 +246,85 @@ describe("parseLadokTranscript", () => {
     ]);
   });
 
+  it("reads a complete degree-project row", () => {
+    const transcript = [
+      "Code Name Scope Grade Date Note",
+      "DA232X Degree Project in Computer Science 30.0 hp P 2026-06-05 1",
+      "Summation",
+    ].join("\n");
+
+    expect(parseLadokTranscript(transcript)).toEqual([
+      {
+        courseCode: "DA232X",
+        courseName: "Degree Project in Computer Science",
+        credits: 30,
+        grade: "P",
+        completedOn: "2026-06-05",
+      },
+    ]);
+  });
+
+  it("reports a wrapped degree-project row through the fallback parser", () => {
+    const transcript = [
+      "Code Name Scope Grade Date Note",
+      "SF279X Degree Project in Applied and",
+      "Computational Mathematics",
+      "Summation",
+    ].join("\n");
+
+    expect(parseLadokTranscript(transcript)).toEqual([
+      {
+        courseCode: "SF279X",
+        courseName: "Degree Project in Applied and Computational Mathematics",
+        credits: null,
+        grade: null,
+        completedOn: null,
+      },
+    ]);
+  });
+
+  it("reads ordinary and degree-project course codes from the same transcript", () => {
+    const transcript = [
+      "Code Name Scope Grade Date Note",
+      "DD1337 Programming 6.0 hp P 2023-06-02 1",
+      "DA232X Degree Project in Computer Science 30.0 hp P 2026-06-05 1",
+      "Summation",
+    ].join("\n");
+
+    expect(
+      parseLadokTranscript(transcript).map(({ courseCode }) => courseCode),
+    ).toEqual(["DD1337", "DA232X"]);
+  });
+
+  it("accepts a transcript containing only a degree-project course", () => {
+    const transcript = [
+      "Code Name Scope Grade Date Note",
+      "SF279X Degree Project 30.0 hp P 2026-06-05 1",
+      "Summation",
+    ].join("\n");
+
+    expect(parseLadokTranscript(transcript)).toHaveLength(1);
+  });
+
+  it("does not accept a three-digit course code with a non-X suffix", () => {
+    const transcript = [
+      "Code Name Scope Grade Date Note",
+      "SF279A Not a KTH Course Code 30.0 hp P 2026-06-05 1",
+      "DD1337 Programming 6.0 hp P 2023-06-02 1",
+      "Summation",
+    ].join("\n");
+
+    expect(parseLadokTranscript(transcript)).toEqual([
+      {
+        courseCode: "DD1337",
+        courseName: "Programming",
+        credits: 6,
+        grade: "P",
+        completedOn: "2023-06-02",
+      },
+    ]);
+  });
+
   it("rejects a document too large to be a transcript, without scanning it", () => {
     const huge = `Code Name Scope Grade Date Note\nSF1625 ${"x".repeat(3_000_000)}`;
 

--- a/apps/web/server/ingest/transcript/parse.ts
+++ b/apps/web/server/ingest/transcript/parse.ts
@@ -34,8 +34,12 @@ const TABLE_HEADER = /^(?:Code|Kod)\s+(?:Name|Benämning)\b/;
 /** First line after the table; Ladok always prints a summation block. */
 const TABLE_END = /^(?:Summation|Summering)\b/;
 
-/** A KTH course code: two or three letters then four digits. */
-const COURSE_CODE = /^[A-ZÅÄÖ]{2,3}\d{4}[A-Z]?$/;
+/**
+ * A KTH course code: two or three letters followed by either four digits and
+ * an optional suffix, or three digits and the degree-project suffix `X`.
+ */
+const COURSE_CODE_SOURCE = "[A-ZÅÄÖ]{2,3}(?:\\d{4}[A-Z]?|\\d{3}X)";
+const COURSE_CODE = new RegExp(`^${COURSE_CODE_SOURCE}$`);
 
 /** The longest course name KTH prints is well under this. */
 const MAX_NAME_LENGTH = 300;
@@ -59,11 +63,11 @@ const MAX_CONTINUATION_LINES = 4;
  * bounded so a failed match cannot backtrack across a long line.
  */
 const ROW = new RegExp(
-  `^([A-ZÅÄÖ]{2,3}\\d{4}[A-Z]?)\\s+(.{1,${MAX_NAME_LENGTH}}?)\\s+(\\d+(?:[.,]\\d+)?)\\s*hp\\s+(\\S{1,3})\\s+(\\d{4}-\\d{2}-\\d{2})(?:\\s+\\d+)?$`,
+  `^(${COURSE_CODE_SOURCE})\\s+(.{1,${MAX_NAME_LENGTH}}?)\\s+(\\d+(?:[.,]\\d+)?)\\s*hp\\s+(\\S{1,3})\\s+(\\d{4}-\\d{2}-\\d{2})(?:\\s+\\d+)?$`,
 );
 
 /** The fallback when a row's trailing columns are unreadable: code and name. */
-const ROW_HEAD = /^([A-ZÅÄÖ]{2,3}\d{4}[A-Z]?)\s+(.*)$/;
+const ROW_HEAD = new RegExp(`^(${COURSE_CODE_SOURCE})\\s+(.*)$`);
 
 /**
  * Marks a line as belonging to the page rather than to the table: the Ladok


### PR DESCRIPTION
## Summary

- share one transcript course-code pattern across row detection and parsing
- accept KTH degree-project codes with three digits followed by `X`
- retain the existing ordinary four-digit course-code behavior without widening other three-digit suffixes

## Validation

- [x] transcript parser tests — 18 passed
- [x] `bun run typecheck`
- [x] `bun run lint`
- [x] independent code review — no findings
- [ ] `bun run test:web` — 1,460 passed; three unrelated PDF extraction tests could not resolve `unpdf` in the isolated local dependency install

No database migration or schema change.

Closes #230
