### PR TITLE
fix(transcript): count only changed fills

### DIFF
--- a/apps/web/server/taken/repository.spec.ts
+++ b/apps/web/server/taken/repository.spec.ts
@@ -1,3 +1,5 @@
+import type { SQL } from "drizzle-orm";
+import { PgDialect } from "drizzle-orm/pg-core";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { db } from "../db";
 import { applyTranscriptConfirmation } from "./repository";
@@ -73,6 +75,94 @@ describe("applyTranscriptConfirmation", () => {
     expect(tx.insert).toHaveBeenCalledTimes(1);
     expect(tx.update).toHaveBeenCalledTimes(1);
   });
+
+  it.each([
+    {
+      state: "every target field is populated",
+      stored: { grade: "B", earnedCredits: 6, attendanceYear: 2022 },
+      expectedUpdated: 0,
+    },
+    {
+      state: "only grade is empty",
+      stored: { grade: null, earnedCredits: 6, attendanceYear: 2022 },
+      expectedUpdated: 1,
+    },
+    {
+      state: "only earned credits is empty",
+      stored: { grade: "B", earnedCredits: null, attendanceYear: 2022 },
+      expectedUpdated: 1,
+    },
+    {
+      state: "only attendance year is empty",
+      stored: { grade: "B", earnedCredits: 6, attendanceYear: null },
+      expectedUpdated: 1,
+    },
+  ])(
+    "counts a fill truthfully when $state",
+    async ({ stored, expectedUpdated }) => {
+      const originalUpdatedAt = new Date("2026-08-20T08:00:00.000Z");
+      let storedUpdatedAt = originalUpdatedAt;
+      let nextUpdatedAt = originalUpdatedAt;
+      let matchesStoredRow = true;
+
+      const updateQuery = {
+        set(values: { updatedAt: Date }) {
+          nextUpdatedAt = values.updatedAt;
+          return this;
+        },
+        where(condition: SQL) {
+          const queryText = new PgDialect()
+            .sqlToQuery(condition)
+            .sql.toLowerCase();
+          matchesStoredRow = [
+            queryText.includes('"grade" is null') && stored.grade === null,
+            queryText.includes('"earned_credits" is null') &&
+              stored.earnedCredits === null,
+            queryText.includes('"attendance_year" is null') &&
+              stored.attendanceYear === null,
+          ].some(Boolean);
+          return this;
+        },
+        returning() {
+          if (!matchesStoredRow) return Promise.resolve([]);
+          storedUpdatedAt = nextUpdatedAt;
+          return Promise.resolve([{ courseCode: "DD1337" }]);
+        },
+      };
+      const tx = {
+        insert: vi.fn(),
+        update: vi.fn(() => updateQuery),
+      };
+      vi.mocked(db.transaction).mockImplementation((callback) =>
+        callback(tx as never),
+      );
+
+      await expect(
+        applyTranscriptConfirmation(
+          "user-1",
+          [],
+          [
+            {
+              courseCode: "DD1337",
+              grade: "A",
+              earnedCredits: 7.5,
+              attendancePeriods: null,
+              attendanceYear: 2023,
+            },
+          ],
+          new Date("2026-09-08T10:00:00.000Z"),
+        ),
+      ).resolves.toEqual({ inserted: 0, updated: expectedUpdated });
+
+      if (expectedUpdated === 0) {
+        expect(storedUpdatedAt).toEqual(originalUpdatedAt);
+      } else {
+        expect(storedUpdatedAt.getTime()).toBeGreaterThan(
+          originalUpdatedAt.getTime(),
+        );
+      }
+    },
+  );
 
   it("rolls back inserts and earlier fills when a later fill fails", async () => {
     let persisted = ["existing:empty"];

--- a/apps/web/server/taken/repository.ts
+++ b/apps/web/server/taken/repository.ts
@@ -1,4 +1,4 @@
-import { and, count, eq, inArray, sql } from "drizzle-orm";
+import { and, count, eq, inArray, isNull, or, sql } from "drizzle-orm";
 import { db } from "../db";
 import * as schema from "../db/schema";
 
@@ -92,7 +92,8 @@ export async function upsertTakenCourses(
  *
  * New rows never replace a concurrent manual write, and fills preserve fields
  * that a concurrent manual edit has already supplied. If any write fails, the
- * inserts and preceding fills are rolled back together.
+ * inserts and preceding fills are rolled back together. `updated` counts only
+ * rows where at least one previously-empty field was filled.
  */
 export async function applyTranscriptConfirmation(
   userId: string,
@@ -122,7 +123,15 @@ export async function applyTranscriptConfirmation(
         : [];
 
     let updated = 0;
+    // This bounded, sequential loop deliberately keeps each fill as a typed,
+    // per-row coalescing UPDATE. Revisit batching only if transcript imports
+    // are measured as slow; UPDATE FROM VALUES would trade away that clarity.
     for (const row of fills) {
+      const fillsGrade = row.grade !== null;
+      const fillsCredits = row.earnedCredits !== null;
+      const fillsYear = row.attendanceYear !== null;
+      if (!fillsGrade && !fillsCredits && !fillsYear) continue;
+
       const filled = await tx
         .update(schema.userTakenCourses)
         .set({
@@ -135,6 +144,15 @@ export async function applyTranscriptConfirmation(
           and(
             eq(schema.userTakenCourses.userId, userId),
             eq(schema.userTakenCourses.courseCode, row.courseCode),
+            or(
+              fillsGrade ? isNull(schema.userTakenCourses.grade) : undefined,
+              fillsCredits
+                ? isNull(schema.userTakenCourses.earnedCredits)
+                : undefined,
+              fillsYear
+                ? isNull(schema.userTakenCourses.attendanceYear)
+                : undefined,
+            ),
           ),
         )
         .returning({ courseCode: schema.userTakenCourses.courseCode });


### PR DESCRIPTION
## Summary

- count a transcript fill only when a non-null incoming value fills a stored null field
- prevent no-op fills from rewriting the taken course timestamp
- document the deliberate bounded per-row update loop and cover every fillable field

## Validation

- [x] focused taken/transcript tests — 33 passed
- [x] `bun run typecheck`
- [x] changed-file Biome check
- [x] independent standards and spec reviews — no findings
- [ ] `bun run test:web` — 1,473 passed; three unrelated PDF extraction tests could not resolve `unpdf` in the isolated local dependency install

No database migration or schema change. No rows are deleted.

Closes #218
