### PR TITLE
fix(workspace): prevent repeated review reveal

### DIFF
--- a/apps/web/features/workspace/components/course-details-panel.tsx
+++ b/apps/web/features/workspace/components/course-details-panel.tsx
@@ -59,9 +59,11 @@ function ScoreBar({
 function ReviewsSummary({
   stats,
   onReadReviews,
+  reviewsOpen,
 }: {
   stats: CourseReviewStats;
   onReadReviews: () => void;
+  reviewsOpen: boolean;
 }) {
   // The same slices the Review Card draws, from the reviews feature's own
   // palette — one examination bar in the app, not two that drift apart.
@@ -162,7 +164,8 @@ function ReviewsSummary({
           <button
             type="button"
             onClick={onReadReviews}
-            className="cursor-pointer text-left font-semibold text-[11.5px] text-cc-dim hover:underline"
+            disabled={reviewsOpen}
+            className="cursor-pointer text-left font-semibold text-[11.5px] text-cc-dim hover:underline disabled:cursor-default disabled:no-underline disabled:opacity-60"
           >
             Read all {stats.reviewCount} reviews →
           </button>
@@ -361,7 +364,11 @@ export function CourseDetailsPanel({
           </div>
         )}
         {statsAnswered && stats !== null && (
-          <ReviewsSummary stats={stats} onReadReviews={revealReviews} />
+          <ReviewsSummary
+            stats={stats}
+            onReadReviews={revealReviews}
+            reviewsOpen={reviewsOpen}
+          />
         )}
 
         <div className="flex items-center justify-between gap-3 rounded-[10px] border border-cc-rule bg-cc-info px-[13px] py-[11px]">

--- a/apps/web/features/workspace/components/workspace-pane.spec.tsx
+++ b/apps/web/features/workspace/components/workspace-pane.spec.tsx
@@ -478,6 +478,44 @@ describe("the details tab", () => {
     expect(screen.getByTestId("review-card")).toHaveTextContent("rev-1");
   });
 
+  it.each([
+    {
+      label: "one review",
+      reviewCount: 1,
+      rows: [{ id: "rev-1", courseCode: "DD2380" }],
+    },
+    {
+      label: "multiple reviews",
+      reviewCount: 2,
+      rows: [
+        { id: "rev-1", courseCode: "DD2380" },
+        { id: "rev-2", courseCode: "DD2380" },
+      ],
+    },
+  ])(
+    "keeps $label revealed when Read all is activated repeatedly",
+    async ({ reviewCount, rows }) => {
+      const user = userEvent.setup({ delay: null });
+      setStats({
+        ...REVIEWED,
+        reviews: REVIEWED.reviews ? { ...REVIEWED.reviews, reviewCount } : null,
+      });
+      setReviewList(rows);
+      renderPane([openCourse("details")]);
+
+      const readAll = screen.getByRole("button", {
+        name: `Read all ${reviewCount} reviews →`,
+      });
+      await user.dblClick(readAll);
+
+      expect(readAll).toBeDisabled();
+      expect(
+        screen.getByRole("button", { name: `Reviews · ${reviewCount}` }),
+      ).toHaveAttribute("aria-expanded", "true");
+      expect(screen.getAllByTestId("review-card")).toHaveLength(rows.length);
+    },
+  );
+
   it("does not put the summary's count over a list that failed", async () => {
     const user = userEvent.setup({ delay: null });
     renderPane([openCourse("details")]);


### PR DESCRIPTION
## Summary

- disable the **Read all reviews** control while the review section is already expanded
- prevent repeated activations from scheduling nested scrolling that can clip the workspace layout
- cover repeated activation for courses with one and multiple reviews

## Validation

- `bun run test:web features/workspace/components/workspace-pane.spec.tsx` — 44 tests passed
- `bun run typecheck`
- Biome check on changed files
- independent standards review: pass, no findings
- independent issue-spec review: pass, no findings

No database, schema, migration, or data changes.

Closes #241
