### PR TITLE
fix(landing): preserve visible community nodes

### DIFF
--- a/apps/web/features/landing/components/hero-network.spec.tsx
+++ b/apps/web/features/landing/components/hero-network.spec.tsx
@@ -433,33 +433,47 @@ describe("HeroNetwork", () => {
     expect(recorder.ctx.fillText).not.toHaveBeenCalled();
   });
 
-  /**
-   * The graph is deliberately a crop of a larger community, so edges may still
-   * leave through the sides and foot of the canvas. The top edge is different:
-   * it touches the landing header, and ink ending there reads as if the header
-   * is obscuring part of the graph rather than as an intentional crop.
-   */
+  /** A header treatment must not hide app-user nodes from the community. */
   it.each([
     {
-      frame: "desktop",
+      frame: "signed-out desktop",
       width: 1920,
       height: 600,
       copy: box(500, 100, 920, 480),
+      showsViewer: false,
     },
     {
-      frame: "narrow",
+      frame: "signed-in desktop",
+      width: 1920,
+      height: 600,
+      copy: box(500, 100, 920, 480),
+      showsViewer: true,
+    },
+    {
+      frame: "signed-out narrow",
       width: 320,
       height: 480,
       copy: box(20, 160, 280, 280),
+      showsViewer: false,
+    },
+    {
+      frame: "signed-in narrow",
+      width: 320,
+      height: 480,
+      copy: box(20, 160, 280, 280),
+      showsViewer: true,
     },
   ])(
-    "keeps painted graph content below the header-adjacent edge on a $frame frame",
-    ({ width, height, copy: copyBox }) => {
+    "keeps every graph node visible at the header-adjacent edge on a $frame frame",
+    ({ width, height, copy: copyBox, showsViewer }) => {
       const graph: GraphWindow = {
         centre: { x: 0, y: 0 },
         nodes: [
           node({ id: "top", x: 0, y: -70 }),
           node({ id: "bottom", x: 0, y: 70 }),
+          ...(showsViewer
+            ? [node({ id: "viewer", x: 0, y: 0, isViewer: true })]
+            : []),
         ],
         edges: [{ fromId: "top", toId: "bottom" }],
       };
@@ -468,7 +482,7 @@ describe("HeroNetwork", () => {
           <div data-hero-clear>
             <span>Find the Course You Will Be Happy You Took</span>
           </div>
-          <HeroNetwork window={graph} labelled={false} />
+          <HeroNetwork window={graph} labelled={showsViewer} />
         </div>,
       );
       const canvas = container.querySelector("canvas");
@@ -482,24 +496,15 @@ describe("HeroNetwork", () => {
       recorder.paths.length = 0;
       onResize?.();
 
-      const visibleTops = recorder.paths
-        .filter((path) => path.filled || path.stroked)
-        .flatMap((path) => {
-          const arcs = path.arcs.flatMap(({ y, r }) =>
-            y + r > 0 && y - r < height ? [Math.max(0, y - r)] : [],
-          );
-          const lineYs = [...path.moves, ...path.lines].map(({ y }) => y);
-          const lines =
-            path.stroked &&
-            lineYs.length > 1 &&
-            Math.max(...lineYs) > 0 &&
-            Math.min(...lineYs) < height
-              ? [Math.max(0, Math.min(...lineYs) - path.width / 2)]
-              : [];
-          return [...arcs, ...lines];
-        });
-      expect(visibleTops.length).toBeGreaterThan(0);
-      expect(Math.min(...visibleTops)).toBeGreaterThanOrEqual(24);
+      const visibleNodes = recorder.paths.filter(
+        (path) =>
+          path.filled &&
+          path.arcs.some(
+            ({ y, r }) => r === NODE_RADIUS && y + r > 0 && y - r < height,
+          ),
+      );
+      expect(visibleNodes).toHaveLength(graph.nodes.length);
+      if (showsViewer) expect(recorder.ctx.fillText).toHaveBeenCalled();
     },
   );
 

--- a/apps/web/features/landing/components/hero-network.tsx
+++ b/apps/web/features/landing/components/hero-network.tsx
@@ -88,18 +88,6 @@ const NODE_ALPHA = 0.82;
 const EDGE_ALPHA = 0.26;
 
 /**
- * Blank canvas kept between the landing header and the first graph mark.
- *
- * Cropping at the other three edges is intentional: it says the community
- * continues beyond this graph window. The top edge abuts an opaque header,
- * however, so the same crop reads as content hidden behind navigation. Treat
- * that strip like the hero copy: nodes are moved clear when the local push can
- * do so, and edges crossing it are not painted. `SAFETY` on the measured rect
- * still leaves enough room for the ±5px drift around a node's home position.
- */
-const HEADER_EDGE_CLEARANCE = 24;
-
-/**
  * A diamond's half-diagonal, as a multiple of `NODE_RADIUS`.
  *
  * Chosen so the square covers the same area as the circle it replaces: a square
@@ -269,16 +257,7 @@ function nodeColour(palette: Palette, colorVar: string) {
  */
 function refreshView(scene: Scene) {
   const measured = measureRects(scene.root, scene.canvas);
-  const content = measured.length ? measured : fallbackRects(scene.w, scene.h);
-  const keepOut = [
-    {
-      x: -SAFETY,
-      y: -SAFETY,
-      w: scene.w + SAFETY * 2,
-      h: HEADER_EDGE_CLEARANCE + SAFETY,
-    },
-    ...content,
-  ];
+  const keepOut = measured.length ? measured : fallbackRects(scene.w, scene.h);
   scene.view = scene.window
     ? projectGraphWindow({
         window: scene.window,


### PR DESCRIPTION
## Summary

- remove the per-node header-edge keep-out introduced by #243 because it hides real app-user nodes
- restore the shared community graph's previous visible-node behavior through a normal forward fix
- replace the insufficient clearance assertion with rendered-canvas regression coverage for signed-in/out desktop and narrow layouts
- verify the viewer node remains visible and labelled for **Find your dot**

## Root cause

The full-width header strip was added to the same keep-out collection used for individual nodes and edges. Upper nodes were pushed farther upward or given insufficient clearance, so they stopped painting. In the reported signed-in view, the visible graph dropped from roughly seven nodes to four.

## Validation

- reproduced on the merged implementation: signed-out fixtures painted 1/2 nodes and signed-in fixtures painted 2/3 nodes at both desktop and narrow sizes
- corrected implementation: `HeroNetwork` suite 34/34 passed
- landing-focused suite: 148/148 passed
- `bun run typecheck`
- changed-file Biome and `git diff --check`
- independent standards review: pass after one terminology correction
- independent behavior/spec review: pass

No database, schema, migration, server, or persisted-data changes.

Follow-up design work for the original header-edge visual issue is tracked in #246.
